### PR TITLE
Updated UniversalStorage for 1.0.0 release.

### DIFF
--- a/NetKAN/UniversalStorage.netkan
+++ b/NetKAN/UniversalStorage.netkan
@@ -1,20 +1,11 @@
 {
-	"spec_version": 1,
-	"identifier": "UniversalStorage",
-	"$kref"		: "#/ckan/kerbalstuff/250",
-	"license"   : "restricted",	
-	"depends" : [ 	{	"name" 	: "USITools" },
-					{	"name"	: "ModuleManager" }
-				],				
-    "install": [
-        {
-            "file"       : "PartCatalog",
-            "install_to" : "GameData",
-            "comment"    : "PartCatalog Data for Universal Storage"
-        },
-        {
-            "file"       : "UniversalStorage",
-            "install_to" : "GameData"
-        }
-    ]
+    "spec_version" : 1,
+    "identifier"   : "UniversalStorage",
+    "$kref"        : "#/ckan/kerbalstuff/250",
+    "license"      : "restricted",	
+    "depends"      : [
+        { "name" : "Regolith" },
+        { "name" : "CommunityResourcePack" },
+        { "name" : "ModuleManager" }
+    ]				
 }


### PR DESCRIPTION
- Now depends upon Regolith and CommunityResourcePack
- No longer requires USITools
- No longer has PartCatalog data
- Can now use the default install stanza.
- Tidied up JSON formatting while I was here.

Many thanks to Hypersaurus for spotting this.
