### PR TITLE
DeadlyReentry now has a minimum ModuleManager version.

### DIFF
--- a/NetKAN/DeadlyReentry.netkan
+++ b/NetKAN/DeadlyReentry.netkan
@@ -11,7 +11,7 @@
         "repository" : "https://github.com/Starwaster/DeadlyReentry"
     },
     "depends"        : [
-        { "name": "ModuleManager" },
+        { "name": "ModuleManager", "min_version" : "2.6.5" },
         { "name": "ModularFlightIntegrator" }
     ],
     "install"        : [


### PR DESCRIPTION
DR comes with MM 2.6.5, so this makes sure that users actually have
that installed. :)