### PR TITLE
Fix min/max on Proton-Bobcat, SovietEngines, and StripSymmetry

### DIFF
--- a/NetKAN/Proton-Bobcat.netkan
+++ b/NetKAN/Proton-Bobcat.netkan
@@ -3,7 +3,6 @@
 	"identifier"	:	"Proton-Bobcat",
 	"license"	:	"restricted",
 	"$kref"		:	"#/ckan/kerbalstuff/373",
-	"ksp_version_min":	"0.25",
         "resources" : {
             "homepage"     : "http://forum.kerbalspaceprogram.com/threads/81754"
         },
@@ -11,5 +10,15 @@
 	{
 		"file"	    :   "SovietPack",
 		"install_to":   "GameData"
-	}]
+	}],
+        "x_netkan_override" : [
+            {
+                "version" : "1.0",
+                "delete" : [ "ksp_version" ],
+                "override" : {
+                    "ksp_version_min" : "0.25",
+                    "ksp_version_max" : "0.90"
+                }
+            }
+        ]
 }

--- a/NetKAN/SovietEngines.netkan
+++ b/NetKAN/SovietEngines.netkan
@@ -2,16 +2,25 @@
 	"spec_version"	:	1,
 	"identifier"	:	"SovietEngines",
 	"$kref"		:	"#/ckan/kerbalstuff/374",
-	"ksp_version_min":	"0.25",
 	"license"	:	"restricted",
 	
 	"resources" : {
-        "homepage"     : "http://forum.kerbalspaceprogram.com/threads/81754"
-    },
+            "homepage"     : "http://forum.kerbalspaceprogram.com/threads/81754"
+        },
 	
 	"install" : [
 	{
 		"file"	:	"BobCatind",
 		"install_to":	"GameData"
-	}]
+	}],
+        "x_netkan_override" : [
+            {
+                "version" : "1.1",
+                "delete" : [ "ksp_version" ],
+                "override" : {
+                    "ksp_version_min" : "0.25",
+                    "ksp_version_max" : "0.90"
+                }
+            }
+        ]
 }

--- a/NetKAN/StripSymmetry.netkan
+++ b/NetKAN/StripSymmetry.netkan
@@ -8,8 +8,9 @@
     "license"      	: "WTFPL",
     "release_status"	: "stable",
     "ksp_version_min"	: "1.0.0",
+    "ksp_version_max"   : "1.0.99",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/80654",
         "repository": "https://github.com/Biotronic/StripSymmetry"
-    },
+    }
 }

--- a/NetKAN/StripSymmetry.netkan
+++ b/NetKAN/StripSymmetry.netkan
@@ -1,17 +1,15 @@
 {
     "spec_version" 	: "v1.4",
     "identifier"   	: "StripSymmetry",
-	"author"		: "Biotronic",
+    "author"		: "Biotronic",
     "$kref"        	: "#/ckan/github/Biotronic/StripSymmetry",
     "name"         	: "Strip Symmetry",
     "abstract"     	: "Remove Symmetry!",
     "license"      	: "WTFPL",
-	
-	"release_status"	: "stable",
-    "ksp_version_min"	: "0.25",
-	
-	"resources": {
-		"homepage": "http://forum.kerbalspaceprogram.com/threads/80654",
-		"repository": "https://github.com/Biotronic/StripSymmetry"
-	}
+    "release_status"	: "stable",
+    "ksp_version_min"	: "1.0.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/80654",
+        "repository": "https://github.com/Biotronic/StripSymmetry"
+    },
 }


### PR DESCRIPTION
Final preening of the great metadata clean in KSP-CKAN/CKAN-meta#628.

Note: At least two of these files were produced by @Felger. If the
Proton and Soviet engines are known to work under 1.0.x, let us know
(or send us a PR) and we'll merge that for great justice!