### PR TITLE
Custom asteroids data packages

### DIFF
--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -1,4 +1,4 @@
-{
+ï»¿{
 	"spec_version": 1,
 	"identifier": "CustomAsteroids-Pops-Stock-Inner",
 	"name": "Custom Asteroids (inner stock system data)",
@@ -17,7 +17,7 @@
 		{ "name" : "AlternisKerbol" }, 
 		{
 			"name": "RealSolarSystem",
-			"comment": "The 6.4× and 10× Kerbol packs are compatible; how to allow them?"
+			"comment": "The 6.4Ã— and 10Ã— Kerbol packs are compatible; how to allow them?"
 		}
 	],
 	"install": [

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -1,4 +1,4 @@
-{
+ï»¿{
 	"spec_version": 1,
 	"identifier": "CustomAsteroids-Pops-Stock-Outer",
 	"name": "Custom Asteroids (outer stock system data)",
@@ -19,7 +19,7 @@
 		{ "name" : "PlanetFactoryCE" }, 
 		{
 			"name": "RealSolarSystem",
-			"comment": "The 6.4× and 10× Kerbol packs are compatible; how to select for them?"
+			"comment": "The 6.4Ã— and 10Ã— Kerbol packs are compatible; how to select for them?"
 		}
 	],
 	"install": [

--- a/NetKAN/CustomAsteroids.netkan
+++ b/NetKAN/CustomAsteroids.netkan
@@ -1,4 +1,4 @@
-{
+﻿{
 	"spec_version": 1,
 	"identifier": "CustomAsteroids",
 	"$kref": "#/ckan/kerbalstuff/251",


### PR DESCRIPTION
I've added support for installation of mod-specific data files for Custom Asteroids. Compatibility files for e.g. RSS or Alternis Kerbol will need to be provided separately. How does relationship resolution work if, for example, a player has RSS but nobody has uploaded any Custom Asteroids data files for it? Will CKAN say "There's no `CustomAsteroids-Pops` that I can install, therefore I can't install Custom Asteroids"?

@pjf, as noted in the JSON comments, I've got a bit of a problem with RSS compatibility. The data files are not compatible with the default RSS settings, but they _are_ compatible if the player's installed an optional config that uses a rescaled Kerbol system instead of the solar system. I'm not sure how to indicate that this is an exception to the overall lack of compatibility.
