### PR TITLE
Filled in more fields of the TACLS netkan file.

### DIFF
--- a/NetKAN/TACLS.netkan
+++ b/NetKAN/TACLS.netkan
@@ -1,20 +1,30 @@
 {
-    "spec_version"   : 1,
+    "spec_version"   : "v1.2",
     "identifier"     : "TACLS",
     "name"           : "TAC Life Support (TACLS)",
+    "author"          : "Taranis Elsu",
     "abstract"       : "Adds life support requirements and resources to all kerbals",
     "$kref"          : "#/ckan/github/taraniselsu/TacLifeSupport",
+    "$vref"         : "#/ckan/ksp-avc",
     "license"        : "CC-BY-NC-SA-3.0",
-    "ksp_version"    : "0.25",
     "release_status" : "stable",
-    "depends"        : [ { "name" : "ModuleManager" }, { "name" : "TACLS-Config" } ],
-    "recommends"     : [ { "name" : "MiniAVC" } ],
-    "suggests"       : [ { "name" : "KSP-AVC" } ],
-    "install" : [ 
+    "depends" : [
+        {   "name" : "ModuleManager" },
+        {   "name" : "TACLS-Config" }
+    ],
+    "suggests" : [
+        {   "name" : "KSP-AVC" }
+    ],
+    "install" : [
         {
             "file"          : "GameData/ThunderAerospace",
             "install_to"    : "GameData",
             "filter_regexp" : "PluginData/TacLifeSupport/LifeSupport\\.cfg$"
         }
-    ]
+    ],
+    "resources" : {
+        "homepage" : "https://github.com/taraniselsu/TacLifeSupport/wiki",
+        "bugtracker" : "https://github.com/taraniselsu/TacLifeSupport/issues",
+        "repository" : "https://github.com/taraniselsu/TacLifeSupport"
+    }
 }


### PR DESCRIPTION
Untested, but hopefully it is correct.

* It is not pulling the version information correctly because of #36.
* I was unable to test using [these instructions](https://github.com/KSP-CKAN/CKAN-support/wiki/Adding-a-mod-to-the-CKAN#testing-your-file). I assume because my mod is already in the "repo"(1). It would be nice if we could test a local copy of the file before sending it off to become the official meta data.


````
(1) The error message:
KSP>ckan-1.5.6.exe install -c TACLS-v0.10.2b.ckan
1) TACLS-Config-RealismOverhaul (TAC Life Support (TACLS) - Realism Overhaul Config)
2) TACLS-Config-Stock (TAC Life Support (TACLS) - stock config)
Enter a number between 1 and 2 (To cancel press "c" or "n".):
2
5008 [1] ERROR CKAN.RelationshipResolver (null) - Assertion failed: Adding TACLS twice in relationship resolution

Unhandled Exception: System.Exception: Exception of type 'System.Exception' was thrown.
   at CKAN.RelationshipResolver.Add(CkanModule module)
   at CKAN.RelationshipResolver..ctor(ICollection`1 modules, RelationshipResolverOptions options, Registry registry, KSPVersion kspversion)
   at CKAN.ModuleInstaller.InstallList(List`1 modules, RelationshipResolverOptions options, NetAsyncDownloader downloader)
   at CKAN.CmdLine.MainClass.Install(InstallOptions options, KSP current_instance, IUser user)
   at CKAN.CmdLine.MainClass.Install(InstallOptions options, KSP current_instance, IUser user)
   at CKAN.CmdLine.MainClass.Main(String[] args)
````