### PR TITLE
Change RasterPropMonitor suggested mods

### DIFF
--- a/NetKAN/RasterPropMonitor.netkan
+++ b/NetKAN/RasterPropMonitor.netkan
@@ -9,7 +9,7 @@
         { "name" : "RasterPropMonitor-Core" }
     ],
     "suggests" : [
-        { "name" : "VesselView-RasterPropMonitor"},
+        { "name" : "VesselView"},
         { "name" : "SCANsat"}
     ],
     "install" : [


### PR DESCRIPTION
I haven't been with the project for very long, and this change seems to date back to #6 so i'd like to get input from someone more senior than me. (@dbent looking your way)

I *think* `VesselView-RasterPropMonitor` was always meant to be `VesselView`. I can say with certainty that there's currently no mod with the ID `VesselView-RasterPropMonitor` but maybe it existed in the past.