### PR TITLE
Transform version to exclude V and v, and force epoch to deal with version inconsistencies.

### DIFF
--- a/NetKAN/TarsierSpaceTechnologyWithGalaxies.netkan
+++ b/NetKAN/TarsierSpaceTechnologyWithGalaxies.netkan
@@ -1,11 +1,18 @@
 {
     "identifier": "TarsierSpaceTechnologyWithGalaxies",
     "spec_version": "v1.4",
-    "x_netkan_force_v" : true,
+    "x_netkan_version_edit": {
+        "find": "^[vV]?(?<version>.+)$",
+        "replace": "${version}"
+    },
+    "x_netkan_epoch": "1",
     "$kref": "#/ckan/kerbalstuff/608",
     "license": "MIT",
 	"install": [
-		{ "find": "TarsierSpaceTech", "install_to": "GameData" }
+		{ 
+            "find": "TarsierSpaceTech", 
+            "install_to": "GameData"
+        }
 	],
 	"recommends": [
 		{ "name": "KAS" },


### PR DESCRIPTION
Duplicate of and closes #1943. Redone to help Jenkins out.