### PR TITLE
Update dependencies for CryoEngines

### DIFF
--- a/NetKAN/CryoEngines.netkan
+++ b/NetKAN/CryoEngines.netkan
@@ -3,7 +3,7 @@
     "$kref": "#/ckan/kerbalstuff/717",
     "license": "CC-BY-NC-SA-4.0",
     "identifier": "CryoEngines",
-	"depends"	:	[ { "name" : "FirespitterCore" },
+	"depends"	:	[ { "name" : "InterstellarFuelSwitch" },
 					{ "name" : "CommunityResourcePack" },
 					{ "name" : "ModuleManager" } ],
 	"install"	: 	[ { "find" : "CryoEngines",


### PR DESCRIPTION
In v0.1.3 dependency on Firespitter was replaced with dependency on
InterstellarFuelSwitch.