### PR TITLE
Edit FAR Version

### DIFF
--- a/NetKAN/FerramAerospaceResearch.netkan
+++ b/NetKAN/FerramAerospaceResearch.netkan
@@ -3,7 +3,8 @@
     "identifier"     : "FerramAerospaceResearch",
     "$kref"          : "#/ckan/kerbalstuff/52",
     "license"        : "GPL-3.0",
-    "x_netkan_epoch" : "2",
+    "x_netkan_epoch" : "3",
+    "x_netkan_version_edit": "^[vV]?(?<version>\d+(?:\.\d+){0,3}[A-Za-z]?)(?:_[A-Za-z0-9]+)?$",
     "release_status" : "stable",
     "resources" : {
         "repository" : "https://github.com/ferram4/Ferram-Aerospace-Research"

--- a/NetKAN/FerramAerospaceResearch.netkan
+++ b/NetKAN/FerramAerospaceResearch.netkan
@@ -4,7 +4,7 @@
     "$kref"          : "#/ckan/kerbalstuff/52",
     "license"        : "GPL-3.0",
     "x_netkan_epoch" : "3",
-    "x_netkan_version_edit": "^[vV]?(?<version>\d+(?:\.\d+){0,3}[A-Za-z]?)(?:_[A-Za-z0-9]+)?$",
+    "x_netkan_version_edit": "^[vV]?(?<version>\\d+(?:\\.\\d+){0,3}[A-Za-z]?)(?:_[A-Za-z0-9]+)?$",
     "release_status" : "stable",
     "resources" : {
         "repository" : "https://github.com/ferram4/Ferram-Aerospace-Research"


### PR DESCRIPTION
Strips leading `v` and any codenames from the version number.

Test with all FAR versions currently on Kerbal Stuff:

![far-versions](https://cloud.githubusercontent.com/assets/1547727/9424544/8fbecc98-48bd-11e5-92ab-93bfd90143b9.png)
