### PR TITLE
Update DangIt dependencies for upcoming 1.02 compatible version

### DIFF
--- a/NetKAN/DangIt.netkan
+++ b/NetKAN/DangIt.netkan
@@ -5,7 +5,6 @@
     "license"        : "GPL-3.0",
     "$kref"          : "#/ckan/kerbalstuff/7",
     "depends" : [
-        { "name" : "CrewFiles" },
         { "name" : "ModuleManager" },
         { "name" : "CommunityResourcePack" }
     ],


### PR DESCRIPTION
We no longer depend on CrewFiles now that we have switched to the stock XP system.