### PR TITLE
Add RemoteTechXF and RemoteTech-common

### DIFF
--- a/NetKAN/RemoteTech-common.netkan
+++ b/NetKAN/RemoteTech-common.netkan
@@ -1,0 +1,35 @@
+{
+	"spec_version": "v1.4",
+	"identifier": "RemoteTech-common",
+	"$kref": "#/ckan/kerbalstuff/134",
+	"license": "restricted",
+	"release_status": "stable",
+	"x_netkan_license_ok": true,
+    "x_netkan_force_v": true,
+	"resources": {
+		"repository": "https://github.com/RemoteTechnologiesGroup/RemoteTech",
+		"bugtracker": "https://github.com/RemoteTechnologiesGroup/RemoteTech/issues",
+		"manual": "http://remotetechnologiesgroup.github.io/RemoteTech/"
+	},
+	"provides" : [ "RemoteTech" ],
+    "depends": [
+		{
+			"name": "ModuleManager",
+			"min_version": "2.3.1",
+			"comment": "Earlier versions of MM have forward compatibility problems, according to the MM release notes."
+		},
+        { "name": "RemoteTech-dll" }
+	],
+
+	"install": [
+		{
+			"find": "RemoteTech",
+			"install_to": "GameData",
+            "filter": "RemoteTech.dll"
+		}
+	],
+	"name": "RemoteTech - common",
+	"abstract": "This is just a module that provides files RemoteTech uses in common with other mods",
+	"author": "Remote Technologies Group",
+	"x_maintained_by": "Peppie23"
+}

--- a/NetKAN/RemoteTech.netkan
+++ b/NetKAN/RemoteTech.netkan
@@ -1,5 +1,5 @@
 {
-	"spec_version": 1,
+	"spec_version": "v1.2",
 	"identifier": "RemoteTech",
 	"$kref": "#/ckan/kerbalstuff/134",
 	"license": "restricted",
@@ -11,17 +11,18 @@
 		"bugtracker": "https://github.com/RemoteTechnologiesGroup/RemoteTech/issues",
 		"manual": "http://remotetechnologiesgroup.github.io/RemoteTech/"
 	},
-	"depends": [
-		{
-			"name": "ModuleManager",
-			"min_version": "2.3.1",
-			"comment": "Earlier versions of MM have forward compatibility problems, according to the MM release notes."
-		}
-	],
+	"provides" : [ "RemoteTech-dll" ],
+    "depends": [
+        { "name": "RemoteTech-common" }
+    ],
+    "conflicts": [
+        { "name": "RemoteTechXF" }
+    ],
+    "comment": "With the addition of RemoteTechXF, this module now only installs the .dll on its own while `RemoteTech-common` actually contains the majority of the mod",
 	"install": [
 		{
-			"file": "GameData/RemoteTech",
-			"install_to": "GameData"
+			"file": "GameData/RemoteTech/Plugins/RemoteTech.dll",
+			"install_to": "GameData/RemoteTech/Plugins"
 		}
 	],
 	"name": "RemoteTech",

--- a/NetKAN/RemoteTechXF.netkan
+++ b/NetKAN/RemoteTechXF.netkan
@@ -1,0 +1,20 @@
+{
+	"spec_version": "v1.4",
+	"identifier": "RemoteTechXF",
+	"$kref": "#/ckan/kerbalstuff/547",
+	"license": "GPL-2.0",
+	"provides": [ "RemoteTech-dll" ],
+    "depends": [
+        { "name": "RemoteTech-common" }
+    ],
+    "conflicts": [
+        { "name": "RemoteTech-dll" }
+    ],
+	"install": [
+		{
+			"find": "RemoteTech",
+			"install_to": "GameData"
+		}
+	],
+	"name": "RemoteTech XF"
+}


### PR DESCRIPTION
For testing, https://github.com/KSP-CKAN/CKAN-meta/archive/RemoteTechXF.zip is setup. Basically, it's setup to avoid end-users having to choose between mods. Instead, the dependency/provide relationships are setup such that if a user chooses to install `RemoteTech` they automatically get the common files installed (unprompted) and the same if a user chooses `RemoteTechXF`. The drawback is that when `RemoteTech-common` `provides` `RemoteTech` without `RemoteTech` itself being installed, an erroneous upgrade checkbox appears. While it doesn't cause any errors or crashes, it's something we'll want to see resolved.