### PR TITLE
NearFutureProps-0.4.2 override ksp min=1.0.2 max=1.0.4

### DIFF
--- a/NetKAN/NearFutureProps.netkan
+++ b/NetKAN/NearFutureProps.netkan
@@ -12,5 +12,15 @@
     ],
     "install" : [
         { "find" : "NearFutureProps", "install_to" : "GameData" }
+    ],
+	"x_netkan_override" : [
+		{
+			"version" : "0.4.2",
+			"delete" : [ "ksp_version" ],
+			"override" : {
+				"ksp_version_min" : "1.0.2",
+				"ksp_version_max" : "1.0.4"
+			}
+		}
     ]
 }


### PR DESCRIPTION
Works in 1.0.4, currently at 1.0.2 and likely will not be rebuilt for it due to no changes needed.

Stockalike Station Parts Expansion depends on this and *is* already updated for 1.0.4 in the CKAN-Meta, so overriding NearFutureProps should make it visible for install via CKAN.  

Already tested and installed on my local test instance via local ckan file installs