### PR TITLE
PortableScienceContainers: Fix install stanza.

### DIFF
--- a/NetKAN/PortableScienceContainer.netkan
+++ b/NetKAN/PortableScienceContainer.netkan
@@ -6,7 +6,7 @@
     "install"      :
     [
         {
-            "file"       : "VerneTech",
+            "file"       : "GameData/VerneTech",
             "install_to" : "GameData"
         }
     ],


### PR DESCRIPTION
The zip file has a change in the naming scheme, this should fix it.