### PR TITLE
build.sh: Evaluate only changes on branch, not absolute diffs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -173,7 +173,7 @@ inject_metadata () {
 if [ -n "$ghprbActualCommit" ]
 then
     echo "Commit hash: $ghprbActualCommit"
-    export COMMIT_CHANGES="`git diff --diff-filter=AM --name-only --stat origin/master`"
+    export COMMIT_CHANGES="`git diff --diff-filter=AM --name-only --stat origin/master...HEAD`"
 else
     echo "No commit provided, skipping further tests."
     exit $EXIT_OK


### PR DESCRIPTION
This change instructs git/build.sh to only examine files which have changed on the current branch from its most-recent-ancestor of `origin/master`. This is better than the absolute differences, as it means `origin/master` can change as much as it likes and we don't care.

Tested locally. I'm sure there's an issue number for this somewhere, so feel free to edit this PR to include that. :)