### PR TITLE
KerbalFoundries works on 1.0.2 to 1.0.4

### DIFF
--- a/NetKAN/KerbalFoundries.netkan
+++ b/NetKAN/KerbalFoundries.netkan
@@ -3,15 +3,23 @@
     "identifier"     : "KerbalFoundries",
     "$kref"          : "#/ckan/kerbalstuff/58",
     "license"        : "GPL-3.0",
-	"ksp_version_min" : "0.25",
     "recommends" : [
         { "name" : "TweakScale" }
     ],
-	
- "install" : [
+    "install" : [
         {
             "find"       : "KerbalFoundries",
             "install_to" : "GameData"
+        }
+    ],
+    "x_netkan_override" : [
+        {
+            "version" : "Beta_1.8g",
+            "delete" : [ "ksp_version" ],
+            "override" : {
+                "ksp_version_min" : "1.0.2",
+                "ksp_version_max" : "1.0.4"
+            }
         }
     ]
 }


### PR DESCRIPTION
Part of KSP-CKAN/CKAN-meta#628.

Depends upon KSP-CKAN/CKAN#1209 being merged in order for `netkan.exe`
to parse the upstream data.

Resulting output on patched `netkan.exe`:

```
{
    "spec_version": "v1.4",
    "identifier": "KerbalFoundries",
    "license": "GPL-3.0",
    "recommends": [
        {
            "name": "TweakScale"
        }
    ],
    "install": [
        {
            "find": "KerbalFoundries",
            "install_to": "GameData"
        }
    ],
    "resources": {
        "homepage": "http://forum.kerbalspaceprogram.com/threads/84102-WIP-PARTS-PLUGIN-0-23-5-Kerbal-Foundries-wheelpack-anti-grav-repulsors",
        "repository": "http://included%20in%20the%20download",
        "kerbalstuff": "https://kerbalstuff.com/mod/58/Kerbal%20Foundries%20Wheels%20and%20Repulsors%20ALPHA"
    },
    "name": "Kerbal Foundries Wheels and Repulsors ALPHA",
    "abstract": "Better wheels and anti-gravity repulsors",
    "author": "KerbalFoundries",
    "version": "Beta_1.8g",
    "download": "https://kerbalstuff.com/mod/58/Kerbal%20Foundries%20Wheels%20and%20Repulsors%20ALPHA/download/Beta_1.8g",
    "x_generated_by": "netkan",
    "x_screenshot": "https://kerbalstuff.com/content/KerbalFoundries_139/Kerbal_Foundries_Wheels_and_Repulsors_ALPHA/Kerbal_Foundries_Wheels_and_Repulsors_ALPHA.png",
    "download_size": 27479482,
    "ksp_version_min": "1.0.2",
    "ksp_version_max": "1.0.4"
}
```