### PR TITLE
Add EvaHandrailsKISCompatibility

### DIFF
--- a/NetKAN/EVAHandrailsPackContinued.netkan
+++ b/NetKAN/EVAHandrailsPackContinued.netkan
@@ -11,6 +11,9 @@
     "depends" : [
         { "name": "ModuleManager", "min_version": "2.6.5" }
     ],
+    "suggests": [
+        { "name": "EvaHandrailsKISCompatibility" }
+    ],
     "install": [
         {
             "file": "NEBULA",
@@ -32,3 +35,4 @@
 		}
     ]
 }
+EvaHandrailsKISCompatibility

--- a/NetKAN/EVAHandrailsPackContinued.netkan
+++ b/NetKAN/EVAHandrailsPackContinued.netkan
@@ -35,4 +35,3 @@
 		}
     ]
 }
-EvaHandrailsKISCompatibility

--- a/NetKAN/EvaHandrailsKISCompatibility.netkan
+++ b/NetKAN/EvaHandrailsKISCompatibility.netkan
@@ -1,0 +1,16 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "EvaHandrailsKISCompatibility",
+    "license": "GPL-2.0",
+    "$kref": "#/ckan/kerbalstuff/1196",
+    "depends": [
+        { "name": "KIS" },
+        { "name": "EVAHandrailsPackContinued" }
+    ],
+    "install": [
+        {
+            "file"       : "EVA-Handrail-KIS-master",
+            "install_to" : "GameData"
+        }
+    ]
+}


### PR DESCRIPTION
Added this as a suggestion to EVAHandrailsPackContinued as KIS is very popular and presenting the patch to users is probably a good choice.

Closes https://github.com/KSP-CKAN/NetKAN/pull/2389