### PR TITLE
Make RPM install Correctly

### DIFF
--- a/NetKAN/RasterPropMonitor-Core.netkan
+++ b/NetKAN/RasterPropMonitor-Core.netkan
@@ -10,14 +10,16 @@
     "license"        : "GPL-3.0",
     "release_status" : "stable",
     "resources" : {
-        "homepage" : "http://forum.kerbalspaceprogram.com/threads/57603"
+        "homepage" : "http://forum.kerbalspaceprogram.com/threads/57603",
+        "manual" : "https://github.com/Mihara/RasterPropMonitor/wiki"
     },
     "depends" : [
         { "name" : "ModuleManager" }
     ],
     "install" : [
         {
-            "file"       : "GameData/JSI/RasterPropMonitor",
+            "file"       : "GameData/JSI",
+            "filter": ["Agencies", "RPMPodPatches"],
             "install_to" : "GameData"
         }
     ]

--- a/NetKAN/RasterPropMonitor.netkan
+++ b/NetKAN/RasterPropMonitor.netkan
@@ -10,7 +10,8 @@
     "release_status" : "stable",
     "$vref"          : "#/ckan/ksp-avc",
     "resources" : {
-        "homepage" : "http://forum.kerbalspaceprogram.com/threads/57603"
+        "homepage" : "http://forum.kerbalspaceprogram.com/threads/57603",
+        "manual" : "https://github.com/Mihara/RasterPropMonitor/wiki"
     },
     "depends" : [
         { "name" : "ModuleManager" },


### PR DESCRIPTION
Fix the installation location of RasterPropMonitor in light of KSP-CKAN/CKAN#287. Also add documentation links, and add `$vref` into the core module.
