### PR TITLE
Enforce tests on CKAN identifiers.

### DIFF
--- a/t/metadata.t
+++ b/t/metadata.t
@@ -20,6 +20,12 @@ foreach my $shortname (sort keys %files) {
         "$shortname.netkan identifer should match filename"
     );
 
+    like(
+        $metadata->{identifier},
+        qr{^[A-Za-z][A-Z-a-z0-9-]*$},
+        "CKAN identifers must consist only of letters, numbers, and dashes, and must start with a letter."
+    );
+
     my $mod_license = $metadata->{license} // "(none)";
 
     ok(


### PR DESCRIPTION
CKAN identifiers have a strict definition of letters, numbers, and
dashes; and must start with a letter. This adds a test to ensure that
incorrect identifiers cannot be submitted.

With our current master, this always causes a failiure, as we have
invalid data in our repo.
