### PR TITLE
Add HGR.netkan

### DIFF
--- a/NetKAN/HGR.netkan
+++ b/NetKAN/HGR.netkan
@@ -1,0 +1,24 @@
+{
+    "spec_version"   : "v1.4",
+	"$kref"			 : "#/ckan/kerbalstuff/869",
+    "identifier"     : "HGR",
+    "license"        : "restricted",
+    "resources" : {
+        "homepage"     : "http://forum.kerbalspaceprogram.com/threads/60974",
+        "x_curse"      : "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts"
+    },
+    "install" : [
+        {
+            "find"       : "HGR",
+            "filter"     : "Props",
+            "install_to" : "GameData"
+        },
+        {
+            "find"       : "HGR_Redux",
+            "install_to" : "GameData"
+        }
+    ],
+    "depends"  : [
+        { "name" : "HGR-Props" }
+    ]
+}


### PR DESCRIPTION
depends on #1476 

Reusing identifier and install stanza from CKAN-meta where we currently index an earlier version from when this was only available on curse.