### PR TITLE
Update VenStockRevamp.netkan

### DIFF
--- a/NetKAN/VenStockRevamp.netkan
+++ b/NetKAN/VenStockRevamp.netkan
@@ -16,7 +16,7 @@
     },
         "x_netkan_override" : [
         {
-            "version" : "v1.2",
+            "version" : "v1.8.1",
             "delete" : [ "ksp_version" ],
             "override" : {
                 "ksp_version_min" : "1.0.0",

--- a/NetKAN/VenStockRevamp.netkan
+++ b/NetKAN/VenStockRevamp.netkan
@@ -9,8 +9,6 @@
     "depends"      : [
         { "name" : "ModuleManager" }
     ],
-    "ksp_version"  : "1.0.2",
-    "comment"      : ".version file currently has accurate mod version but incorrect KSP version",
 	"resources" : {
         "homepage"     : "http://forum.kerbalspaceprogram.com/threads/92764"
     },


### PR DESCRIPTION
VenStockRevamp does not have a version `v1.2`, the most recent version is `v1.8.1` (per CKAN listing and per https://github.com/VenVen/Stock-Revamp/releases) which is what this override seems to want to address.