### PR TITLE
[Kopernicus] seperated examples / moved repository

### DIFF
--- a/NetKAN/KopernicusExamples.netkan
+++ b/NetKAN/KopernicusExamples.netkan
@@ -21,7 +21,7 @@
     },
     "ksp_version": "1.0",
     "depends":	[
-        { "name" : "ModuleManager", "min_version": "2.6.6" }
+        { "name" : "ModuleManager", "min_version": "2.6.6" },
 		{ "name" : "Kopernicus", "min_version": "0.3.2" }
     ],
     "install": [

--- a/NetKAN/KopernicusExamples.netkan
+++ b/NetKAN/KopernicusExamples.netkan
@@ -2,7 +2,6 @@
     "spec_version": "v1.4",
     "identifier": "KopernicusExamples",
     "$kref": "#/ckan/github/Kopernicus/KopernicusExamples",
-    "x_netkan_epoch": "1",
     "name": "Kopernicus Examples",
     "abstract": "Examples of how to use Kopernicus",
     "release_status": "development",

--- a/NetKAN/KopernicusExamples.netkan
+++ b/NetKAN/KopernicusExamples.netkan
@@ -1,10 +1,10 @@
 {
     "spec_version": "v1.4",
-    "identifier": "Kopernicus",
-    "$kref": "#/ckan/github/Kopernicus/Kopernicus",
+    "identifier": "KopernicusExamples",
+    "$kref": "#/ckan/github/Kopernicus/KopernicusExamples",
     "x_netkan_epoch": "1",
-    "name": "Kopernicus Planetary System Modifier",
-    "abstract": "Allows users to replace the planetary system used by the game.",
+    "name": "Kopernicus Examples",
+    "abstract": "Examples of how to use Kopernicus",
     "release_status": "development",
     "license": "LGPL-3.0",
     "author": [
@@ -17,18 +17,17 @@
     ],
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/114649",
-        "repository": "http://github.com/Kopernicus/Kopernicus"
+        "repository": "http://github.com/Kopernicus/KopernicusExamples"
     },
     "ksp_version": "1.0",
     "depends":	[
         { "name" : "ModuleManager", "min_version": "2.6.6" }
+		{ "name" : "Kopernicus", "min_version": "0.3.2" }
     ],
     "install": [
         {
-            "find": "Kopernicus",
-            "install_to": "GameData",
-            "filter": "Cache",
-            "comment": "At time of writing the Cache folder does not exist, but it may in the future so we filter it"
+            "find": "KopernicusExamples",
+            "install_to": "GameData"
         }
     ]
 }


### PR DESCRIPTION
We transfered the repository for Kopernicus, seperated the examples from the main plugin.
I will release an update after the changes have been merged (that's why the exaples depend on a Kopernicus 0.3.2).

Cheers
Thomas