### PR TITLE
Add SolverEngines and ModuleAnimateEmissive

### DIFF
--- a/NetKAN/KWRocketry.netkan
+++ b/NetKAN/KWRocketry.netkan
@@ -3,18 +3,12 @@
     "identifier"   : "KWRocketry",
     "$kref"        : "#/ckan/kerbalstuff/67",
     "license"      : "CC-BY-SA-3.0",
-    "comment"      : "It looks like KWRocketry is the only thing that uses ModuleAnimateEmissive for now.",
     "depends"      : [
         { "name": "ModuleAnimateEmissive" }
     ],
-    "provides"     : [ "ModuleAnimateEmissive" ],
     "install"      : [
         {
             "file": "KW Release Package v2.7 (Open this, don't extract it)/GameData/KWRocketry",
-            "install_to": "GameData"
-        },
-        {
-            "file": "KW Release Package v2.7 (Open this, don't extract it)/GameData/ModuleAnimateEmissive",
             "install_to": "GameData"
         }
     ]

--- a/NetKAN/ModuleAnimateEmissive.netkan
+++ b/NetKAN/ModuleAnimateEmissive.netkan
@@ -2,11 +2,11 @@
 	"spec_version"	:	"v1.4",
 	"$kref"			:	"#/ckan/github/KSP-RO/SolverEngines",
 	"identifier"	:	"ModuleAnimateEmissive",
-	"name"			:	"Module Animate Emissive",
+	"name"			:	"Animate Emissive Module",
 	"abstract"		:	"ModuleAnimateEmissive replaces ModuleAnimateHeat with a more flexible, configurable module.",
 	"license"		:	"LGPL-2.1",
 	"release_status":	"stable",
 	"install"		:	[ { "find" : "SolverEngines",
 							"install_to" : "GameData",
-							"filter_regexp" : "^(?!ModuleAnimateEmissive.dll)" } ]
+							"filter" : [ "Icons", "PluginData" , "SolverEngines.dll"] } ]
 }

--- a/NetKAN/ModuleAnimateEmissive.netkan
+++ b/NetKAN/ModuleAnimateEmissive.netkan
@@ -1,0 +1,12 @@
+{
+	"spec_version"	:	"v1.4",
+	"$kref"			:	"#/ckan/github/KSP-RO/SolverEngines",
+	"identifier"	:	"ModuleAnimateEmissive",
+	"name"			:	"Module Animate Emissive",
+	"abstract"		:	"ModuleAnimateEmissive replaces ModuleAnimateHeat with a more flexible, configurable module.",
+	"license"		:	"LGPL-2.1",
+	"release_status":	"stable",
+	"install"		:	[ { "find" : "SolverEngines",
+							"install_to" : "GameData",
+							"filter_regexp" : "^(?!ModuleAnimateEmissive.dll)" } ]
+}

--- a/NetKAN/SolverEngines.netkan
+++ b/NetKAN/SolverEngines.netkan
@@ -9,5 +9,5 @@
 	"depends"		:	[ { "name" : "ModuleAnimateEmissive" } ],
 	"install"		:	[ { "find" : "SolverEngines",
 							"install_to" : "GameData",
-							"filter" : "ModuleAnimateEmissive.dll" } ]
+							"filter" : [ "ModuleAnimateEmissive.dll", "PluginData" ] } 
 }

--- a/NetKAN/SolverEngines.netkan
+++ b/NetKAN/SolverEngines.netkan
@@ -9,5 +9,5 @@
 	"depends"		:	[ { "name" : "ModuleAnimateEmissive" } ],
 	"install"		:	[ { "find" : "SolverEngines",
 							"install_to" : "GameData",
-							"filter" : [ "ModuleAnimateEmissive.dll", "PluginData" ] } 
+							"filter" : [ "ModuleAnimateEmissive.dll", "PluginData" ] } ]
 }

--- a/NetKAN/SolverEngines.netkan
+++ b/NetKAN/SolverEngines.netkan
@@ -1,0 +1,13 @@
+{
+	"spec_version"	:	"v1.4",
+	"$kref"			:	"#/ckan/github/KSP-RO/SolverEngines",
+	"identifier"	:	"SolverEngines",
+	"name"			:	"Solver Engines plugin",
+	"abstract"		:	"SolverEngines is at its heart a replacement paradigm for how KSP deals with engines",
+	"license"		:	"LGPL-2.1",
+	"release_status":	"stable",
+	"depends"		:	[ { "name" : "ModuleAnimateEmissive" } ],
+	"install"		:	[ { "find" : "SolverEngines",
+							"install_to" : "GameData",
+							"filter" : "ModuleAnimateEmissive.dll" } ]
+}


### PR DESCRIPTION
As requested by @NathanKell 

I split out ModuleAnimateEmissive since we have a case of a mod depending on it in KW.

Upcoming version of RealFuels and AJE depends on SolverEngines.

100% handwritten .netkan files so I'm bound to get some errors on the first run through Jenkins