### PR TITLE
Update StockBugFixModules.netkan

### DIFF
--- a/NetKAN/StockBugFixModules.netkan
+++ b/NetKAN/StockBugFixModules.netkan
@@ -5,6 +5,15 @@
     "name"           : "Stock Bug Fix Modules",
     "abstract"       : "Stand alone fixes for common stock KSP bugs",
     "license"        : "CC-BY-NC-SA-4.0",
-    "ksp_version"    : "0.90"
+    "ksp_version"    : "1.0.0",
+    "install": [
+        {
+            "file": "StockBugFixModules",
+            "install_to": "GameData"
+        }
+    ],
+    "depends" : [
+        { "name" : "ModuleManager" }
+    ]
 }
  


### PR DESCRIPTION
Marking as updated to 1.0 and adding MM as required as per http://forum.kerbalspaceprogram.com/threads/97285.

netkan.exe would throw "CKAN.FileNotFoundKraken: Could not find StockBugFixModules directory in zipfile to install" without using an install section. Is this intended behavior @hakan42? If so there could be many other silently broken mods.