### PR TITLE
Updates the Kerbin Space Station file.

### DIFF
--- a/NetKAN/ContractConfigurator-KerbinSpaceStation.netkan
+++ b/NetKAN/ContractConfigurator-KerbinSpaceStation.netkan
@@ -7,8 +7,11 @@
     "license"      : "CC-BY-SA-3.0",
     "$vref"        : "#/ckan/ksp-avc",
     "depends" : [
-        { "name": "ContractConfigurator" },
-        { "name": "ModuleManager" }
+        {
+            "name" : "ContractConfigurator",
+            "min_version" : "0.7.12"
+        },
+        { "name" : "ModuleManager" }
     ],
     "install" : [
         {
@@ -16,7 +19,7 @@
             "install_to" : "GameData/ContractPacks"
         }
     ],
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113642"
+    "resources" : {
+        "homepage" : "http://forum.kerbalspaceprogram.com/threads/113642"
     }
 }


### PR DESCRIPTION
Specifically, the forums state that it depends on Contract Configurator 0.7.12 or higher, but right now it's (hypothetically) possible to meet the dependency with something as low as 0.3.2, as the new "$vref" line allowed it to work on KSP 0.9 as well.