### PR TITLE
Add EmDrive

### DIFF
--- a/NetKAN/EmDrive-TweakPatch.netkan
+++ b/NetKAN/EmDrive-TweakPatch.netkan
@@ -1,0 +1,18 @@
+{
+    "spec_version": 1,
+    "license": "GPL-3.0",
+    "$kref": "#/ckan/kerbalstuff/907",
+    "identifier": "EmDrive-TweakPatch",
+    "name"        : "EmDrive - TweakScale Patch",
+    "abstract"    : "A patch for compatibility between EmDrive and TweakScale.",
+    "depends": [
+        { "name": "EmDrive" },
+        { "name": "TweakScale" }
+    ],
+    "install": [
+        {
+            "file": "GameData/TweakScale",
+            "install_to" : "GameData"
+        }
+    ]
+}

--- a/NetKAN/EmDrive-TweakPatch.netkan
+++ b/NetKAN/EmDrive-TweakPatch.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.2",
     "license": "GPL-3.0",
     "$kref": "#/ckan/kerbalstuff/907",
     "identifier": "EmDrive-TweakPatch",

--- a/NetKAN/EmDrive.netkan
+++ b/NetKAN/EmDrive.netkan
@@ -1,0 +1,26 @@
+{
+    "spec_version": "v1.10",
+    "license": "GPL-3.0",
+    "$kref": "#/ckan/kerbalstuff/907",
+    "$vref" : "#/ckan/ksp-avc",
+    "identifier": "EmDrive",
+    "depends": [
+        { "name": "CryoEngines" }
+    ],
+    "recommends": [
+        { "name": "TACLS" }
+    ],
+    "suggests": [
+        { "name": "EmDrive-TweakPatch" }
+    ],
+    "install": [
+        {
+            "find_regexp": "EmDrive[\\s\\S]*",
+            "install_to" : "GameData/EmDrive"
+        },
+        {
+            "find"       : "Flags",
+            "install_to" : "GameData/EmDrive"
+        }
+    ]
+}


### PR DESCRIPTION
Closes #1596
I used `find_regexp` because I think `Emdrive R1` is likely to change names. The end result of the install isn't pretty `GameData/EmDrive/EmDrive R1` but since this is a parts-only pack there's no reason to think it will create any files that would prevent the `EmDrive R1` folder from being deleted and replaced with `EmDrive R2` down the line.