### PR TITLE
TarsierSpaceTech: Update install stanza to reflect zip file path.

### DIFF
--- a/NetKAN/TarsierSpaceTechnologyWithGalaxies.netkan
+++ b/NetKAN/TarsierSpaceTechnologyWithGalaxies.netkan
@@ -5,6 +5,6 @@
     "$kref": "#/ckan/kerbalstuff/608",
     "license": "MIT",
 	"install": [
-		{ "file": "TarsierSpaceTech", "install_to": "GameData" }
+		{ "file": "GameData/TarsierSpaceTech", "install_to": "GameData" }
 	]
 }


### PR DESCRIPTION
The zip file is the latest version does not match the install stanza in the netkan file. Updated to reflect the changes, such that netkan-bot can process it again.