### PR TITLE
Near

### DIFF
--- a/NetKAN/KerbinSide.netkan
+++ b/NetKAN/KerbinSide.netkan
@@ -1,9 +1,0 @@
-{
-	"spec_version" : 1,
-	"identifier"   : "KerbinSide",
-	"$kref"        : "#/ckan/kerbalstuff/77",
-	
-	"depends": [
-        { "name": "KerbalKonstructs" }
-    ]
-}


### PR DESCRIPTION
If @ferram4 is okay with it, I'd like to add NEAR to the CKAN.

Please note that I used NEAR as identifier, instead of the full name: this is not consistent with FAR, that uses the full name, but it is consistent with the name of the folder to install.
@ferram4: what id should we use?

File validated and tested.
