### PR TITLE
Always start FireSpitter versions with `v`.

### DIFF
--- a/NetKAN/Firespitter.netkan
+++ b/NetKAN/Firespitter.netkan
@@ -1,11 +1,11 @@
 {
     "spec_version" : 1,
     "identifier"   : "Firespitter",
-	"name"         : "Firespitter",
-	"abstract"     : "Propeller plane and helicopter parts",
+    "name"         : "Firespitter",
+    "abstract"     : "Propeller plane and helicopter parts",
     "$kref"        : "#/ckan/github/snjo/Firespitter",
     "license"      : "restricted",
-	"$vref"        : "#/ckan/ksp-avc",
+    "$vref"        : "#/ckan/ksp-avc",
     "x_netkan_force_v" : true,
     "resources" : {
         "homepage" : "http://snjo.github.io/",

--- a/NetKAN/FirespitterCore.netkan
+++ b/NetKAN/FirespitterCore.netkan
@@ -3,9 +3,10 @@
     "identifier"      : "FirespitterCore",
     "$kref"           : "#/ckan/kerbalstuff/777",
     "license"         : "restricted",
-   "name" : "Firespitter Core",
-   "abstract" : "Core Firespitter.dll. Install `Firespitter` for the whole shebang",
-	"$vref"			:	"#/ckan/ksp-avc",
+    "name"            : "Firespitter Core",
+    "abstract"        : "Core Firespitter.dll. Install `Firespitter` for the whole shebang",
+    "$vref"           : "#/ckan/ksp-avc",
+    "x_netkan_force_v" : true,
     "resources" : {
         "homepage" : "http://snjo.github.io/",
         "repository"  : "https://github.com/snjo/Firespitter"
@@ -15,9 +16,9 @@
             "file"       : "Firespitter/Plugins",
             "install_to" : "GameData/Firespitter"
         },
-		{
-			"file" : "Firespitter/Firespitter.version",
-			"install_to" : "GameData/Firespitter"
-		}
+        {
+            "file" : "Firespitter/Firespitter.version",
+            "install_to" : "GameData/Firespitter"
+        }
     ]
 }


### PR DESCRIPTION
We were doing this for the full FS package, but not the core.

Closes #1675.