### PR TITLE
Added 10 planes and edited another 5 from LuizChacon.

### DIFF
--- a/NetKAN/A6Intruder.netkan
+++ b/NetKAN/A6Intruder.netkan
@@ -4,7 +4,8 @@
     "spec_version": 1,
     "identifier": "A6Intruder",
 	"depends"	:	[ { "name" : "AdjustableLandingGear" },
-					{ "name" : "BDArmory" } ],
+					{ "name" : "BDArmory" },
+                    { "name": "AircraftIVAHelmet"}],
 	"install"	:	[ { "file" : "A6Intruder",
 						"install_to" : "GameData" } ]
 }

--- a/NetKAN/A7Corsair2.netkan
+++ b/NetKAN/A7Corsair2.netkan
@@ -4,7 +4,8 @@
     "license": "GPL-3.0",
     "identifier": "A7Corsair2",
     "depends": [
-        { "name" : "AdjustableLandingGear" }
+        { "name" : "AdjustableLandingGear" },
+        { "name": "AircraftIVAHelmet"}
     ],
     "suggests": [
         { "name" : "BDArmory" }

--- a/NetKAN/A7Corsair2.netkan
+++ b/NetKAN/A7Corsair2.netkan
@@ -1,7 +1,7 @@
 {
     "$kref": "#/ckan/kerbalstuff/810",
     "spec_version": "v1.2",
-    "license": "GPL-3.0",
+    "license": "WTFPL",
     "identifier": "A7Corsair2",
     "depends": [
         { "name" : "AdjustableLandingGear" },

--- a/NetKAN/AV8HarrierWITHTRUEVTOLFlight.netkan
+++ b/NetKAN/AV8HarrierWITHTRUEVTOLFlight.netkan
@@ -13,7 +13,7 @@
 
     "install": [
         {
-            "file"       : "Av8c",
+            "file"       : "Av8C",
             "install_to" : "GameData"
         }
     ]

--- a/NetKAN/AV8HarrierWITHTRUEVTOLFlight.netkan
+++ b/NetKAN/AV8HarrierWITHTRUEVTOLFlight.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
-    "$kref": "#/ckan/kerbalstuff/848",
-    "identifier": "F117",
+    "$kref": "#/ckan/kerbalstuff/877",
+    "identifier": "AV8HarrierWITHTRUEVTOLFlight",
     "license": "WTFPL",
    
     "depends": [
@@ -10,7 +10,11 @@
         { "name": "BahamutoDynamicsPartsPack"},
         { "name": "AircraftIVAHelmet"}
     ],
-	
-	"install":	[ { "file" : "F117",
-					"install_to" : "GameData" } ]
+
+    "install": [
+        {
+            "file"       : "Av8c",
+            "install_to" : "GameData"
+        }
+    ]
 }

--- a/NetKAN/AircraftIVAHelmet.netkan
+++ b/NetKAN/AircraftIVAHelmet.netkan
@@ -1,0 +1,13 @@
+{
+    "spec_version": 1,
+    "$kref": "#/ckan/kerbalstuff/872",
+    "identifier": "AircraftIVAHelmet",
+    "license": "WTFPL",
+
+    "install": [
+        {
+            "file"       : "Cockpit",
+            "install_to" : "GameData"
+        }
+    ]
+}

--- a/NetKAN/EF2000EuroFighter.netkan
+++ b/NetKAN/EF2000EuroFighter.netkan
@@ -14,8 +14,7 @@
         {
             "file"       : "EuroFighter2000",
             "install_to" : "GameData",
-            "filter"     : "Cockpit",
-            "filter"     : "Thumbs.db"
+            "filter"     : [ "Cockpit", "Thumbs.db" ]
         }
     ]
 }

--- a/NetKAN/EF2000EuroFighter.netkan
+++ b/NetKAN/EF2000EuroFighter.netkan
@@ -1,0 +1,21 @@
+{
+    "spec_version": 1,
+    "$kref": "#/ckan/kerbalstuff/860",
+    "identifier": "EF2000EuroFighter",
+    "license": "WTFPL",
+   
+    "depends": [
+        { "name": "FirespitterCore" },
+        { "name": "BahamutoDynamicsPartsPack"},
+        { "name": "AircraftIVAHelmet"}
+    ],
+
+    "install": [
+        {
+            "file"       : "EuroFighter2000",
+            "install_to" : "GameData",
+            "filter"     : "Cockpit",
+            "filter"     : "Thumbs.db"
+        }
+    ]
+}

