### PR TITLE
AntennaRange, QuantumStrutsContinued, TweakableEverything, VOID: Revised...

### DIFF
--- a/NetKAN/AntennaRange.netkan
+++ b/NetKAN/AntennaRange.netkan
@@ -7,13 +7,10 @@
         {
             "file": "GameData/AntennaRange",
             "install_to": "GameData"
-        },
-        {
-            "file": "GameData/ToadicusTools",
-            "install_to": "GameData"
         }
     ],
     "depends": [
-        { "name": "ModuleManager" }
+        { "name": "ModuleManager" },
+        { "name": "ToadicusTools" }
     ]
 }

--- a/NetKAN/QuantumStrutsContinued.netkan
+++ b/NetKAN/QuantumStrutsContinued.netkan
@@ -7,10 +7,6 @@
         {
             "file": "GameData/QuantumStrutsContinued",
             "install_to": "GameData"
-        },
-        {
-            "file": "GameData/ToadicusTools",
-            "install_to": "GameData"
         }
     ],
     "suggests": [

--- a/NetKAN/TweakableEverything.netkan
+++ b/NetKAN/TweakableEverything.netkan
@@ -7,13 +7,10 @@
         {
             "file": "GameData/TweakableEverything",
             "install_to": "GameData"
-        },
-        {
-            "file": "GameData/ToadicusTools",
-            "install_to": "GameData"
         }
     ],
     "depends": [
-        { "name": "ModuleManager" }
+        { "name": "ModuleManager" },
+        { "name": "ToadicusTools" }
     ]
 }

--- a/NetKAN/VOID.netkan
+++ b/NetKAN/VOID.netkan
@@ -7,10 +7,9 @@
         {
             "file": "GameData/VOID",
             "install_to": "GameData"
-        },
-        {
-            "file": "GameData/ToadicusTools",
-            "install_to": "GameData"
         }
+    ],
+    "depends": [
+        { "name": "ToadicusTools" }
     ]
 }


### PR DESCRIPTION
... or added "install" and sometimes "depends" or "suggests" entries, as approrpriate.

AntennaRange just got some whitespace cleaning because I'm OCD or something; another maintainer fixed it to properly "install" AntennaRange and ToadicusTools while depending on ModuleManager (thanks!).
QuantumStrutsContinued packages an MM config for interoperability with KAS but does not depend on it; now "suggests" KAS and ModuleManager.
TweakableEverything now "install"s TweakableEverything and ToadicusTools, depends on ModuleManager.
VOID now "install"s VOID and ToadicusTools.
