### PR TITLE
KOSMOS-URM : file -> find to circumvent new folderstructure

### DIFF
--- a/NetKAN/KOSMOS-URM.netkan
+++ b/NetKAN/KOSMOS-URM.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version"	: 1,
+    "spec_version"	: "v1.4",
     "identifier"   	: "KOSMOS-URM",
     "$kref"        	: "#/ckan/kerbalstuff/323",
     "license"		: "CC-BY-NC-ND-3.0",
@@ -11,7 +11,7 @@
 	
 	"install" : [
 		{
-			"file" : "GameData/KOSMOS",
+			"find" : "KOSMOS",
 			"install_to" : "GameData"
 		}
 	]


### PR DESCRIPTION
Version in CKAN-meta is _old_ and it seems to be due to folderstructure having changed in a newer release. This should hopefully fix it.