### PR TITLE
Update Kerbulator to support up to KSP 1.0.4

### DIFF
--- a/NetKAN/Kerbulator.netkan
+++ b/NetKAN/Kerbulator.netkan
@@ -5,7 +5,8 @@
     "name"         : "Kerbulator",
     "abstract"     : "Calculator plugin for Kerbal Space Program",
     "license"      : "GPL-3.0",
-    "ksp_version"  : "1.0.2",
+    "ksp_version_min"  : "1.0.2",
+    "ksp_version_max"  : "1.0.4",
 	"resources" : {
         "homepage"     : "http://forum.kerbalspaceprogram.com/threads/69406"
     }


### PR DESCRIPTION
The author bumped the supported version in the [forum thread](http://forum.kerbalspaceprogram.com/threads/69406-1-0-3-Kerbulator-use-your-own-math!).

Is this how the metadata for the supported version work?