### PR TITLE
Update KerbolPlus.netkan to use github

### DIFF
--- a/NetKAN/KerbolPlus.netkan
+++ b/NetKAN/KerbolPlus.netkan
@@ -1,8 +1,11 @@
 {
-    "$kref": "#/ckan/kerbalstuff/628",
+    "$kref"        : "#/ckan/github/Amarius1/Kerbol-Plus",
     "spec_version": "v1.4",
     "identifier": "KerbolPlus",
     "license": "CC-BY-NC-SA",
+    "name"         : "Kerbol Plus",
+    "abstract"     : "This mod aims to expand the stock kerbol system with 2 more gas giants and lots of moons.",
+    "ksp_version"  : "1.0.4",
 	"depends"	:	[ { "name" : "KopernicusTech" },
 					{ "name" : "ModuleManager" } ],
 	"provides": [ "PlanetPack" ],
@@ -10,7 +13,7 @@
 					{ "name" : "KittopiaTech" },
 					{ "name" : "PlanetPack" }
 					],
-	"install"		:	[ { "find" : "Kerbol+",
+	"install"		:	[ { "find" : "KerbolPlus",
 						"install_to" : "GameData" },
 						{ "find" : "KittopiaSpace",
 						"install_to" : "GameData",

--- a/NetKAN/KerbolPlus.netkan
+++ b/NetKAN/KerbolPlus.netkan
@@ -19,5 +19,6 @@
 						"install_to" : "GameData",
 						"filter" : [ "StarFix.cfg", "Help.cr_help", "plugins", "KittopiaSpace/Textures/Default" ]
 						} 
-					]
+					],
+    "x_netkan_force_v": true
 }


### PR DESCRIPTION
Updated hosting from KerbalStuff (their old page is 404) to github.
Updated KerbolPlus' part of the stanza to reflect folder changes.

I'm trusting that @Dazpoet in #983 knew what he was doing so I didn't touch relationships to other mods or the KittopiaSpace install.