### PR TITLE
Extant RP-0 releases should be for KSP 0.90 only.

### DIFF
--- a/NetKAN/RP-0.netkan
+++ b/NetKAN/RP-0.netkan
@@ -30,5 +30,13 @@
             "file"       : "GameData/RP-0",
             "install_to" : "GameData"
         }
+    ],
+    "x_netkan_override" : [
+        {
+            "version" : "<= v0.33",
+            "override" : {
+                "ksp_version" : "0.90"
+            }
+        }
     ]
 }


### PR DESCRIPTION
The netkan side of CKAN-meta#701.