### PR TITLE
Environmental Visual Enhancement: Core Mod and Config split, act 2

### DIFF
--- a/NetKAN/EnvironmentalVisualEnhancements-HR.netkan
+++ b/NetKAN/EnvironmentalVisualEnhancements-HR.netkan
@@ -3,7 +3,7 @@
     "identifier"   	: "EnvironmentalVisualEnhancements-HR",
     "$kref"        	: "#/ckan/github/rbray89/EnvironmentalVisualEnhancements/asset_match/(?<!-LR)\\.zip$",
     "name"         	: "Environmental Visual Enhancements - High Resolution",
-    "abstract"     	: "City Lights for Kerbin and Clouds for Any planet you wish",
+    "abstract"          : "Default configuration for EVE",
     "license"      	: "MIT",
     "ksp_version_min"	: "0.25",
     "resources"		: {
@@ -16,10 +16,10 @@
         }
     ],
     "provides": [
-        "EnvironmentalVisualEnhancements"
+        "EnvironmentalVisualEnhancements-Config"
     ],
     "depends": [
-        { "name" : "EnvironmentalVisualEnhancements-Config" }
+        { "name" : "EnvironmentalVisualEnhancements" }
     ],
     "conflicts": [
         { "name" : "EnvironmentalVisualEnhancements-LR" }

--- a/NetKAN/EnvironmentalVisualEnhancements-LR.netkan
+++ b/NetKAN/EnvironmentalVisualEnhancements-LR.netkan
@@ -3,7 +3,7 @@
     "identifier"        : "EnvironmentalVisualEnhancements-LR",
     "$kref"             : "#/ckan/github/rbray89/EnvironmentalVisualEnhancements/asset_match/(?<=-LR)\\.zip$",
     "name"              : "Environmental Visual Enhancements - Low Resolution",
-    "abstract"          : "City Lights for Kerbin and Clouds for Any planet you wish",
+    "abstract"          : "Default configuration for EVE",
     "license"           : "MIT",
     "ksp_version_min"   : "0.25",
     "resources"         : {
@@ -16,10 +16,10 @@
         }
     ],
     "provides": [
-        "EnvironmentalVisualEnhancements"
+        "EnvironmentalVisualEnhancements-Config"
     ],
     "depends": [
-        { "name" : "EnvironmentalVisualEnhancements-Config" }
+        { "name" : "EnvironmentalVisualEnhancements" }
     ],
     "conflicts": [
         { "name" : "EnvironmentalVisualEnhancements-HR" }

--- a/NetKAN/EnvironmentalVisualEnhancements.netkan
+++ b/NetKAN/EnvironmentalVisualEnhancements.netkan
@@ -1,9 +1,9 @@
 {
     "spec_version"      : 1,
-    "identifier"        : "EnvironmentalVisualEnhancements-Config-Default",
+    "identifier"        : "EnvironmentalVisualEnhancements",
     "$kref"             : "#/ckan/github/rbray89/EnvironmentalVisualEnhancements/asset_match/(?<!-LR)\\.zip$",
-    "name"              : "Environmental Visual Enhancements - Default configuration",
-    "abstract"          : "Default configuration for EVE",
+    "name"              : "Environmental Visual Enhancements",
+    "abstract"     	: "City Lights for Kerbin and Clouds for Any planet you wish",
     "license"           : "MIT",
     "ksp_version_min"   : "0.25",
     "resources"         : {
@@ -15,10 +15,7 @@
             "install_to" : "GameData"
         }
     ],
-    "provides": [
-        "EnvironmentalVisualEnhancements-Config"
-    ],
     "depends": [
-        { "name": "EnvironmentalVisualEnhancements" }
+        { "name": "EnvironmentalVisualEnhancements-Config" }
     ]
 }


### PR DESCRIPTION
So it seems my previous correction of the EVE split was only partially correct. Not only the directories were inverted, but the entire mod was too. It is not the core mod that needs to be split into HR and LR variants, but rather the default configuration.

This PR makes EnvironmentalVisualEnhancements-HR and -LR into default configuration packages in their respective resolutions, renames EnvironmentalVisualEnhancements-Config-Default into EnvironmentalVisualEnhancements and makes it into the core package. The whole thing now finally makes sense.