### PR TITLE
Update Jenkins - Help wanted

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,11 +42,12 @@ then
 fi
 
 mkdir dummy_ksp
-echo Version 1.0.0 > dummy_ksp/readme.txt
+echo Version 1.0.2 > dummy_ksp/readme.txt
 mkdir dummy_ksp/GameData
 mkdir dummy_ksp/Ships/
 mkdir dummy_ksp/Ships/VAB
 mkdir dummy_ksp/Ships/SPH
+mkdir dummy_ksp/Ships/@thumbs
 
 if [ -z ${ghprbActualCommit} ]
 then


### PR DESCRIPTION
I looked through the build.sh and from what I gather this is the only file I need to change to update the build parameters for Jenkins?

Expected outcome of these changes:

- Jenkins will properly run his tests as if he was on KSP version 1.0.2
- Jenkins "KSP install" will now properly have the `/Ships/@thumbs` folder introduced in KSP 1.0.0

Worries:

- Will the "@" in the foldername be a problem?