### PR TITLE
Change provide/conflict fields in EVE to match eachother

### DIFF
--- a/NetKAN/EnvironmentalVisualEnhancements-HR.netkan
+++ b/NetKAN/EnvironmentalVisualEnhancements-HR.netkan
@@ -22,6 +22,6 @@
         { "name" : "EnvironmentalVisualEnhancements" }
     ],
     "conflicts": [
-        { "name" : "EnvironmentalVisualEnhancements-LR" }
+        { "name" : "EnvironmentalVisualEnhancements-Config" }
     ]
 }

--- a/NetKAN/EnvironmentalVisualEnhancements-LR.netkan
+++ b/NetKAN/EnvironmentalVisualEnhancements-LR.netkan
@@ -22,6 +22,6 @@
         { "name" : "EnvironmentalVisualEnhancements" }
     ],
     "conflicts": [
-        { "name" : "EnvironmentalVisualEnhancements-HR" }
+        { "name" : "EnvironmentalVisualEnhancements-Config" }
     ]
 }


### PR DESCRIPTION
The current setup seems to have a weird interaction with astronomers pack and tbh I've never seen one like it.

This change will fail the build since the two packs inherently conflict.

This PR will make EVE behave like all other mods who have provide/conflict solutions.