### PR TITLE
Update license for K2CommandPod

### DIFF
--- a/NetKAN/K2CommandPod.netkan
+++ b/NetKAN/K2CommandPod.netkan
@@ -1,8 +1,8 @@
 {
     "identifier": "K2CommandPod", 
-    "x_netkan_license_ok": true, 
     "$kref": "#/ckan/kerbalstuff/445", 
     "spec_version": "v1.4",
+	"license" : "CC-BY-NC-SA-4.0",
 	"install": [
 	{ "file": "GameData/JFJohnny5", "install_to": "GameData" }
 	]


### PR DESCRIPTION
Author did an update of the license on KS and changed it from MIT to something the bot can't read since it's not in CKAN.schema, this fixes it.