### PR TITLE
UniversalStorage shouldn't be packaging MiniAVC.xml

### DIFF
--- a/NetKAN/UniversalStorage.netkan
+++ b/NetKAN/UniversalStorage.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version" : 1,
+    "spec_version" : "v1.4",
     "identifier"   : "UniversalStorage",
     "$kref"        : "#/ckan/kerbalstuff/250",
     "license"      : "restricted",	
@@ -7,11 +7,16 @@
         { "name" : "CommunityResourcePack" },
         { "name" : "ModuleManager" }
     ],
-	"x_conflicts": [
-		{ "name": "UniversalStorage-ECLSS" },
-		{ "name": "UniversalStorage-IFI" },
-		{ "name": "UniversalStorage-KAS" },
-		{ "name": "UniversalStorage-SNACKS" },
-		{ "name": "UniversalStorage-TAC" }
-	]
+    "x_conflicts": [
+        { "name": "UniversalStorage-ECLSS" },
+        { "name": "UniversalStorage-IFI" },
+        { "name": "UniversalStorage-KAS" },
+        { "name": "UniversalStorage-SNACKS" },
+        { "name": "UniversalStorage-TAC" }
+    ],
+    "install" : [ {
+        "find"       : "UniversalStorage",
+        "install_to" : "GameData",
+        "filter"     : [ "MiniAVC.xml" ]
+    } ]
 }


### PR DESCRIPTION
Because it does, upgrading fails as we try to overwrite an
auto-generated file. This causes it to be ignored.

Closes KSP-CKAN/CKAN#853.