### PR TITLE
Restore 1.0.2 compatibility for BULB-1.1.2

### DIFF
--- a/NetKAN/BULB.netkan
+++ b/NetKAN/BULB.netkan
@@ -11,5 +11,15 @@
     ],
     "depends" : [
         { "name" : "ModuleManager", "min_version" : "2.5.9" }
+    ],
+    "x_netkan_override" : [
+		{
+			"version" : "1.1.2",
+			"delete" : [ "ksp_version" ],
+			"override" : {
+				"ksp_version_min" : "1.0.2",
+				"ksp_version_max" : "1.0.4"
+			}
+		}
     ]
 }


### PR DESCRIPTION
Noticed that https://github.com/KSP-CKAN/CKAN-meta/commit/7a189015ff68eedd3e4a3c00ba9ef4606e451f00 breaks the mod for 1.0.2 users. Opened KSP-CKAN/NetKAN-bot#26 with more information.

The change in this PR simply adds an override to the version which will give us the appropriate compatibility range.