### PR TITLE
Add GPWS

### DIFF
--- a/NetKAN/GPWS.netkan
+++ b/NetKAN/GPWS.netkan
@@ -1,6 +1,7 @@
 {
     "spec_version": "v1.4",
     "name": "Ground Proximity Warning System (GPWS)",
+    "author": "bssthu",
     "abstract": "Warning System for Kerbal Space Program",
     "identifier": "GPWS",
     "license": "CC-BY-NC-SA-4.0",
@@ -10,7 +11,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/112420",
         "repository": "https://github.com/bssthu/KSP_GPWS"
     },
-    "$kref": "#/ckan/http/https://github.com/bssthu/KSP_GPWS/releases/download/v0.3-beta.2/GPWSv0.3-beta.2.zip",
+    "$kref": "#/ckan/github/bssthu/KSP_GPWS",
     "$vref": "#/ckan/ksp-avc",
     "install": [
         {

--- a/NetKAN/GPWS.netkan
+++ b/NetKAN/GPWS.netkan
@@ -1,0 +1,31 @@
+{
+    "spec_version": "v1.4",
+    "name": "Ground Proximity Warning System (GPWS)",
+    "abstract": "Warning System for Kerbal Space Program",
+    "identifier": "GPWS",
+    "license": "CC-BY-NC-SA-4.0",
+    "release_status": "development",
+    "ksp_version": "1.0.4",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/112420",
+        "repository": "https://github.com/bssthu/KSP_GPWS"
+    },
+    "$kref": "#/ckan/http/https://github.com/bssthu/KSP_GPWS/releases/download/v0.3-beta.2/GPWSv0.3-beta.2.zip",
+    "$vref": "#/ckan/ksp-avc",
+    "install": [
+        {
+            "find": "GPWS",
+            "install_to": "GameData"
+        }
+    ],
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "Toolbar"
+        }
+    ]
+}


### PR DESCRIPTION
This closes #2406 (this time for real).

I don't know if it is possible to fetch pre-releases from a github repo, so I pointed the download directly to the file. I know it is an ugly work around and I will fix it if there is another way to get files tagged as pre-release.

Also, the mod bundles a dll from Advanced Fly-by-wire but it looks like it is no longer supported/distributed by CKAN for KSP 1.0.4. For right now, I just ignore those files. Any ideas on how to work around this?