### PR TITLE
Latest TACLS works on KSP 1.0.2-1.0.4

### DIFF
--- a/NetKAN/TACLS.netkan
+++ b/NetKAN/TACLS.netkan
@@ -22,5 +22,15 @@
         "homepage" : "https://github.com/taraniselsu/TacLifeSupport/wiki",
         "bugtracker" : "https://github.com/taraniselsu/TacLifeSupport/issues",
         "repository" : "https://github.com/taraniselsu/TacLifeSupport"
-    }
+    },
+    "x_netkan_override" : [
+        {
+            "version" : "v0.11.1.20",
+            "delete" : [ "ksp_version" ],
+            "override" : {
+                "ksp_version_min" : "1.0.2",
+                "ksp_version_max" : "1.0.4"
+            }
+        }
+    ]
 }


### PR DESCRIPTION
This requires KSP-CKAN/CKAN#1197 to be merged to actually function,
but can be safely be merged before then (as `x_netkan_override` is
ignored in the current netkan build).

Part of KSP-CKAN/CKAN#1184.