### PR TITLE
Update BackgroundProcessing

### DIFF
--- a/NetKAN/BackgroundProcessing.netkan
+++ b/NetKAN/BackgroundProcessing.netkan
@@ -2,6 +2,7 @@
     "spec_version" : 1,
     "identifier"   : "BackgroundProcessing",
     "$kref"        : "#/ckan/kerbalstuff/302",
+    "x_netkan_license_ok" : true,
     "install": [
         {
             "file"      : "BackgroundProcessing-0.4.1.0.dll",

--- a/NetKAN/BackgroundProcessing.netkan
+++ b/NetKAN/BackgroundProcessing.netkan
@@ -2,10 +2,9 @@
     "spec_version" : 1,
     "identifier"   : "BackgroundProcessing",
     "$kref"        : "#/ckan/kerbalstuff/302",
-    "x_netkan_license_ok" : true,
     "install": [
         {
-            "file"      : "BackgroundProcessing-0.4.0.1.dll",
+            "file"      : "BackgroundProcessing-0.4.1.0.dll",
             "install_to": "GameData"
         }
     ]


### PR DESCRIPTION
Update for newest version, ~~and remove the `x_netkan_license_ok` as I don't think that's necessary anymore~~. Apparently it still is.

KSP-CKAN/CKAN-core#131 would be useful here:
```json
{
    "install": [
        {
            "find_regexp": "(^|/)BackgroundProcessing(.+?)?\\.dll$",
            "install_to": "GameData"
        }
    ]
}
```