### PR TITLE
Added Regolith for 0.90

### DIFF
--- a/NetKAN/Karbonite.netkan
+++ b/NetKAN/Karbonite.netkan
@@ -15,7 +15,7 @@
         { "name" : "USITools" },
         { "name" : "CommunityResourcePack" },
         { "name" : "FirespitterCore" },
-        { "name" : "ORSX" },
+        { "name" : "Regolith" },
         { "name" : "ModuleManager" }
     ],
     "suggests" : [

--- a/NetKAN/Regolith.netkan
+++ b/NetKAN/Regolith.netkan
@@ -1,0 +1,10 @@
+ {
+    "spec_version" : 1,
+    "identifier" : "Regolith",
+    "$kref" : "#/ckan/github/BobPalmer/Regolith",
+    "name" : "Regolith",
+    "abstract" : "Provides a new resource framework for KSP",
+    "license" : "CC-BY-NC-SA-4.0",
+    "ksp_version" : "0.90",
+    "depends" : [ { "name" : "CommunityResourcePack" } ]
+}


### PR DESCRIPTION
Karbonite now requires this rather than ORSX.

@BobPalmer's other mods may also depend on Regolith where they
previously used ORSX, but since it's past 4am localtime I'll leave them
to one of our more wakeful indexers. :)

Also many thanks to @DuoDex, who atually did most of the work here in
