### PR TITLE
Manual update of CRP ksp_version field

### DIFF
--- a/NetKAN/CommunityResourcePack.netkan
+++ b/NetKAN/CommunityResourcePack.netkan
@@ -7,7 +7,7 @@
     "abstract"       : "Common resources for KSP mods",
     "license"        : "CC-BY-NC-SA-4.0",
     "release_status" : "stable",
-    "ksp_version"    : "0.90",
+    "ksp_version"    : "1.0.0",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/91998"
     },


### PR DESCRIPTION
This seems to be the reason all USI mods are stuck in limbo and I'm tired of being asked about them already so I'm doing a manual fix.

Latest version in CKAN-meta is the one compiled for 1.0 so this will overwrite that and everyone will be happy.