### PR TITLE
Add ModuleManager dependencies to AerojetKerbodyne and RealPlume

### DIFF
--- a/NetKAN/AerojetKerbodyne.netkan
+++ b/NetKAN/AerojetKerbodyne.netkan
@@ -12,7 +12,8 @@
     "depends" : [
         { "name" : "FirespitterCore" },
         { "name" : "TweakScale" },
-        { "name" : "VirginKalactic-NodeToggle" }
+        { "name" : "VirginKalactic-NodeToggle" },
+        { "name" : "ModuleManager" }
                 ],
     "recommends" : [
         { "name" : "SmokeScreen" }

--- a/NetKAN/RealPlume.netkan
+++ b/NetKAN/RealPlume.netkan
@@ -8,10 +8,11 @@
     "license"        : "CC-BY-SA",
     "release_status" : "stable",
     "depends" : [
-		{ "name" : "RealismOverhaul" },
-		{ "name" : "SmokeScreen" }
+        { "name" : "RealismOverhaul" },
+        { "name" : "SmokeScreen" },
+        { "name" : "ModuleManager" }
     ],
-	"conflicts" : [ { "name" : "HotRockets" } ],
+    "conflicts" : [ { "name" : "HotRockets" } ],
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/99966"
     },


### PR DESCRIPTION
This is adds the `ModuleManager` dependency to `AerojetKerbodyne` and `RealPlume` to compliment KSP-CKAN/CKAN-meta#554.