### PR TITLE
Adding a forced v to SCANSat

### DIFF
--- a/NetKAN/SCANsat.netkan
+++ b/NetKAN/SCANsat.netkan
@@ -3,6 +3,7 @@
     "identifier"   : "SCANsat",
     "$kref"        : "#/ckan/kerbalstuff/249",
     "license"      : "restricted",
+	"x_netkan_force_v"	:	"true",
 	"recommends": [
         { "name": "Toolbar" },
 		{ "name": "ModuleManager" }


### PR DESCRIPTION
https://github.com/KSP-CKAN/CKAN-meta/issues/563 pointed out that SCANSat 12.1 wasn't in CKAN and although the problem seems to originate from the [NetKAN-bot outage](https://github.com/KSP-CKAN/NetKAN-bot/issues/13) the removal of the v from the version is bound to cause grief down the road so I'm fixing it here, which should also force-index SCANSats latest version.