### PR TITLE
HorizontalLandingAid Delete request

### DIFF
--- a/NetKAN/HorizontalLandingAid.netkan
+++ b/NetKAN/HorizontalLandingAid.netkan
@@ -1,5 +1,5 @@
 {
-    "identifier": "HorizontalLandingAid", 
+    "identifier": "HorizontalLandingAidDELETETHIS", 
     "license": "GPL-3.0", 
     "$kref": "#/ckan/kerbalstuff/460", 
     "spec_version": "v1.4",


### PR DESCRIPTION
This is duplicate of RCSLandingAid, please delete.

Also, can you please check your bot or whatever is making these, I make very sure the "Add to CKAN" box is unchecked when I add my mods to kerbal stuff as I want CKAN pointing to my github and the bot messes up the install directory.