### PR TITLE
Remove DDSLoader dependency from OuterPlanetsMod

### DIFF
--- a/NetKAN/OuterPlanetsMod.netkan
+++ b/NetKAN/OuterPlanetsMod.netkan
@@ -4,7 +4,6 @@
     "$kref": "#/ckan/kerbalstuff/437", 
     "spec_version": "v1.4",
 	"depends"	:	[ { "name" : "ModuleManager" },
-					{ "name" : "DDSLoader" },
 					{ "name" : "KopernicusTech" } ],
 	"recommends":	[ { "name" : "NearFuturePropulsion" },
 					{ "name" : "NearFutureElectrical" },


### PR DESCRIPTION
DDS loading functionality is now stock in v1.0 and the DDSLoader plugin
will not be updated.

http://forum.kerbalspaceprogram.com/threads/96729?p=1869823#post1869823