### PR TITLE
Fix invalid identifier in R&SCapsuledyne

### DIFF
--- a/NetKAN/RandSCapsuledyne.netkan
+++ b/NetKAN/RandSCapsuledyne.netkan
@@ -1,16 +1,16 @@
 {
     "spec_version" : 1,
     "name"         : "Taurus HCV - 3.75 m Stock-ish Crew Pod",
-    "identifier"   : "R&SCapsuledyne",
+    "identifier"   : "RandSCapsuledyne",
     "$kref"        : "#/ckan/kerbalstuff/13",
     "license"      : "CC-BY-SA-3.0",
-	"install" : [
+    "install" : [
         {
             "file"       : "GameData/R&SCapsuledyne",
             "install_to" : "GameData"
         }
-                ],
+    ],
     "depends" : [
         { "name" : "BDAnimationModules" }
-				]
+    ]
 }


### PR DESCRIPTION
CKAN identifiers may not contain characters other than letters, numbers,
and dashes. This renames R&SCapsuledyne to RandSCapsuledyne, which is
currently causing travis to weep greatly when the bot tries to submit
this to CKAN-meta.
