### PR TITLE
Create FingerboxesCore.netkan

### DIFF
--- a/NetKAN/FingerboxesCore.netkan
+++ b/NetKAN/FingerboxesCore.netkan
@@ -1,0 +1,16 @@
+{
+    "spec_version" : "v1.4",
+    "identifier"   : "FingerboxesCore",
+    "$kref"        : "#/ckan/github/fingerboxes/FingerboxLib",
+    "name"         : "Fingerboxes Core Plugin",
+    "abstract"     : "(KSP Mod) Common methods library for KSP mods - This mod is intended for use by some of my other mods, it does nothing on its own. It contains some code from TriggerAU, licensed under MIT.",
+    "license"      : "MIT",
+    "ksp_version"  : "1.0.2",
+    
+        "install": [
+        {
+            "find"       : "FingerboxLib.dll",
+            "install_to" : "GameData/Fingerboxes/Common/Plugins"
+        }
+    ]
+}

--- a/NetKAN/FingerboxesCore.netkan
+++ b/NetKAN/FingerboxesCore.netkan
@@ -10,7 +10,7 @@
         "install": [
         {
             "file"       : "GameData/Fingerboxes/Common/Plugins",
-            "install_to" : "GameData/Fingerboxes/Common/Plugins"
+            "install_to" : "GameData/Fingerboxes/Common"
         }
     ]
 }

--- a/NetKAN/FingerboxesCore.netkan
+++ b/NetKAN/FingerboxesCore.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version" : "v1.4",
+    "spec_version" : 1,
     "identifier"   : "FingerboxesCore",
     "$kref"        : "#/ckan/github/fingerboxes/CrewQueue",
     "name"         : "Fingerboxes Core Plugin",
@@ -9,7 +9,7 @@
     
         "install": [
         {
-            "find"       : "FingerboxLib.dll",
+            "file"       : "GameData/Fingerboxes/Common/Plugins",
             "install_to" : "GameData/Fingerboxes/Common/Plugins"
         }
     ]

--- a/NetKAN/FingerboxesCore.netkan
+++ b/NetKAN/FingerboxesCore.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version" : "v1.4",
     "identifier"   : "FingerboxesCore",
-    "$kref"        : "#/ckan/github/fingerboxes/FingerboxLib",
+    "$kref"        : "#/ckan/github/fingerboxes/CrewQueue",
     "name"         : "Fingerboxes Core Plugin",
     "abstract"     : "(KSP Mod) Common methods library for KSP mods - This mod is intended for use by some of my other mods, it does nothing on its own. It contains some code from TriggerAU, licensed under MIT.",
     "license"      : "MIT",

--- a/NetKAN/FingerboxesCore.netkan
+++ b/NetKAN/FingerboxesCore.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version" : 1,
+    "spec_version" : "v1.2",
     "identifier"   : "FingerboxesCore",
     "$kref"        : "#/ckan/github/fingerboxes/CrewQueue",
     "name"         : "Fingerboxes Core Plugin",


### PR DESCRIPTION
This wont work as it is. There is no release for the core plugin, but its included in releases for CrewQueue. 

To get this to work, does the mod author need to label the core plugin as released?