### PR TITLE
remove ksp_version field from antennarange

### DIFF
--- a/NetKAN/AntennaRange.netkan
+++ b/NetKAN/AntennaRange.netkan
@@ -3,7 +3,6 @@
     "identifier"    : "AntennaRange",
     "$kref"         : "#/ckan/kerbalstuff/254",
     "license"       : "BSD-3-clause",
-    "ksp_version"   : "0.90",
     "install": [
         {
             "file": "GameData/AntennaRange",


### PR DESCRIPTION
Why this even has a ksp_version field is beyong me, so I'm removing it to let us use the awesome metadata of KerbalStuff.