### PR TITLE
Add KWRocketry-CommunityFixes and interstage

### DIFF
--- a/NetKAN/KWRocketry-CommunityFixes-interstage.netkan
+++ b/NetKAN/KWRocketry-CommunityFixes-interstage.netkan
@@ -1,0 +1,27 @@
+{
+    "spec_version"  : "v1.2",
+    "identifier"    : "KWRocketry-CommunityFixes-interstage",
+    "$kref"         : "#/ckan/kerbalstuff/1036",
+    "$vref"         : "#/ckan/ksp-avc",
+    "license"       : "GPL-3.0",
+    "depends": [
+        {
+            "name": "KWRocketry-CommunityFixes",
+            "version": "0.1.0"
+        }
+    ],
+    "install": [
+        {
+            "file": "Gamedata/KWCommunityFixes/KWPatch-interstage.cfg",
+            "install_to": "GameData/KWCommunityFixes"
+        }
+    ],
+    "name": "KW Rocketry - Community Fixes - Interstage config",
+    "abstract": "Optional config for KW Community Fixes. THIS IS CONVCEIVABLY CRAFT BREAKING! This file switches the interstage fairings over to omni decouplers and removes the finicky extra node on engines/shrouds.",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/129918-KW-Rocketry-Community-Fixes",
+        "kerbalstuff": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes",
+        "repository":"https://github.com/linuxgurugamer/KW-Rocketry-Community-Fixes",
+        "x_screenshot": "https://kerbalstuff.com/content/Winston_229/KW_Rocketry/KW_Rocketry-1431743324.7172647.jpg"
+    }
+}

--- a/NetKAN/KWRocketry-CommunityFixes.netkan
+++ b/NetKAN/KWRocketry-CommunityFixes.netkan
@@ -1,0 +1,36 @@
+{
+    "spec_version"  : 1,
+    "identifier"    : "KWRocketry-CommunityFixes",
+    "$kref"         : "#/ckan/kerbalstuff/1036",
+    "$vref"         : "#/ckan/ksp-avc",
+    "license"       : "GPL-3.0",
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "KWRocketry",
+            "version": "2.7.0-community"
+        }
+    ],
+    "suggests": [
+        {
+          "name": "KWRocketry-CommunityFixes-interstage"
+        }
+    ],
+    "install": [
+        {
+            "file": "Gamedata/KWCommunityFixes",
+            "install_to": "GameData",
+            "filter": "KWPatch-interstage.cfg"
+        }
+    ],
+    "name": "KW Rocketry - Community Fixes",
+    "abstract": "This is a set of patches created by the community to bring KW up to 1.0.4 compatibility.",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/129918-KW-Rocketry-Community-Fixes",
+        "kerbalstuff": "https://kerbalstuff.com/mod/1036/KW-Rocketry-Community-Fixes",
+        "repository":"https://github.com/linuxgurugamer/KW-Rocketry-Community-Fixes",
+        "x_screenshot": "https://kerbalstuff.com/content/Winston_229/KW_Rocketry/KW_Rocketry-1431743324.7172647.jpg"
+    }
+}

--- a/NetKAN/KWRocketry.netkan
+++ b/NetKAN/KWRocketry.netkan
@@ -1,14 +1,18 @@
 {
-    "spec_version" : 1,
+    "spec_version" : "v1.4",
     "identifier"   : "KWRocketry",
     "$kref"        : "#/ckan/kerbalstuff/67",
     "license"      : "CC-BY-SA-3.0",
     "depends"      : [
         { "name": "ModuleAnimateEmissive" }
     ],
+    "conflicts" : [
+        { "name" : "KWRocketry-CommunityFixes" },
+        { "name" : "KWRocketry-CommunityFixes-interstage"  }
+    ],
     "install"      : [
         {
-            "file": "KW Release Package v2.7 (Open this, don't extract it)/GameData/KWRocketry",
+            "find"      : "KWRocketry",
             "install_to": "GameData"
         }
     ]


### PR DESCRIPTION
And add conflict to netkan of KWRocketry (Community fixes are to be applied to non-netkan version of KWRocketry).

@dbent would love a second set of eyes on this.

Thanks to @TeddyDD whose metadata I basically copy + pasted.
Related issue: https://github.com/KSP-CKAN/CKAN-meta/pull/724

This adds netkans for `CommunityFixes` and `interstage` in case they need updates. This also adds a conflict to `KWRocketry` so that any version other than `2.7.0-community` (which isn't netkan-generated) will have a conflict to the fixes.