### PR TITLE
Update KerbalAircraftExpansion.netkan

### DIFF
--- a/NetKAN/KerbalAircraftExpansion.netkan
+++ b/NetKAN/KerbalAircraftExpansion.netkan
@@ -7,7 +7,9 @@
 	"install" : [
 		{
 			"file" : "KAX",
-			"install_to" : "GameData"
+			"install_to" : "GameData",
+			"file" : "Firespitter/Resources",
+			"install_to" : "GameData/Firespitter"
 		}
 	],
 	"depends": [


### PR DESCRIPTION
#224 should be handled like this since the file is included in the KAX download. This also prevents all the firespitter parts from being installed.