### PR TITLE
Adding Sigma Mod Expansion

### DIFF
--- a/NetKAN/OuterPlanetsMod.netkan
+++ b/NetKAN/OuterPlanetsMod.netkan
@@ -5,7 +5,8 @@
   "license": "CC-BY-NC-SA-4.0",
   "depends": [
     { "name" : "ModuleManager" },
-    { "name" : "Kopernicus" }
+    { "name" : "Kopernicus" },
+    { "name" : "Wal" }
   ],
   "conflicts": [
     { "name": "CustomBiomes" },
@@ -39,7 +40,7 @@
   ],
   "install" : [
     { "find": "OPM", "install_to" : "GameData" },
-    { "find": "Kopernicus", "install_to": "GameData" },
+    { "find": "Kopernicus", "install_to": "GameData", "filter": "Wal.bin" },
     { "find": "TextureReplacer", "install_to" : "GameData" }
   ]
 }

--- a/NetKAN/SigmaModExpansions.netkan
+++ b/NetKAN/SigmaModExpansions.netkan
@@ -1,0 +1,25 @@
+{
+    "spec_version": 1,
+    "identifier": "SigmaModExpansions",
+    "$kref": "#/ckan/kerbalstuff/816",
+    "$vref" : "#/ckan/ksp-avc",
+    "license": "CC-BY-NC-SA-4.0",
+    
+    "depends": [
+        { "name" : "OuterPlanetsMod" },
+        { "name" : "Wal-SME" }
+    ],
+    
+    "install": [
+        {
+            "file"       : "GameData/Kopernicus",
+            "install_to" : "GameData",
+            "filter"    :  "Wal.bin"
+        },
+        {
+            "file"       : "GameData/Sigma",
+            "install_to" : "GameData"
+        }
+    ]
+}
+

--- a/NetKAN/SigmaModExpansions.netkan
+++ b/NetKAN/SigmaModExpansions.netkan
@@ -6,8 +6,8 @@
     "license": "CC-BY-NC-SA-4.0",
     
     "depends": [
-        { "name" : "OuterPlanetsMod" },
-        { "name" : "Wal-SME" }
+        { "name" : "Wal-SME" },
+        { "name" : "OuterPlanetsMod" }
     ],
     
     "install": [

--- a/NetKAN/Wal-OPM.netkan
+++ b/NetKAN/Wal-OPM.netkan
@@ -3,7 +3,8 @@
     "identifier": "Wal-OPM",
     "$kref": "#/ckan/kerbalstuff/437",
     "license": "CC-BY-NC-SA-4.0",
-    "abstract": "This is the Outer Planets Mod version of the planet Wal.",
+    "name": "Outer Planets Mod - Planet Wal",
+    "abstract": "This is the Outer Planets Mod version of the planet Wal. This should only be installed/removed if you're getting conflicts with the Sigma Mod Expansions version of the planet Wal.",
 
     "depends": [
         { "name" : "OuterPlanetsMod" }

--- a/NetKAN/Wal-OPM.netkan
+++ b/NetKAN/Wal-OPM.netkan
@@ -1,0 +1,24 @@
+{
+    "spec_version": "v1.2",
+    "identifier": "Wal-OPM",
+    "$kref": "#/ckan/kerbalstuff/437",
+    "license": "CC-BY-NC-SA-4.0",
+    "abstract": "This is the Outer Planets Mod version of the planet Wal.",
+
+    "depends": [
+        { "name" : "OuterPlanetsMod" }
+    ],
+
+    "conflicts": [
+        { "name": "Wal" }
+    ],
+
+    "provides": [ "Wal" ],
+
+    "install": [
+        { 
+            "file"       : "GameData/Kopernicus/Cache/Wal.bin",
+            "install_to" : "GameData/Kopernicus/Cache"
+        }
+    ]
+}

--- a/NetKAN/Wal-SME.netkan
+++ b/NetKAN/Wal-SME.netkan
@@ -1,0 +1,24 @@
+{
+    "spec_version": "v1.2",
+    "identifier": "Wal-SME",
+    "$kref": "#/ckan/kerbalstuff/816",
+    "license": "CC-BY-NC-SA-4.0",
+    "abstract": "This is the Sigma Mod Expansions version of the planet Wal.",
+
+    "depends": [
+        { "name" : "SigmaModExpansions" }
+    ],
+
+    "conflicts": [
+        { "name": "Wal" }
+    ],
+
+    "provides": [ "Wal" ],
+
+    "install": [
+        {
+            "file"       : "GameData/Kopernicus/Cache/Wal.bin",
+            "install_to" : "GameData/Kopernicus/Cache"
+        }
+    ]
+}

--- a/NetKAN/Wal-SME.netkan
+++ b/NetKAN/Wal-SME.netkan
@@ -3,7 +3,8 @@
     "identifier": "Wal-SME",
     "$kref": "#/ckan/kerbalstuff/816",
     "license": "CC-BY-NC-SA-4.0",
-    "abstract": "This is the Sigma Mod Expansions version of the planet Wal.",
+    "name": "Sigma Mod Expansions - Planet Wal",
+    "abstract": "This is the Sigma Mod Expansions version of the planet Wal. This should only be installed/removed if you're getting conflicts with the Outer Planet Mod version of the planet Wal.",
 
     "depends": [
         { "name" : "SigmaModExpansions" }


### PR DESCRIPTION
My attempt to resolve #1309.

@Sigma88 As your archive currently exists, your flags can't be included. CKAN can't handle a .zip inside a .zip. If you put them in a folder, we'd be happy to adjust the install to include them.

The only conflict between Outer Planet Mod (OPM) and Sigma Mod Expansion (SME) is GameData/Kopernicus/Cache/Wal.bin. So I have both mods filter it from their install.

I don't think there's a way around splitting OPM into core and the planet, but I see 2 ways to solve the issue for SME. SME could "provide" "Wal" or I could split SME into its core and the planet. I chose the latter for better readability when people install OPM and need to choose which mod provides "Wal". (It would look weird to choose between a full mod and a mod that only includes a planet)

I have SME explicitly depending on SME-Wal so that it highlights the conflict if OPM is already installed (since OPM-Wal provides "Wal"). The drawback is that if someone wants OPM's Wal with SME installed, that can't be accommodated. To help with that/obscure that, the order of the depends explicitly has SME-Wal first (if the order is reversed, the client will try to fulfill OPM's dependency on Wal first and thus give the user the option).

Paging @politas because you wanted to see how the issue might be solved.