### PR TITLE
Add KWRocketry-LegacyFairings

### DIFF
--- a/NetKAN/KWRocketry-LegacyFairings.netkan
+++ b/NetKAN/KWRocketry-LegacyFairings.netkan
@@ -1,0 +1,29 @@
+{
+    "spec_version": 1,
+    "identifier": "KWRocketry-LegacyFairings",
+    "$kref": "#/ckan/kerbalstuff/67",
+    "license": "CC-BY-SA-3.0",
+    "depends": [
+        { "name": "KWRocketry", "min_version": "2.7" },
+        { "name": "FerramAerospaceResearch", "min_version": "v0.15.0_Euler" }
+    ],
+    "install": [
+        {
+            "file": "KW Release Package v2.7 (Open this, don't extract it)/Extras/OldFARFairings/GameData/KWRocketry",
+            "install_to": "GameData",
+            "comment": "These files are duplicated but are identical to what's installed by default.",
+            "filter": [
+                "fairings_diff_KWBlack.dds",
+                "fairings_diff_KWWhite.dds",
+                "KW2mFairingBase8bit.dds",
+                "KW2mFairingBaseNormal.dds",
+                "KW_Fairing_Base1m.mu",
+                "KW_Fairing_Base2m.mu",
+                "KW_Fairing_Base3m.mu",
+                "Part1mPF.cfg",
+                "Part2mPF.cfg",
+                "Part3mPF.cfg"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Adds the legacy (non-procedural) fairings included in the extras portion of the distribution. These fairings require nuFAR to be used properly.

I would like to have used a `find` clause in the `install` stanza, but what I really want is to express:
"*Find* `OldFARFairings`  *Then Find* `KWRocketry`", something like a `find_regexp`: `OldFARFairings/.*/KWRocketry`, which I don't believe exists.