### PR TITLE
Remove CIT-Util dependency from UKS and USI-EXP

### DIFF
--- a/NetKAN/UKS.netkan
+++ b/NetKAN/UKS.netkan
@@ -37,10 +37,6 @@
     {
       "name": "Regolith",
       "min_version": "0.1.0"
-    },
-    {
-      "name" : "CIT-Util",
-      "min_version" : "1.0.4"
     }
   ],
   "suggests": [

--- a/NetKAN/USI-EXP.netkan
+++ b/NetKAN/USI-EXP.netkan
@@ -25,10 +25,6 @@
           "min_version": "0.2.4"
         },
         {
-          "name" : "CIT-Util",
-          "min_version" : "1.0.4"
-        },
-        {
           "name": "CommunityResourcePack",
           "min_version": "0.2.3"
         },


### PR DESCRIPTION
Missed this in the last PR -- CIT-Util hasn't been updated for 0.90 and neither of these mods depend on it anymore.
