### PR TITLE
Switch RPM over to KS hosting for ksp_version consistency

### DIFF
--- a/NetKAN/RasterPropMonitor-Core.netkan
+++ b/NetKAN/RasterPropMonitor-Core.netkan
@@ -1,19 +1,10 @@
 {
     "spec_version"   : 1,
-    "name"           : "RasterPropMonitor Core",
     "identifier"     : "RasterPropMonitor-Core",
-    "$kref"          : "#/ckan/github/Mihara/RasterPropMonitor",
+    "$kref"          : "#/ckan/kerbalstuff/734",
     "author"         : [ "MOARdV", "Mihara" ],
-    "abstract"       : "A toolkit for creating interactive IVA experiences.",
     "comment"        : "This package contains the plugin, and the standard parts library.",
-
     "license"        : "GPL-3.0",
-    "ksp_version": "1.0",
-    "release_status" : "stable",
-    "resources" : {
-        "homepage" : "http://forum.kerbalspaceprogram.com/threads/117471",
-        "manual" : "https://github.com/Mihara/RasterPropMonitor/wiki"
-    },
     "depends" : [
         { "name" : "ModuleManager" }
     ],

--- a/NetKAN/RasterPropMonitor-Core.netkan
+++ b/NetKAN/RasterPropMonitor-Core.netkan
@@ -1,6 +1,7 @@
 {
     "spec_version"   : 1,
     "identifier"     : "RasterPropMonitor-Core",
+	"name"			:	"RasterPropMonitor-Core",
     "$kref"          : "#/ckan/kerbalstuff/734",
     "author"         : [ "MOARdV", "Mihara" ],
     "comment"        : "This package contains the plugin, and the standard parts library.",

--- a/NetKAN/RasterPropMonitor-Core.netkan
+++ b/NetKAN/RasterPropMonitor-Core.netkan
@@ -8,7 +8,7 @@
     "comment"        : "This package contains the plugin, and the standard parts library.",
 
     "license"        : "GPL-3.0",
-    "ksp_version_min": "0.25.0",
+    "ksp_version": "1.0",
     "release_status" : "stable",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/117471",

--- a/NetKAN/RasterPropMonitor-Core.netkan
+++ b/NetKAN/RasterPropMonitor-Core.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version"   : 1,
     "identifier"     : "RasterPropMonitor-Core",
-	"name"			:	"RasterPropMonitor-Core",
+	"name"			:	"RasterPropMonitor Core",
     "$kref"          : "#/ckan/kerbalstuff/734",
     "author"         : [ "MOARdV", "Mihara" ],
     "comment"        : "This package contains the plugin, and the standard parts library.",

--- a/NetKAN/RasterPropMonitor.netkan
+++ b/NetKAN/RasterPropMonitor.netkan
@@ -8,7 +8,7 @@
     "comment"        : "This package contains the stock IVA patches and the JSI agency.",
     "license"        : "GPL-3.0",
     "release_status" : "stable",
-    "$vref"          : "#/ckan/ksp-avc",
+    "ksp_version": "1.0",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/117471",
         "manual" : "https://github.com/Mihara/RasterPropMonitor/wiki"

--- a/NetKAN/RasterPropMonitor.netkan
+++ b/NetKAN/RasterPropMonitor.netkan
@@ -1,18 +1,9 @@
 {
     "spec_version"   : 1,
-    "name"           : "RasterPropMonitor",
     "identifier"     : "RasterPropMonitor",
-    "$kref"          : "#/ckan/github/Mihara/RasterPropMonitor",
+    "$kref"          : "#/ckan/kerbalstuff/734",
     "author"         : [ "MOARdV", "Mihara" ],
-    "abstract"       : "Makes Stock IVAs more interactive.",
-    "comment"        : "This package contains the stock IVA patches and the JSI agency.",
     "license"        : "GPL-3.0",
-    "release_status" : "stable",
-    "ksp_version": "1.0",
-    "resources" : {
-        "homepage" : "http://forum.kerbalspaceprogram.com/threads/117471",
-        "manual" : "https://github.com/Mihara/RasterPropMonitor/wiki"
-    },
     "depends" : [
         { "name" : "ModuleManager" },
         { "name" : "RasterPropMonitor-Core" }


### PR DESCRIPTION
closes https://github.com/KSP-CKAN/CKAN-meta/pull/434

Basically I set the RPM version numbers to the ones from Kerbalstuff

RPM-Core does not contain a .version file since it does not install the folder which contains it making an older hardcoded value being used instead. A solution for this specificsituation is probably to switch over to using KS hosting which will give us less exact ksp_version fields but will make them consistent for both Core and RPM and preventing this situation from occuring again.