### PR TITLE
Detached FinePrint config from FinePrint itself.

### DIFF
--- a/NetKAN/FinePrint-Config-Stock.netkan
+++ b/NetKAN/FinePrint-Config-Stock.netkan
@@ -1,0 +1,14 @@
+{
+    "spec_version" : 1,
+    "identifier"   : "FinePrint-Config-Stock",
+    "$kref"        : "#/ckan/kerbalstuff/81",
+    "$vref"        : "#/ckan/ksp-avc",
+    "license"      : "GPL-3.0",
+    "provides"     : [ "FinePrint-Config" ],
+    "conflicts"    : [ { "name" : "FinePrint-Config" } ],
+    "install"      : [ {
+        "file"          : "FinePrint",
+        "install_to"    : "GameData",
+        "filter_regexp" : "^(?!FinePrint/FinePrint.cfg)"
+    } ]
+}

--- a/NetKAN/FinePrint.netkan
+++ b/NetKAN/FinePrint.netkan
@@ -3,5 +3,12 @@
     "identifier"   : "FinePrint",
     "$kref"        : "#/ckan/kerbalstuff/81",
     "$vref"        : "#/ckan/ksp-avc",
-    "license"      : "GPL-3.0"
+    "license"      : "GPL-3.0",
+    "depends"      : [ { "name" : "FinePrint-Config" } ],
+    "recommends"   : [ { "name" : "FinePrint-Config-Stock" } ],
+    "install"      : [ {
+        "file"       : "FinePrint",
+        "install_to" : "GameData",
+        "filter"     : "FinePrint.cfg"
+    } ]
 }

--- a/NetKAN/RP-0.netkan
+++ b/NetKAN/RP-0.netkan
@@ -18,5 +18,17 @@
         { "name" : "ProceduralDynamics" },
         { "name" : "TweakScale" },
         { "name" : "ProceduralParts" }
+    ],
+    "provides"  : [ "FinePrint-Config" ],
+    "conflicts" : [ { "name" : "FinePrint-Config" } ],
+    "install" : [
+        {
+            "file"       : "GameData/RP-0",
+            "install_to" : "GameData"
+        },
+        {
+            "file"       : "GameData/FinePrint",
+            "install_to" : "GameData"
+        }
     ]
 }


### PR DESCRIPTION
FinePrint's config file is not accessible to ModuleManager, meaning that
mods which wish to modify it need to overwrite the existing file. While
we anticipate this behaviour will change with KSP 0.90 (when FinePrint
enters core), in the meantime we still need a way to handle it.

This change has FinePrint require a config file, but allows mods to
supply their own. Currently only _recent_ releases of RP-0 do this,
and I've updated the NetKAN file to correctly support those.

Happily tested with my own setup, and you can test this right now on
the super secret PaulKAN:

```
ckan.exe update --repo=https://github.com/pjf/CKAN-meta/archive/paulkan.zip
```
