### PR TITLE
Fixed EngineerLevelFixer to include it's ModuleManager dependency

### DIFF
--- a/NetKAN/EngineerLevelFixer.netkan
+++ b/NetKAN/EngineerLevelFixer.netkan
@@ -3,5 +3,9 @@
     "x_via": "Automated KerbalStuff CKAN submission",
     "identifier": "EngineerLevelFixer",
     "license": "MIT",
-    "$kref": "#/ckan/kerbalstuff/1155"
+    "$kref": "#/ckan/kerbalstuff/1155",
+    "$vref": "#/ckan/ksp-avc",
+    "depends" : [
+      { "name" : "ModuleManager" }
+    ]
 }


### PR DESCRIPTION
I entered a mod the other day, but I didn't realize that I needed to declare it has a ModuleManager dependency or that it has a KSP AVC file.