### PR TITLE
Fixing .netkan for RSCapsuledyne

### DIFF
--- a/NetKAN/RandSCapsuledyne.netkan
+++ b/NetKAN/RandSCapsuledyne.netkan
@@ -6,7 +6,7 @@
     "license"      : "CC-BY-SA-3.0",
     "install" : [
         {
-            "file"       : "GameData/R&SCapsuledyne",
+            "file"       : "GameData/RSCapsuledyne",
             "install_to" : "GameData"
         }
     ],


### PR DESCRIPTION
Removed an ampersand that's no longer part of the foldername we want to install.