### PR TITLE
RealFuels needs a forced update

### DIFF
--- a/NetKAN/RealFuels.netkan
+++ b/NetKAN/RealFuels.netkan
@@ -8,9 +8,7 @@
     "author"       : [ "ialdabaoth", "NathanKell" ],
     "release_status" : "stable",
     "ksp_version"  : "1.0.2",
-    "resources" : {
-        "homepage" : "http://forum.kerbalspaceprogram.com/threads/64118"
-    },
+    "resources" : { "homepage" : "http://forum.kerbalspaceprogram.com/threads/64118" },
     "install" : [
         {
             "file"       : "RealFuels",


### PR DESCRIPTION
For some unknown reason our indexer overwrote itself.

After #1404 was merged the bot triggered and built https://github.com/KSP-CKAN/CKAN-meta/commit/4e698cb3440787b67731a8361a90504e4495ecac

Then a while afterwards https://github.com/KSP-CKAN/CKAN-meta/commit/c4895bc8b7644f959bb2dfa06d18fbf9fd438208 came along and ruined everything and leaving us with a borked version.

I'm hoping that pushing this minimal formatting change will force the bot to retrigger and fix what it broke once and for all. This is an extremely suboptimal way of doing this but it's the only one I can come up with while nearly falling asleep in my chair.

Pinging @techman83 who might be able to explain what went wrong here?