### PR TITLE
Add epoch to CivilianPopulation

### DIFF
--- a/NetKAN/CivilianPopulation.netkan
+++ b/NetKAN/CivilianPopulation.netkan
@@ -8,6 +8,7 @@
     "license"        : "CC-BY-NC-SA",
     "release_status" : "stable",
     "$vref"          : "#/ckan/ksp-avc",
+    "x_netkan_epoch" : "1",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/124162-1-0-2-Civilian-Population-1-5-1-%28update-6-4-15%29"
     },


### PR DESCRIPTION
CKAN is listing 1.41 (for KSP 0.90) instead of 1.6.2 (for KSP 1.0.2). 1.41 was supposed to be 1.4.1