### PR TITLE
Corrects the RoverNOthers packages

### DIFF
--- a/NetKAN/RoversNOthersSet1.netkan
+++ b/NetKAN/RoversNOthersSet1.netkan
@@ -3,7 +3,7 @@
     "identifier"   : "RoversNOthersSet1",
     "$kref"        : "#/ckan/kerbalstuff/78",
 	
-	"license": "unknown", "comment": "Waiting for author to clarify the license",
+	"license": "restricted",
 	
 	"install": [
         {

--- a/NetKAN/RoversNOthersSet2.netkan
+++ b/NetKAN/RoversNOthersSet2.netkan
@@ -3,7 +3,7 @@
     "identifier"   : "RoversNOthersSet2",
     "$kref"        : "#/ckan/kerbalstuff/107",
 	
-	"license": "unknown", "comment": "Waiting for author to clarify the license",
+	"license": "restricted",
 	
 	"install": [
         {

--- a/NetKAN/RoversNOthersSet3.netkan
+++ b/NetKAN/RoversNOthersSet3.netkan
@@ -3,7 +3,7 @@
     "identifier"   : "RoversNOthersSet3",
     "$kref"        : "#/ckan/kerbalstuff/336",
 	
-	"license": "unknown", "comment": "Waiting for author to clarify the license",
+	"license": "restricted",
 	
 	"install": [
         {


### PR DESCRIPTION
Rovers N Others is actually split in 3 packages on kerbalstuff, which I
originally missed.
This adds the other two sets adding the other two as suggested.
