### PR TITLE
Add 1.0.4 override for new version of RoutineMissionManager

### DIFF
--- a/NetKAN/RoutineMissionManager.netkan
+++ b/NetKAN/RoutineMissionManager.netkan
@@ -14,15 +14,7 @@
     ],
     "x_netkan_override" : [
 		{
-			"version" : "012",
-			"delete" : [ "ksp_version" ],
-			"override" : {
-				"ksp_version_min" : "1.0.2",
-				"ksp_version_max" : "1.0.4"
-			}
-		},
-        {
-			"version" : "013",
+			"version" : [ ">=012", "<=013" ],
 			"delete" : [ "ksp_version" ],
 			"override" : {
 				"ksp_version_min" : "1.0.2",

--- a/NetKAN/RoutineMissionManager.netkan
+++ b/NetKAN/RoutineMissionManager.netkan
@@ -20,6 +20,14 @@
 				"ksp_version_min" : "1.0.2",
 				"ksp_version_max" : "1.0.4"
 			}
+		},
+        {
+			"version" : "013",
+			"delete" : [ "ksp_version" ],
+			"override" : {
+				"ksp_version_min" : "1.0.2",
+				"ksp_version_max" : "1.0.4"
+			}
 		}
     ]
 }


### PR DESCRIPTION
If there's a way to just have a range of versions, I'd love to know about it.