### PR TITLE
Bump epoch of RandSCapsuledyne

### DIFF
--- a/NetKAN/RandSCapsuledyne.netkan
+++ b/NetKAN/RandSCapsuledyne.netkan
@@ -5,6 +5,7 @@
     "$kref"        : "#/ckan/kerbalstuff/13",
     "author"       : [ "jnrobinson", "bsquiklehausen" ],
     "license"      : "CC-BY-SA-3.0",
+    "x_netkan_epoch" : "1",
     "install" : [
         {
             "file"       : "GameData/RSCapsuledyne",


### PR DESCRIPTION
CKAN thinks that the 1.5.01 version of this mod is higher than 1.5.1, or atleast it reports the incorrect version as newest.

`ckan compare 1.5.1 1.5.01` and `ckan compare 1.5.01 1.5.1` both give `-1` as output so something if afoot, but this should solve it and stop causing grief to the author.