### PR TITLE
Add SigmaBinary-core and SigmaBinary-DunaIke

### DIFF
--- a/NetKAN/SigmaBinary-DunaIke.netkan
+++ b/NetKAN/SigmaBinary-DunaIke.netkan
@@ -1,0 +1,19 @@
+{
+    "spec_version": "v1.4",
+    "license": "CC-BY-NC-SA-4.0",
+    "$kref": "#/ckan/kerbalstuff/992",
+    "identifier": "SigmaBinary-DunaIke",
+    "name"        : "Sigma Binary - Duna + Ike Binary",
+    "abstract"    : "Contains a Duna + Ike binary system.",
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus"},
+        { "name": "SigmaBinary-core"}
+    ],
+    "install": [
+        {
+            "find"       : "DunaIke Binary",
+            "install_to" : "GameData/Sigma/BinaryExpansion"
+        }
+    ]
+}

--- a/NetKAN/SigmaBinary-DunaIke.netkan
+++ b/NetKAN/SigmaBinary-DunaIke.netkan
@@ -6,8 +6,6 @@
     "name"        : "Sigma Binary - Duna + Ike Binary",
     "abstract"    : "Contains a Duna + Ike binary system.",
     "depends": [
-        { "name": "ModuleManager" },
-        { "name": "Kopernicus"},
         { "name": "SigmaBinary-core"}
     ],
     "install": [

--- a/NetKAN/SigmaBinary-core.netkan
+++ b/NetKAN/SigmaBinary-core.netkan
@@ -1,0 +1,22 @@
+{
+    "spec_version": "v1.4",
+    "license": "CC-BY-NC-SA-4.0",
+    "$kref": "#/ckan/kerbalstuff/992",
+    "$vref" : "#/ckan/ksp-avc",
+    "identifier": "SigmaBinary-core",
+    "name"        : "Sigma Binary",
+    "abstract"    : "This mod enables the creation of binary systems but does not contain any binary systems itself.",
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus"}
+    ],
+    "suggests": [
+        { "name": "SigmaBinary-DunaIke" }
+    ],
+    "install": [
+        {
+            "find"       : "Sigma",
+            "install_to" : "GameData"
+        }
+    ]
+}


### PR DESCRIPTION
Paging @Sigma88 for input.

`SigmaBinary-core` installs the `GameData` contents and has an abstract which informs users that this mod on its own won't create binary systems.

`SigmaBinary-DunaIke` installs the Duna + Ike binary system to `GameData/Sigma/BinaryExpansion` (would like to know if you prefer a different destination)

In using `SigmaBinary-core` as the idenfitier (seen only to CKAN's code) it would allow for easy creation of an eventual `SigmaBinary` install which includes the core and the default binaries, or can easily accept binaries from other sources. Currently the mod's name (visible to users) is `Sigma Binary` to help people find it and to provide simplicity until such a time as a full `SigmaBinary` install exists.

A question though, do .cfgs like `DunaIke.cfg` conflict with others or can multiple .cfgs be included to create multiple binary systems?

Closes #1890