### PR TITLE
Updating RFStockalike name so it appears near RealFuels in the GUI

### DIFF
--- a/NetKAN/RFStockalike.netkan
+++ b/NetKAN/RFStockalike.netkan
@@ -2,7 +2,7 @@
 	"spec_version" : 1,
 	"identifier"   : "RFStockalike",
 	"$kref"        : "#/ckan/github/Raptor831/RFStockalike",
-	"name"         : "Stockalike RF Configs",
+	"name"         : "RealFuels: Stockalike RF Configs",
 	"abstract"     : "Adds RealFuels configs to stock and many mods' engines, keeping engine role as designed to fit with stock and stock-aligned mods.",
 	"license"      : "CC-BY-SA",
 	"install" : [


### PR DESCRIPTION
Had a request on the KSP forum to change the name so it appears next to RealFuels in the program. Seemed like a good idea.