### PR TITLE
Update Kopernicus

### DIFF
--- a/NetKAN/Kopernicus.netkan
+++ b/NetKAN/Kopernicus.netkan
@@ -1,26 +1,34 @@
 {
-    "spec_version"   : "v1.4",
-    "identifier"     : "Kopernicus",
-    "$kref"          : "#/ckan/github/BryceSchroeder/Kopernicus",
-    "name"           : "Kopernicus Planetary System Modifier",
-    "abstract"       : "Kopernicus Planetary System Modifier",
-    "description"    : "Kopernicus Planetary System Modifier",
-    "release_status" : "development",
-    "license"        : "LGPL-2.0",
-    "author"         : "BryceSchroeder",
-    "resources"      : {
-        "homepage"   : "http://forum.kerbalspaceprogram.com/threads/88168",
-        "repository" : "http://github.com/BryceSchroeder/Kopernicus"
+    "spec_version": "v1.4",
+    "identifier": "Kopernicus",
+    "$kref": "#/ckan/github/BryceSchroeder/Kopernicus",
+    "x_netkan_epoch": "1",
+    "name": "Kopernicus Planetary System Modifier",
+    "abstract": "Allows users to replace the planetary system used by the game.",
+    "release_status": "development",
+    "license": "LGPL-2.0",
+    "author": [
+        "BryceSchroeder",
+        "Teknoman117",
+        "Thomas P.",
+        "NathanKell",
+        "Gravitasi",
+        "KCreator"
+    ],
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/114649",
+        "repository": "http://github.com/BryceSchroeder/Kopernicus"
     },
-	"depends":	[
-		{ "name" : "ModuleManager" }
-	],
+    "ksp_version": "1.0",
+    "depends":	[
+        { "name" : "ModuleManager", "min_version": "2.6.6" }
+    ],
     "install": [
         {
-            "find"       : "Kopernicus",
-            "install_to" : "GameData",
-			"filter"	:	"Cache",
-			"comment"	:	"At time of writing the Cache folder does not exist, but it may in the future so we filter it"
+            "find": "Kopernicus",
+            "install_to": "GameData",
+            "filter": "Cache",
+            "comment": "At time of writing the Cache folder does not exist, but it may in the future so we filter it"
         }
     ]
 }


### PR DESCRIPTION
- New beta versioning scheme, so bump epoch.
- Specify a `ksp_version` of `1.0`
- Remove redundant `abstract` and `description`
- Updated `homepage` to release thread
- Specify `ModuleManager` `min_version` of `2.6.6` to correspond with what's distributed.
- Add all authors listed on the forum post
- General cleanup