### PR TITLE
Deprecate KSPAPIExt by confining it to 0.90

### DIFF
--- a/NetKAN/Hangar.netkan
+++ b/NetKAN/Hangar.netkan
@@ -15,8 +15,7 @@
     
     "depends": 
     [
-        { "name": "ModuleManager" },
-        { "name" : "KSPAPIExtensions" }
+        { "name": "ModuleManager" }
     ],
     
     "suggests": 
@@ -31,9 +30,7 @@
 	[
 		{
 			"file": "GameData/Hangar",
-			"install_to": "GameData",
-			"filter": "KSPAPIExtensions.dll",
-			"comment": "Contains KSPAPIExtensions mod in this distribution"
+			"install_to": "GameData"
 		}
 	]
 }

--- a/NetKAN/KSPAPIExtensions.netkan
+++ b/NetKAN/KSPAPIExtensions.netkan
@@ -5,7 +5,7 @@
     "name"         : "KAE - KSPAPIExtensions",
     "abstract"     : "This package contains a bunch of utility methods for general use to modders.",
     "license"      : "CC-BY-3.0",
-    "ksp_version"  : "1.0.2",
+    "ksp_version"  : "0.90",
 	"install" : [
 		{
 			"file" : "KSPAPIExt",


### PR DESCRIPTION
KSPAPIExtensions clashes wildly with how CKAN does things. Reading its [forum thread](http://forum.kerbalspaceprogram.com/threads/81496-0-90-KSPAPIExtensions-V1-7-2-Utilities-for-shared-mod-use-16-Dec?p=1184389&viewfull=1#post1184389) it states that each mod should install it's own version of the .dll and the thread also includes confirmation of this still being the case  [here](http://forum.kerbalspaceprogram.com/threads/81496-0-90-KSPAPIExtensions-V1-7-2-Utilities-for-shared-mod-use-16-Dec?p=1664750&viewfull=1#post1664750).

Right now we have mods both installing and not installing their own version of KSPAPIExtensions which is the worst of both worlds. Mods like NearFuturePropulsion and ExtraplanetaryLaunchpads bundle the .dll while a [single mod](https://github.com/KSP-CKAN/NetKAN/blob/4b96e4929e317b905554f9c3f8a78b7b0f0cef3f/NetKAN/Hangar.netkan) [still](https://github.com/KSP-CKAN/NetKAN/pull/975) depends on us installing it.

I had a brief chat on irc with taniwha a while back and though I don't have the log handy to give exact wording it was pretty clear that us supplying the .dll as a depends rather than having the mods handle it themselves was far from an optimal solution.

We already have a history of not stripping it out as can be seen in https://github.com/KSP-CKAN/CKAN-meta/pull/331 so this PR goes the distance and set KSPAPIExtensions.netkan hardcoded to 0.90 aswell as fixes Hangar metadata. Assuming Hangar will get no more 0.90 compatible versions this will net no effect on the endusers.