--- a/NetKAN/F14CTomcat.netkan
+++ b/NetKAN/F14CTomcat.netkan
@@ -7,7 +7,8 @@
     "depends": [
         { "name": "FirespitterCore" },
         { "name": "BDArmory" },
-        { "name": "BahamutoDynamicsPartsPack"}
+        { "name": "BahamutoDynamicsPartsPack"},
+        { "name": "AircraftIVAHelmet"}
     ],
    "install":	[ { "file" : "F14CTomcat",
 					"install_to" : "GameData" } ]

--- a/NetKAN/F15DCStrikeEagle.netkan
+++ b/NetKAN/F15DCStrikeEagle.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
-    "$kref": "#/ckan/kerbalstuff/848",
-    "identifier": "F117",
+    "$kref": "#/ckan/kerbalstuff/870",
+    "identifier": "F15DCStrikeEagle",
     "license": "WTFPL",
    
     "depends": [
@@ -10,7 +10,12 @@
         { "name": "BahamutoDynamicsPartsPack"},
         { "name": "AircraftIVAHelmet"}
     ],
-	
-	"install":	[ { "file" : "F117",
-					"install_to" : "GameData" } ]
+
+    "install": [
+        {
+            "file"       : "F_15D",
+            "install_to" : "GameData",
+            "filter"     : "Thumbs.db"
+        }
+    ]
 }

--- a/NetKAN/F16FightingFalcon.netkan
+++ b/NetKAN/F16FightingFalcon.netkan
@@ -1,0 +1,26 @@
+{
+    "spec_version": 1,
+    "$kref": "#/ckan/kerbalstuff/854",
+    "identifier": "F16FightingFalcon",
+    "license": "WTFPL",
+   
+    "depends": [
+        { "name": "FirespitterCore" },
+        { "name": "BahamutoDynamicsPartsPack"},
+        { "name": "AircraftIVAHelmet"}
+    ],
+    
+    "recommends": [
+        { "name": "BDArmory" },
+        { "name": "AdjustableLandingGear"},
+        { "name": "AviationLights"}
+    ],
+    
+    "install": [
+        {
+            "file"       : "F16C_Falcon",
+            "install_to" : "GameData",
+            "filter"     : "Thumbs.db"
+        }
+    ]
+}

--- a/NetKAN/F18ASuperHornet.netkan
+++ b/NetKAN/F18ASuperHornet.netkan
@@ -3,8 +3,9 @@
     "license"	:	"WTFPL",
     "spec_version": "v1.2",
     "identifier": "F18ASuperHornet",
-	"depends"	:	[ { "name"	:	"AdjustableLandingGear" } ],
+	"depends"	:	[ { "name"	:	"AdjustableLandingGear" }, { "name": "AircraftIVAHelmet"} ],
 	"recommends"	:	[ { "name" : "BDArmory" } ],
 	"install"		:	[ { "file"	:	"F18A_Hornet",
-							"install_to" : "GameData" } ]
+							"install_to" : "GameData",
+                            "filter"     : "Thumbs.db" } ]
 }

--- a/NetKAN/F22Lightning2OrRaptor.netkan
+++ b/NetKAN/F22Lightning2OrRaptor.netkan
@@ -1,0 +1,21 @@
+{
+    "spec_version": 1,
+    "$kref": "#/ckan/kerbalstuff/852",
+    "identifier": "F22Lightning2OrRaptor",
+    "license": "WTFPL",
+   
+    "depends": [
+        { "name": "FirespitterCore" },
+        { "name": "BahamutoDynamicsPartsPack"},
+        { "name": "AdjustableLandingGear"},
+        { "name": "AircraftIVAHelmet"}
+    ],
+
+    "install": [
+        {
+            "file"       : "F22Lightning2",
+            "install_to" : "GameData",
+            "filter"     : "Thumbs.db"
+        }
+    ]
+}

