### PR TITLE
Add KabinKraziness.netkan and fix AmpYear metadata

### DIFF
--- a/NetKAN/AmpYearPowerManager.netkan
+++ b/NetKAN/AmpYearPowerManager.netkan
@@ -5,6 +5,6 @@
     "$kref": "#/ckan/kerbalstuff/630",
     "license": "GPL-3.0",
 	"install": [
-		{ "file": "GameData/AmpYear", "install_to": "GameData" }
+		{ "find": "REPOSoftTech", "install_to": "GameData" }
 	]
 }

--- a/NetKAN/KabinKraziness.netkan
+++ b/NetKAN/KabinKraziness.netkan
@@ -5,6 +5,7 @@
     "license": "CC-BY-NC-SA-3.0",
 	"depends" : [	{ "name" : "ModuleManager" },
 					{ "name" : "AmpYearPowerManager" } ],
+	"recommends" : [ { "name" : "Toolbar" } ],
 	"install" : [ { "find" : "REPOSoftTech",
 					"install_to" : "GameData",
 					"filter_regexp" : "KKInterfaces.dll" } ]

--- a/NetKAN/KabinKraziness.netkan
+++ b/NetKAN/KabinKraziness.netkan
@@ -1,0 +1,11 @@
+{
+    "$kref": "#/ckan/kerbalstuff/684",
+    "spec_version": "v1.4",
+    "identifier": "KabinKraziness",
+    "license": "CC-BY-NC-SA-3.0",
+	"depends" : [	{ "name" : "ModuleManager" },
+					{ "name" : "AmpYearPowerManager" } ],
+	"install" : [ { "find" : "REPOSoftTech",
+					"install_to" : "GameData",
+					"filter_regexp" : "KKInterfaces.dll" } ]
+}


### PR DESCRIPTION
KK depends on AmpYear and that's how I found that it seems to have updated it's folderstructure. This commit adds KK and fixes AY metadata.

Supercedes https://github.com/KSP-CKAN/NetKAN/pull/910