### PR TITLE
Add conflict to ContractConfigurator-ScanSatLite as it's now included in SCANsat

### DIFF
--- a/NetKAN/SCANsat.netkan
+++ b/NetKAN/SCANsat.netkan
@@ -11,12 +11,15 @@
         { "name": "Toolbar" },
 		{ "name": "ContractConfigurator" }
     ],
+    "suggests": [
+		{ "name": "RasterPropMonitor" }
+	],
+    "conflicts": [
+		{ "name": "ContractConfigurator-ScanSatLite" }
+	],
 	"resources" : {
 		"repository"   : "https://github.com/S-C-A-N/SCANsat"
 	},	
-	"suggests": [
-		{ "name": "RasterPropMonitor" }
-	],
 	"x_netkan_override" : [
 		{
 			"version" : "v12.1",


### PR DESCRIPTION
As stated in #2248 SCANsat now includes this functionality (as of v14.2), so adding a conflict to the current .netkan will update the v14.2 .ckan and onward.
Closes  #2248