### PR TITLE
NearFuturePropulsion MM patches for nukes

### DIFF
--- a/NetKAN/NearFuturePropulsionExtras.netkan
+++ b/NetKAN/NearFuturePropulsionExtras.netkan
@@ -1,0 +1,22 @@
+{
+    "spec_version" : 1,
+    "identifier"   : "NearFuturePropulsionExtras",
+    "name"         : "Near Future Propulsion - Hydrogen NTRs",
+    "abstract"     : "Converts your nuclear engines into using Liquid Hydrogen",
+    "version"      : "0.4.0",
+    "author"       : "Nertea",
+    "$kref"        : "#/ckan/kerbalstuff/347",
+    "license"      : "CC-BY-NC-SA-3.0",
+    "install" : [
+        {
+            "file"       : "Extras/Hydrogen NTRs",
+            "install_to" : "GameData"
+        }
+                ],
+    "depends" : [
+        { "name" : "NearFuturePropulsion" }
+                ],
+ "suggests"     : [
+        { "name" : "CommunityTechTree" }
+    ],
+}

--- a/NetKAN/NearFuturePropulsionExtras.netkan
+++ b/NetKAN/NearFuturePropulsionExtras.netkan
@@ -18,5 +18,5 @@
                 ],
  "suggests"     : [
         { "name" : "CommunityTechTree" }
-    ],
+    ]
 }


### PR DESCRIPTION
Adds the ability to install the optional ModuleManager configs bundled
with NearFuturePropulsion for nuclear engines.