### PR TITLE
Update NearFuturePropulsion.netkan

### DIFF
--- a/NetKAN/NearFuturePropulsion.netkan
+++ b/NetKAN/NearFuturePropulsion.netkan
@@ -5,13 +5,14 @@
 
     "depends": [
         { "name": "ModuleManager" },
+        { "name": "CommunityResourcePack" },
         { "name": "CrossFeedEnabler" }
     ],
     
     "suggests": [
         { "name" : "CommunityTechTree" },
-		{ "name" : "NearFuturePropulsionExtras"}
+	{ "name" : "NearFuturePropulsionExtras"}
     ],
-    "license" : "CC-BY-NC-SA-3.0"
+    "license" : "CC-BY-NC-SA-4.0"
 
 }


### PR DESCRIPTION
Added Community Resource Pack, per the install instructions on KerbalStuff.  
Updated the file extension to .netkan so the buildbot will catch it.
Updated license to match KerbalStuff

Assuming nothing else has changed, this installation should work.