--- a/NetKAN/F35BSTOLStealthMultiroleFighter.netkan
+++ b/NetKAN/F35BSTOLStealthMultiroleFighter.netkan
@@ -1,0 +1,21 @@
+{
+    "spec_version": 1,
+    "$kref": "#/ckan/kerbalstuff/881",
+    "identifier": "F35BSTOLStealthMultiroleFighter",
+    "license": "WTFPL",
+   
+    "depends": [
+        { "name": "FirespitterCore" },
+        { "name": "BDArmory" },
+        { "name": "BahamutoDynamicsPartsPack"},
+        { "name": "AircraftIVAHelmet"}
+    ],
+
+    "install": [
+        {
+            "file"       : "F35Lightning2",
+            "install_to" : "GameData",
+            "filter"     : "Thumbs.db"
+        }
+    ]
+}

--- a/NetKAN/FairchildRepublicA10Warthog.netkan
+++ b/NetKAN/FairchildRepublicA10Warthog.netkan
@@ -1,0 +1,20 @@
+{
+    "spec_version": 1,
+    "$kref": "#/ckan/kerbalstuff/853",
+    "identifier": "FairchildRepublicA10Warthog",
+    "license": "WTFPL",
+   
+    "depends": [
+        { "name": "BDArmory" },
+        { "name": "BahamutoDynamicsPartsPack"},
+        { "name": "AircraftIVAHelmet"}
+    ],
+
+    "install": [
+        {
+            "file"       : "A10C_Warthog_Plane",
+            "install_to" : "GameData",
+            "filter"     : "Thumbs.db"
+        }
+    ]
+}

--- a/NetKAN/MIG29Fulcrum.netkan
+++ b/NetKAN/MIG29Fulcrum.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version": 1,
-    "$kref": "#/ckan/kerbalstuff/848",
-    "identifier": "F117",
+    "$kref": "#/ckan/kerbalstuff/876",
+    "identifier": "MIG29Fulcrum",
     "license": "WTFPL",
    
     "depends": [
@@ -10,7 +10,12 @@
         { "name": "BahamutoDynamicsPartsPack"},
         { "name": "AircraftIVAHelmet"}
     ],
-	
-	"install":	[ { "file" : "F117",
-					"install_to" : "GameData" } ]
+
+    "install": [
+        {
+            "file"       : "MIG29",
+            "install_to" : "GameData",
+            "filter"     : "Thumbs.db"
+        }
+    ]
 }

--- a/NetKAN/SukhoiSU27Flanker.netkan
+++ b/NetKAN/SukhoiSU27Flanker.netkan
@@ -1,0 +1,21 @@
+{
+    "spec_version": 1,
+    "$kref": "#/ckan/kerbalstuff/882",
+    "identifier": "SukhoiSU27Flanker",
+    "license": "WTFPL",
+   
+    "depends": [
+        { "name": "FirespitterCore" },
+        { "name": "BDArmory" },
+        { "name": "BahamutoDynamicsPartsPack"},
+        { "name": "AircraftIVAHelmet"}
+    ],
+
+    "install": [
+        {
+            "file"       : "SU27FLANKER",
+            "install_to" : "GameData",
+            "filter"     : "Thumbs.db"
+        }
+    ]
+}


### PR DESCRIPTION
AircraftIVAHelmet depend added to all planes from this author as, according to https://kerbalstuff.com/mod/872/Aircraft%20IVA%20Helmet it's unclear *which* planes actually require it.

Some KS pages for these mods don't explicitly state any dependencies, though from the screenshots they seem to use the same parts, therefore planes with no explicit dependencies will have the "Standard 4" dependencies of FirespitterCore, BDArmory, BahamutoDynamicsPartsPack, and AircraftIVAHelmet.

All mods licensed under WTFPL as per http://kscsm.freeforums.net/thread/20/question-licenses-dependencies-ckan-indexing

Closes #1441 - Depends per KS page
Closes #1442 - Depends per KS page
Closes #1448 - Depends per KS page
Closes #1456 - Filtered cockpit from archive, added depend to AircraftIVAHelmet
Closes #1470 - No depends listed, added Standard 4
Closes #1479 - No depends listed, added Standard 4
Closes #1472 - AircraftIVAHelmet
Closes #1486 - No depends listed, added Standard 4
Closes #1491 - No depends listed, added Standard 4
Closes #1495 - No depends listed, added Standard 4