### PR TITLE
Bump KerbinSide epoch

### DIFF
--- a/NetKAN/KerbinSide.netkan
+++ b/NetKAN/KerbinSide.netkan
@@ -1,9 +1,10 @@
 {
-	"spec_version" : 1,
-	"identifier"   : "KerbinSide",
-	"$kref"        : "#/ckan/kerbalstuff/77",
-	"license"      : "BSD-3-clause",
-	"depends": [
+    "spec_version"   : 1,
+    "identifier"     : "KerbinSide",
+    "$kref"          : "#/ckan/kerbalstuff/77",
+    "license"        : "BSD-3-clause",
+    "x_netkan_epoch" : "1",
+    "depends"        : [
         { "name": "KerbalKonstructs" }
     ]
 }


### PR DESCRIPTION
Somewhere in the past KerbinSide made a `v0.41.1` release, but all its other releases didn't have a trailing 'v'. It's now up to `1.0.3`, but clients on the `v0.41.1` release won't auto-upgrade to that.

This change bumps the KerbinSide epoch so that existing users will get the upgrades automatically, without having to uninstall and reinstall.

Thanks to Blu3wolf for helping me spot this.