### PR TITLE
Hack around USI Core being in too many places.

### DIFF
--- a/NetKAN/Karbonite.netkan
+++ b/NetKAN/Karbonite.netkan
@@ -9,7 +9,11 @@
     "release_status" : "stable",
     "$vref"          : "#/ckan/ksp-avc",
     "resources" : {
-        "homepage" : "http://forum.kerbalspaceprogram.com/threads/89401"
+        "homepage" : "http://forum.kerbalspaceprogram.com/threads/89401",
+        "license"      : "https://github.com/BobPalmer/Karbonite/blob/master/FOR_RELEASE/license.txt",
+        "bugtracker"   : "https://github.com/BobPalmer/Karbonite/issues",
+        "repository"   : "https://github.com/BobPalmer/Karbonite" ,
+        "kerbalstuff"  : "https://kerbalstuff.com/mod/759/Karbonite"
     },
     "depends" : [
         { "name" : "USITools" },

--- a/NetKAN/Karbonite.netkan
+++ b/NetKAN/Karbonite.netkan
@@ -13,6 +13,7 @@
     },
     "depends" : [
         { "name" : "USITools" },
+        { "name" : "USI-Core" },
         { "name" : "CommunityResourcePack" },
         { "name" : "FirespitterCore" },
         { "name" : "ModuleManager" }
@@ -26,7 +27,7 @@
         {
             "file"       : "GameData/UmbraSpaceIndustries",
             "install_to" : "GameData",
-            "filter"     : "USICore.version",
+            "filter"     : ["USICore.version", "CHANGELOG.txt", "Kontainers", "ReactorPack"],
             "comment"    : "The filter is just a hacky solution until RoverDude's mod restructuring is complete."
         }
     ],

--- a/NetKAN/Karbonite.netkan
+++ b/NetKAN/Karbonite.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version"   : 1,
+    "spec_version"   : "v1.4",
     "name"           : "Karbonite",
     "identifier"     : "Karbonite",
     "$kref"          : "#/ckan/github/BobPalmer/Karbonite",
@@ -25,10 +25,8 @@
     "provides" : [ "USI-Karbonite" ],
     "install" : [
         {
-            "file"       : "GameData/UmbraSpaceIndustries",
-            "install_to" : "GameData",
-            "filter"     : ["USICore.version", "CHANGELOG.txt", "Kontainers", "ReactorPack"],
-            "comment"    : "The filter is just a hacky solution until RoverDude's mod restructuring is complete."
+            "find"       : "UmbraSpaceIndustries/Karbonite",
+            "install_to" : "GameData/UmbraSpaceIndustries"
         }
     ],
     "x_netkan_override" : [

--- a/NetKAN/UKS.netkan
+++ b/NetKAN/UKS.netkan
@@ -25,7 +25,9 @@
   "install" : [
     {
       "file"       : "GameData/UmbraSpaceIndustries",
-      "install_to" : "GameData"
+      "install_to" : "GameData",
+      "filter"     : [ "CHANGELOG.txt", "USICore.version", "Kontainers", "ReactorPack"],
+      "comment"    : "The filter is just a hacky solution until RoverDude's mod restructuring is complete."
     }
   ],
 
@@ -41,6 +43,10 @@
     {
       "name": "USITools",
       "min_version": "0.4.0"
+    },
+    {
+      "name": "USI-Core",
+      "min_version": "0.0.1.0"
     },
     {
       "name": "CommunityResourcePack",

--- a/NetKAN/UKS.netkan
+++ b/NetKAN/UKS.netkan
@@ -19,7 +19,10 @@
   
   "resources" : {
     "homepage"     : "http://forum.kerbalspaceprogram.com/threads/79588",
-    "license"      : "https://github.com/BobPalmer/MKS/blob/master/license.txt"
+    "license"      : "https://github.com/BobPalmer/MKS/blob/master/license.txt",
+    "bugtracker"   : "https://github.com/BobPalmer/MKS/issues",
+    "repository"   : "https://github.com/BobPalmer/MKS",
+    "kerbalstuff"  : "https://kerbalstuff.com/mod/788/USI%20Kolonization%20Systems%20%28MKS/OKS%29"
   },
   
   "install" : [

--- a/NetKAN/UKS.netkan
+++ b/NetKAN/UKS.netkan
@@ -1,5 +1,5 @@
 {
-  "spec_version"   : 1,
+  "spec_version"   : "v1.4",
   "name"           : "USI Kolonization Systems (MKS/OKS)",
   "identifier"     : "UKS",
   "$kref"          : "#/ckan/github/BobPalmer/MKS",
@@ -24,10 +24,8 @@
   
   "install" : [
     {
-      "file"       : "GameData/UmbraSpaceIndustries",
-      "install_to" : "GameData",
-      "filter"     : [ "CHANGELOG.txt", "USICore.version", "Kontainers", "ReactorPack"],
-      "comment"    : "The filter is just a hacky solution until RoverDude's mod restructuring is complete."
+      "find"       : "UmbraSpaceIndustries/Kolonization",
+      "install_to" : "GameData/UmbraSpaceIndustries"
     }
   ],
 
@@ -45,8 +43,7 @@
       "min_version": "0.4.0"
     },
     {
-      "name": "USI-Core",
-      "min_version": "0.0.1.0"
+      "name": "USI-Core"
     },
     {
       "name": "CommunityResourcePack",

--- a/NetKAN/USI-Core.netkan
+++ b/NetKAN/USI-Core.netkan
@@ -1,0 +1,21 @@
+{
+    "spec_version"   : 1,
+    "$kref"          : "#/ckan/github/BobPalmer/USI_Core",
+    "name"           : "USI Core",
+    "author"         : "RoverDude",
+    "identifier"     : "USI-Core",
+    "abstract"       : "Reactors, Containers, and other common USI bits and pieces.",
+    "license"        : "CC-BY-NC-SA-4.0",
+    "release_status" : "stable",
+	"ksp_version" : "1.0",
+    "provides"       : [ "USI-Core" ],
+    "install" : [
+        {
+            "file"       : "GameData/UmbraSpaceIndustries",
+            "install_to" : "GameData"
+        }
+    ],
+    "depends" : [
+        {"name" : "USITools"}
+    ]
+}

--- a/NetKAN/USI-Core.netkan
+++ b/NetKAN/USI-Core.netkan
@@ -6,6 +6,10 @@
     "identifier"     : "USI-Core",
     "abstract"       : "Reactors, Containers, and other common USI bits and pieces.",
     "license"        : "CC-BY-NC-SA-4.0",
+    "resources"      : {
+        "bugtracker"   : "https://github.com/BobPalmer/USI_Core/issues",
+        "repository"   : "https://github.com/BobPalmer/USI_Core" 
+    },
     "release_status" : "stable",
 	"ksp_version" : "1.0",
     "provides"       : [ "USI-Core" ],


### PR DESCRIPTION
The metadata for RoverDude's projects no longer matches his current project configuration.  Specifically his USI-Core project is included in multiple other projects.  The fixes the ones that are currently in ckan.

It adds the USI-Core to ckan.  Makes both UKS and Karbonite depend on it, and then filters the USI-Core files back out of both of those .netkan files.

When people want to add MKS-Lite and Orion all they will have to do is create netkan files that depend on USI-Core and add a filter 
 "filter"     : ["USICore.version", "CHANGELOG.txt", "Kontainers", "ReactorPack"],
.

I have tested this on my install and the final outcome is the same as manually unpacking the zipfiles.  I also tested in game that all of the parts are there, and they are.