### PR TITLE
Moved Firespitter.cfg form Firespitter to FirespitterCore

### DIFF
--- a/NetKAN/Firespitter.netkan
+++ b/NetKAN/Firespitter.netkan
@@ -19,7 +19,7 @@
         {
             "file"       : "Firespitter",
             "install_to" : "GameData",
-            "filter"     : [ "Firespitter.dll", "FSFuelSwitchTweakScale.cfg", "Firespitter.version" ],
+            "filter"     : [ "Firespitter.dll", "FSFuelSwitchTweakScale.cfg", "Firespitter.version", "Firespitter.cfg" ],
             "comment"    : "The DLL is installed from FirespitterCore"
         },
         {

--- a/NetKAN/FirespitterCore.netkan
+++ b/NetKAN/FirespitterCore.netkan
@@ -18,6 +18,10 @@
 		{
 			"file" : "Firespitter/Firespitter.version",
 			"install_to" : "GameData/Firespitter"
+		},
+		{
+			"file": "Firespitter/Resources/Firespitter.cfg",
+			"install_to": "GameData/Firespitter/Resources/"
 		}
     ]
 }

--- a/NetKAN/KerbalAircraftExpansion.netkan
+++ b/NetKAN/KerbalAircraftExpansion.netkan
@@ -8,10 +8,6 @@
 		{
 			"file" : "KAX",
 			"install_to" : "GameData"
-		},
-		{
-			"file": "Firespitter/Resources/Firespitter.cfg",
-			"install_to": "GameData/Firespitter/Resources/"
 		}
 	],
 	"depends": [


### PR DESCRIPTION
removed Firespitter.cfg from KAX (it is provided by FirespitterCore)
fixes https://github.com/KSP-CKAN/CKAN-meta/issues/472 and https://github.com/KSP-CKAN/CKAN-meta/issues/356

It would be really nice if someone could test it. FirespitterCore is quiet... touchy module. Many other modules depends on it. I would not screw it up ;)