### PR TITLE
Add case in build script for ksp_version being 1.0.99

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -59,6 +59,10 @@ create_dummy_ksp () {
         echo "Overidding '1.0' with '$KSP_VERSION_DEFAULT'"
         KSP_VERSION=$KSP_VERSION_DEFAULT
         ;;
+    "1.0.99")
+        echo "Overidding '1.0.99' with '$KSP_VERSION_DEFAULT'"
+        KSP_VERSION=$KSP_VERSION_DEFAULT
+        ;;
     "any")
         echo "Overridding any with '$KSP_VERSION_DEFAULT'"
         KSP_VERSION=$KSP_VERSION_DEFAULT


### PR DESCRIPTION
Many mods have `ksp_version_max: 1.0.99` and dependencies fail because not all mods have such a high compatibility ceiling. So instead lets use the default ksp version when we hit 1.0.99.