### PR TITLE
Update KWRocketry and Add ModuleAnimateEmissive

### DIFF
--- a/NetKAN/KWRocketry.netkan
+++ b/NetKAN/KWRocketry.netkan
@@ -2,5 +2,20 @@
     "spec_version" : 1,
     "identifier"   : "KWRocketry",
     "$kref"        : "#/ckan/kerbalstuff/67",
-    "license"      : "CC-BY-SA-3.0"
+    "license"      : "CC-BY-SA-3.0",
+    "comment"      : "It looks like KWRocketry is the only thing that uses ModuleAnimateEmissive for now.",
+    "depends"      : [
+        { "name": "ModuleAnimateEmissive" }
+    ],
+    "provides"     : [ "ModuleAnimateEmissive" ],
+    "install"      : [
+        {
+            "file": "KW Release Package v2.7 (Open this, don't extract it)/GameData/KWRocketry",
+            "install_to": "GameData"
+        },
+        {
+            "file": "KW Release Package v2.7 (Open this, don't extract it)/GameData/ModuleAnimateEmissive",
+            "install_to": "GameData"
+        }
+    ]
 }


### PR DESCRIPTION
KWRocketry 2.7 includes a new dependency, ModuleAnimateEmissive, that seems
to be only distributed by KWRocketry and is only used by KWRocketry. So
make KWRocketry depend on and provide ModuleAnimateEmissive.

If something else in the future depends on ModuleAnimateEmissive it should
be straightforward to update.

This could really use a `find_regexp` in the `install` stanza.