### PR TITLE
KSPI-E needs InterstellarFuelSwitch 1.4

### DIFF
--- a/NetKAN/KSPInterstellarExtended.netkan
+++ b/NetKAN/KSPInterstellarExtended.netkan
@@ -13,7 +13,7 @@
     "depends" : [
         { "name"         : "CommunityResourcePack" },
         { "name"         : "Toolbar" },
-        { "name"         : "InterstellarFuelSwitch" },
+        { "name"         : "InterstellarFuelSwitch", "min_version" : "1.4" },
         { "name"         : "TweakScale"},
         { "name"         : "ModuleManager", "min_version" : "2.6.3" }
     ],


### PR DESCRIPTION
KSPI-E needs InterstellarFuelSwitch 1.4 otherwise people vessels might explode/implode