### PR TITLE
adding USIKS (MKS/OKS) mod

### DIFF
--- a/NetKAN/USIKolonizationSystems.netkan
+++ b/NetKAN/USIKolonizationSystems.netkan
@@ -2,7 +2,7 @@
   "spec_version": 1,
   "$kref": "#/ckan/github/BobPalmer/MKS",
   "name": "USI Kolonization Systems (MKS/OKS)",
-  "identifier": "USIKolonizationSytems",
+  "identifier": "USIKolonizationSystems",
   "abstract": "a series of interlocking modules for building long-term, self sustaining colonies on other planets and moons.",
   "license": "CC BY-NC-SA 4.0",
   "release_status": "stable",


### PR DESCRIPTION
should tick the checkmark of MKS/OKS in https://github.com/KSP-CKAN/CKAN-meta/issues/23

I'm unsure how many of the dependencies are required, but I chose to mark every module that is bundled with the MKS/OKS release zip-file as a dependency.
