### PR TITLE
KerbalAircraftExpansion depends on Firespitter (not FSCore)

### DIFF
--- a/NetKAN/KerbalAircraftExpansion.netkan
+++ b/NetKAN/KerbalAircraftExpansion.netkan
@@ -11,6 +11,6 @@
 		}
 	],
 	"depends": [
-		{ "name" : "FirespitterCore" }
+		{ "name" : "Firespitter" }
 	]
 }


### PR DESCRIPTION
As reported here:
http://forum.kerbalspaceprogram.com/threads/100067-The-Comprehensive-Kerbal-Archive-Network-(CKAN)-Package-Manager-v1-3-0-16-Dec-2014?p=1611991&viewfull=1#post1611991
