### PR TITLE
ImageViewer plugin added

### DIFF
--- a/NetKAN/ImageViewer.netkan
+++ b/NetKAN/ImageViewer.netkan
@@ -1,0 +1,14 @@
+{
+    "spec_version" : 1,
+    "identifier"   : "ImageViewer",
+    "$kref"        : "#/ckan/kerbalstuff/76",
+    "x_netkan_license_ok" : true,
+    "license": "GPL-3.0",
+
+    "install": [
+      {
+        "file": "GameData/img_viewer",
+        "install_to": "GameData"
+      }
+    ]
+}


### PR DESCRIPTION
Explicit license have been set due to exception for parsing GNUv3 license type.
