### PR TITLE
Use explicit asset_match for StockBugFixModules

### DIFF
--- a/NetKAN/StockBugFixModules.netkan
+++ b/NetKAN/StockBugFixModules.netkan
@@ -1,13 +1,14 @@
 {
     "spec_version"   : 1,
     "identifier"     : "StockBugFixModules",
-    "$kref"          : "#/ckan/github/ClawKSP/KSP-Stock-Bug-Fix-Modules",
+    "$kref"          : "#/ckan/github/ClawKSP/KSP-Stock-Bug-Fix-Modules/asset_match/StockBugFixModules.*?\\.zip",
     "name"           : "Stock Bug Fix Modules",
     "abstract"       : "Stand alone fixes for common stock KSP bugs",
     "license"        : "CC-BY-NC-SA-4.0",
     "ksp_version"    : "1.0",
     "resources" : {
-        "homepage" : "http://forum.kerbalspaceprogram.com/threads/97285"
+        "homepage" : "http://forum.kerbalspaceprogram.com/threads/97285",
+        "repository" : "https://github.com/ClawKSP/KSP-Stock-Bug-Fix-Modules"
     },
     "install": [
         {


### PR DESCRIPTION
Now that StockBugFixModules distributes two zip files in its releases, let's be explicit about which one to use.

Also, hardcode `repository` due to KSP-CKAN/CKAN#1075.
