### PR TITLE
Update ContractConfigurator-GrandTours.netkan

### DIFF
--- a/NetKAN/ContractConfigurator-GrandTours.netkan
+++ b/NetKAN/ContractConfigurator-GrandTours.netkan
@@ -4,6 +4,7 @@
     "$kref"          : "#/ckan/kerbalstuff/689",
     "release_status" : "stable",
     "x_netkan_license_ok" : true,
+    "x_netkan_epoch" : "1",
     "resources" : {
         "homepage"    : "http://forum.kerbalspaceprogram.com/threads/113400",
         "kerbalstuff" : "https://kerbalstuff.com/mod/689/Contract%20Pack:%20Grand%20Tours",


### PR DESCRIPTION
Adding an epoch because the versioning broke when the author put the former version up on KS as 1.0.6 rather than 0.1.6 making the newest version 0.1.7 not show up as the latest one in CKAN.