### PR TITLE
adding Karbonite Plus mod

### DIFF
--- a/NetKAN/KarbonitePlus.netkan
+++ b/NetKAN/KarbonitePlus.netkan
@@ -1,0 +1,23 @@
+{
+    "spec_version"   : 1,
+    "name"           : "KarbonitePlus",
+    "identifier"     : "KarbonitePlus",
+    "$kref"          : "#/ckan/github/BobPalmer/KarbonitePlus",
+    "author"         : "RoverDude",
+    "abstract"       : "New resources and parts for Karbonite, including the resource Karborundum",
+    "license"        : "CC-BY-NC-SA-4",
+    "release_status" : "stable",
+    "ksp_version"    : "0.25",
+    "resources" : {
+        "homepage" : "http://forum.kerbalspaceprogram.com/threads/93054"
+    },
+    "depends" : [
+        { "name" : "Karbonite" },
+    ],
+    "install" : [
+        {
+            "file"       : "GameData/UmbraSpaceIndustries",
+            "install_to" : "GameData"
+        }
+    ]
+}


### PR DESCRIPTION
The parts all seem to be there. Scanning showed some ORS blobs indicating Karbonite concentrations. I got a non-zero percentage of Karborundum. I didn't test sifting Karborundum from the air, but I suspect all the pieces are accounted for so that it can happen.

This commit should tick the checkmark of Karbonite Plus in https://github.com/KSP-CKAN/CKAN-meta/issues/23
