### PR TITLE
Remove TrackingStationAmbientlight conflict with AmbientLightAdjustment.

### DIFF
--- a/NetKAN/TrackingStationAmbientlight.netkan
+++ b/NetKAN/TrackingStationAmbientlight.netkan
@@ -12,10 +12,5 @@
     ],
     "resources" : {
         "bugtracker" : "https://github.com/mhoram-kerbin/TrackingStationAmbientlight/issues"
-    },
-    "conflicts": [
-        {
-            "name": "AmbientLightAdjustment"
-        }
-    ]
+    }
 }


### PR DESCRIPTION
New version disables itself when the other mod is detected