### PR TITLE
Adds DMagicOrbitalScience

### DIFF
--- a/NetKAN/DMagicOrbitalScience.netkan
+++ b/NetKAN/DMagicOrbitalScience.netkan
@@ -1,0 +1,12 @@
+{
+    "spec_version" : 1,
+    "identifier"   : "DMagicOrbitalScience",
+    "$kref"        : "#/ckan/kerbalstuff/5",
+	
+	"install": [
+        {
+            "file"       : "GameData/DMagic Orbital Science",
+            "install_to" : "GameData"
+        }
+    ]
+}


### PR DESCRIPTION
If @DMagic1 is okay with it, I'd like to add DMagic Orbital Science to the CKAN.

A warning, though: when I tried using the vref to get the version info from the .version file, netkan encountered an error: "Bad embedded KSP-AVC file". I don't know what's causing that, but if we skip avc support, the mod installs just fine.
