### PR TITLE
ActiveStruts by marce

### DIFF
--- a/NetKAN/ActiveStruts.netkan
+++ b/NetKAN/ActiveStruts.netkan
@@ -1,24 +1,24 @@
 {
-    "spec_version": "1.4",
-    "identifier"  : "ActiveStruts",
-    "name"        : "CIT - ActiveStruts",
-    "author"      : "marce",
-    "abstract"    : "Allows struts to be created and removed in the editor & in flight. Plus automatic strutting, flexible struts and a Kerbal-Tether",
-    "license"     : "CC-BY-NC-SA-4.0",
+	"spec_version": "1.4",
+	"identifier"  : "ActiveStruts",
+	"name"        : "CIT - ActiveStruts",
+	"author"      : "marce",
+	"abstract"    : "Allows struts to be created and removed in the editor & in flight. Plus automatic strutting, flexible struts and a Kerbal-Tether",
+	"license"     : "CC-BY-NC-SA-4.0",
 	"$kref": "#/ckan/http/https://ksp.marce.at/Home/DownloadMod?modId=1",
 	"$vref" : "#/ckan/ksp-avc/CIT/ActiveStruts/ActiveStruts.version",
 	"depends": [
-        { "name": "CIT-Util" }
-    ],
+		{ "name": "CIT-Util" }
+	],
 	"suggests": [
 		{ "name": "KAS" }
 	],
 	"install": [
-        {
-            "file"       : "CIT/ActiveStruts",
-            "install_to" : "GameData/CIT/ActiveStruts"
-        }
-    ],
+	{
+		"file"       : "CIT/ActiveStruts",
+		"install_to" : "GameData/CIT/ActiveStruts"
+	}
+	],
 	"resources": {
 		"homepage": "https://ksp.marce.at/"
 	}


### PR DESCRIPTION
https://github.com/KSP-CKAN/NetKAN/pull/387 merged with my fixes.
Uses the new "http" $kref plus the new $vref extended remote specifier, also the new AVC inflate "version" thing from https://github.com/KSP-CKAN/CKAN-netkan/pull/20.

Produced .ckan file:

```
{
    "abstract": "Allows struts to be created and removed in the editor & in flight. Plus automatic strutting, flexible struts and a Kerbal-Tether",
    "author": "marce",
    "depends": [
        {
            "name": "CIT-Util"
        }
    ],
    "download": "https://ksp.marce.at/Home/DownloadMod?modId=1",
    "identifier": "ActiveStruts",
    "install": [
        {
            "file": "CIT/ActiveStruts",
            "install_to": "GameData/CIT/ActiveStruts"
        }
    ],
    "ksp_version": "0.90.0",
    "license": "CC-BY-NC-SA-4.0",
    "name": "CIT - ActiveStruts",
    "resources": {
        "homepage": "https://ksp.marce.at/"
    },
    "spec_version": "1.4",
    "suggests": [
        {
            "name": "KAS"
        }
    ],
    "version": "1.1.0"
}
```
