### PR TITLE
Add ContractConfigurator-MaritimeMissionsandBoatNavigationPlugin

### DIFF
--- a/NetKAN/ContractConfigurator-MaritimeMissionsandBoatNavigationPlugin.netkan
+++ b/NetKAN/ContractConfigurator-MaritimeMissionsandBoatNavigationPlugin.netkan
@@ -1,0 +1,26 @@
+{
+    "spec_version": "v1.4",
+    "license": "CC-BY-NC-SA-4.0",
+    "$kref": "#/ckan/kerbalstuff/1121",
+    "identifier": "ContractConfigurator-MaritimeMissionsandBoatNavigationPlugin",
+    "depends": [
+        { "name": "ContractConfigurator" },
+        { "name": "MaritimePack" }
+        
+    ],
+    "recommends": [
+        { "name": "KAS" },
+        { "name": "BDArmory" }
+        
+    ],
+    "install": [
+        {
+            "find"       : "MaritimeMissions",
+            "install_to" : "GameData/ContractPacks"
+        },
+        {
+            "find"       : "BoatNavigation",
+            "install_to" : "GameData"
+        }
+    ]
+}


### PR DESCRIPTION
There is an argument to be made for splitting this into multiple mods, but as the author hasn't split it, I opted to keep it as one module (for now).

For posterity: If this mod is to be split, the contracts should remain under the ID `ContractConfigurator-MaritimeMissionsandBoatNavigationPlugin` with a `name` hardcoded and the plugin should be split into a new .netkan.