### PR TITLE
Fix syntax error for provides field of NearFuturePropulsionExtras.netkan

### DIFF
--- a/NetKAN/NearFuturePropulsionExtras.netkan
+++ b/NetKAN/NearFuturePropulsionExtras.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version"   : "v1.4",
     "identifier"     : "NearFuturePropulsionExtras",
-    "provides"       : "NearFuturePropulsionNTRConfigs",
+    "provides"       : [ "NearFuturePropulsionNTRConfigs" ],
     "$kref"          : "#/ckan/kerbalstuff/347",
     "name"           : "Near Future Propulsion Extras: Hydrogen NTR Configs",
     "abstract"       : "This patch changes most known nuclear thermal rocket engines (stock and modded) to use liquid hydrogen instead of stock liquid fuel. Having a mod that provides matching tanks (like Near Future Propulsion) is recommended.",


### PR DESCRIPTION
Running the existing NearFuturePropulsionExtras.netkan file through netkan.exe revealed a syntax error causing parsing to fail.