### PR TITLE
KerbalJointReinforcment v3.1.4 minmax override

### DIFF
--- a/NetKAN/KerbalJointReinforcement.netkan
+++ b/NetKAN/KerbalJointReinforcement.netkan
@@ -7,5 +7,15 @@
     "release_status" : "stable",
     "resources"      : {
         "repository"     : "https://github.com/ferram4/Kerbal-Joint-Reinforcement/"
-    }
+    },
+    "x_netkan_override" : [
+        {
+            "version" : "v3.1.4",
+            "delete" : [ "ksp_version" ],
+            "override" : {
+                "ksp_version_min" : "1.0.2",
+                "ksp_version_max" : "1.0.4"
+            }
+        }
+    ]
 }


### PR DESCRIPTION
provide ranged version override of ksp_version for compat marking 1.0.2, 1.0.3, 1.0.4