### PR TITLE
Deadly Reentry adjustments

### DIFF
--- a/NetKAN/DeadlyReentry.netkan
+++ b/NetKAN/DeadlyReentry.netkan
@@ -11,13 +11,13 @@
         "repository" : "https://github.com/Starwaster/DeadlyReentry"
     },
     "depends"        : [
-        { "name": "ModuleManager", "min_version" : "2.6.5" },
-        { "name": "ModularFlightIntegrator" }
+        { "name": "ModuleManager", "min_version" : "2.6.5" }
     ],
     "install"        : [
         {
             "find": "DeadlyReentry",
             "install_to": "GameData"
         }
-    ]
+    ],
+    "x_netkan_force_v": true
 }


### PR DESCRIPTION
- No longer depends on ModularFlightIntegrator (mentioned in the 7.2.1 release notes)
- Force a 'v' onto the version string, as DR seems to lose them starting with 7.2.0