### PR TITLE
Update FASA.netkan

### DIFF
--- a/NetKAN/FASA.netkan
+++ b/NetKAN/FASA.netkan
@@ -3,7 +3,7 @@
 	"identifier"	:	"FASA",
 	"$kref"			:	"#/ckan/kerbalstuff/27",
 	"license" : "restricted",
-    "depends" : [ { "name" : "RasterPropMonitor" } ],
+    "recommends" : [ { "name" : "RasterPropMonitor" } ],
 	"install" : [
 	{
 		"file"		:	"GameData/FASA",


### PR DESCRIPTION
Update dependency on RPM to recommendation, fully functional without Raster Prop Monitor, will allow 0.90 installations of FASA.