### PR TITLE
SerialIO works fine in v1.0.4 (override)

### DIFF
--- a/NetKAN/SerialIO.netkan
+++ b/NetKAN/SerialIO.netkan
@@ -9,10 +9,20 @@
             "install_to": "GameData"
         }
     ],
-
-	"conflicts": [
-		{
-			"name": "SerialIO-MacLinuxWin"
-		}
-	]
+    "conflicts": [
+        {
+            "name": "SerialIO-MacLinuxWin"
+        }
+    ],
+    "x_netkan_force_v" : true,
+    "x_netkan_override" : [
+        {
+            "version" : "v0.17.3",
+            "delete" : [ "ksp_version" ],
+            "override" : {
+                "ksp_version_min" : "1.0.2",
+                "ksp_version_max" : "1.0.4"
+            }
+        }
+    ]
 }


### PR DESCRIPTION
Also forced prepending `v` onto the version due to past version number
inconsistencies.

Closes KSP-CKAN/CKAN#1280.