### PR TITLE
Create StockLS.netkan

### DIFF
--- a/NetKAN/StockLS.netkan
+++ b/NetKAN/StockLS.netkan
@@ -1,0 +1,27 @@
+{
+    "spec_version": "v1.4",
+    "x_via": "Automated KerbalStuff CKAN submission",
+    "identifier": "StockLS",
+    "license": "MIT",
+    "$kref": "#/ckan/kerbalstuff/1210",
+    "install": [
+        {
+            "file"       : "StockLS/GameData/StockLS",
+            "install_to" : "GameData"
+        }
+    ],
+    "depends": [
+        { "name": "ModuleManager", "min_version" : "2.6.0" }
+    ],
+    "recommends": [
+        { "name": "USILifeSupport" }
+    ],
+    "suggests": [
+        { "name": "StockPlugins" },
+        { "name": "StockRT" },
+        { "name": "StockSCANSat" }
+    ],
+    "supports": [
+        { "name": "USILifeSupport" }
+    ]
+}

--- a/NetKAN/StockLS.netkan
+++ b/NetKAN/StockLS.netkan
@@ -1,12 +1,11 @@
 {
     "spec_version": "v1.4",
-    "x_via": "Automated KerbalStuff CKAN submission",
     "identifier": "StockLS",
     "license": "MIT",
     "$kref": "#/ckan/kerbalstuff/1210",
     "install": [
         {
-            "file"       : "StockLS/GameData/StockLS",
+            "file"       : "GameData/StockLS",
             "install_to" : "GameData"
         }
     ],


### PR DESCRIPTION
Closes #2409
@vosechu I'd like your input on the install. Written as is this will only install `USILifeSupport.cfg` into `GameData/StockLS`. While I'd like to install the other files (.version file, readme, license) that would result in an odd install structure for users:

````
D:\TESTSUITE\DUMMY_KSP\GAMEDATA
|   
\---StockLS
    |   .DS_Store
    |   LICENSE
    |   README.md
    |   StockLS.version
    |   
    +---AutoPruner
    |   \---PRNLs
    |           StockLS.prnl
    |           
    \---GameData
        \---StockLS
                USILifeSupport.cfg
````

Basically the path to `USILifeSupport.cfg` would be `KSP/GameData/StockLS/GameData/StockLS/USILifeSupport.cfg`

Lemme know how you'd like to proceed, if you're happy with just installing `GameData/StockLS/USILifeSupport.cfg` or if you want to restructure the .zip, or whatever.