### PR TITLE
Add the BD crafts from KSCSM

### DIFF
--- a/NetKAN/A6Intruder.netkan
+++ b/NetKAN/A6Intruder.netkan
@@ -1,6 +1,6 @@
 {
     "$kref": "#/ckan/kerbalstuff/839",
-    "license": "GPL-3.0",
+    "license": [ "GPL-3.0", "WTFPL" ],
     "spec_version": 1,
     "identifier": "A6Intruder",
 	"depends"	:	[ { "name" : "AdjustableLandingGear" },

--- a/NetKAN/A6Intruder.netkan
+++ b/NetKAN/A6Intruder.netkan
@@ -1,0 +1,10 @@
+{
+    "$kref": "#/ckan/kerbalstuff/839",
+    "license": "GPL-3.0",
+    "spec_version": 1,
+    "identifier": "A6Intruder",
+	"depends"	:	[ { "name" : "AdjustableLandingGear" },
+					{ "name" : "BDArmory" } ],
+	"install"	:	[ { "file" : "A6Intruder",
+						"install_to" : "GameData" } ]
+}

--- a/NetKAN/A6Intruder.netkan
+++ b/NetKAN/A6Intruder.netkan
@@ -1,6 +1,6 @@
 {
     "$kref": "#/ckan/kerbalstuff/839",
-    "license": [ "GPL-3.0", "WTFPL" ],
+    "license": "WTFPL",
     "spec_version": 1,
     "identifier": "A6Intruder",
 	"depends"	:	[ { "name" : "AdjustableLandingGear" },

--- a/NetKAN/F117.netkan
+++ b/NetKAN/F117.netkan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "$kref": "#/ckan/kerbalstuff/848",
     "identifier": "F117",
-    "license": "GPL-3.0",
+    "license": [ "GPL-3.0", "WTFPL" ],
    
     "depends": [
         { "name": "FirespitterCore" },

--- a/NetKAN/F117.netkan
+++ b/NetKAN/F117.netkan
@@ -1,0 +1,15 @@
+{
+    "spec_version": 1,
+    "$kref": "#/ckan/kerbalstuff/848",
+    "identifier": "F117",
+    "license": "GPL-3.0",
+   
+    "depends": [
+        { "name": "FirespitterCore" },
+        { "name": "BDArmory" },
+        { "name": "BahamutoDynamicsPartsPack"}
+    ],
+	
+	"install":	[ { "file" : "F117",
+					"install_to" : "GameData" } ]
+}

--- a/NetKAN/F117.netkan
+++ b/NetKAN/F117.netkan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "$kref": "#/ckan/kerbalstuff/848",
     "identifier": "F117",
-    "license": [ "GPL-3.0", "WTFPL" ],
+    "license": "WTFPL",
    
     "depends": [
         { "name": "FirespitterCore" },

--- a/NetKAN/F14CTomcat.netkan
+++ b/NetKAN/F14CTomcat.netkan
@@ -1,0 +1,15 @@
+{
+    "spec_version": 1,
+    "$kref": "#/ckan/kerbalstuff/849",
+    "identifier": "F14CTomcat",
+    "license": "GPL-3.0",
+   
+    "depends": [
+        { "name": "FirespitterCore" },
+        { "name": "BDArmory" },
+        { "name": "BahamutoDynamicsPartsPack"}
+    ],
+   "install":	[ { "file" : "F14CTomcat",
+					"install_to" : "GameData" } ]
+   
+}

--- a/NetKAN/F14CTomcat.netkan
+++ b/NetKAN/F14CTomcat.netkan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "$kref": "#/ckan/kerbalstuff/849",
     "identifier": "F14CTomcat",
-    "license": "GPL-3.0",
+    "license": [ "GPL-3.0", "WTFPL" ],
    
     "depends": [
         { "name": "FirespitterCore" },

--- a/NetKAN/F14CTomcat.netkan
+++ b/NetKAN/F14CTomcat.netkan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "$kref": "#/ckan/kerbalstuff/849",
     "identifier": "F14CTomcat",
-    "license": [ "GPL-3.0", "WTFPL" ],
+    "license": "WTFPL",
    
     "depends": [
         { "name": "FirespitterCore" },

--- a/NetKAN/F18ASuperHornet.netkan
+++ b/NetKAN/F18ASuperHornet.netkan
@@ -1,7 +1,7 @@
 {
     "$kref": "#/ckan/kerbalstuff/840",
-    "license": "GPL-3.0",
-    "spec_version": 1,
+    "licenses": [ "GPL-3.0", "CC-BY-NC-4.0", "WTFPL" ],
+    "spec_version": "v1.2",
     "identifier": "F18ASuperHornet",
 	"depends"	:	[ { "name"	:	"AdjustableLandingGear" } ],
 	"recommends"	:	[ { "name" : "BDArmory" } ],

--- a/NetKAN/F18ASuperHornet.netkan
+++ b/NetKAN/F18ASuperHornet.netkan
@@ -1,0 +1,10 @@
+{
+    "$kref": "#/ckan/kerbalstuff/840",
+    "license": "GPL-3.0",
+    "spec_version": 1,
+    "identifier": "F18ASuperHornet",
+	"depends"	:	[ { "name"	:	"AdjustableLandingGear" } ],
+	"recommends"	:	[ { "name" : "BDArmory" } ],
+	"install"		:	[ { "file"	:	"F18A_Hornet",
+							"install_to" : "GameData" } ]
+}

--- a/NetKAN/F18ASuperHornet.netkan
+++ b/NetKAN/F18ASuperHornet.netkan
@@ -1,6 +1,7 @@
 {
     "$kref": "#/ckan/kerbalstuff/840",
-    "licenses": [ "GPL-3.0", "CC-BY-NC-4.0", "WTFPL" ],
+    "license"	:	"GPL-3.0",
+	"licenses": [ "CC-BY-NC-4.0", "WTFPL" ],
     "spec_version": "v1.2",
     "identifier": "F18ASuperHornet",
 	"depends"	:	[ { "name"	:	"AdjustableLandingGear" } ],

--- a/NetKAN/F18ASuperHornet.netkan
+++ b/NetKAN/F18ASuperHornet.netkan
@@ -1,6 +1,6 @@
 {
     "$kref": "#/ckan/kerbalstuff/840",
-    "license"	:	["GPL-3.0", "CC-BY-NC-4.0", "WTFPL" ],
+    "license"	:	"WTFPL",
     "spec_version": "v1.2",
     "identifier": "F18ASuperHornet",
 	"depends"	:	[ { "name"	:	"AdjustableLandingGear" } ],

--- a/NetKAN/F18ASuperHornet.netkan
+++ b/NetKAN/F18ASuperHornet.netkan
@@ -1,7 +1,6 @@
 {
     "$kref": "#/ckan/kerbalstuff/840",
-    "license"	:	"GPL-3.0",
-	"licenses": [ "CC-BY-NC-4.0", "WTFPL" ],
+    "license"	:	["GPL-3.0", "CC-BY-NC-4.0", "WTFPL" ],
     "spec_version": "v1.2",
     "identifier": "F18ASuperHornet",
 	"depends"	:	[ { "name"	:	"AdjustableLandingGear" } ],


### PR DESCRIPTION
Both are tested and working locally on a KSP 0.90 install.

.craft file from F18 not installed since I cannot install to a subfolder of Ships as per the CKAN spec.

BDArmory not a distinct dependency for A6Intruder but it seems you can't do much without it so I've elected to have it as a dependency for it. Text on F18 page is not as outspoken about needing BDArmory which is why it "merely" recommends it.

GPL-3.0 chosen as license for F18 since afaik it's the most restrictive of the 3 listed ones (CC-BY-NC-4.0, GPL-3.0 and WTFPL)