### PR TITLE
Added explicit name for EntropyRealChute.

### DIFF
--- a/NetKAN/EntropyRealChute.netkan
+++ b/NetKAN/EntropyRealChute.netkan
@@ -3,6 +3,7 @@
     "identifier"     : "EntropyRealChute",
     "release_status" : "development",
     "license"        : "GPL-3.0",
+    "name"           : "Entropy extensions for RealChute",
     "$kref"          : "#/ckan/kerbalstuff/388",
     "depends" : [
         { "name" : "DangIt" },


### PR DESCRIPTION
Since this refers to the same KS metadata as Entropy itself, it ends up
with the same name, which sure is confusing!

Thanks to @RichardLake for spotting this.
