### PR TITLE
Update HeatControl.netkan

### DIFF
--- a/NetKAN/HeatControl.netkan
+++ b/NetKAN/HeatControl.netkan
@@ -1,6 +1,7 @@
 {
     "spec_version"   : "v1.4",
     "identifier"     : "HeatControl",
+    "name"           : "HeatControl",
     "$kref"          : "#/ckan/kerbalstuff/890",
     "release_status" : "stable",
     "license"        : "CC-BY-NC-SA-4.0",


### PR DESCRIPTION
Changed display name in CKAN client so both core pack and full pack appear next to each other and not with unrelated mod 'Heat Management' sitting in between.