### PR TITLE
Preparing AdvancedJetEngine.netkan for new version

### DIFF
--- a/NetKAN/AdvancedJetEngine.netkan
+++ b/NetKAN/AdvancedJetEngine.netkan
@@ -5,7 +5,8 @@
     "spec_version": "v1.4",
 	"depends" : [
         { "name" : "FerramAerospaceResearch" },
-        { "name" : "ModuleManager" }
+        { "name" : "ModuleManager" },
+        { "name" : "SolverEngines" }
     ],
     "recommends" : [
         { "name" : "RealFuels" },


### PR DESCRIPTION
This basically reverts #1552 and adds the dependency listed in #1451

This PR must *NOT* be merged until the new AJE version is out since we'll otherways end up writing this new dependency to the latest 0.90 version in CKAN-meta which would be incorrect.

Once new AJE hits the market just do a #rebuild to see if everything checks out and then merge this :)