### PR TITLE
Split PlanetShine into core and default config

### DIFF
--- a/NetKAN/PlanetShine-Config-Default.netkan
+++ b/NetKAN/PlanetShine-Config-Default.netkan
@@ -1,0 +1,25 @@
+{
+    "spec_version"   : 1,
+    "identifier"     : "PlanetShine-Config-Default",
+    "$kref"          : "#/ckan/kerbalstuff/266",
+    "license"        : "Apache-2.0",
+    "install": [
+        {
+            "file": "GameData/PlanetShine/Config",
+            "install_to": "GameData/PlanetShine"
+        }
+    ],
+    "depends": [
+        {
+            "name": "PlanetShine"
+        }
+    ],
+    "provides": [
+        "PlanetShine-Config"
+    ],
+    "conflicts": [
+        {
+            "name": "PlanetShine-Config"
+        }
+    ]
+}

--- a/NetKAN/PlanetShine.netkan
+++ b/NetKAN/PlanetShine.netkan
@@ -2,5 +2,24 @@
     "spec_version"   : 1,
     "identifier"     : "PlanetShine",
     "$kref"          : "#/ckan/kerbalstuff/266",
-    "license"        : "Apache-2.0"
+    "license"        : "Apache-2.0",
+    "install": [
+        {
+            "file": "GameData/PlanetShine/Icons",
+            "install_to": "GameData/PlanetShine"
+        },
+        {
+            "file": "GameData/PlanetShine/Plugins",
+            "install_to": "GameData/PlanetShine"
+        },
+        {
+            "file": "GameData/PlanetShine/LICENSE",
+            "install_to": "GameData/PlanetShine"
+        }
+    ],
+    "depends": [
+        {
+            "name": "PlanetShine-Config"
+        }
+    ]
 }


### PR DESCRIPTION
Preparatory work for other mods that tweak the PlanetShine config - Astronomer's Pack is one of them.