### PR TITLE
Remove conflict with InterstellarFuelSwitch-Core

### DIFF
--- a/NetKAN/FuelSwitchtoeverytank-default.netkan
+++ b/NetKAN/FuelSwitchtoeverytank-default.netkan
@@ -14,7 +14,6 @@
     ],
     
     "conflicts": [
-        { "name": "InterstellarFuelSwitch-Core" },
         { "name": "StockFuelSwitch" },
         { "name": "FuelSwitchtoeverytank" },
         { "name": "ThermalPaint" }


### PR DESCRIPTION
According to #1981, these mods shouldn't conflict.