### PR TITLE
Fix metadata of EngineIgnitor-Unofficial-Repack

### DIFF
--- a/NetKAN/EngineIgnitor-Unofficial-Repack.netkan
+++ b/NetKAN/EngineIgnitor-Unofficial-Repack.netkan
@@ -9,9 +9,11 @@
     "license"        : "MIT",
     "release_status" : "stable",
     "depends" : [
-        { "name" : "RealFuels" },
         { "name" : "ModuleManager" }
     ],
+	"recommends": [ { "name" : "RealFuels" },
+					{ "name" : "KAS" },
+					{ "name" : "RasterPropMonitor" } ],
     "suggests" : [
         { "name" : "RealismOverhaul" }
     ],

--- a/NetKAN/EngineIgnitor-Unofficial-Repack.netkan
+++ b/NetKAN/EngineIgnitor-Unofficial-Repack.netkan
@@ -11,12 +11,10 @@
     "depends" : [
         { "name" : "ModuleManager" }
     ],
-	"recommends": [ { "name" : "RealFuels" },
+	"suggests": [ { "name" : "RealFuels" },
 					{ "name" : "KAS" },
-					{ "name" : "RasterPropMonitor" } ],
-    "suggests" : [
-        { "name" : "RealismOverhaul" }
-    ],
+					{ "name" : "RasterPropMonitor" },
+					{ "name" : "RealismOverhaul" } ],
     "provides" : [ "EngineIgnitor" ],
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/51880"


### PR DESCRIPTION
closes https://github.com/KSP-CKAN/CKAN-meta/issues/337

Since this is a repack by @pjf I'd like him to be able to comment on this PR before we consider merging it. This is the first (only?) unofficial repack I see in CKAN so I'm not sure what the policy are for these.

I can see no reason that this should depend on RealFuels, I assume it is because it is part of RO or something along those lines? I also added the recommended mods from the forum thread for EngineIgnitor as recommends in the metadata.

Proposed changes are based on the issuereport which this PR closes.
