### PR TITLE
KWS must conflict with KerbalWind

### DIFF
--- a/NetKAN/KerbalWeatherSystems.netkan
+++ b/NetKAN/KerbalWeatherSystems.netkan
@@ -6,5 +6,9 @@
 	
 	"depends" : [
 		{ "name" : "FerramAerospaceResearch" }
-	]
+	],
+	
+	"comment": "FAR only supports one wind provider at once",
+	"provides" : [ "FARWind" ],
+	"conflicts": [ {"name": "FARWind" } ]
 }

--- a/NetKAN/KerbalWind.netkan
+++ b/NetKAN/KerbalWind.netkan
@@ -15,6 +15,11 @@
 	"resources" : {
 		"homepage" : "http://forum.kerbalspaceprogram.com/threads/107989"
 	},
+	
+	"comment": "FAR only supports one wind provider at once",
+	"provides" : [ "FARWind" ],
+	"conflicts": [ {"name": "FARWind" } ],
+	
 	"author" : "DaMichel, silverfox8124",
 	"release_status" : "stable"
 }


### PR DESCRIPTION
The FAR Wind API currently supports only one client at any time,
so these two must conflict.
Using a provides so it's easy to extend in the future.