### PR TITLE
Fix duplication of HangarExtender for 1.0 and up

### DIFF
--- a/NetKAN/FShangarExtender.netkan
+++ b/NetKAN/FShangarExtender.netkan
@@ -3,6 +3,6 @@
 	"identifier"	: "FShangarExtender",
 	"$kref"        	: "#/ckan/kerbalstuff/18",
 	"license"		: "CC-BY-4.0",
-	"ksp_version"	: "0.90"
+	"ksp_version"	: "0.90",
 	"abstract"		: "Please use the other Hangar Extender mod, this is the wrong one"
 }

--- a/NetKAN/FShangarExtender.netkan
+++ b/NetKAN/FShangarExtender.netkan
@@ -2,5 +2,7 @@
 	"spec_version"	: 1,
 	"identifier"	: "FShangarExtender",
 	"$kref"        	: "#/ckan/kerbalstuff/18",
-	"license"		: "CC-BY-4.0"
+	"license"		: "CC-BY-4.0",
+	"ksp_version"	: "0.90"
+	"abstract"		: "Please use the other Hangar Extender mod, this is the wrong one"
 }

--- a/NetKAN/RealismOverhaul.netkan
+++ b/NetKAN/RealismOverhaul.netkan
@@ -25,7 +25,7 @@
 		{ "name" : "DeadlyReentry" },
 		{ "name" : "EngineIgnitor" },
 		{ "name" : "FilterExtensions" },
-		{ "name" : "FShangarExtender" },
+		{ "name" : "HangarExtender" },
 		{ "name" : "KSP-AVC" },
 		{ "name" : "MechJeb2" },
 		{ "name" : "ModuleFixer" },


### PR DESCRIPTION
closes https://github.com/KSP-CKAN/NetKAN/issues/866

This will look interesting for 0.90 users since they will keep the duplication but for users of KSP 1.0 and up this fixes the double Hangar Extender in the modlist.

I choose to keep HangarExtender rather than FSHangarExtender since it was created first. I also updated RO to properly recommend the now correct mod.

notifying @Felger that I've done this since he created the original FShangarExtender which I now deprecate.