### PR TITLE
Corrected Hangar.netkan. Added suggestions and removed KSPAPIExtensions filter as it breaks the installation.

### DIFF
--- a/NetKAN/Hangar.netkan
+++ b/NetKAN/Hangar.netkan
@@ -1,19 +1,17 @@
 {
-	"spec_version" : 1,
-	"identifier" : "Hangar",
-	"$kref" : "#/ckan/kerbalstuff/270",
-	"license" : "CC-BY-4.0",
-	"depends": [
-		{ "name" : "ModuleManager" },
-		{ "name" : "KSPAPIExtensions" }
-	],
-	"install": [
-		{
-			"file": "GameData/Hangar",
-			"install_to": "GameData",
-			"filter": "KSPAPIExtensions.dll",
-			"comment": "Contains KSPAPIExtensions mod in this distribution"
-		}
-	],
-	"x_netkan_license_ok": true
+    "spec_version" : 1,
+    "identifier"   : "Hangar",
+    "$kref"        : "#/ckan/kerbalstuff/270",
+    "x_netkan_license_ok": true,
+    
+    "depends": 
+    [
+        { "name": "ModuleManager" },
+    ],
+    
+    "suggests": 
+    [
+        { "name": "Extraplanetary-Launchpads" },
+        { "name": "EditorExtensions" },
+    ],
 }


### PR DESCRIPTION
The current version of Hangar.dll is linked with the requirement of the local
copy of KSPAPIExtensions.dll in the GameData/Hangar/Plugins/