### PR TITLE
Update Proton-Bobcat.netkan

### DIFF
--- a/NetKAN/Proton-Bobcat.netkan
+++ b/NetKAN/Proton-Bobcat.netkan
@@ -3,6 +3,7 @@
 	"identifier"	:	"Proton-Bobcat",
 	"license"	:	"restricted",
 	"$kref"		:	"#/ckan/kerbalstuff/373",
+	"ksp_version_min":	"0.25",
 	"install" : [
 	{
 		"file"	    :   "SovietPack",


### PR DESCRIPTION
Forward compatible, not noted as such on the kerbalstuff page.  Setting as explicit.