### PR TITLE
Tests: v1.12+ required for `Ships` with path.

### DIFF
--- a/t/metadata.t
+++ b/t/metadata.t
@@ -82,6 +82,13 @@ foreach my $shortname (sort keys %files) {
             );
         }
 
+        if ($install->{install_to} =~ m{^Ships/}) {
+            ok(
+                compare_version($spec_version,"v1.12"),
+                "$shortname - spec_version v.12+ required to install to Ships/ with path."
+            );
+        }
+
         if ($install->{find}) {
             ok(
                 compare_version($spec_version,"v1.4"),


### PR DESCRIPTION
Part of #1257 and #1243.

Can be happily merged even before v1.12 has been released, since we can start writing metadata for v1.12 now. :)