### PR TITLE
Added EPL Regolith Adaptation

### DIFF
--- a/NetKAN/ExtraPlanetaryLaunchpads-RegolithAdaptation.netkan
+++ b/NetKAN/ExtraPlanetaryLaunchpads-RegolithAdaptation.netkan
@@ -1,0 +1,24 @@
+{
+    "spec_version"   : 1,
+    "identifier"     : "ExtraPlanetaryLaunchpads-RegolithAdaptation",
+    "$kref"          : "#/ckan/kerbalstuff/494",
+    "license"        : "GPL-3.0",
+    "release_status" : "stable",
+    "resources"      : {
+          "homepage" : "http://forum.kerbalspaceprogram.com/threads/89774"
+    },
+    "depends" : [
+        {"name" : "ModuleManager"},
+        {"name" : "ExtraPlanetaryLaunchpads"},
+        {"name" : "Regolith"}
+    ],
+    "recommends" : [
+        {"name" : "Karbonite"}
+    ],
+    "install" : [
+        {
+            "file"       : "GameData/WombatConversions",
+            "install_to" : "GameData"
+        }
+    ]
+}


### PR DESCRIPTION
EPL-Regolith is on Kerbalstuff now. This improves upon the hand-written meta file that fetched its archive from dropbox.