### PR TITLE
Change version fields on pFairings and IR

### DIFF
--- a/NetKAN/InfernalRobotics.netkan
+++ b/NetKAN/InfernalRobotics.netkan
@@ -5,7 +5,7 @@
     "name"         : "Magic Smoke Industries Infernal Robotics",
     "abstract"     : "Makes stuff move",
     "license"      : "GPL-3.0",
-	"ksp_version"	: "0.90",
+	"ksp_version"	: "1.0",
 	"recommends"	: [ { "name" : "IR-Model-Rework-Core" },
 						{ "name" : "IR-Model-Rework-Expansion" },
 						{ "name" : "IR-Model-Rework-Utility" },

--- a/NetKAN/ProceduralFairings.netkan
+++ b/NetKAN/ProceduralFairings.netkan
@@ -5,7 +5,7 @@
     "name"		:	"Procedural Fairings",
     "abstract"		:	"Fairings that automatically reshape for any attached payload",
     "license"		:	"CC-BY-3.0",
-    "ksp_version"	:	"0.90",
+    "ksp_version"	:	"1.0",
 	"resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/39512"
     },


### PR DESCRIPTION
Their respective githubs have notes saying the newest versions are 1.0 compatible so this is just a matter of changing the hardcoded version.

IR should probably be moved over to KerbalStuff in the .netkan file to resolve this for them forever.