### PR TITLE
Rename 001ControlLock to just ControlLock

### DIFF
--- a/NetKAN/ControlLock.netkan
+++ b/NetKAN/ControlLock.netkan
@@ -2,7 +2,7 @@
 "spec_version" : 1,
 "$kref" : "#/ckan/github/SirDiazo/ControlLock",
 "name" : "Control Lock",
-"identifier" : "001ControlLock",
+"identifier" : "ControlLock",
 "author" : "Diazo",
 "abstract" : "Lock KSP so that when entering text in a text field, you do not pass commands to your vessel.",
 "license" : "public-domain",


### PR DESCRIPTION
The CKAN spec specifies that mods *must* start with a letter. Despite
the fact that `netkan.exe` will process this file, it may not in the
future, and at the moment our bot chokes on the validation phase.

This change renames the identifier to one that's CKAN friendly.

Unfortunately, users who already have the mod installed won't be able to
auto-upgrade with the identifier change, but they can uninstall with the old
identifier and install with the new identifer just fine.