### PR TITLE
Replacing Auto NyrathsUSAFOrion.netkan

### DIFF
--- a/NetKAN/NyrathsUSAFOrion.netkan
+++ b/NetKAN/NyrathsUSAFOrion.netkan
@@ -1,0 +1,19 @@
+{
+    "spec_version": "v1.4",
+    "x_via": "Automated KerbalStuff CKAN submission",
+    "identifier": "NyrathsUSAFOrion",
+    "abstract"  : "Orion drive for KSP"
+    "name"      : "USAF Orion Mod"
+    "license": "CC BY-SA 3.0",
+    "$kref": "#/ckan/kerbalstuff/1170"
+     "install": [
+        {
+            "file": "USAFOrionMod/GameData/Nyrath",
+            "install_to": "GameData"
+        }
+    ]
+    "resources" : {
+        "homepage"  : "http://forum.kerbalspaceprogram.com/threads/28428-Orion-aka-Ol-Boom-boom",
+        "repository" : "repository"
+        },
+}

--- a/NetKAN/NyrathsUSAFOrion.netkan
+++ b/NetKAN/NyrathsUSAFOrion.netkan
@@ -13,6 +13,6 @@
     ],
     "resources" : {
         "homepage"       : "http://forum.kerbalspaceprogram.com/threads/28428-Orion-aka-Ol-Boom-boom",
-        "repository"     : "repository"
+        "repository"     : "https://github.com/cerebrate/USAFOrion"
         }
 }

--- a/NetKAN/NyrathsUSAFOrion.netkan
+++ b/NetKAN/NyrathsUSAFOrion.netkan
@@ -2,18 +2,18 @@
     "spec_version": "v1.4",
     "x_via": "Automated KerbalStuff CKAN submission",
     "identifier": "NyrathsUSAFOrion",
-    "abstract"  : "Orion drive for KSP"
-    "name"      : "USAF Orion Mod"
+    "abstract"  : "Orion drive for KSP",
+    "name"      : "USAF Orion Mod",
     "license": "CC BY-SA 3.0",
-    "$kref": "#/ckan/kerbalstuff/1170"
-     "install": [
+    "$kref": "#/ckan/kerbalstuff/1170",
+    "install": [
         {
             "file": "USAFOrionMod/GameData/Nyrath",
             "install_to": "GameData"
         }
-    ]
+    ],
     "resources" : {
         "homepage"  : "http://forum.kerbalspaceprogram.com/threads/28428-Orion-aka-Ol-Boom-boom",
         "repository" : "repository"
-        },
+        }
 }

--- a/NetKAN/NyrathsUSAFOrion.netkan
+++ b/NetKAN/NyrathsUSAFOrion.netkan
@@ -1,19 +1,18 @@
 {
     "spec_version": "v1.4",
-    "x_via": "Automated KerbalStuff CKAN submission",
     "identifier": "NyrathsUSAFOrion",
     "abstract"  : "Orion drive for KSP",
     "name"      : "USAF Orion Mod",
-    "license": "CC-BY-SA-3.0",
-    "$kref": "#/ckan/kerbalstuff/1170",
-    "install": [
+    "license"   : "CC-BY-SA-3.0",
+    "$kref"     : "#/ckan/kerbalstuff/1170",
+    "install"   : [
         {
-            "file": "USAFOrionMod/GameData/Nyrath",
-            "install_to": "GameData"
+            "find"       : "Nyrath",
+            "install_to" : "GameData"
         }
     ],
     "resources" : {
-        "homepage"  : "http://forum.kerbalspaceprogram.com/threads/28428-Orion-aka-Ol-Boom-boom",
-        "repository" : "repository"
+        "homepage"       : "http://forum.kerbalspaceprogram.com/threads/28428-Orion-aka-Ol-Boom-boom",
+        "repository"     : "repository"
         }
 }

--- a/NetKAN/NyrathsUSAFOrion.netkan
+++ b/NetKAN/NyrathsUSAFOrion.netkan
@@ -4,7 +4,7 @@
     "identifier": "NyrathsUSAFOrion",
     "abstract"  : "Orion drive for KSP",
     "name"      : "USAF Orion Mod",
-    "license": "CC BY-SA 3.0",
+    "license": "CC-BY-SA-3.0",
     "$kref": "#/ckan/kerbalstuff/1170",
     "install": [
         {


### PR DESCRIPTION
The auto generated NyrathsUSAFOrion.netkan from Kerbal Stuff seems to have been broken first by lack of clear install folders, and secondly by me using a long license description.  And then I think I've muffed the git pull/push fixups to the point neither I nor github have any clue which file is which.
Anyway, this is a fresh netkan file with extra details to match spec where info is available.  I've left x_via in as per the auto, 'cos I'm not sure if that's needed for the version checking.