### PR TITLE
Update StockPlugins

### DIFF
--- a/NetKAN/StockPlugins.netkan
+++ b/NetKAN/StockPlugins.netkan
@@ -3,52 +3,20 @@
 	"identifier" : "StockPlugins",
 	"$kref" : "#/ckan/kerbalstuff/402",
 	"license": "public-domain",
-	"install": [
-	{
-		"file" : "GameData/KerbalEngineer_Stock",
-		"install_to" : "GameData"
-	},
-	{
-		"file" : "GameData/KerbalGPS_Stock",
-		"install_to" : "GameData"
-	},
-	{
-		"file" : "GameData/Kerbaltek_Stock",
-		"install_to" : "GameData"
-	},
-	{
-		"file" : "GameData/kOS_Stock",
-		"install_to" : "GameData"
-	},
-	{
-		"file" : "GameData/MechJeb2_Stock",
-		"install_to" : "GameData"
-	},
-	{
-		"file" : "GameData/Protractor_Stock",
-		"install_to" : "GameData"
-	}
-	],
-	"depends": [
-	{
-		"name": "ModuleManager"
-	}
-	],
-	"suggests": [
-	{
-		"name": "StockRT"
-	},
-	{
-		"name": "KerbalEngineerRedux"
-	},
-	{
-		"name": "kOS"
-	},
-	{
-		"name": "MechJeb2"
-	},
-	{
-		"name": "Protractor"
-	}
-	]
+    	"resources": {
+        	"homepage": "http://forum.kerbalspaceprogram.com/threads/99869",
+        	"repository": "https://github.com/malahx/StockPlugins"
+    	},
+    	"depends": [
+		{ "name": "ModuleManager", "min_version": "2.6.0" }
+    	],
+	 "suggests": [
+        	{ "name": "DeadlyReentry" },
+        	{ "name": "Graphotron" },
+        	{ "name": "KerbalEngineerRedux" },
+        	{ "name": "kOS" },
+        	{ "name": "MechJeb2" },
+        	{ "name": "Protractor" },
+        	{ "name": "Telemachus" }
+    ]
 }


### PR DESCRIPTION
Hello, I've changed the folders of StockPlugins and it needs an update on CKAN.
But I don't know which version of spec_version I need to put, I let it to what it was before ;)

#### Changelog

v1.10 - 2015.06.09
* New: Added support of DeadlyReentry,
* Fix: Merged all folders to keep only one folder "StockPlugins",
* Fix: Tweaked the MM syntax,
* Optional: Added an optional version of Stock DeadlyReentry to keep the DeadlyReentry parts and block the Stock HeatShields,
* Optional: Added an optional version of Stock MechJeb which enable all MechJeb function at the start of a Career,
* Update ModuleManager to 2.6.5,
* /!\ for this update you need to delete all the old folders of StockPlugins: Telemachus_Stock, Protractor_Stock, MechJeb2_Stock, kOS_Stock, Kerbaltek_Stock, KerbalGPS_Stock and KerbalEngineer_Stock.