### PR TITLE
Add conflicts to space station contract packs

### DIFF
--- a/NetKAN/ContractConfigurator-KerbinSpaceStation.netkan
+++ b/NetKAN/ContractConfigurator-KerbinSpaceStation.netkan
@@ -13,6 +13,11 @@
         },
         { "name" : "ModuleManager" }
     ],
+    "conflicts" : [
+        {
+            "name" : "ContractConfigurator-UsefulSpaceStations"
+        }
+    ],
     "install" : [
         {
             "find" : "KerbinSpaceStation",

--- a/NetKAN/ContractConfigurator-UsefulSpaceStations.netkan
+++ b/NetKAN/ContractConfigurator-UsefulSpaceStations.netkan
@@ -13,6 +13,11 @@
         },
         { "name" : "ModuleManager" }
     ],
+    "conflicts" : [
+        {
+            "name" : "ContractConfigurator-KerbinSpaceStation"
+        }
+    ],
     "install" : [
         {
             "find" : "UsefulSpaceStations",


### PR DESCRIPTION
Quote from the author on being asked about installing both.

> I wouldn't recommend it - as they are now, CC would complain that you've got 2 contracts with the same name. You could workaround, and make them work together, but there would not be much point.

http://forum.kerbalspaceprogram.com/threads/113642-1-0-2-Severedsolo-s-Space-Station-Contract-Packs?p=2006147&viewfull=1#post2006147