### PR TITLE
Clean up NewHorizons for newer releases.

### DIFF
--- a/NetKAN/NewHorizons.netkan
+++ b/NetKAN/NewHorizons.netkan
@@ -1,25 +1,29 @@
 {
-    "$kref": "#/ckan/kerbalstuff/661",
-    "spec_version": "v1.4",
-    "identifier": "NewHorizons",
-    "license": "CC-BY-NC-SA-4.0",
-	"depends"	:	[ { "name" : "Kopernicus" },
-					{ "name" : "Kopernicus-Config-Default" },
-					{ "name" : "ModuleManager" },
-					{ "name" : "KittopiaTech"} ],
-	"recommends":	[ { "name" : "ADIOS" },
-					{ "name" : "RemoteTech" },
-					{ "name" : "DeadlyReentry" } ],
-	"supports"	:	[ { "name" : "Regolith"} ],
-	"provides": [ "PlanetPack" ],
-	"conflicts"	:	[ { "name" : "KopernicusTech" },
-					{ "name" : "PlanetPack" }
-					],
-	"install"		:	[ { "find" : "New_Horizons",
-						"install_to" : "GameData" },
-						{ "find" : "KittopiaSpace",
-						"install_to" : "GameData",
-						"filter" : [ "StarFix.cfg", "Help.cr_help", "plugins", "Textures" ]
-						} 
-					]
+    "$kref"        : "#/ckan/kerbalstuff/661",
+    "spec_version" : "v1.4",
+    "identifier"   : "NewHorizons",
+    "license"      : "CC-BY-NC-SA-4.0",
+    "depends"      : [
+        { "name" : "Kopernicus" },
+        { "name" : "ModuleManager" },
+    ],
+    "recommends"   : [
+        { "name" : "ADIOS" },
+        { "name" : "RemoteTech" },
+        { "name" : "DeadlyReentry" } 
+    ],
+    "supports"     : [
+        { "name"   : "Regolith"}
+    ],
+    "provides"     : [ "PlanetPack" ],
+    "conflicts"    : [
+        { "name" : "KopernicusTech" },
+        { "name" : "PlanetPack" }
+    ],
+    "install"      : [
+        {
+            "find" : "New_Horizons",
+            "install_to" : "GameData" 
+        }
+    ]
 }


### PR DESCRIPTION
New Horizons has progressed a lot. It's installation is simpler, as are its dependencies. This commit cleans up the install (which is currently failing) as well as the JSON formatting.

I'm not a NewHorizons user, but I've thrown the test output at @TinyPirate who is (and will hopefully confirm/deny the validity of my work).