### PR TITLE
Create SDHI-SharedAssets.netkan

### DIFF
--- a/NetKAN/SDHI-ServiceModuleSystem.netkan
+++ b/NetKAN/SDHI-ServiceModuleSystem.netkan
@@ -5,7 +5,7 @@
     "name"         : "Sum Dum Heavy Industries - Service Module System",
     "abstract"     : "Service Module and accessories designed specifically for use with the stock Mk1-2 Command Pod, vaguely resembling NASA's Orion MPCV. May or may not have a convincing stockalike appearance.",
     "license"      : "CC-BY-SA-4.0",
-    "ksp_version"  : "1.0",
+    "ksp_version"  : "0.90",
     "resources"    : {
         "homepage"   : "http://forum.kerbalspaceprogram.com/threads/52362",
         "repository" : "https://github.com/sumghai/SDHI_ServiceModuleSystem"
@@ -13,22 +13,31 @@
     "install": [
       {
         "file": "GameData/SDHI",
+<<<<<<< HEAD
         "install_to": "GameData",
         "filter" : [
                "Agencies"
         ]
+=======
+        "install_to": "GameData"
+>>>>>>> parent of fea2dc6... Update SDHI SMS
       }
     ],
     "depends"      : [
         { "name" : "AnimatedDecouplers" },
         { "name" : "ModuleManager" },
+<<<<<<< HEAD
         { "name" : "RealChute" },
         { "name" : "SDHI-SharedAssets" },
+=======
+        { "name" : "RealChute" }
+>>>>>>> parent of fea2dc6... Update SDHI SMS
     ],
     "suggests"     : [
         { "name" : "DeadlyReentry" },
         { "name" : "FerramAerospaceResearch" },
         { "name" : "HotRockets" },
+        { "name" : "NodeResizer" },
         { "name" : "TACLS" },
         { "name" : "ShipManifest" },
         { "name" : "ConnectedLivingSpace" }

--- a/NetKAN/SDHI-ServiceModuleSystem.netkan
+++ b/NetKAN/SDHI-ServiceModuleSystem.netkan
@@ -22,7 +22,7 @@
     "depends"      : [
         { "name" : "AnimatedDecouplers" },
         { "name" : "ModuleManager" },
-        { "name" : "RealChute" }
+        { "name" : "RealChute" },
         { "name" : "SDHI-SharedAssets" },
     ],
     "suggests"     : [

--- a/NetKAN/SDHI-ServiceModuleSystem.netkan
+++ b/NetKAN/SDHI-ServiceModuleSystem.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version" : 1,
+    "spec_version" : "1.4",
     "identifier"   : "SDHI-ServiceModuleSystem",
     "$kref"        : "#/ckan/github/sumghai/SDHI_ServiceModuleSystem",
     "name"         : "Sum Dum Heavy Industries - Service Module System",

--- a/NetKAN/SDHI-ServiceModuleSystem.netkan
+++ b/NetKAN/SDHI-ServiceModuleSystem.netkan
@@ -14,7 +14,7 @@
       {
         "file": "GameData/SDHI",
         "install_to": "GameData"
-        "filter_regexp" : [
+        "filter" : [
                "Agencies"
         ]
       }

--- a/NetKAN/SDHI-ServiceModuleSystem.netkan
+++ b/NetKAN/SDHI-ServiceModuleSystem.netkan
@@ -13,7 +13,7 @@
     "install": [
       {
         "file": "GameData/SDHI",
-        "install_to": "GameData"
+        "install_to": "GameData",
         "filter" : [
                "Agencies"
         ]

--- a/NetKAN/SDHI-ServiceModuleSystem.netkan
+++ b/NetKAN/SDHI-ServiceModuleSystem.netkan
@@ -5,7 +5,7 @@
     "name"         : "Sum Dum Heavy Industries - Service Module System",
     "abstract"     : "Service Module and accessories designed specifically for use with the stock Mk1-2 Command Pod, vaguely resembling NASA's Orion MPCV. May or may not have a convincing stockalike appearance.",
     "license"      : "CC-BY-SA-4.0",
-    "ksp_version"  : "0.90",
+    "ksp_version"  : "1.0",
     "resources"    : {
         "homepage"   : "http://forum.kerbalspaceprogram.com/threads/52362",
         "repository" : "https://github.com/sumghai/SDHI_ServiceModuleSystem"
@@ -14,18 +14,21 @@
       {
         "file": "GameData/SDHI",
         "install_to": "GameData"
+        "filter_regexp" : [
+               "Agencies"
+        ]
       }
     ],
     "depends"      : [
         { "name" : "AnimatedDecouplers" },
         { "name" : "ModuleManager" },
         { "name" : "RealChute" }
+        { "name" : "SDHI-SharedAssets" },
     ],
     "suggests"     : [
         { "name" : "DeadlyReentry" },
         { "name" : "FerramAerospaceResearch" },
         { "name" : "HotRockets" },
-        { "name" : "NodeResizer" },
         { "name" : "TACLS" },
         { "name" : "ShipManifest" },
         { "name" : "ConnectedLivingSpace" }

--- a/NetKAN/SDHI-SharedAssets.netkan
+++ b/NetKAN/SDHI-SharedAssets.netkan
@@ -1,9 +1,9 @@
 {
-    "spec_version"   : 1,
+    "spec_version"   : "1.4",
     "identifier"     : "SDHI-SharedAssets",
     "$kref"          : "#/ckan/github/sumghai/SDHI_SharedAssets",
     "name"           : "Sum Dum Heavy Industries - Shared Assets",
-    "abstract"       : "Agency folders shared by multiple SDHI-branded add-ons for Kerbal Space Program ",
+    "abstract"       : "Agency folders shared by multiple SDHI-branded add-ons for Kerbal Space Program",
     "license"        : "unknown",
     "release_status" : "stable",
     "x_netkan_license_ok": true,

--- a/NetKAN/SDHI-SharedAssets.netkan
+++ b/NetKAN/SDHI-SharedAssets.netkan
@@ -1,0 +1,19 @@
+{
+    "spec_version"   : 1,
+    "identifier"     : "SDHI-SharedAssets",
+    "$kref"          : "#/ckan/github/sumghai/SDHI_SharedAssets",
+    "name"           : "Sum Dum Heavy Industries - Shared Assets",
+    "abstract"       : "Agency folders shared by multiple SDHI-branded add-ons for Kerbal Space Program ",
+    "license"        : "unknown",
+    "release_status" : "stable",
+    "x_netkan_license_ok": true,
+    "resources" : {
+        "repository"   : "https://github.com/sumghai/SDHI_SharedAssets"
+    },
+    "install" : [
+        {
+            "file"       : "Agencies",
+            "install_to" : "GameData/SDHI"
+        }
+    ]
+}


### PR DESCRIPTION
 - Incremented ksp_version to 1.0
 - Drop NodeResizer as suggested add-on (obsolete)
 - Tell CKAN to ignore Agencies folder bundled in GitHub download, and instead install it from SDHI-SharedAssets
    - This allows CKAN users to have multiple SDHI add-ons without each add-on fighting to overwrite each other's copies of the Agencies folder; users manually installing from the GitHub download will continue to use the bundled Agencies folder