### PR TITLE
PersistentThrust and SolarSailNavigator

### DIFF
--- a/NetKAN/PersistentThrust.netkan
+++ b/NetKAN/PersistentThrust.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version" : 1,
     "name"         : "Persistent Thrust",
-    "abstract"     : "PersistentThrust is a plugin that allows propulsion systems to operate during timewarp. The plugin includes a new solar sail part and module that allows a spacecraft to be propelled only by sunlight. It also adds a module with a patch to the stock ion engine that allows engines to thrust during timewarp.",
+    "abstract"     : "PersistentThrust is a plugin that allows propulsion systems to operate during timewarp. The plugin includes a new solar sail part and module that allows a spacecraft to be propelled only by sunlight. It also adds a module with a patch to the stock ion engine that allows engines to thrust during timewarp. ",
     "identifier"   : "PersistentThrust",
     "$kref"        : "#/ckan/github/bld/PersistentThrust",
     "license"      : "open-source",

--- a/NetKAN/PersistentThrust.netkan
+++ b/NetKAN/PersistentThrust.netkan
@@ -6,16 +6,15 @@
     "$kref"        : "#/ckan/github/bld/PersistentThrust",
     "license"      : "open-source",
     "author"       : "mrsolarsail",
-    "release_status" : "stable",
+    "release_status" : "development",
     "ksp_version"  : "1.0.4",
     "resources" : { "homepage" : "http://forum.kerbalspaceprogram.com/threads/133735" },
+    "depends" : [ { "name" : "ModuleManager" } ],
+    "recommends" : [ { "name" : "SolarSailNavigator" } ],
     "install" : [
         {
             "file"       : "PersistentThrust",
             "install_to" : "GameData",
         }
-    ],
-    "recommends" : [
-        { "name" : "SolarSailNavigator" }
     ]
 }

--- a/NetKAN/PersistentThrust.netkan
+++ b/NetKAN/PersistentThrust.netkan
@@ -1,0 +1,21 @@
+{
+    "spec_version" : 1,
+    "name"         : "Persistent Thrust",
+    "abstract"     : "PersistentThrust is a plugin that allows propulsion systems to operate during timewarp. The plugin includes a new solar sail part and module that allows a spacecraft to be propelled only by sunlight. It also adds a module with a patch to the stock ion engine that allows engines to thrust during timewarp.",
+    "identifier"   : "PersistentThrust",
+    "$kref"        : "#/ckan/github/bld/PersistentThrust",
+    "license"      : "open-source",
+    "author"       : "mrsolarsail",
+    "release_status" : "stable",
+    "ksp_version"  : "1.0.4",
+    "resources" : { "homepage" : "http://forum.kerbalspaceprogram.com/threads/133735" },
+    "install" : [
+        {
+            "file"       : "PersistentThrust",
+            "install_to" : "GameData",
+        }
+    ],
+    "recommends" : [
+        { "name" : "SolarSailNavigator" }
+    ]
+}

--- a/NetKAN/PersistentThrust.netkan
+++ b/NetKAN/PersistentThrust.netkan
@@ -14,7 +14,7 @@
     "install" : [
         {
             "file"       : "PersistentThrust",
-            "install_to" : "GameData",
+            "install_to" : "GameData"
         }
     ]
 }

--- a/NetKAN/SolarSailNavigator.netkan
+++ b/NetKAN/SolarSailNavigator.netkan
@@ -15,5 +15,5 @@
             "file"       : "SolarSailNavigator",
             "install_to" : "GameData"
         }
-    ],
+    ]
 }

--- a/NetKAN/SolarSailNavigator.netkan
+++ b/NetKAN/SolarSailNavigator.netkan
@@ -9,11 +9,7 @@
     "release_status" : "development",
     "ksp_version"  : "1.0.4",
     "resources" : { "homepage" : "http://forum.kerbalspaceprogram.com/threads/119579" },
-    "depends": [
-        { 
-            "name": "ModuleManager",
-            "name": "PersistentThrust",
-        }],
+    "depends": [ { "name": "PersistentThrust" } ],
     "install" : [
         {
             "file"       : "SolarSailNavigator",

--- a/NetKAN/SolarSailNavigator.netkan
+++ b/NetKAN/SolarSailNavigator.netkan
@@ -5,6 +5,8 @@
     "spec_version": 1,
     "license": "unrestricted",
     "depends": [
-        { "name": "ModuleManager" }
-        ]
+        { 
+            "name": "ModuleManager",
+            "name": "PersistentEngines",
+        }]
 }

--- a/NetKAN/SolarSailNavigator.netkan
+++ b/NetKAN/SolarSailNavigator.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version" : 1,
-    "name"         : "Persistent Thrust",
-    "abstract"     : "PersistentThrust is a plugin that allows propulsion systems to operate during timewarp. The plugin includes a new solar sail part and module that allows a spacecraft to be propelled only by sunlight. It also adds a module with a patch to the stock ion engine that allows engines to thrust during timewarp.",
+    "name"         : "Solar Sail Navigator",
+    "abstract"     : "SolarSailNavigator is a new plugin (ALPHA: you have been warned) to navigate continuous thrust spacecraft with sunlight-propelled solar sails and ion engines. The sail model and force models are derived from KSP Interstellar. The goal of this plugin is to make solar sailing and continuous thrust engines a practical means of travel throughout the KSP solar system.",
     "identifier"   : "SolarSailNavigator",
     "$kref"        : "#/ckan/github/bld/SolarSailNavigator",
     "license"      : "LGPL-2.1",

--- a/NetKAN/SolarSailNavigator.netkan
+++ b/NetKAN/SolarSailNavigator.netkan
@@ -13,7 +13,7 @@
     "install" : [
         {
             "file"       : "SolarSailNavigator",
-            "install_to" : "GameData",
+            "install_to" : "GameData"
         }
     ],
 }

--- a/NetKAN/SolarSailNavigator.netkan
+++ b/NetKAN/SolarSailNavigator.netkan
@@ -1,12 +1,23 @@
 {
-    "$kref": "#/ckan/kerbalstuff/752",
-    "x_via": "Automated KerbalStuff CKAN submission",
-    "identifier": "SolarSailNavigator",
-    "spec_version": 1,
-    "license": "unrestricted",
+    "spec_version" : 1,
+    "name"         : "Persistent Thrust",
+    "abstract"     : "PersistentThrust is a plugin that allows propulsion systems to operate during timewarp. The plugin includes a new solar sail part and module that allows a spacecraft to be propelled only by sunlight. It also adds a module with a patch to the stock ion engine that allows engines to thrust during timewarp.",
+    "identifier"   : "SolarSailNavigator",
+    "$kref"        : "#/ckan/github/bld/SolarSailNavigator",
+    "license"      : "LGPL-2.1",
+    "author"       : "mrsolarsail",
+    "release_status" : "development",
+    "ksp_version"  : "1.0.4",
+    "resources" : { "homepage" : "http://forum.kerbalspaceprogram.com/threads/119579" },
     "depends": [
         { 
             "name": "ModuleManager",
-            "name": "PersistentEngines",
-        }]
+            "name": "PersistentThrust",
+        }],
+    "install" : [
+        {
+            "file"       : "SolarSailNavigator",
+            "install_to" : "GameData",
+        }
+    ],
 }


### PR DESCRIPTION
Fix PersistentThrust and SolarSailNavigator, change to pull from Github rather than Kerbalstuff at author's request.  Aware this is redundant to KerbalStuffBot, this is a better netkan overall.