### PR TITLE
Bump FAR epoch number.

### DIFF
--- a/NetKAN/FerramAerospaceResearch.netkan
+++ b/NetKAN/FerramAerospaceResearch.netkan
@@ -3,13 +3,14 @@
     "identifier"     : "FerramAerospaceResearch",
     "$kref"          : "#/ckan/kerbalstuff/52",
     "license"        : "GPL-3.0",
+    "x_netkan_epoch" : "1",
     "release_status" : "stable",
     "resources" : {
         "repository" : "https://github.com/ferram4/Ferram-Aerospace-Research"
     },
 	
-	"provides"  : [ "AerodynamicModel", "FAR" ],
-	"conflicts" : [ { "name" : "AerodynamicModel" } ],
+    "provides"  : [ "AerodynamicModel", "FAR" ],
+    "conflicts" : [ { "name" : "AerodynamicModel" } ],
 	
     "depends" : [
     	{ "name" : "ModuleManager" },


### PR DESCRIPTION
According to KSP-CKAN/CKAN#1174, FAR's releases are sorting funny.
This bumps the epoch so the latest release is considered the latest
release, no matter how funny the version numbers are.

I've also fixed some errant whitespace. :)