### PR TITLE
Add PhoenixIndustries...netkan

### DIFF
--- a/NetKAN/PhoenixIndustriesCargoResupplySystem.netkan
+++ b/NetKAN/PhoenixIndustriesCargoResupplySystem.netkan
@@ -1,0 +1,12 @@
+{
+    "spec_version": 1,
+    "x_netkan_license_ok": true,
+    "identifier": "PhoenixIndustriesCargoResupplySystem",
+    "license": "CC-BY-NC-SA-4.0",
+    "release_status" : "stable",
+    "$kref": "#/ckan/kerbalstuff/831",
+    "recommends": [
+        { "name": "KIS" },
+        { "name": "MechJeb2" }
+    ]
+}

--- a/NetKAN/PhoenixIndustriesCargoResupplySystem.netkan
+++ b/NetKAN/PhoenixIndustriesCargoResupplySystem.netkan
@@ -10,5 +10,6 @@
         { "name": "MechJeb2" }
     ],
 	"install"	:	[	{ "find"	:	"CTN",
-						"install_to":	"GameData" } ]
+						"install_to":	"GameData",
+						"filter"	:	"Thumds.db"} ]
 }

--- a/NetKAN/PhoenixIndustriesCargoResupplySystem.netkan
+++ b/NetKAN/PhoenixIndustriesCargoResupplySystem.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "x_netkan_license_ok": true,
     "identifier": "PhoenixIndustriesCargoResupplySystem",
     "license": "CC-BY-NC-SA-4.0",
@@ -8,5 +8,7 @@
     "recommends": [
         { "name": "KIS" },
         { "name": "MechJeb2" }
-    ]
+    ],
+	"install"	:	[	{ "find"	:	"CTN"
+						"install_to":	"GameData" } ]
 }

--- a/NetKAN/PhoenixIndustriesCargoResupplySystem.netkan
+++ b/NetKAN/PhoenixIndustriesCargoResupplySystem.netkan
@@ -9,6 +9,6 @@
         { "name": "KIS" },
         { "name": "MechJeb2" }
     ],
-	"install"	:	[	{ "find"	:	"CTN"
+	"install"	:	[	{ "find"	:	"CTN",
 						"install_to":	"GameData" } ]
 }


### PR DESCRIPTION
I wonder if this works... if it does it's amazing.

So currently we have https://github.com/KSP-CKAN/CKAN-meta/pull/528 which added a small and large version of this mod. Both versions are now consolidated into a single package so we can catch it with a .netkan rather than handpackaging. Both old mods provide and conflict with this identifier.

I'm not sure if this will provide and upgradepath though or if old users will have to reinstall. Also names of the parts appears to have changed to accomodate for both being in the same package so the update is most probably craftbreaking.