### PR TITLE
Fix `ClampOTronAPAS` and `DockingTarget` both trying to install the same flags.

### DIFF
--- a/NetKAN/ClampOTronAPAS.netkan
+++ b/NetKAN/ClampOTronAPAS.netkan
@@ -1,15 +1,19 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "license": "CC-BY-SA-4.0",
     "$kref": "#/ckan/kerbalstuff/1002",
     "identifier": "ClampOTronAPAS",
     "depends": [
         { "name": "HullcamVDS" }
     ],
+    "recommends": [
+        { "name": "FederalProductions-Flags" }
+    ],
     "install": [
         {
-            "file"       : "GameData/FederalProductions",
-            "install_to" : "GameData"
+            "find"       : "FederalProductions",
+            "install_to" : "GameData",
+            "filter"     : "Flags"
         }
     ]
 }

--- a/NetKAN/DockingTarget.netkan
+++ b/NetKAN/DockingTarget.netkan
@@ -3,6 +3,9 @@
     "license": "CC-BY-SA-4.0",
     "$kref": "#/ckan/kerbalstuff/1044",
     "identifier": "DockingTarget",
+    "recommends": [
+        { "name": "FederalProductions-Flags" }
+    ],
     "suggests": [
         { "name": "HullcamVDS" }
     ],
@@ -12,7 +15,8 @@
 "install": [
         {
             "find"       : "FederalProductions",
-            "install_to" : "GameData"
+            "install_to" : "GameData",
+            "filter"     : "Flags"
         }
     ]
 }

--- a/NetKAN/FederalProductions-Flags.netkan
+++ b/NetKAN/FederalProductions-Flags.netkan
@@ -5,6 +5,8 @@
     "identifier": "FederalProductions-Flags",
     "name"        : "Federal Productions Flags",
     "abstract"    : "A set of flags by TG626.",
+    "ksp_version"    : "any",
+    "comment"        : "flagmod",
     "install": [
         {
             "find"       : "Flags",

--- a/NetKAN/FederalProductions-Flags.netkan
+++ b/NetKAN/FederalProductions-Flags.netkan
@@ -1,0 +1,14 @@
+{
+    "spec_version": "v1.4",
+    "license": "CC-BY-SA-4.0",
+    "$kref": "#/ckan/kerbalstuff/1044",
+    "identifier": "FederalProductions-Flags",
+    "name"        : "Federal Productions Flags",
+    "abstract"    : "A set of flags by TG626.",
+    "install": [
+        {
+            "find"       : "Flags",
+            "install_to" : "GameData/FederalProductions"
+        }
+    ]
+}


### PR DESCRIPTION
Closes https://github.com/KSP-CKAN/CKAN-meta/issues/733