### PR TITLE
Add Super 67 and 100 command pods

### DIFF
--- a/NetKAN/RaptorAerospacial-Textures.netkan
+++ b/NetKAN/RaptorAerospacial-Textures.netkan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.2",
+    "license": "CC-BY-4.0",
+    "$kref": "#/ckan/kerbalstuff/904",
+    "identifier": "RaptorAerospacial-Textures",
+    "name"        : "RaptorAerospacial-Textures",
+    "abstract"    : "Textures for Raptor Aerospacial heatshields (for Super 100 and Super 69 command pods), you shouldn't need to install this on its own.",
+    "install": [
+        {
+            "find"       : "Extras",
+            "install_to" : "GameData/RaptorAerospacial/Extras",
+            "filter"     : "Heatshield.cfg"
+        }
+    ]
+}

--- a/NetKAN/Super100ShootingStarCommandPod-heatshield.netkan
+++ b/NetKAN/Super100ShootingStarCommandPod-heatshield.netkan
@@ -1,0 +1,19 @@
+{
+    "spec_version": "v1.2",
+    "license": "CC-BY-4.0",
+    "$kref": "#/ckan/kerbalstuff/904",
+    "identifier": "Super100ShootingStarCommandPod-heatshield",
+    "name"        : "Super 100 Shooting Star Command Pod-heatshield",
+    "abstract"    : "A heatshield for the Super 100 Shooting Star Command Pod",
+    "install": [
+        {
+            "find"       : "Extras",
+            "install_to" : "GameData/RaptorAerospacial",
+            "filter"     : [ "Fairing.dds", "heatshield.dds", "Heatshield.mu" ]
+        }
+    ],
+    "depends": [
+        { "name": "RaptorAerospacial-Textures" },
+        { "name": "Super100ShootingStarCommandPod" }
+    ]
+}

--- a/NetKAN/Super100ShootingStarCommandPod.netkan
+++ b/NetKAN/Super100ShootingStarCommandPod.netkan
@@ -1,0 +1,22 @@
+{
+    "spec_version": "v1.2",
+    "license": "CC-BY-4.0",
+    "$kref": "#/ckan/kerbalstuff/904",
+    "identifier": "Super100ShootingStarCommandPod",
+    "install": [
+        {
+            "file"       : "Super100/RaptorAerospacial/Super100",
+            "install_to" : "GameData/RaptorAerospacial"
+        },
+        {
+            "file"       : "Super100/RaptorAerospacial/Spaces",
+            "install_to" : "GameData/RaptorAerospacial"
+        }
+    ],
+    "depends": [
+        { "name": "RasterPropMonitor-Core" }
+    ],
+    "recommends": [
+        { "name": "Super100ShootingStarCommandPod-heatshield" }
+    ]
+}

--- a/NetKAN/Super100ShootingStarCommandPod.netkan
+++ b/NetKAN/Super100ShootingStarCommandPod.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": 1,
     "license": "CC-BY-4.0",
     "$kref": "#/ckan/kerbalstuff/904",
     "identifier": "Super100ShootingStarCommandPod",

--- a/NetKAN/Super67LittleStarCommandPod-heatshield.netkan
+++ b/NetKAN/Super67LittleStarCommandPod-heatshield.netkan
@@ -1,0 +1,19 @@
+{
+    "spec_version": "v1.2",
+    "license": "CC-BY-4.0",
+    "$kref": "#/ckan/kerbalstuff/923",
+    "identifier": "Super67LittleStarCommandPod-heatshield",
+    "name"        : "Super 67 Little Star Command Pod-heatshield",
+    "abstract"    : "A heatshield for the Super 67 Little Star Command Pod",
+    "install": [
+        {
+            "find"       : "Extras",
+            "install_to" : "GameData/RaptorAerospacial",
+            "filter"     : [ "Fairing.dds", "heatshield.dds", "Heatshield.mu" ]
+        }
+    ],
+    "depends": [
+        { "name": "RaptorAerospacial-Textures" },
+        { "name": "Super67LittleStarCommandPod" }
+    ]
+}

--- a/NetKAN/Super67LittleStarCommandPod.netkan
+++ b/NetKAN/Super67LittleStarCommandPod.netkan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.2",
+    "license": "CC-BY-4.0",
+    "$kref": "#/ckan/kerbalstuff/923",
+    "identifier": "Super67LittleStarCommandPod",
+    "install": [
+        {
+            "find"       : "Super 67",
+            "install_to" : "GameData/RaptorAerospacial"
+        }
+    ],
+    "recommends": [
+        { "name": "Super67LittleStarCommandPod-heatshield" }
+    ]
+}


### PR DESCRIPTION
Should close #1625, close #1588

5 packs to add 2 parts from 2 KerbalStuff pages. Common files are extracted from Super100 because it seems to be the 'base' (and was up to date at the time of this writing).
```
\---RaptorAerospacial
    +---Extras
    |       Fairing.dds * Exists in both archives, provided by RaptorAerospacial-Textures
    |       Heatshield 2.5.cfg * Only needed for Super67, provided by Super67-heatshield
    |       Heatshield.cfg * Only needed for Super100, provided by Super100-heatshield
    |       heatshield.dds * Exists in both archives, provided by RaptorAerospacial-Textures
    |       Heatshield.mu * Exists in both archives, provided by RaptorAerospacial-Textures
    |       
    +---Spaces
    |   \---IVA_S100 * Only needed for and provided by Super100
    |           IVA.dds
    |           IVA_S100.cfg
    |           IVA_S100.mu
    |           
    +---Super 67 * Provided by Super67
    |       model.mu
    |       Super 67.dds
    |       Super67.cfg
    |       
    \---Super100 * Provided by Super100
            model.mu
            Super 100.dds
            Super 100_LUM.dds
            Super100.cfg
```
This was one possible option to resolve the situation, the other was to have 2 separate folders in `GameData` but that would becomes a progressively more ugly fix if the author continues to add parts.

Dependency/recommendation structure:

Super67, no deps but recs Super67-heatshield.
Super100 deps RPM-core and recs Super100-heatshield.
Super67-heatshield deps Super67 and RA-textures.
Super100-heatshield deps Super100 and RA-textures.

This whole setup is kind of a house of cards, 1 filename or folder name change and it all falls down. =(