### PR TITLE
Fix 'Module contains no files to install.'

### DIFF
--- a/NetKAN/RoboBrakes.netkan
+++ b/NetKAN/RoboBrakes.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.10",
     "license": "MIT",
     "$kref": "#/ckan/kerbalstuff/1041",
     "identifier": "RoboBrakes",
@@ -8,8 +8,8 @@
     ],
     "install": [
         {
-            "file"       : "RoboBrakes",
-            "install_to" : "GameData"
+            "find_regexp"   : "RoboBrakes(.+)?",
+            "install_to"    : "GameData/RoboBrakes"
         }
     ]
 }

--- a/NetKAN/RoboBrakes.netkan
+++ b/NetKAN/RoboBrakes.netkan
@@ -9,7 +9,7 @@
     "install": [
         {
             "find_regexp"   : "RoboBrakes.v[\\d+.]{5}",
-            "install_to"    : "GameData/RoboBrakes"
+            "install_to"    : "GameData"
         }
     ]
 }

--- a/NetKAN/RoboBrakes.netkan
+++ b/NetKAN/RoboBrakes.netkan
@@ -8,7 +8,7 @@
     ],
     "install": [
         {
-            "find_regexp"   : "RoboBrakes(.+)?",
+            "find_regexp"   : "RoboBrakes.v[\\d+.]{5}",
             "install_to"    : "GameData/RoboBrakes"
         }
     ]


### PR DESCRIPTION
NetKAN currently broken, this should fix it and continue working if the folder reverts to 'RoboBrakes'.