### PR TITLE
Update AGExt.netkan

### DIFF
--- a/NetKAN/AGExt.netkan
+++ b/NetKAN/AGExt.netkan
@@ -12,6 +12,9 @@
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/74195"
     },
+    "depends": [
+{ "name": "ModuleManager" }
+],
     "recommends" : [ { "name" : "Toolbar" } ],
     "install" : [
         {


### PR DESCRIPTION
ModuleManager is now 'depends', was not referenced before
