### PR TITLE
CrossFeedEnabler and ModuleRCSFX are now 0.90

### DIFF
--- a/NetKAN/CrossFeedEnabler.netkan
+++ b/NetKAN/CrossFeedEnabler.netkan
@@ -5,5 +5,5 @@
     "name"         : "Crossfeed Enabler",
     "abstract"     : "Adds toggleable fuel crossfeed between the part it's added to, and the part this part is surface-attached to. Use it for radial tanks.",
     "license"      : "CC-BY-SA",
-    "ksp_version"  : "0.25"
+    "ksp_version"  : "0.90"
 }

--- a/NetKAN/ModuleRCSFX.netkan
+++ b/NetKAN/ModuleRCSFX.netkan
@@ -7,7 +7,7 @@
     "license"        : "CC-BY-SA",
     "author"         : [ "ialdabaoth", "NathanKell" ],
     "release_status" : "stable",
-    "ksp_version"    : "0.25",
+    "ksp_version"    : "0.90",
     "resources" : {
         "homepage"   : "http://forum.kerbalspaceprogram.com/threads/92290"
     }


### PR DESCRIPTION
It'd be awesome if we could slowly get all the github releases to
include valid KSP-AVC files, then we'd never need to bump version
numbers again. :)

CC: @NathanKell
