### PR TITLE
Removed outdated, license from KStuff

### DIFF
--- a/NetKAN/KerbalFoundries.netkan
+++ b/NetKAN/KerbalFoundries.netkan
@@ -2,28 +2,8 @@
     "spec_version"   : "v1.4",
     "identifier"     : "KerbalFoundries",
     "$kref"          : "#/ckan/kerbalstuff/58",
-    "license"        : "GPL-3.0",
-	"resources": 
-	{
-		"repository": " https://kerbalstuff.com/mod/58/"
-    },
+    "x_netkan_license_ok": true,
     "recommends" : [
         { "name" : "TweakScale" }
     ],
-    "install" : [
-        {
-            "find"       : "KerbalFoundries",
-            "install_to" : "GameData"
-        }
-    ],
-    "x_netkan_override" : [
-        {
-            "version" : "Beta_1.8g",
-            "delete" : [ "ksp_version" ],
-            "override" : {
-                "ksp_version_min" : "1.0.2",
-                "ksp_version_max" : "1.0.4"
-            }
-        }
-    ]
 }


### PR DESCRIPTION
How do I force it to grab a newer version, if the version naming changed? Is the only way renaming the  old versions on KStuff?
```
Version 1.9g for Kerbal Space Program 1.0.4
Released on 2015-09-10

Version Beta_1.9f for Kerbal Space Program 1.0.4
Released on 2015-08-24

Version Beta_19.b for Kerbal Space Program 1.0.4 <- This is what CKAN currently indexes.
Released on 2015-08-10
```