### PR TITLE
Added dependency on ModularFlightIntegrator.

### DIFF
--- a/NetKAN/FerramAerospaceResearch.netkan
+++ b/NetKAN/FerramAerospaceResearch.netkan
@@ -11,7 +11,10 @@
 	"provides"  : [ "AerodynamicModel", "FAR" ],
 	"conflicts" : [ { "name" : "AerodynamicModel" } ],
 	
-    "depends" : [ { "name" : "ModuleManager" } ],
+    "depends" : [
+        { "name" : "ModuleManager" },
+        { "name" : "ModularFlightIntegrator" }
+    ],
     "install" : [
         {
             "file"       : "GameData/FerramAerospaceResearch",


### PR DESCRIPTION
FAR now depends on ModularFlightIntegrator. I don't know if this is the right way to do this merge, as it might influence previous versions, so I will also open a PR for the metadata for just Euler.