### PR TITLE
Add InstellIncorporatedExperimentalEngines, modified from automated PR.

### DIFF
--- a/NetKAN/InstellIncorporatedExperimentalEngines.netkan
+++ b/NetKAN/InstellIncorporatedExperimentalEngines.netkan
@@ -9,11 +9,11 @@
     ],
     "install" : [
         {
-            "find" : "GameData/Intstell Inc",
+            "file" : "GameData/Intstell Inc",
             "install_to" : "GameData"
         },
         {
-            "find" : "Ships",
+            "file" : "Ships",
             "install_to" : "Ships"
         }
     ]

--- a/NetKAN/InstellIncorporatedExperimentalEngines.netkan
+++ b/NetKAN/InstellIncorporatedExperimentalEngines.netkan
@@ -1,0 +1,20 @@
+{
+    "$kref" : "#/ckan/kerbalstuff/750",
+    "identifier" : "InstellIncorporatedExperimentalEngines",
+    "spec_version" : 1,
+    "license" : "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License",
+    "x_netkan_license_ok" : true,
+    "depends" : [
+        { "name" : "FirespitterCore" }
+    ],
+    "install" : [
+        {
+            "find" : "GameData/Intstell Inc",
+            "install_to" : "GameData"
+        },
+        {
+            "find" : "Ships",
+            "install_to" : "Ships"
+        }
+    ]
+} 

--- a/NetKAN/InstellIncorporatedExperimentalEngines.netkan
+++ b/NetKAN/InstellIncorporatedExperimentalEngines.netkan
@@ -2,8 +2,7 @@
     "$kref" : "#/ckan/kerbalstuff/750",
     "identifier" : "InstellIncorporatedExperimentalEngines",
     "spec_version" : 1,
-    "license" : "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License",
-    "x_netkan_license_ok" : true,
+    "license" : "CC-BY-NC-SA-4.0",
     "depends" : [
         { "name" : "FirespitterCore" }
     ],
@@ -17,4 +16,4 @@
             "install_to" : "Ships"
         }
     ]
-} 
+}


### PR DESCRIPTION
Suppresses license warning on accepted license, adds missing dependency on FirespitterCore and fixes install stanza. @Dazpoet may be able to answer is the ships part is necessary.

Closes #1182.