### PR TITLE
Add Haystack Continued Mod to CKAN

### DIFF
--- a/NetKAN/HaystackContinued.netkan
+++ b/NetKAN/HaystackContinued.netkan
@@ -1,0 +1,11 @@
+{
+    "spec_version"   : 1,
+    "identifier"     : "HaystackContinued",
+    "$kref"          : "#/ckan/kerbalstuff/100",
+    "license"        : "CC-BY-NC-SA-4.0",
+    "release_status" : "stable",
+    "resources"      : {
+        "homepage"   : "http://forum.kerbalspaceprogram.com/threads/89920",
+		"repository" : "https://github.com/qberticus/HaystackContinued"
+    }
+}


### PR DESCRIPTION
The Mod is actually licensed both MIT and CC-BY-NC-SA 4.0, but I could not make netkan accept a list of licenses. Single "MIT" and single "CC-BY-NC-SA 4.0" both work for themselves alone.
