### PR TITLE
InfernalRobotics Github->KS

### DIFF
--- a/NetKAN/InfernalRobotics.netkan
+++ b/NetKAN/InfernalRobotics.netkan
@@ -1,11 +1,8 @@
 {
     "spec_version" : "v1.4",
     "identifier"   : "InfernalRobotics",
-    "$kref"        : "#/ckan/github/MagicSmokeIndustries/InfernalRobotics",
-    "name"         : "Magic Smoke Industries Infernal Robotics",
-    "abstract"     : "Makes stuff move",
+    "$kref"        : "#/ckan/kerbalstuff/8",
     "license"      : "GPL-3.0",
-	"ksp_version"	: "1.0",
 	"recommends"	: [ { "name" : "IR-Model-Rework-Core" },
 						{ "name" : "IR-Model-Rework-Expansion" },
 						{ "name" : "IR-Model-Rework-Utility" },


### PR DESCRIPTION
KS seems to be getting updates faster than Github, KS also has better metadata so I'm undoing my switch over to github for this mod and going back to KS.

Original switch was because it seemed github would deprecate the KS entry and add a new one, this did not happen so there's no reason not to use KS.