### PR TITLE
Adjusts KeepFit installation directory.

### DIFF
--- a/NetKAN/KeepFit.netkan
+++ b/NetKAN/KeepFit.netkan
@@ -13,7 +13,7 @@
 	"install" : [
 		{
 			"find" : "KeepFit",
-			"install_to": "GameData/Timmers"
+			"install_to": "GameData"
 		}
 	]
 }


### PR DESCRIPTION
When launching, KeepFit complains that it should now be installed directly in the GameData directory.  This untested change ought to put it where it belongs.