### PR TITLE
Change dependency in KSPInterstellarExtended to allow RealFuels as an alternative to InterstellarFuelSwitch

### DIFF
--- a/NetKAN/InterstellarFuelSwitch.netkan
+++ b/NetKAN/InterstellarFuelSwitch.netkan
@@ -11,8 +11,9 @@
 	"abstract"       : "Library that enables switching the contents, meshes, and textures of tanks.",
 	"description"    : "Interstellar Fuel Switch is mend for mod makers which want to add resource/mesh/texture switching to their tanks\nInterstellar Fuel Switch is an improved version of FSFuelSwitch, FSMeshSwitch and FSTextureSwitch, FSTextureSwitch2 made by Snjo",
     "suggests":[
-	{ "name" : "CommunityResourcePack" }
+        { "name" : "CommunityResourcePack" }
     ],
+    "provides": [ "KSPIE-fuelswitch" ],
 	"resources" : {
 		"homepage"     : "http://forum.kerbalspaceprogram.com/threads/117932",
 		"bugtracker"   : "https://github.com/sswelm/KSPInterstellar/issues",

--- a/NetKAN/KSPInterstellarExtended.netkan
+++ b/NetKAN/KSPInterstellarExtended.netkan
@@ -13,7 +13,7 @@
     "depends" : [
         { "name"         : "CommunityResourcePack", "min_version" : "0.4.2" },
         { "name"         : "Toolbar", "min_version" : "1.7.9" },
-        { "name"         : "InterstellarFuelSwitch", "min_version" : "1.7" },
+        { "name"         : "KSPIE-fuelswitch"},
         { "name"         : "TweakScale", "min_version" : "2.1"},
         { "name"         : "ModuleManager", "min_version" : "2.6.3" }
     ],

--- a/NetKAN/RealFuels.netkan
+++ b/NetKAN/RealFuels.netkan
@@ -16,6 +16,7 @@
 			"filter"	: ".DS_Store"
         }
     ],
+    "provides": [ "KSPIE-fuelswitch" ],
     "depends" : [
         { "name" : "ModuleManager" },
         { "name" : "RealFuels-Engine-Configs" },


### PR DESCRIPTION
Closes https://github.com/KSP-CKAN/CKAN-meta/pull/601 (whether merged or not)
Pinging @sswelm to find out if you're ok with this change or not. Of particular note: if users choose RealFuels, they cannot install InterstellarFS due to their conflict relationship.