### PR TITLE
Update RealSolarSystem.netkan

### DIFF
--- a/NetKAN/RealSolarSystem.netkan
+++ b/NetKAN/RealSolarSystem.netkan
@@ -12,7 +12,6 @@
         { "name" : "RSSTextures" }
     ],
     "recommends" : [
-        { "name" : "CustomBiomes-Data-RSS" },
         { "name" : "RealismOverhaul" },
         { "name" : "Toolbar" }
     ],

--- a/NetKAN/RealSolarSystem.netkan
+++ b/NetKAN/RealSolarSystem.netkan
@@ -1,6 +1,6 @@
 {
-    "spec_version"   : 1,
-    "$kref"          : "#/ckan/github/NathanKell/RealSolarSystem",
+    "spec_version"   : "v1.4",
+    "$kref"          : "#/ckan/github/KSP-RO/RealSolarSystem",
     "$vref"          : "#/ckan/ksp-avc",
     "name"           : "Real Solar System",
     "identifier"     : "RealSolarSystem",
@@ -8,9 +8,8 @@
     "license"        : "CC-BY-NC-SA",
     "release_status" : "stable",
     "depends" : [
-        { "name" : "RSSTextures" },
-        { "name" : "DDSLoader" },
-        { "name" : "ModuleManager", "min_version" : "2.5.0" }
+		{ "name" : "Kopernicus" },
+        { "name" : "RSSTextures" }
     ],
     "recommends" : [
         { "name" : "CustomBiomes-Data-RSS" },
@@ -25,8 +24,12 @@
     },
     "install" : [
         {
-            "file"       : "RealSolarSystem",
+            "find"       : "RealSolarSystem",
             "install_to" : "GameData"
-        }
+        },
+		{
+			"find"		 : "Cache",
+			"install_to" : "GameData/Kopernicus"
+		}
     ]
 }


### PR DESCRIPTION
:warning: DO NOT MERGE :warning: 

This should not be merged until RSS10 is out! Else we'll retroactively overwrite the latest 0.90 RSS version over in CKAN-meta.

Accomodating the changes seen in the RSS pre-release found [here](http://forum.kerbalspaceprogram.com/threads/55145-0-90-Real-Solar-System-v8-6-1-Mar-30?p=1999650&viewfull=1#post1999650).

ModuleManager removed as a depdency since Kopernicus depends on it and therefore RSS implicitly does when depending on Kopernicus. Not sure if this is the best practice though.

Switched to the new RSS repository over at KSP-RO.

Not sure what to do with the [`Custombiomes-Data-RSS`](https://github.com/KSP-CKAN/CKAN-meta/tree/master/CustomBiomes-Data-RSS) and [`RemoteTech-Config-RSS`](https://github.com/KSP-CKAN/CKAN-meta/tree/master/RemoteTech-Config-RSS). Currently the ones in CKAN-meta are marked for `"ksp_version" : "any"` but I doubt very much that they work for this release of RSS? Are they even supposed to still be in this netkan? @NathanKell can probably answer that.

It seems we index `CustomBiomes-Data-RSS` directly from the older RSS releases but at least the pre-release for RSS10 no longer has it. `RemoteTech-Config-RSS` seems to have been handpackaged and derived from RO.