### PR TITLE
Update NewHorizons.netkan for new versions

### DIFF
--- a/NetKAN/NewHorizons.netkan
+++ b/NetKAN/NewHorizons.netkan
@@ -14,7 +14,7 @@
         { "name" : "DeadlyReentry" } 
     ],
     "supports"     : [
-        { "name"   : "Regolith"}
+        { "name"   : "CommunityResourcePack"}
     ],
     "provides"     : [ "PlanetPack" ],
     "conflicts"    : [

--- a/NetKAN/NewHorizons.netkan
+++ b/NetKAN/NewHorizons.netkan
@@ -16,10 +16,9 @@
     "supports"     : [
         { "name"   : "CommunityResourcePack"}
     ],
-    "provides"     : [ "PlanetPack" ],
     "conflicts"    : [
         { "name" : "KopernicusTech" },
-        { "name" : "PlanetPack" }
+        { "name" : "RealSolarSystem" }
     ],
     "install"      : [
         {

--- a/NetKAN/NewHorizons.netkan
+++ b/NetKAN/NewHorizons.netkan
@@ -3,6 +3,7 @@
     "spec_version": "v1.4",
     "identifier": "NewHorizons",
     "license": "CC-BY-NC-SA-4.0",
+    "x_netkan_epoch": "1",
 	"depends"	:	[ { "name" : "Kopernicus" },
 					{ "name" : "ModuleManager" } ],
 	"recommends":	[ { "name" : "ADIOS" },

--- a/NetKAN/NewHorizons.netkan
+++ b/NetKAN/NewHorizons.netkan
@@ -4,9 +4,7 @@
     "identifier": "NewHorizons",
     "license": "CC-BY-NC-SA-4.0",
 	"depends"	:	[ { "name" : "Kopernicus" },
-					{ "name" : "Kopernicus-Config-Default" },
-					{ "name" : "ModuleManager" },
-					{ "name" : "KittopiaTech"} ],
+					{ "name" : "ModuleManager" } ],
 	"recommends":	[ { "name" : "ADIOS" },
 					{ "name" : "RemoteTech" },
 					{ "name" : "DeadlyReentry" } ],
@@ -16,10 +14,6 @@
 					{ "name" : "PlanetPack" }
 					],
 	"install"		:	[ { "find" : "New_Horizons",
-						"install_to" : "GameData" },
-						{ "find" : "KittopiaSpace",
-						"install_to" : "GameData",
-						"filter" : [ "StarFix.cfg", "Help.cr_help", "plugins", "Textures" ]
-						} 
+						"install_to" : "GameData" }
 					]
 }

--- a/NetKAN/NewHorizons.netkan
+++ b/NetKAN/NewHorizons.netkan
@@ -1,20 +1,30 @@
 {
-    "$kref": "#/ckan/kerbalstuff/661",
-    "spec_version": "v1.4",
-    "identifier": "NewHorizons",
-    "license": "CC-BY-NC-SA-4.0",
+    "$kref"        : "#/ckan/kerbalstuff/661",
+    "spec_version" : "v1.4",
+    "identifier"   : "NewHorizons",
+    "license"      : "CC-BY-NC-SA-4.0",
     "x_netkan_epoch": "1",
-	"depends"	:	[ { "name" : "Kopernicus" },
-					{ "name" : "ModuleManager" } ],
-	"recommends":	[ { "name" : "ADIOS" },
-					{ "name" : "RemoteTech" },
-					{ "name" : "DeadlyReentry" } ],
-	"supports"	:	[ { "name" : "Regolith"} ],
-	"provides": [ "PlanetPack" ],
-	"conflicts"	:	[ { "name" : "KopernicusTech" },
-					{ "name" : "PlanetPack" }
-					],
-	"install"		:	[ { "find" : "New_Horizons",
-						"install_to" : "GameData" }
-					]
+    "depends"      : [
+        { "name" : "Kopernicus" },
+        { "name" : "ModuleManager" }
+    ],
+    "recommends"   : [
+        { "name" : "ADIOS" },
+        { "name" : "RemoteTech" },
+        { "name" : "DeadlyReentry" } 
+    ],
+    "supports"     : [
+        { "name"   : "Regolith"}
+    ],
+    "provides"     : [ "PlanetPack" ],
+    "conflicts"    : [
+        { "name" : "KopernicusTech" },
+        { "name" : "PlanetPack" }
+    ],
+    "install"      : [
+        {
+            "find" : "New_Horizons",
+            "install_to" : "GameData" 
+        }
+    ]
 }


### PR DESCRIPTION
These are the minimum required changes to allows indexing of `NewHorizons` versions past 1.35.
I'd like to dig into the relationships more but just don't have the time at the moment.

Pinging @Olympic1 in the hopes you can look into it more as you're sorting through the `PlanetPacks` mods.

Closes KSP-CKAN/CKAN-meta#767
Closes #2199 

Edit: I realized after I had done the first two commits that #2199 had all the same changes, so I took @pjf's formatting and added `netkan_epoch` to it.