### PR TITLE
Create BDArmory Sorting.netkan

### DIFF
--- a/NetKAN/BDArmory Sorting.netkan
+++ b/NetKAN/BDArmory Sorting.netkan
@@ -1,0 +1,11 @@
++{
++    "x_via": "Automated KerbalStuff CKAN submission",
++    "spec_version": 1,
++    "$kref": "#/ckan/kerbalstuff/1116",
++    "license": "MIT",
++    "identifier": "BDArmory Sorting",
++    "depends": [
++        { "name": "ModuleManager" },
++        { "name": "BDArmory" }
++    ]
++}


### PR DESCRIPTION
Remove BDArmory's parts from Utility, because now they have their own tab.
As I detect, modname and filename must be the same.