### PR TITLE
add Infernal robotics model rework - utility pack

### DIFF
--- a/NetKAN/IR-Model-Rework-Utility.netkan
+++ b/NetKAN/IR-Model-Rework-Utility.netkan
@@ -2,7 +2,7 @@
     "spec_version" : "v1.4",
     "identifier"   : "IR-Model-Rework-Utility",
     "$kref"        : "#/ckan/kerbalstuff/677",
-    "license"		: "CC-BY-NC-ND-4.0"
+    "license"		: "CC-BY-NC-ND-4.0",
 	"depends"		: [ { "name" : "InfernalRobotics-Rework" },
 						{ "name" : "IR-Model-Rework-Core" },
 						{ "name" : "TweakableEverything" },

--- a/NetKAN/IR-Model-Rework-Utility.netkan
+++ b/NetKAN/IR-Model-Rework-Utility.netkan
@@ -6,13 +6,16 @@
 	"depends"		: [ { "name" : "InfernalRobotics-Rework" },
 						{ "name" : "IR-Model-Rework-Core" },
 						{ "name" : "TweakableEverything" },
-						{ "name" : "ToadicusTools" },
-						{ "name" : "CIT-Util" },
-						{ "name" : "ActiveStruts" }	],
+						{ "name" : "ToadicusTools" } ],
 	"recommends"	: [ { "name" : "IR-Model-Rework-Expansion" } ],
-	
+	"conflicts"		: [ { "name" : "CIT-Util"},
+						{ "name" : "ActiveStruts"},
+						{ "comment" : "These should be dependencies but https://github.com/KSP-CKAN/NetKAN/issues/932 happened"} ],
 	"install"		: [ { "find" : "MagicSmokeIndustries",
 						"install_to" : "GameData",
 						"filter_regexp" : [	"Rework_License.txt",
-											"Rework_TweakScale.cfg" ] } ]
+											"Rework_TweakScale.cfg" ] },
+						{ "find" : "CIT",
+						"install_to" : "GameData",
+						"comment" : "ugly hack to get this pack working for now. This will bite me (Daz) in the ass down the line for sure" } ]
 }

--- a/NetKAN/IR-Model-Rework-Utility.netkan
+++ b/NetKAN/IR-Model-Rework-Utility.netkan
@@ -3,7 +3,7 @@
     "identifier"   : "IR-Model-Rework-Utility",
     "$kref"        : "#/ckan/kerbalstuff/677",
     "license"		: "CC-BY-NC-ND-4.0",
-	"depends"		: [ { "name" : "InfernalRobotics-Rework" },
+	"depends"		: [ { "name" : "InfernalRobotics" },
 						{ "name" : "IR-Model-Rework-Core" },
 						{ "name" : "TweakableEverything" },
 						{ "name" : "ToadicusTools" } ],

--- a/NetKAN/IR-Model-Rework-Utility.netkan
+++ b/NetKAN/IR-Model-Rework-Utility.netkan
@@ -1,0 +1,18 @@
+{
+    "spec_version" : (v1.4),
+    "identifier"   : "IR-Model-Rework-Utility",
+    "$kref"        : "#/ckan/kerbalstuff/677",
+    "license"		: "CC-BY-NC-ND-4.0"
+	"depends"		: [ { "name" : "InfernalRobotics-Rework" },
+						{ "name" : "IR-Model-Rework-Core" },
+						{ "name" : "TweakableEverything" },
+						{ "name" : "ToadicusTools" },
+						{ "name" : "CIT-Util" },
+						{ "name" : "ActiveStruts" }	],
+	"recommends"	: [ { "name" : "IR-Model-Rework-Expansion" } ],
+	
+	"install"		: [ { "find" : "MagicSmokeIndustries",
+						"install_to" : "GameData",
+						"filter_regexp" : [	"Rework_License.txt",
+											"Rework_TweakScale.cfg" ] } ]
+}

--- a/NetKAN/IR-Model-Rework-Utility.netkan
+++ b/NetKAN/IR-Model-Rework-Utility.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version" : (v1.4),
+    "spec_version" : "v1.4",
     "identifier"   : "IR-Model-Rework-Utility",
     "$kref"        : "#/ckan/kerbalstuff/677",
     "license"		: "CC-BY-NC-ND-4.0"


### PR DESCRIPTION
Depends on #951 and requires a solution to https://github.com/KSP-CKAN/NetKAN/issues/932 since it depends on those mods. An alternate route might be to have this install and conflict with `CIT-Util` and `ActiveStruts` since it redistributes them within the .zip.

We'll see once #951 is merged how to resolve this, CIT mods might be back on the market by the time IR-Rework have had their first release.