### PR TITLE
Add rss textures

### DIFF
--- a/NetKAN/RSSTextures2048.netkan
+++ b/NetKAN/RSSTextures2048.netkan
@@ -14,6 +14,6 @@
     ],
 	
 	"install"		:	[ 
-		{ "find" : "RSS-Textures"
+		{ "find" : "RSS-Textures",
 		"install_to" : "GameData" } ]
 }

--- a/NetKAN/RSSTextures2048.netkan
+++ b/NetKAN/RSSTextures2048.netkan
@@ -1,0 +1,19 @@
+{
+	"spec_version"	:	"v1.4",
+	"license"		:	"CC-BY-NC-SA",
+	"name"			:	"Real Solar System Textures - 2048 x 1024",
+	"identifier"	:	"RSSTextures2048",
+	"$kref"			:	"#/ckan/github/KSP-RO/RSS-Textures/asset_match/2048",
+    "abstract"		:	"Textures for Real Solar Systems",
+	"ksp_version"	:	"1.0",
+	"release_status":	"stable",
+	"resources"		:	{ "repository" : "https://github.com/KSP-RO/RSS-Textures" },
+	"provides"		:	[ "RSSTextures" ],
+    "conflicts"		:	[
+        { "name" : "RSSTextures" }
+    ],
+	
+	"install"		:	[ 
+		{ "find" : "RSS-Textures"
+		"install_to" : "GameData" } ]
+}

--- a/NetKAN/RSSTextures4096.netkan
+++ b/NetKAN/RSSTextures4096.netkan
@@ -14,6 +14,6 @@
     ],
 	
 	"install"		:	[ 
-		{ "find" : "RSS-Textures"
+		{ "find" : "RSS-Textures",
 		"install_to" : "GameData" } ]
 }

--- a/NetKAN/RSSTextures4096.netkan
+++ b/NetKAN/RSSTextures4096.netkan
@@ -1,0 +1,19 @@
+{
+	"spec_version"	:	"v1.4",
+	"license"		:	"CC-BY-NC-SA",
+	"name"			:	"Real Solar System Textures - 4096 x 2048",
+	"identifier"	:	"RSSTextures4096",
+	"$kref"			:	"#/ckan/github/KSP-RO/RSS-Textures/asset_match/4096",
+    "abstract"		:	"Textures for Real Solar Systems",
+	"ksp_version"	:	"1.0",
+	"release_status":	"stable",
+	"resources"		:	{ "repository" : "https://github.com/KSP-RO/RSS-Textures" },
+	"provides"		:	[ "RSSTextures" ],
+    "conflicts"		:	[
+        { "name" : "RSSTextures" }
+    ],
+	
+	"install"		:	[ 
+		{ "find" : "RSS-Textures"
+		"install_to" : "GameData" } ]
+}

--- a/NetKAN/RSSTextures8192.netkan
+++ b/NetKAN/RSSTextures8192.netkan
@@ -14,6 +14,6 @@
     ],
 	
 	"install"		:	[ 
-		{ "find" : "RSS-Textures"
+		{ "find" : "RSS-Textures",
 		"install_to" : "GameData" } ]
 }

--- a/NetKAN/RSSTextures8192.netkan
+++ b/NetKAN/RSSTextures8192.netkan
@@ -1,0 +1,19 @@
+{
+	"spec_version"	:	"v1.4",
+	"license"		:	"CC-BY-NC-SA",
+	"name"			:	"Real Solar System Textures - 8192 x 4096",
+	"identifier"	:	"RSSTextures8192",
+	"$kref"			:	"#/ckan/github/KSP-RO/RSS-Textures/asset_match/8192",
+    "abstract"		:	"Textures for Real Solar Systems",
+	"ksp_version"	:	"1.0",
+	"release_status":	"stable",
+	"resources"		:	{ "repository" : "https://github.com/KSP-RO/RSS-Textures" },
+	"provides"		:	[ "RSSTextures" ],
+    "conflicts"		:	[
+        { "name" : "RSSTextures" }
+    ],
+	
+	"install"		:	[ 
+		{ "find" : "RSS-Textures"
+		"install_to" : "GameData" } ]
+}


### PR DESCRIPTION
These have previously been manually indexed but are now up for grabs here on GitHub \o/

Having never used asset_match before I'm not sure these are correct in all ways but "Works on my machine (TM)"

While making these I noticed the ones over in CKAN-meta are rather malformed and also have `"ksp_version" : "any"` so I'll head over there and slap a _max onto them and confine them to 0.90 since these new ones take over from there.

There are no distinct DDS texturepacks anymore since KSP is all about DDS now, I've therefore elected to use the identifiers `RSSTextures*` rather than `RSSTexturesDDS*` and hope that is acceptable for all parties.