### PR TITLE
Epic suits update

### DIFF
--- a/NetKAN/EpicSuits.netkan
+++ b/NetKAN/EpicSuits.netkan
@@ -1,6 +1,5 @@
 {
     "$kref": "#/ckan/kerbalstuff/767",
-    "x_via": "Automated KerbalStuff CKAN submission",
     "identifier": "EpicSuits",
     "spec_version": "v1.4",
     "license": "CC-BY-NC-SA-4.0",
@@ -11,12 +10,7 @@
     ],
     "install": [
         {
-            "file": "epic suits/EVAtexture.png",
-            "install_to": "GameData/TextureReplacer/Default",
-            "filter": ".DS_Store"
-        },
-        {
-            "file": "epic suits/Red shirt and suit",
+            "file": "epic suits/blue shirt and suit",
             "install_to": "GameData/TextureReplacer/Suits",
             "filter": ".DS_Store"
         },
@@ -31,6 +25,21 @@
             "filter": ".DS_Store"
         },
         {
+            "file": "epic suits/gold ish  suit",
+            "install_to": "GameData/TextureReplacer/Suits",
+            "filter": ".DS_Store"
+        },
+        {
+            "file": "epic suits/murica suit",
+            "install_to": "GameData/TextureReplacer/Suits",
+            "filter": ".DS_Store"
+        },
+        {
+            "file": "epic suits/orange shirt and suit",
+            "install_to": "GameData/TextureReplacer/Suits",
+            "filter": ".DS_Store"
+        },
+        {
             "file": "epic suits/orange suit",
             "install_to": "GameData/TextureReplacer/Suits",
             "filter": ".DS_Store"
@@ -41,16 +50,31 @@
             "filter": ".DS_Store"
         },
         {
+            "file": "epic suits/Red shirt and suit",
+            "install_to": "GameData/TextureReplacer/Suits",
+            "filter": ".DS_Store"
+        },
+                {
             "file": "epic suits/red suit",
             "install_to": "GameData/TextureReplacer/Suits",
             "filter": ".DS_Store"
         },
-        {
+                {
+            "file": "epic suits/white shirt and suit",
+            "install_to": "GameData/TextureReplacer/Suits",
+            "filter": ".DS_Store"
+        },
+                {
             "file": "epic suits/white suit",
             "install_to": "GameData/TextureReplacer/Suits",
             "filter": ".DS_Store"
         },
-        {
+                {
+            "file": "epic suits/yellow shirt and suit",
+            "install_to": "GameData/TextureReplacer/Suits",
+            "filter": ".DS_Store"
+        },
+                {
             "file": "epic suits/yellow suit",
             "install_to": "GameData/TextureReplacer/Suits",
             "filter": ".DS_Store"


### PR DESCRIPTION
Never used this mod or TextureReplacer, but I'm taking for granted that the previous .netkan install paths still hold true, this is just that .netkan with new installs for the new folders, and it's in alphabetical order for simplicity in reading.

"epic suits/EVAtexture.png" install removed (file not present in new zip).

Resolves #1483... probably.