### PR TITLE
Create BlackTippedNosecone.netkan

### DIFF
--- a/NetKAN/BlackTippedNosecone.netkan
+++ b/NetKAN/BlackTippedNosecone.netkan
@@ -1,0 +1,15 @@
+{
+    "identifier"   : "BlackTippedNosecone",
+    "$kref"        : "#/ckan/kerbalstuff/434",
+    "spec_version" : 1,
+    "license"      : "unrestricted",
+    "install"      : [
+      {
+        "file": "DarkNosecone/GameData/PhaserLabs",
+        "install_to": "GameData"
+      }
+    ],
+    "depends"      : [
+        { "name" : "ModuleManager" }
+    ]
+}


### PR DESCRIPTION
for @PhaserArray on IRC for https://kerbalstuff.com/mod/434
netkan.exe still crashes on the WTFPL license even though it's in the [schema](https://github.com/KSP-CKAN/CKAN/blob/master/CKAN.schema#L274) and [StripSymmetry](https://github.com/KSP-CKAN/NetKAN/pull/318) appears to be held up by the same problem. I've set the license to 'unrestricted' for the time being.