### PR TITLE
Update USI mods with new Regolith dependency

### DIFF
--- a/NetKAN/UKS.netkan
+++ b/NetKAN/UKS.netkan
@@ -35,8 +35,8 @@
       "min_version": "0.2.3"
     },
     {
-      "name": "ORSX",
-      "min_version": "0.1.3"
+      "name": "Regolith",
+      "min_version": "0.1.0"
     },
     {
       "name" : "CIT-Util",

--- a/NetKAN/USI-ART.netkan
+++ b/NetKAN/USI-ART.netkan
@@ -29,8 +29,8 @@
           "min_version": "0.2.3"
         },
         {
-          "name": "ORSX",
-          "min_version": "0.1.3"
+          "name": "Regolith",
+          "min_version": "0.1.0"
         }
     ],
     "install" : [

--- a/NetKAN/USI-EXP.netkan
+++ b/NetKAN/USI-EXP.netkan
@@ -33,8 +33,8 @@
           "min_version": "0.2.3"
         },
         {
-          "name": "ORSX",
-          "min_version": "0.1.3"
+          "name": "Regolith",
+          "min_version": "0.1.0"
         },
         {
           "name": "ModuleRCSFX"

--- a/NetKAN/USI-FTT.netkan
+++ b/NetKAN/USI-FTT.netkan
@@ -29,8 +29,8 @@
           "min_version": "0.2.3"
         },
         {
-          "name": "ORSX",
-          "min_version": "0.1.3"
+          "name": "Regolith",
+          "min_version": "0.1.0"
         }
     ],
     "install" : [

--- a/NetKAN/USI-SRV.netkan
+++ b/NetKAN/USI-SRV.netkan
@@ -7,7 +7,7 @@
     "abstract"       : "Deployable Emergency Reentry Pod (DERP)",
     "license"        : "CC-BY-NC-SA",
     "release_status" : "stable",
-    "ksp_version"    : "0.25",
+    "ksp_version"    : "0.90",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/84359"
     },
@@ -29,8 +29,8 @@
           "min_version": "0.2.3"
         },
         {
-          "name": "ORSX",
-          "min_version": "0.1.3"
+          "name": "Regolith",
+          "min_version": "0.1.0"
         }
     ],
     "install" : [


### PR DESCRIPTION
- Replaced ORSX with Regolith for UKS and USI-{ART,EXP,FTT,SRV}
- Marked USI-SRV as 0.90 compatible
