### PR TITLE
HullcamVDS update broke CKAN and new dependencies

### DIFF
--- a/NetKAN/HullcamVDS.netkan
+++ b/NetKAN/HullcamVDS.netkan
@@ -11,7 +11,17 @@
         {
             "file"       : "HullCameraVDS",
             "install_to" : "GameData"
+            "filter": [
+                "Thumbs.db",
+                "Thumbs.db:encryptable"
+            ],
+            "filter_regexp": [
+                "ModuleManager.*dll$"
+            ]
         }
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ],
     "x_netkan_override" : [
 		{


### PR DESCRIPTION
0.50 archive contains files with colons in their names, which causes CKAN to crash upon installation. Also, the mod added a dependency of Module Manager - added exclusion of the file and added the dependency spec.

See https://github.com/KSP-CKAN/CKAN/issues/1364