### PR TITLE
added netkan for Kerbal flight Indicators

### DIFF
--- a/NetKAN/KerbalFlightIndicators.netkan
+++ b/NetKAN/KerbalFlightIndicators.netkan
@@ -1,0 +1,17 @@
+{
+    "spec_version" : 1,
+    "identifier"   : "KerbalFlightIndicators",
+    "$kref"        : "#/ckan/github/DaMichel/KerbalFlightIndicators",
+    "name"         : "Kerbal Flight Indicators",
+    "abstract"     : "Draws a flight vector indicator and other things in your field of view.",
+    "license"      : "CC BY-NC-SA 3.0",
+    "ksp_version"  : "0.25",
+    "recommends" : [
+        { "name" : "Toolbar" }
+    ],
+	"resources" : {
+		"homepage" : "http://forum.kerbalspaceprogram.com/threads/80277"
+	},
+	"author" : "DaMichel",
+	 "release_status" : "stable",
+}


### PR DESCRIPTION
I'd like ckan support for my mods. I tested this file locally and was able to get ckan to download and install KFI from github. So it should be fine.
