### PR TITLE
ADIOS dependency on ContractConfigurator.

### DIFF
--- a/NetKAN/ADIOS.netkan
+++ b/NetKAN/ADIOS.netkan
@@ -6,6 +6,7 @@
     "ksp_version": "0.90",
 
 	"depends": [
+		{ "name": "ContractConfigurator" },
 		{ "name": "TechManager" }
 	],
 


### PR DESCRIPTION
I'll confirm on the forums that Arachnidek is fine with this change, but he should be since he currently bundles ContractConfigurator and the current NetKAN strips it out.  This changes makes the CKAN install more consistent with a manual install of ADIOS.