### PR TITLE
Change ProceduralParts to depend on ModuleManager

### DIFF
--- a/NetKAN/ProceduralParts.netkan
+++ b/NetKAN/ProceduralParts.netkan
@@ -9,7 +9,7 @@
 	"resources" : {
         "homepage"     : "https://github.com/Swamp-Ig/ProceduralParts"
     },
-    "recommends" : [ 
+    "depends" : [ 
         { "name" : "ModuleManager" }
     ],
     "suggests" : [ 


### PR DESCRIPTION
I've found that Procedural Parts will not run without Module Manager. See Swamp-Ig/ProceduralParts#152