### PR TITLE
NearFutureElectrical-0.5.2 no longer depends on HeatControl-Core

### DIFF
--- a/NetKAN/NearFutureElectrical.netkan
+++ b/NetKAN/NearFutureElectrical.netkan
@@ -6,11 +6,11 @@
     "license"        : "CC-BY-NC-SA-4.0",
     "depends" : [
         { "name" : "CommunityResourcePack" },
-        { "name" : "HeatControl-Core" },
         { "name" : "NearFutureElectrical-Core" },
         { "name" : "ModuleManager" }
     ],
     "recommends": [
+        { "name" : "HeatControl-Core" },
         { "name" : "CommunityTechTree" }
     ],
     "suggests": [


### PR DESCRIPTION
changed to Recommends until/unless is changed back.

Per release note comment 0.5.2: 
"Retuned radiator and reactor parts to work with stock radiator system"

Installed and tested, it works without HeatControl.  Verified by user post in forum as well.