### PR TITLE
License fixes

### DIFF
--- a/NetKAN/KSPInterstellarLite.netkan
+++ b/NetKAN/KSPInterstellarLite.netkan
@@ -4,7 +4,7 @@
     "name"                  : "KSP Interstellar Lite",
     "abstract"              : "Lite version of KSP Interstellar",
     "$kref"                 : "#/ckan/github/WaveFunctionP/KSPInterstellar",
-    "license"               : "unknown",
+    "license"               : "restricted",
     "ksp_version"           : "0.24.2",
     "x_netkan_license_ok"   : true,
     "x_maintained_by"       : "distantcam",

--- a/NetKAN/KSPInterstellarLite.netkan
+++ b/NetKAN/KSPInterstellarLite.netkan
@@ -4,7 +4,7 @@
     "name"                  : "KSP Interstellar Lite",
     "abstract"              : "Lite version of KSP Interstellar",
     "$kref"                 : "#/ckan/github/WaveFunctionP/KSPInterstellar",
-    "license"               : "restricted",
+    "license"               : "unrestricted",
     "ksp_version"           : "0.24.2",
     "x_netkan_license_ok"   : true,
     "x_maintained_by"       : "distantcam",

--- a/NetKAN/MunarSurfaceExperimentPackage.netkan
+++ b/NetKAN/MunarSurfaceExperimentPackage.netkan
@@ -3,5 +3,5 @@
     "x_via": "Automated KerbalStuff CKAN submission",
     "spec_version": 1,
     "$kref": "#/ckan/kerbalstuff/634",
-    "license": "unknown"
+    "license": "restricted"
 }

--- a/NetKAN/ODFC.netkan
+++ b/NetKAN/ODFC.netkan
@@ -4,7 +4,7 @@
     "name"           : "On Demand Fuel Cells [ODFC]",
     "identifier"     : "ODFC",
     "$kref"          : "#/ckan/kerbalstuff/596",
-    "license"        : "unknown",
+    "license"        : "restricted",
     "release_status" : "stable",
     "x_netkan_license_ok": true,
     "resources" : {

--- a/NetKAN/OkramSA.netkan
+++ b/NetKAN/OkramSA.netkan
@@ -5,7 +5,7 @@
     "abstract"       : "Shared assets (flags & agency) for use with various Okram Industries mods",
     "identifier"     : "OkramSA",
     "$kref"          : "#/ckan/github/Orum/OkramSharedAssets",
-    "license"        : "restricted",
+    "license"        : "unknown",
     "release_status" : "stable",
     "x_netkan_license_ok": true,
     "resources" : {

--- a/NetKAN/OkramSA.netkan
+++ b/NetKAN/OkramSA.netkan
@@ -5,7 +5,7 @@
     "abstract"       : "Shared assets (flags & agency) for use with various Okram Industries mods",
     "identifier"     : "OkramSA",
     "$kref"          : "#/ckan/github/Orum/OkramSharedAssets",
-    "license"        : "unknown",
+    "license"        : "restricted",
     "release_status" : "stable",
     "x_netkan_license_ok": true,
     "resources" : {

--- a/NetKAN/SatBatts.netkan
+++ b/NetKAN/SatBatts.netkan
@@ -4,7 +4,7 @@
     "name"           : "SatBatts",
     "identifier"     : "SatBatts",
     "$kref"          : "#/ckan/kerbalstuff/290",
-    "license"        : "unknown",
+    "license"        : "restricted",
     "release_status" : "stable",
     "x_netkan_license_ok": true,
     "resources" : {

--- a/NetKAN/dockingtube.netkan
+++ b/NetKAN/dockingtube.netkan
@@ -2,7 +2,7 @@
     "identifier": "dockingtube",
     "spec_version": 1,
     "$kref": "#/ckan/kerbalstuff/619",
-    "license": "unknown",
+    "license": "unrestricted",
 	
 	"depends" : [ { "name": "KAS" } ]
 }


### PR DESCRIPTION
The overall premise is that we should either:

- Only list explicitly ARR as `restricted` while assigning `unknown` to any license not explicitly defined in CKAN.schema.

or
- List licenses that have no restrictions as `unrestricted`, list licenses that have any kind of restriction as `restricted`, and list mods with an absence of a license as `restricted` since many countries imply an ARR license.

I opt for the latter and I'll lay out the case for each decision.

dockingtube `unrestricted`
No requirements or restrictions, only "would be nice"
"Unlike a number of other mods you are positivly encouraged to modify 
this mod! AND release it should you desire.
A mention in the credits would be nice."

KSPInterstellarLite: `restricted`
Includes the same license as KSPI: Allows distribution, modification, etc. but ultimately has restrictions. KSPI license listed as `restricted`

MunarSurfaceExperimentPackage `restricted`
KerbalStuff page indicates BSD as a license, but from the KSP forum thread:
All models and textures are copyright of AlbertKermin, all rights reserved.

ODFC `restricted`
From the forum page: "3. Additionally, explicitly forbidden is the following:" 4 items are listed including repackaging, but the important part is that there are restrictions.

OkramSA `restricted`
No license whatsoever found in the github repo. In many countries no license = ARR, so that's what we should list it as.

SatBatts `restricted`
In the forum thread there are 3 clauses, I'll list 1: "You may not: - Use any part config, texture, or model for a derivative work without first receiving permission from Orum on the KSP forums."