### PR TITLE
Update SCANsat depends section

### DIFF
--- a/NetKAN/SCANsat.netkan
+++ b/NetKAN/SCANsat.netkan
@@ -4,9 +4,11 @@
     "$kref"        : "#/ckan/kerbalstuff/249",
     "license"      : "restricted",
 	"x_netkan_force_v"	:	"true",
+	"depends" : [
+        { "name" : "ModuleManager" }
+    ],
 	"recommends": [
-        { "name": "Toolbar" },
-		{ "name": "ModuleManager" }
+        { "name": "Toolbar" }
     ],
 	"resources" : {
 		"repository"   : "https://github.com/S-C-A-N/SCANsat"


### PR DESCRIPTION
Module Manager is more-or-less required for full SCANsat functionality now, so it should probably go in the depends section.

I'm not sure if that override section is still needed, but I left it as is.