### PR TITLE
Last (?) update of firespitter

### DIFF
--- a/NetKAN/FirespitterCore.netkan
+++ b/NetKAN/FirespitterCore.netkan
@@ -12,7 +12,7 @@
     "install"  : [
         {
             "file"       : "Firespitter/Plugins",
-            "install_to" : "GameData"
+            "install_to" : "GameData/Firespitter"
         },
 		{
 			"file" : "Firespitter/Firespitter.version",


### PR DESCRIPTION
I'm going insane about this file.

Missed adding a subfolder in the install-stanza. This'll probably force people to totally reinstall it on the next update of firespittercore which will lead to some backlash. I'm terribly sorry, firespitter was kinda stressed out due to public demand and then changed around between hosts to find the most up to date version and fix the versioning of previous versions.

This is hopefully the last change I'll ever do to firespittercore.