### PR TITLE
Remove OpenTree conflict from CommunityTechTree

### DIFF
--- a/NetKAN/CommunityTechTree.netkan
+++ b/NetKAN/CommunityTechTree.netkan
@@ -10,8 +10,7 @@
     "conflicts" : [
         { "name" : "ETT" },
         { "name" : "ModOrientedTechTree" },
-        { "name" : "ModOrientedTechTree-Unmanned" },
-        { "name" : "OpenTree" }
+        { "name" : "ModOrientedTechTree-Unmanned" }
     ],
     "install" : [
         { "find" : "CommunityTechTree", "install_to" : "GameData" }


### PR DESCRIPTION
Remove conflict on OpenTree since that now apparently does not [conflict](http://forum.kerbalspaceprogram.com/threads/122571).

Replaces KSP-CKAN/CKAN-meta#654