### PR TITLE
Updated EngineIgnitor repack

### DIFF
--- a/NetKAN/EngineIgnitor-Unofficial-Repack.netkan
+++ b/NetKAN/EngineIgnitor-Unofficial-Repack.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version"   : 1,
+    "spec_version"   : "v1.4",
     "$kref"          : "#/ckan/github/pjf/EngineIgnitor",
     "$vref"          : "#/ckan/ksp-avc",
     "identifier"     : "EngineIgnitor-Unofficial-Repack",
@@ -21,7 +21,7 @@
     },
     "install" : [
         {
-            "file" : "EngineIgnitor-3.4.1.1/GameData/EngineIgnitor",
+            "find"       : "EngineIgnitor",
             "install_to" : "GameData"
         }
     ]


### PR DESCRIPTION
The repack works just fine in 0.90 as well as 0.25, and remains
identical to the official release, so I've made a new release with
updated AVC info. This PR updates the metadata to use the `find` keyword
for locating the files, removing a rather ugly kludge with a hard-coded
version number.