### PR TITLE
Updates to RealismOverhaul relationships

### DIFF
--- a/NetKAN/RealismOverhaul.netkan
+++ b/NetKAN/RealismOverhaul.netkan
@@ -38,20 +38,14 @@
 		{ "name" : "TweakScale" }
     ],
 	"suggests"   : [
-		{ "name" : "6S_Service_Compartments" },
+		{ "name" : "Service-Compartments-6S" },
 		{ "name" : "DMagicOrbitalScience" },
 		{ "name" : "FASA" },
 		{ "name" : "KAS" },
 		{ "name" : "KWRocketry" },
 		{ "name" : "LazTekSpaceXExploration" },
-		{ "name" : "LazTekSpaceXExplorationHD" },
-		{ "name" : "LazTekSpaceXExplorationLR" },
 		{ "name" : "LazTekSpaceXHistoric" },
-		{ "name" : "LazTekSpaceXHistoricHD" },
-		{ "name" : "LazTekSpaceXHistoricLR" },
 		{ "name" : "LazTekSpaceXLaunch" },
-		{ "name" : "LazTekSpaceXLaunchHD" },
-		{ "name" : "LazTekSpaceXLaunchLR" },
 		{ "name" : "NearFutureConstruction" },
 		{ "name" : "NearFutureElectric" },
 		{ "name" : "NearFuturePropulsion" },
@@ -63,9 +57,9 @@
 		{ "name" : "RLA-Stockalike" },
 		{ "name" : "RocketdyneF-1" },
 		{ "name" : "SovietEngines" },
-		{ "name" : "UniversalStorageCore" },
-		{ "name" : "UniversalStorageKAS" },
-		{ "name" : "UniversalStorageTAC" }
+		{ "name" : "UniversalStorage" },
+		{ "name" : "UniversalStorage-KAS" },
+		{ "name" : "UniversalStorage-TAC" }
 	],
     "provides" : [ "RealFuels-Engine-Configs" ],
     "resources" : {


### PR DESCRIPTION
- Renamed 6S Service Compartments ID (ids can't start with a number,
  sorry)
- Suggests only basic versions of LazTek. Otherwise
  `--with-all-suggests` will try to get conflicting mods.
- Updated Universal Storage to new names.

@Felger, can I get you to check these look sensible?
