### PR TITLE
NEAR

### DIFF
--- a/NetKAN/NEAR.netkan
+++ b/NetKAN/NEAR.netkan
@@ -1,0 +1,12 @@
+{
+    "spec_version"   : 1,
+    "identifier"     : "NEAR",
+    "$kref"          : "#/ckan/kerbalstuff/54",
+	"license": "GPL-3.0",
+	"$vref" : "#/ckan/ksp-avc",
+	
+	"provides"  : [ "AerodynamicModel" ],
+	"conflicts" : [ { "name" : "AerodynamicModel" } ],
+	
+    "depends" : [ { "name" : "ModuleManager" } ]
+}


### PR DESCRIPTION
The license on kerbalstuff is not spelled like our bots like it to be,
so it's overridden in the file.
