### PR TITLE
gcmonitor is compatible with ksp 1.0.2

### DIFF
--- a/NetKAN/GCMonitor.netkan
+++ b/NetKAN/GCMonitor.netkan
@@ -18,5 +18,5 @@
         "homepage"  : "http://forum.kerbalspaceprogram.com/threads/92907",
         "repository": "https://github.com/sarbian/GCMonitor/"
     },
-    "ksp_version": "1.0"
+    "ksp_version": "1.0.2"
 }


### PR DESCRIPTION
Setting the ksp_version field to 1.0 causes the mod to be incompatible with ksp1.0.2.
Maybe ckan's version checking logic needs to be reworked to account for Squads post 1.0 versioning scheme?