### PR TITLE
Fixing firespitter to work through CKAN

### DIFF
--- a/NetKAN/Firespitter.netkan
+++ b/NetKAN/Firespitter.netkan
@@ -17,7 +17,7 @@
         {
             "file"       : "Firespitter",
             "install_to" : "GameData",
-            "filter"     : [ "Firespitter.dll", "Firespitter.cfg" ],
+            "filter"     : [ "Firespitter.dll" ],
             "comment"    : "The DLL is installed from FirespitterCore"
         },
         {


### PR DESCRIPTION
I'm not sure why Firespitter.cfg was filtered out in the first place but it makes KSP start on loadup with firespitter installed through CKAN since FirespitterCore does not contain the .cfg file.

Relevant forum thread [here](http://forum.kerbalspaceprogram.com/threads/113809) and shoutout to @NathanKell who brought it to my attention.

I'm unsure if this will autogenerate a new (fixed) .ckan file, if not can someone trigger that interaction and/or tell me how to?