### PR TITLE
Update RealFuels.netkan

### DIFF
--- a/NetKAN/RealFuels.netkan
+++ b/NetKAN/RealFuels.netkan
@@ -26,7 +26,6 @@
         { "name" : "ModularFuelSystem" },
         { "name" : "ModularFuelTanks"  },
         { "name" : "InterstellarFuelSwitch" },
-        { "name" : "InterstellarFuelSwitch-Core" },
         { "name" : "Fuelswitchtoeverytank" },
         { "name" : "StockFuelSwitch" }
     ],

--- a/NetKAN/RealFuels.netkan
+++ b/NetKAN/RealFuels.netkan
@@ -24,7 +24,11 @@
     ],
     "conflicts" : [
         { "name" : "ModularFuelSystem" },
-        { "name" : "ModularFuelTanks"  }
+        { "name" : "ModularFuelTanks"  },
+        { "name" : "InterstellarFuelSwitch" },
+        { "name" : "InterstellarFuelSwitch-Core" },
+        { "name" : "Fuelswitchtoeverytank" },
+        { "name" : "StockFuelSwitch" }
     ],
     "recommends" : [
         { "name" : "CrossFeedEnabler" }


### PR DESCRIPTION
Just saw it mentioned on irc that RealFuels collides with the various fuelswitches out there. I think I got all of them. RF does not collide with `FirespitterCore`, only with stuff adding FSFuelswitch to various things. Also I'm sure _something_ in `RealismOverhaul` somehow need `FirespitterCore` so conflicting with it seems unwise.