### PR TITLE
DockingportAlignmentIndicator 6.2 KSP Override using min-max

### DIFF
--- a/NetKAN/DockingPortAlignmentIndicator.netkan
+++ b/NetKAN/DockingPortAlignmentIndicator.netkan
@@ -16,5 +16,15 @@
             "file": "GameData/NavyFish",
             "install_to": "GameData"
         }
+    ],
+	"x_netkan_override" : [
+        {
+            "version" : "6.2",
+            "delete" : [ "ksp_version" ],
+            "override" : {
+                "ksp_version_min" : "1.0.2",
+                "ksp_version_max" : "1.0.4"
+            }
+        }
     ]
 }


### PR DESCRIPTION
Added min-max 1.0.2-1.0.4 override to netkan file.