### PR TITLE
Create CTN.nkan

### DIFF
--- a/NetKAN/CTN
+++ b/NetKAN/CTN
@@ -1,0 +1,17 @@
+
+{ 
+    "spec_version": 1, 
+    "x_netkan_license_ok": true, 
+    "identifier": "CTN", 
+    "license": "CC-BY-NC-SA", 
+    "release_status" : "stable", 
+    "$kref": "#/ckan/kerbalstuff/831", 
+    "recommends": [ 
+        { 
+            "name": "KIS" 
+        }, 
+        {
+            "name": "MechJeb2" 
+        }
+    ]
+}


### PR DESCRIPTION
Created a .nkan file to add Phoenix-Industries-Cargo-Resupply-System v1.5 and replace the old one wherever it is(?)

The nkan has been tested: it parses and generated proper .ckan file, which installs just fine via the GUI CKAN app.  Only question is the name - I named it after the directory in which it installs per the quick guide, but a more descriptive name might be better (PICRS?)  There is also another discussion/pull at https://github.com/KSP-CKAN/NetKAN/pull/1457 , but I am new so Im am unsure how to do this other than by the basic instructions.