### PR TITLE
InterstellarFuelSwitch 1.5 contains a missing dll needed for the corr…

### DIFF
--- a/NetKAN/CryoEngines.netkan
+++ b/NetKAN/CryoEngines.netkan
@@ -3,7 +3,7 @@
     "$kref": "#/ckan/kerbalstuff/717",
     "license": "CC-BY-NC-SA-4.0",
     "identifier": "CryoEngines",
-	"depends"	:	[ { "name" : "InterstellarFuelSwitch-Core" },
+	"depends"	:	[ { "name" : "InterstellarFuelSwitch-Core, "min_version" : "1.5" },
 					{ "name" : "CommunityResourcePack" },
 					{ "name" : "ModuleManager" } ],
 	"install"	: 	[ { "find" : "CryoEngines",


### PR DESCRIPTION
…ect operation of KSP

InterstellarFuelSwitch 1.5 contains a missing dll *Scale_Redist.dll) which needed for the correct operation of KSP people game will not function properly