### PR TITLE
PartMapper: Fix release status beta -> testing

### DIFF
--- a/NetKAN/PartMapper.netkan
+++ b/NetKAN/PartMapper.netkan
@@ -5,7 +5,7 @@
     "author"         : "katateochi",
     "name"           : "KerbalX Part Mapper",
     "abstract"       : "Mapping tool for craft sharing site with Auto Mod Detection and Search-By-Mod feature",
-    "release_status" : "beta",
+    "release_status" : "testing",
     "license"        : "GPL-3.0",
     "resources" : {
         "homepage"     : "http://forum.kerbalspaceprogram.com/threads/93548",


### PR DESCRIPTION
The spec doesn't have a `beta` status as far as I can tell. This sets it
to `testing` (which is in the spec).