### PR TITLE
Scatterer: force leading 'v'.

### DIFF
--- a/NetKAN/Scatterer.netkan
+++ b/NetKAN/Scatterer.netkan
@@ -3,7 +3,10 @@
     "license": "GPL-3.0",
     "release_status": "development",
     "$kref": "#/ckan/kerbalstuff/700",
+    "x_netkan_force_v": true,
     "spec_version": "v1.4",
-	"install" : [ { "find" : "scatterer",
-					"install_to" : "GameData" } ]
+    "install" : [ {
+        "find" : "scatterer",
+        "install_to" : "GameData"
+    } ]
 }


### PR DESCRIPTION
Some older versions of Scatterer had a leading 'v'. New ones don't.