### PR TITLE
Firespitter new core

### DIFF
--- a/NetKAN/Firespitter.netkan
+++ b/NetKAN/Firespitter.netkan
@@ -23,7 +23,7 @@
         {
             "file"       : "Firespitter",
             "install_to" : "GameData",
-            "filter"     : [ "Firespitter.dll", "FSFuelSwitchTweakScale.cfg", "Firespitter.version", "Firespitter.cfg", "Old Example Craft.zip" ],
+            "filter"     : [ "Firespitter.dll", "FSFuelSwitchTweakScale.cfg", "Firespitter.version", "Resources", "Old Example Craft.zip" ],
             "comment"    : "The DLL is installed from FirespitterCore"
         }
     ]

--- a/NetKAN/Firespitter.netkan
+++ b/NetKAN/Firespitter.netkan
@@ -1,11 +1,11 @@
 {
-    "spec_version"    : 1,
-    "identifier"      : "Firespitter",
-	"name"			: "Firespitter",
-	"abstract"		: "Propeller plane and helicopter parts",
-    "$kref"           : "#/ckan/github/snjo/Firespitter",
-    "license"         : "restricted",
-	"ksp_version"	:	"1.0.2",
+    "spec_version" : 1,
+    "identifier"   : "Firespitter",
+	"name"         : "Firespitter",
+	"abstract"     : "Propeller plane and helicopter parts",
+    "$kref"        : "#/ckan/github/snjo/Firespitter",
+    "license"      : "restricted",
+	"$vref"        : "#/ckan/ksp-avc",
     "resources" : {
         "homepage" : "http://snjo.github.io/",
         "repository"  : "https://github.com/snjo/Firespitter"
@@ -19,18 +19,12 @@
             "name" : "FirespitterResourcesConfig"
         }
     ],
-    "x_supports" : [ { "name" : "PartCatalog" } ],
     "install"  : [
         {
             "file"       : "Firespitter",
             "install_to" : "GameData",
-            "filter"     : [ "Firespitter.dll", "FSFuelSwitchTweakScale.cfg", "Firespitter.version", "Firespitter.cfg" ],
+            "filter"     : [ "Firespitter.dll", "FSFuelSwitchTweakScale.cfg", "Firespitter.version", "Firespitter.cfg", "Old Example Craft.zip" ],
             "comment"    : "The DLL is installed from FirespitterCore"
-        },
-        {
-            "file"       : "PartCatalog",
-            "install_to" : "GameData",
-            "comment"    : "Firespitter graphics for PartCatalog"
         }
     ]
 }

--- a/NetKAN/Firespitter.netkan
+++ b/NetKAN/Firespitter.netkan
@@ -10,16 +10,21 @@
         "homepage" : "http://snjo.github.io/",
         "repository"  : "https://github.com/snjo/Firespitter"
     },
