### PR TITLE
Force v for RemoteTech.netkan

### DIFF
--- a/NetKAN/RemoteTech.netkan
+++ b/NetKAN/RemoteTech.netkan
@@ -5,7 +5,7 @@
 	"license": "restricted",
 	"release_status": "stable",
 	"x_netkan_license_ok": true,
-    "x_netkan_force_v": 1,
+    "x_netkan_force_v": "true",
 	"resources": {
 		"repository": "https://github.com/RemoteTechnologiesGroup/RemoteTech",
 		"bugtracker": "https://github.com/RemoteTechnologiesGroup/RemoteTech/issues",

--- a/NetKAN/RemoteTech.netkan
+++ b/NetKAN/RemoteTech.netkan
@@ -5,6 +5,7 @@
 	"license": "restricted",
 	"release_status": "stable",
 	"x_netkan_license_ok": true,
+    "x_netkan_force_v": 1,
 	"resources": {
 		"repository": "https://github.com/RemoteTechnologiesGroup/RemoteTech",
 		"bugtracker": "https://github.com/RemoteTechnologiesGroup/RemoteTech/issues",

--- a/NetKAN/RemoteTech.netkan
+++ b/NetKAN/RemoteTech.netkan
@@ -5,7 +5,7 @@
 	"license": "restricted",
 	"release_status": "stable",
 	"x_netkan_license_ok": true,
-    "x_netkan_force_v": "true",
+    "x_netkan_force_v": true,
 	"resources": {
 		"repository": "https://github.com/RemoteTechnologiesGroup/RemoteTech",
 		"bugtracker": "https://github.com/RemoteTechnologiesGroup/RemoteTech/issues",

--- a/NetKAN/SCANsat.netkan
+++ b/NetKAN/SCANsat.netkan
@@ -3,7 +3,7 @@
     "identifier"   : "SCANsat",
     "$kref"        : "#/ckan/kerbalstuff/249",
     "license"      : "restricted",
-	"x_netkan_force_v"	:	"true",
+	"x_netkan_force_v"	:	true,
 	"depends" : [
         { "name" : "ModuleManager" }
     ],

--- a/NetKAN/SDHI-ServiceModuleSystem.netkan
+++ b/NetKAN/SDHI-ServiceModuleSystem.netkan
@@ -33,5 +33,5 @@
         { "name" : "ShipManifest" },
         { "name" : "ConnectedLivingSpace" }
     ],
-    "x_netkan_force_v" : "true"
+    "x_netkan_force_v" : true
 }

--- a/NetKAN/TarsierSpaceTechnologyWithGalaxies.netkan
+++ b/NetKAN/TarsierSpaceTechnologyWithGalaxies.netkan
@@ -1,7 +1,7 @@
 {
     "identifier": "TarsierSpaceTechnologyWithGalaxies",
     "spec_version": "v1.4",
-    "x_netkan_force_v" : "true",
+    "x_netkan_force_v" : true,
     "$kref": "#/ckan/kerbalstuff/608",
     "license": "MIT",
 	"install": [


### PR DESCRIPTION
Less an issue for 1.0.4, but an issue that means there are no releases for 1.0.2.