### PR TITLE
Hardcode OPTMk3MiniExpansion to 0.90

### DIFF
--- a/NetKAN/OPTMk3MiniExpansion.netkan
+++ b/NetKAN/OPTMk3MiniExpansion.netkan
@@ -3,6 +3,7 @@
     "identifier"   : "OPTMk3MiniExpansion",
     "license": "CC-BY-NC-SA-4.0",
     "$kref": "#/ckan/kerbalstuff/449",
+	"ksp_version"	:	"0.90",
 	"install": [
 		{
 		"file": "GameData/OPT/Parts",


### PR DESCRIPTION
Based on https://github.com/KSP-CKAN/CKAN-meta/issues/261 I'm hereby locking OPTMk3... to 0.90 so the problem will not move on over to KSP 1.0.

This will have a negative effect on people who have the "wrong" one installed in CKAN and then updates to 1.0 of KSP without clearing their modcache. This crowd have so far not been gigantic and this is one of the few ways I can think of to fix this without horrible breaking stuff for 0.90 users seeing as we lack a means of deprecation.

notifying @TeddyDD and @hakan42 who discussed the original issue.