### PR TITLE
RKE_Kanadarm works on 1.0.2 - 1.0.4

### DIFF
--- a/NetKAN/RKE-Kanadarm.netkan
+++ b/NetKAN/RKE-Kanadarm.netkan
@@ -9,5 +9,16 @@
             "find"       : "RKE_Kanadarm",
             "install_to" : "GameData"
         }
+    ],
+    "x_netkan_override" : [
+        {
+            "version" : "0.11.0",
+            "override" : {
+                "ksp_min_version" : "1.0.2",
+                "ksp_max_version" : "1.0.4"
+            },
+            "delete" : [ "ksp_version" ],
+            "comment" : "The AVC file really wants to say it's 1.0.2"
+        }
     ]
 }


### PR DESCRIPTION
Netkan.exe is currently too insistant on using the embedded AVC file.  This adjusts the versions somewhat.