### PR TITLE
Sigma expansion split

### DIFF
--- a/NetKAN/SigmaOPMExpansion.netkan
+++ b/NetKAN/SigmaOPMExpansion.netkan
@@ -12,7 +12,7 @@
         { "name": "OuterPlanetsMod" },
         { "name": "Kopernicus" }
     ],
-    "recommends": [
+    "suggests": [
         { "name": "SigmaOPMRecolor" }
     ],
     "resources": {

--- a/NetKAN/SigmaOPMExpansion.netkan
+++ b/NetKAN/SigmaOPMExpansion.netkan
@@ -1,16 +1,29 @@
 {
-    "spec_version": 1,
-    "identifier": "SigmaOPMExpansion",
-    "$kref": "#/ckan/kerbalstuff/912",
-    "license": "CC-BY-NC-SA-4.0",
+    "spec_version" : "v1.4",
+    "identifier"   : "SigmaOPMExpansion",
+    "$kref"        : "#/ckan/github/Sigma88/Sigma-OPMTilt",
+    "$vref"        : "#/ckan/ksp-avc",
+    "name"         : "Sigma: OPM Tilt",
+    "abstract"     : "This mod gives Urlum (OPM) a 90° axial tilt.",
+    "license"      : "CC-BY-NC-SA-4.0",
+    "author"       : "Sigma88",
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "OuterPlanetsMod" }
+        { "name": "OuterPlanetsMod" },
+        { "name": "Kopernicus" }
     ],
+    "recommends": [
+        { "name": "SigmaOPMRecolor" }
+    ],
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/112095"
+    },
     "install": [
         {
-            "file": "GameData/Sigma",
-            "install_to": "GameData"
+            "find": "OPMTilt",
+            "install_to": "GameData/Sigma"
         }
-    ]
+    ],
+    "x_netkan_epoch": "1",
+    "comment": "This mod used to be packaged differently but is now repackaged to allow an upgrade path."
 }

--- a/NetKAN/SigmaOPMRecolor.netkan
+++ b/NetKAN/SigmaOPMRecolor.netkan
@@ -12,6 +12,9 @@
         { "name": "OuterPlanetsMod" },
         { "name": "Kopernicus" }
     ],
+    "recommends": [
+        { "name": "SigmaOPMExpansion" }
+    ],
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/112095"
     },

--- a/NetKAN/SigmaOPMRecolor.netkan
+++ b/NetKAN/SigmaOPMRecolor.netkan
@@ -12,7 +12,7 @@
         { "name": "OuterPlanetsMod" },
         { "name": "Kopernicus" }
     ],
-    "recommends": [
+    "suggests": [
         { "name": "SigmaOPMExpansion" }
     ],
     "resources": {

--- a/NetKAN/SigmaOPMRecolor.netkan
+++ b/NetKAN/SigmaOPMRecolor.netkan
@@ -1,0 +1,24 @@
+{
+    "spec_version" : "v1.4",
+    "identifier"   : "SigmaOPMRecolor",
+    "$kref"        : "#/ckan/github/Sigma88/Sigma-OPMRecolor",
+    "$vref"        : "#/ckan/ksp-avc",
+    "name"         : "Sigma: OPM Recolor",
+    "abstract"     : "This mod changes the colors of the OPM Gas Giants: Sarnus, Urlum and Neidon are now light blue, red and orange.",
+    "license"      : "CC-BY-NC-SA-4.0",
+    "author"       : "Sigma88",
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "OuterPlanetsMod" },
+        { "name": "Kopernicus" }
+    ],
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/112095"
+    },
+    "install": [
+        {
+            "find": "OPMRecolor",
+            "install_to": "GameData/Sigma"
+        }
+    ]
+}

--- a/NetKAN/SigmaPluronKhato.netkan
+++ b/NetKAN/SigmaPluronKhato.netkan
@@ -1,0 +1,23 @@
+{
+    "spec_version" : "v1.4",
+    "identifier"   : "SigmaPluronKhato",
+    "$kref"        : "#/ckan/github/Sigma88/Sigma-PluronKhato",
+    "$vref"        : "#/ckan/ksp-avc",
+    "name"         : "Sigma: PluronKhato",
+    "abstract"     : "This mod will add a Kerbal analogue to the Pluto-Charon system.",
+    "license"      : "CC-BY-NC-SA-4.0",
+    "author"       : "Sigma88",
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus" }
+    ],
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/112095"
+    },
+    "install": [
+        {
+            "find": "PluronKhato",
+            "install_to": "GameData/Sigma"
+        }
+    ]
+}


### PR DESCRIPTION
`SigmaOPMExpansion` was split into 3 mods.
`SigmaPluronKhato` are 2 planets, `SigmaOPMRecolor` is a recolor of one of the OPM planets, and "SigmaOPMTilt" I kept under the ID `SigmaOPMExpansion` to provide some kind of upgrade path (`SigmaOPMExpansion` is discontinued and old links are dead).

Branched under the NetKAN repo to allow anyone to modify as needed.

See the referenced issue for any missing details.
Closes https://github.com/KSP-CKAN/NetKAN/issues/2382

@Olympic1 `SigmaPluronKhato` will fall under your planetpack purview. https://github.com/KSP-CKAN/CKAN-meta/issues/588

@Sigma88 let me know if you want modifications to the relationships (if you want them to recommend each other or any others from your suite of mods).