### PR TITLE
Add VesselView.netkan

### DIFF
--- a/NetKAN/VesselView.netkan
+++ b/NetKAN/VesselView.netkan
@@ -1,0 +1,9 @@
+{
+    "spec_version": 1,
+    "$kref": "#/ckan/kerbalstuff/731",
+    "license": "MIT",
+    "identifier": "VesselView",
+	"depends"	: [ { "name" : "Toolbar" },
+					{ "name" : "RasterPropMonitor-Core" } ],
+	"recommends":	[ { "name" : "RasterPropMonitor" } ]
+}


### PR DESCRIPTION
closes #1103 

There is an old handpackaged version of this mod that has a different set of workings to get it working. 

The mod author has chosen to only upload the complete edition to Kerbalstuff and not the broken into smaller pieces versions that only depend on Toolbar or RPM rather than, as in this case, both. I've elected to add the same one to NetKAN in an attempt to fullfill the wishes of the mod author and as such I've repackaged this to use a simpler format than the older handpackaged ones.

The versions available since earlier stop the compatibility at ksp_version_max 0.25 and as such I forsee no conflicts by the above way of working.