### PR TITLE
Updated QuickHide

### DIFF
--- a/NetKAN/QuickHide.netkan
+++ b/NetKAN/QuickHide.netkan
@@ -9,7 +9,7 @@
 		"install_to" : "GameData"
 	}
 	],
-	"depends": [
+	"suggests": [
 	{
 	"name": "Toolbar"
 	}


### PR DESCRIPTION
Toolbar is not a dependency since QuickHide v2.00