### PR TITLE
Update JSIPartUtilities.netkan

### DIFF
--- a/NetKAN/JSIPartUtilities.netkan
+++ b/NetKAN/JSIPartUtilities.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version" : 1,
+    "spec_version" : "v1.4",
     "identifier"   : "JSIPartUtilities",
     "$kref"        : "#/ckan/github/Mihara/PartUtilities",
     "name"         : "JSIPartUtilities",
@@ -9,7 +9,8 @@
     "install" : [
         {
             "file"       : "GameData/JSI",
-            "install_to" : "GameData"
+            "install_to" : "GameData",
+            "filter"     : "Agencies"
         }
     ]
 }


### PR DESCRIPTION
Temporarily remove the Agencies folder to avoid clashes with RasterPropMonitor.

@Dazpoet Both RPM and JSIPartUtilities provides the same Agencies, do we split them up and make a new package JSIAgency and let them both depend on it?

Part of the solution for https://github.com/KSP-CKAN/CKAN-support/issues/145.

Closes https://github.com/KSP-CKAN/CKAN-meta/issues/493.