### PR TITLE
Add BDarmory-common, add BDArmoryDMPAddon, modify BDArmory

### DIFF
--- a/NetKAN/BDArmory-common.netkan
+++ b/NetKAN/BDArmory-common.netkan
@@ -1,0 +1,32 @@
+{
+    "spec_version" : "v1.4",
+    "identifier"   : "BDArmory-common",
+    "name"         : "BahamutoD's Armory-common",
+    "abstract"     : "This is just a module that provides files BDArmory uses in common with other mods",
+    "resources"    : {
+        "homepage" : "http://forum.kerbalspaceprogram.com/threads/85209"
+    },
+    "$kref"        : "#/ckan/kerbalstuff/90",
+	"license"	   : "CC-BY-SA-2.0",
+    "provides" : [ "BDArmory" ],
+    "depends": [
+        { "name": "BDArmory-turret" }
+    ],
+    "install": [
+        {
+            "find"       : "BDArmory",
+            "install_to" : "GameData",
+            "filter"     : "BahaTurret.dll"
+        }
+    ],
+    "x_netkan_override" : [
+		{
+			"version" : "v0.8.3",
+			"delete" : [ "ksp_version" ],
+			"override" : {
+				"ksp_version_min" : "1.0.2",
+				"ksp_version_max" : "1.0.4"
+			}
+		}
+    ]
+}

--- a/NetKAN/BDArmory.netkan
+++ b/NetKAN/BDArmory.netkan
@@ -1,11 +1,25 @@
 {
-    "spec_version" : 1,
+    "spec_version" : "v1.2",
     "identifier"   : "BDArmory",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/85209"
     },
     "$kref"        : "#/ckan/kerbalstuff/90",
 	"license"	   : "CC-BY-SA-2.0",
+    "provides" : [ "BDArmory-turret" ],
+    "depends": [
+        { "name": "BDArmory-common" }
+    ],
+    "conflicts": [
+        { "name": "BDArmouryDMPAddon" }
+    ],
+    "comment": "With the addition of BDArmouryDMPAddon, this module now only installs the turret .dll on its own while `BDArmory-core` actually contains the majority of the mod",
+    "install": [
+        {
+            "file"       : "GameData/BDArmory/Plugins/BahaTurret.dll",
+            "install_to" : "GameData/BDArmory/Plugins"
+        }
+    ],
     "x_netkan_override" : [
 		{
 			"version" : "v0.8.3",

--- a/NetKAN/BDArmouryDMPAddon.netkan
+++ b/NetKAN/BDArmouryDMPAddon.netkan
@@ -1,0 +1,26 @@
+{
+    "spec_version"      : "v1.4",
+    "license"           : "CC0",
+    "$kref"             : "#/ckan/kerbalstuff/1050",
+    "identifier"        : "BDArmouryDMPAddon",
+    "name"              : "BahamutoD's Armory-DarkMultiPlayer addon",
+    "abstract"          : "A BDArmory install for use in DarkMultiPlayer (install this instead of BDArmory if you're playing multiplayer)(not written by BahamutoD)",
+    "provides": [ "BDArmory-turret" ],
+    "depends": [
+        { "name": "DarkMultiPlayer" },
+        { "name": "BDArmory-common" }
+    ],
+    "conflicts": [
+        { "name": "BDArmory-turret" }
+    ],
+    "install": [
+        {
+            "find"       : "z_BDDMP",
+            "install_to" : "GameData"
+        },
+        {
+            "file"       : "GameData/BDArmory/Plugins/BahaTurret.dll",
+            "install_to" : "GameData/BDArmory/Plugins"
+        }
+    ]
+}


### PR DESCRIPTION
For testing, https://github.com/KSP-CKAN/CKAN-meta/archive/BDArmoryTest.zip is setup. Basically, it's setup to avoid end-users having to choose between mods. Instead, the dependency/provide relationships are setup such that if a user chooses to install `BDArmory` they automatically get the common files installed (unprompted) and the same if a user chooses the multiplayer addon. The drawback is that when `BDArmory-common` `provides` `BDArmory`, `BDArmory` has an erroneous upgrade checkbox. While it doesn't cause any errors or crashes, it's something we'll want to see resolved.

@dbent I like your input/verification on these more complex PRs, if you please. =)