### PR TITLE
Add install and depends to AntennaRange

### DIFF
--- a/NetKAN/AntennaRange.netkan
+++ b/NetKAN/AntennaRange.netkan
@@ -2,5 +2,20 @@
     "spec_version"  : 1,
     "identifier"    : "AntennaRange",
     "$kref"         : "#/ckan/kerbalstuff/254",
-    "license"       : "BSD-3-clause"
+    "license"       : "BSD-3-clause",
+    "install": [
+    {
+      "file": "GameData/AntennaRange",
+      "install_to": "GameData"
+    },
+    {
+      "file": "GameData/ToadicusTools",
+      "install_to": "GameData"
+    }
+    ],
+    "depends": [
+        {
+         "name": "ModuleManager"
+     }
+    ]
 }


### PR DESCRIPTION
I added the explicit installation of the two folders and the mod's dependency on ModuleManager.
I tested it on my machine and I was able to install the mod without issues.
See https://github.com/KSP-CKAN/CKAN-meta/pull/88 for previous discussion.
