### PR TITLE
Add Telemachus addon to CKAN

### DIFF
--- a/NetKAN/Telemachus.netkan
+++ b/NetKAN/Telemachus.netkan
@@ -1,0 +1,6 @@
+{
+    "spec_version" : 1,
+    "identifier"   : "Telemachus",
+    "$kref"        : "#/ckan/kerbalstuff/197",
+    "license"      : "restricted"
+}


### PR DESCRIPTION
Richard chose a "modified BSD" licence ( https://github.com/richardbunt/Telemachus/blob/master/Licences/LICENCE ), therefore I chose "restricted". I'll start a discussion why he chose that modification and whether we can go to the standard BSD one in upcoming releases.
