### PR TITLE
Add ALCOR suite of mods

### DIFF
--- a/NetKAN/ALCOR.netkan
+++ b/NetKAN/ALCOR.netkan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.4",
+    "license"     : "CC-BY-NC-SA-3.0",
+    "$kref": "#/ckan/kerbalstuff/1015",
+    "identifier": "ALCOR",
+    "depends": [
+        { "name": "ALCORIVAPatch" }
+    ],
+    "install": [
+        {
+            "find"       : "ASET",
+            "install_to" : "GameData"
+        }
+    ]
+}

--- a/NetKAN/ALCORIVAPatch.netkan
+++ b/NetKAN/ALCORIVAPatch.netkan
@@ -1,0 +1,22 @@
+{
+    "spec_version": "v1.4",
+    "license"     : "CC-BY-NC-SA-3.0",
+    "$kref": "#/ckan/kerbalstuff/1020",
+    "identifier": "ALCORIVAPatch",
+    "depends": [
+        { "name": "ASETProps" },
+        { "name": "RasterPropMonitor-Core", "min_version" : "0.21.2" }
+    ],
+    "suggests": [
+        { "name": "SCANsat" },
+        { "name": "MechJeb2" },
+        { "name": "VesselView" },
+        { "name": "DockingPortAlignmentIndicator"}
+    ],
+    "install": [
+        {
+            "find"       : "ASET",
+            "install_to" : "GameData"
+        }
+    ]
+}

--- a/NetKAN/ASETProps.netkan
+++ b/NetKAN/ASETProps.netkan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.4",
+    "license"     : "CC-BY-NC-SA-3.0",
+    "$kref": "#/ckan/kerbalstuff/1021",
+    "identifier": "ASETProps",
+    "depends": [
+        { "name": "RasterPropMonitor-Core", "min_version" : "0.21.2" }
+    ],
+    "install": [
+        {
+            "find"       : "ASET",
+            "install_to" : "GameData"
+        }
+    ]
+}


### PR DESCRIPTION
Closes #1965, closes #1966 , closes #1967 

Adding the ALCOR IVA as a `depends` to ALCOR because we don't index the VNG plugin, and without either ALCOR IVA or the VNG plugin parts of the capsule will be broken.