-    "depends" : [ {
-        "name"        : "FirespitterCore",
-        "min_version" : "7.1"
-    } ],
+    "depends" : [
+        {
+            "name"        : "FirespitterCore",
+            "min_version" : "7.1"
+        },
+        {
+            "name" : "FirespitterResourcesConfig"
+        }
+    ],
     "x_supports" : [ { "name" : "PartCatalog" } ],
     "install"  : [
         {
             "file"       : "Firespitter",
             "install_to" : "GameData",
-            "filter"     : [ "Firespitter.dll", "FSFuelSwitchTweakScale.cfg", "Firespitter.version" ],
+            "filter"     : [ "Firespitter.dll", "FSFuelSwitchTweakScale.cfg", "Firespitter.version", "Firespitter.cfg" ],
             "comment"    : "The DLL is installed from FirespitterCore"
         },
         {

--- a/NetKAN/Firespitter.netkan
+++ b/NetKAN/Firespitter.netkan
@@ -6,6 +6,7 @@
     "$kref"        : "#/ckan/github/snjo/Firespitter",
     "license"      : "restricted",
 	"$vref"        : "#/ckan/ksp-avc",
+    "x_netkan_force_v" : true,
     "resources" : {
         "homepage" : "http://snjo.github.io/",
         "repository"  : "https://github.com/snjo/Firespitter"

--- a/NetKAN/FirespitterCore.netkan
+++ b/NetKAN/FirespitterCore.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version"    : "v1.2",
     "identifier"      : "FirespitterCore",
-    "$kref"           : "#/ckan/github/snjo/Firespitter",
+    "$kref"           : "#/ckan/kerbalstuff/777",
     "license"         : "restricted",
    "name" : "Firespitter Core",
    "abstract" : "Core Firespitter.dll. Install `Firespitter` for the whole shebang",

--- a/NetKAN/FirespitterResourcesConfig.netkan
+++ b/NetKAN/FirespitterResourcesConfig.netkan
@@ -1,0 +1,19 @@
+{
+    "spec_version"    : "v1.2",
+    "identifier"      : "FirespitterResourcesConfig",
+    "$kref"           : "#/ckan/github/snjo/Firespitter",
+    "license"         : "restricted",
+   "name" : "Firespitter Resources config",
+   "abstract" : "Resource definition required by some mods",
+	"$vref"			:	"#/ckan/ksp-avc",
+    "resources" : {
+        "homepage" : "http://snjo.github.io/",
+        "repository"  : "https://github.com/snjo/Firespitter"
+    },
+    "install"  : [
+        {
+            "file"       : "Firespitter/Resources",
+            "install_to" : "GameData/Firespitter"
+        }
+    ]
+}

--- a/NetKAN/KerbalAircraftExpansion.netkan
+++ b/NetKAN/KerbalAircraftExpansion.netkan
@@ -6,12 +6,15 @@
 	"x_netkan_license_ok": true,
 	"install" : [
 		{
-			"file" : "KAX",
-			"install_to" : "GameData"
+			"file": "KAX",
+			"install_to": "GameData",
+			"filter" : ["KAX 2.4.2 dds textures.7z", "Example Craft"],
+			"comment": "Example crafts are filtered out becouse its impossible to install ships to subdirectory."
 		}
 	],
 	"depends": [
 		{ "name" : "FirespitterCore" },
-		{ "name" : "FirespitterResourcesConfig"}
+		{ "name" : "FirespitterResourcesConfig"},
+		{ "name" : "ModuleManager"}
 	]
 }

--- a/NetKAN/KerbalAircraftExpansion.netkan
+++ b/NetKAN/KerbalAircraftExpansion.netkan
@@ -8,13 +8,10 @@
 		{
 			"file" : "KAX",
 			"install_to" : "GameData"
-		},
-		{
-			"file": "Firespitter/Resources/Firespitter.cfg",
-			"install_to": "GameData/Firespitter/Resources/"
 		}
 	],
 	"depends": [
-		{ "name" : "FirespitterCore" }
+		{ "name" : "FirespitterCore" },
+		{ "name" : "FirespitterResourcesConfig"}
 	]
 }


### PR DESCRIPTION
Changes:
- FirespitterCore now use #1227 as a source
- Moved conflicting file Firespitter.cfg from Firespitter to new package
- Updated Firespitter and KAX to depend on new package (FirespitterResourcesConfig)

- addev ksp/avc $vref to Firespitter (instead of hardcoded "ksp_version")
- removed PartCatalog support from Firespitter (it's no longer present in
  Firespitter zip archive - version 7.1.2)
- filter some files from KAX (zip file with old textures)
- added missing dependency to KAX (ModuleManager)

This should fix/close:
https://github.com/KSP-CKAN/NetKAN/pull/1217
https://github.com/KSP-CKAN/CKAN-meta/issues/472
https://github.com/KSP-CKAN/CKAN-meta/issues/356
https://github.com/KSP-CKAN/NetKAN/pull/1227
https://github.com/KSP-CKAN/CKAN/issues/859

If you want to test this you can install it from my testing repo

https://github.com/TeddyDD/CKAN-testing/archive/master.zip

It works for me at least :smiling_imp: 
