### PR TITLE
RoverDude/USI mod metadata overhaul

### DIFF
--- a/NetKAN/AlcubierreStandalone.netkan
+++ b/NetKAN/AlcubierreStandalone.netkan
@@ -1,20 +1,20 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "AlcubierreStandalone",
     "author": "RoverDude",
     "$kref": "#/ckan/github/BobPalmer/WarpDrive",
+    "$vref": "#/ckan/ksp-avc",
     "name": "Alcubierre Warp Drive (Stand-alone)",
     "abstract": "The Alcubierre drive works by moving space around your ship, not through acceleration.",
     "license": "CC-BY-NC-SA-4.0",
-	"ksp_version" : "1.0",
   "resources": {
     "homepage": "http://forum.kerbalspaceprogram.com/threads/100798",
 	 "repository" : "https://github.com/BobPalmer/WarpDrive"
 	},
     "install": [
 					{
-						"file": "GameData/UmbraSpaceIndustries",
-						"install_to": "GameData"
+						"find": "UmbraSpaceIndustries/WarpDrive",
+						"install_to": "GameData/UmbraSpaceIndustries"
 					}
 				]
 }

--- a/NetKAN/CommunityResourcePack.netkan
+++ b/NetKAN/CommunityResourcePack.netkan
@@ -1,13 +1,13 @@
 {
     "spec_version"   : 1,
     "$kref"          : "#/ckan/github/BobPalmer/CommunityResourcePack",
+    "$vref"          : "#/ckan/ksp-avc",
     "name"           : "Community Resource Pack",
     "author"         : "RoverDude",
     "identifier"     : "CommunityResourcePack",
     "abstract"       : "Common resources for KSP mods",
     "license"        : "CC-BY-NC-SA-4.0",
     "release_status" : "stable",
-    "ksp_version"    : "1.0",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/91998"
     },

--- a/NetKAN/Karbonite.netkan
+++ b/NetKAN/Karbonite.netkan
@@ -38,5 +38,6 @@
                 "ksp_version_max" : "1.0.4"
             }
         }
-    ]
+    ],
+    "x_netkan_epoch": "1"
 }

--- a/NetKAN/Karbonite.netkan
+++ b/NetKAN/Karbonite.netkan
@@ -1,18 +1,19 @@
 {
-    "spec_version"   : 1,
+    "spec_version"   : "v1.4",
     "name"           : "Karbonite",
     "identifier"     : "Karbonite",
     "$kref"          : "#/ckan/github/BobPalmer/Karbonite",
+    "$vref"          : "#/ckan/ksp-avc",
     "author"         : "RoverDude",
     "abstract"       : "A newly discovered mineral that has hydrocarbon-like properties and is perfect for processing into a fuel. It's easily mined from the surface, and can be found in liquid or gaseous forms on certain planets.",
-    "license"        : "CC-BY-NC-SA",
+    "license"        : "CC-BY-NC-SA-4.0",
     "release_status" : "stable",
-    "$vref"          : "#/ckan/ksp-avc",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/89401"
     },
     "depends" : [
         { "name" : "USITools" },
+        { "name" : "USI-Core" },
         { "name" : "CommunityResourcePack" },
         { "name" : "FirespitterCore" },
         { "name" : "ModuleManager" }
@@ -24,10 +25,8 @@
     "provides" : [ "USI-Karbonite" ],
     "install" : [
         {
-            "file"       : "GameData/UmbraSpaceIndustries",
-            "install_to" : "GameData",
-            "filter"     : "USICore.version",
-            "comment"    : "The filter is just a hacky solution until RoverDude's mod restructuring is complete."
+            "find"       : "UmbraSpaceIndustries/Karbonite",
+            "install_to" : "GameData/UmbraSpaceIndustries"
         }
     ],
     "x_netkan_override" : [

--- a/NetKAN/KarbonitePlus.netkan
+++ b/NetKAN/KarbonitePlus.netkan
@@ -1,13 +1,13 @@
 {
-    "spec_version"   : 1,
+    "spec_version"   : "v1.4",
     "name"           : "KarbonitePlus",
     "identifier"     : "KarbonitePlus",
     "$kref"          : "#/ckan/github/BobPalmer/KarbonitePlus",
+    "$vref"          : "#/ckan/ksp-avc",
     "author"         : "RoverDude",
     "abstract"       : "New resources and parts for Karbonite, including the resource Karborundum",
     "license"        : "CC-BY-NC-SA-4.0",
     "release_status" : "stable",
-	"ksp_version" : "1.0",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/93054"
     },
@@ -18,8 +18,8 @@
     "provides" : [ "USI-KarbonitePlus" ],
     "install" : [
         {
-            "file"       : "GameData/UmbraSpaceIndustries",
-            "install_to" : "GameData"
+            "find"       : "UmbraSpaceIndustries/KarbonitePlus",
+            "install_to" : "GameData/UmbraSpaceIndustries"
         }
     ]
 }

--- a/NetKAN/UKS.netkan
+++ b/NetKAN/UKS.netkan
@@ -1,66 +1,63 @@
 {
-  "spec_version"   : 1,
-  "name"           : "USI Kolonization Systems (MKS/OKS)",
-  "identifier"     : "UKS",
-  "$kref"          : "#/ckan/github/BobPalmer/MKS",
-  "author"         : "RoverDude",
-  "abstract"       : "a series of interlocking modules for building long-term, self sustaining colonies in orbit and on other planets and moons.",
-  "license"        : "CC-BY-NC-SA-4.0",
-  "release_status" : "stable",
-  "ksp_version"    : "1.0",
-  "description"    : "MKS introduces a series of parts specifically designed to provide self-sustaining life support for multiple Kerbals for users of TAC-Life Support. While the parts will function without TAC-LS, the design is centered around providing an appropriate challenge where players will weigh the costs, risks, and rewards of supplying missions exclusively with carried life support supplies, or in making the investment in a permanent colony. That being said, this is not just a single greenhouse part (although food production is part of the mod). Rather, it brings an entire colonization end-game to KSP in a fun and challenging way.",
-  "comment"        : "This may be renamed to USI-UKS in the future",
-  
-  "provides" : [
-    "MKS",
-    "OKS",
-    "USI-UKS"
-  ],
-  
-  "resources" : {
-    "homepage"     : "http://forum.kerbalspaceprogram.com/threads/79588",
-    "license"      : "https://github.com/BobPalmer/MKS/blob/master/license.txt"
-  },
-  
-  "install" : [
-    {
-      "file"       : "GameData/UmbraSpaceIndustries",
-      "install_to" : "GameData"
-    }
-  ],
-
-  "depends" : [
-    {
-      "name": "FirespitterCore",
-      "min_version": "7.0.5398.27328"
+    "spec_version"   : "v1.4",
+    "name"           : "USI Kolonization Systems (MKS/OKS)",
+    "identifier"     : "UKS",
+    "$kref"          : "#/ckan/github/BobPalmer/MKS",
+    "$vref"          : "#/ckan/ksp-avc",
+    "author"         : "RoverDude",
+    "abstract"       : "a series of interlocking modules for building long-term, self sustaining colonies in orbit and on other planets and moons.",
+    "license"        : "CC-BY-NC-SA-4.0",
+    "release_status" : "stable",
+    "description"    : "MKS introduces a series of parts specifically designed to provide self-sustaining life support for multiple Kerbals for users of TAC-Life Support. While the parts will function without TAC-LS, the design is centered around providing an appropriate challenge where players will weigh the costs, risks, and rewards of supplying missions exclusively with carried life support supplies, or in making the investment in a permanent colony. That being said, this is not just a single greenhouse part (although food production is part of the mod). Rather, it brings an entire colonization end-game to KSP in a fun and challenging way.",
+    "comment"        : "This may be renamed to USI-UKS in the future",
+    "provides" : [
+        "MKS",
+        "OKS",
+        "USI-UKS"
+    ],
+    "resources" : {
+        "homepage"     : "http://forum.kerbalspaceprogram.com/threads/79588",
+        "license"      : "https://github.com/BobPalmer/MKS/blob/master/license.txt"
     },
-    {
-      "name": "ModuleManager",
-      "min_version": "2.5.1"
-    },
-    {
-      "name": "USITools",
-      "min_version": "0.4.0"
-    },
-    {
-      "name": "CommunityResourcePack",
-      "min_version": "0.2.3"
-    }
-  ],
-  
-  "suggests" : [
-    {
-      "name": "USI-LS",
-      "min_version": "v0.1.0"
-    }
-  ],
-  
-  "conflicts" : [
-    {
-      "name": "MKS"
-    },
-    {
-      "name": "OKS"
-    }
-  ]
+    "install" : [
+        {
+            "find"       : "UmbraSpaceIndustries/Kolonization",
+            "install_to" : "GameData/UmbraSpaceIndustries"
+        }
+    ],
+    "depends" : [
+        {
+            "name": "FirespitterCore",
+            "min_version": "7.0.5398.27328"
+        },
+        {
+            "name": "ModuleManager",
+            "min_version": "2.5.1"
+        },
+        {
+            "name": "USITools",
+            "min_version": "0.4.0"
+        },
+        {
+            "name": "CommunityResourcePack",
+            "min_version": "0.2.3"
+        },
+        {
+            "name": "USI-Core"
+        }
+    ],
+    "suggests" : [
+        {
+            "name": "USI-LS",
+            "min_version": "v0.1.0"
+        }
+    ],
+    "conflicts" : [
+        {
+            "name": "MKS"
+        },
+        {
+            "name": "OKS"
+        }
+    ]
 }

--- a/NetKAN/UKS.netkan
+++ b/NetKAN/UKS.netkan
@@ -59,5 +59,6 @@
         {
             "name": "OKS"
         }
-    ]
+    ],
+    "x_netkan_epoch": "1"
 }

--- a/NetKAN/USI-Core.netkan
+++ b/NetKAN/USI-Core.netkan
@@ -9,7 +9,7 @@
     "license"        : "CC-BY-NC-SA-4.0",
     "release_status" : "stable",
     "resources": {
-        "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
+        "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/"
     },
     "depends" : [
         { "name" : "USITools" }

--- a/NetKAN/USI-Core.netkan
+++ b/NetKAN/USI-Core.netkan
@@ -1,20 +1,22 @@
 {
     "spec_version"   : 1,
-    "$kref"          : "#/ckan/github/BobPalmer/UmbraSpaceIndustries",
+    "$kref"          : "#/ckan/github/BobPalmer/USI_Core",
     "$vref"          : "#/ckan/ksp-avc",
-    "name"           : "USI Tools",
+    "name"           : "USI Core",
     "author"         : "RoverDude",
-    "identifier"     : "USITools",
-    "abstract"       : "Common libraries for Umbra Space Industries mods",
+    "identifier"     : "USI-Core",
+    "abstract"       : "Kontainers and Reactors and shared tools for USI mods",
     "license"        : "CC-BY-NC-SA-4.0",
     "release_status" : "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
     },
-    "provides"       : [ "USI-Tools" ],
+    "depends" : [
+        { "name" : "USITools" }
+    ],
     "install" : [
         {
-            "file"       : "GameData/000_USITools",
+            "file"       : "GameData/UmbraSpaceIndustries",
             "install_to" : "GameData"
         }
     ]

--- a/NetKAN/USI-EXP.netkan
+++ b/NetKAN/USI-EXP.netkan
@@ -1,41 +1,27 @@
 {
-    "spec_version"   : 1,
+    "spec_version"   : "v1.4",
     "name"           : "USI Exploration Pack",
     "identifier"     : "USI-EXP",
     "$kref"          : "#/ckan/github/BobPalmer/ExplorationPack",
+    "$vref"          : "#/ckan/ksp-avc",
     "author"         : "RoverDude",
     "abstract"       : "PackRat Rover and parts geared towards planetary exploration",
-    "license"        : "CC-BY-NC-SA",
+    "license"        : "CC-BY-NC-SA-4.0",
     "release_status" : "stable",
-	"ksp_version" : "1.0",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/86695"
     },
     "depends" : [
-        {
-          "name": "FirespitterCore",
-          "min_version": "7.0.5398.27328"
-        },
-        {
-          "name": "ModuleManager",
-          "min_version": "2.5.1"
-        },
-        {
-          "name": "USITools",
-          "min_version": "0.4.0"
-        },
-        {
-          "name": "CommunityResourcePack",
-          "min_version": "0.2.3"
-        },
-        {
-          "name": "ModuleRCSFX"
-        }
+        { "name": "FirespitterCore", "min_version": "7.0.5398.27328" },
+        { "name": "ModuleManager", "min_version": "2.5.1" },
+        { "name": "USITools", "min_version": "0.4.0" },
+        { "name": "CommunityResourcePack", "min_version": "0.2.3" },
+        { "name": "ModuleRCSFX" }
     ],
     "install" : [
         {
-            "file"       : "GameData/UmbraSpaceIndustries",
-            "install_to" : "GameData"
+            "find"       : "UmbraSpaceIndustries/ExpPack",
+            "install_to" : "GameData/UmbraSpaceIndustries"
         }
     ]
 }

--- a/NetKAN/USI-FTT.netkan
+++ b/NetKAN/USI-FTT.netkan
@@ -1,13 +1,13 @@
 {
-    "spec_version"   : 1,
+    "spec_version"   : "v1.4",
     "name"           : "USI Freight Transport Technologies",
     "identifier"     : "USI-FTT",
     "$kref"          : "#/ckan/github/BobPalmer/FTT",
+    "$vref"          : "#/ckan/ksp-avc",
     "author"         : "RoverDude",
     "abstract"       : "A series of modular parts for all of your hauling, mining, and exploration needs!",
-    "license"        : "CC-BY-NC-SA",
+    "license"        : "CC-BY-NC-SA-4.0",
     "release_status" : "stable",
-	"ksp_version" : "1.0",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/91706"
     },
@@ -31,8 +31,8 @@
     ],
     "install" : [
         {
-            "file"       : "GameData/UmbraSpaceIndustries",
-            "install_to" : "GameData"
+            "find"       : "UmbraSpaceIndustries/FTT",
+            "install_to" : "GameData/UmbraSpaceIndustries"
         }
     ]
 }

--- a/NetKAN/USI-FTT.netkan
+++ b/NetKAN/USI-FTT.netkan
@@ -12,22 +12,10 @@
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/91706"
     },
     "depends" : [
-        {
-          "name": "FirespitterCore",
-          "min_version": "7.0.5398.27328"
-        },
-        {
-          "name": "ModuleManager",
-          "min_version": "2.5.1"
-        },
-        {
-          "name": "USITools",
-          "min_version": "0.4.0"
-        },
-        {
-          "name": "CommunityResourcePack",
-          "min_version": "0.2.3"
-        }
+        { "name": "FirespitterCore", "min_version": "7.0.5398.27328" },
+        { "name": "ModuleManager", "min_version": "2.5.1" },
+        { "name": "USITools", "min_version": "0.4.0" },
+        { "name": "CommunityResourcePack", "min_version": "0.2.3" }
     ],
     "install" : [
         {

--- a/NetKAN/USI-FTT.netkan
+++ b/NetKAN/USI-FTT.netkan
@@ -3,7 +3,7 @@
     "name"           : "USI Freight Transport Technologies",
     "identifier"     : "USI-FTT",
     "$kref"          : "#/ckan/github/BobPalmer/FTT",
-    "$vref"          : "#/ckan/ksp-avc",
+    "ksp_version"    : "1.0",
     "author"         : "RoverDude",
     "abstract"       : "A series of modular parts for all of your hauling, mining, and exploration needs!",
     "license"        : "CC-BY-NC-SA-4.0",

--- a/NetKAN/USI-LS.netkan
+++ b/NetKAN/USI-LS.netkan
@@ -1,20 +1,20 @@
 {
-    "spec_version"   : 1,
+    "spec_version"   : "v1.4",
     "name"           : "USI Life Support",
     "identifier"     : "USI-LS",
     "$kref"          : "#/ckan/github/BobPalmer/USI-LS",
+    "$vref"          : "#/ckan/ksp-avc",
     "author"         : "RoverDude",
     "abstract"       : "UmbraSpaceIndustries take on life support",
     "license"        : "CC-BY-NC-SA-4.0",
     "release_status" : "stable",
-    "$vref"          : "#/ckan/ksp-avc",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/116790"
     },
     "install" : [
         {
-            "file"       : "GameData/UmbraSpaceIndustries",
-            "install_to" : "GameData"
+            "find"       : "UmbraSpaceIndustries/LifeSupport",
+            "install_to" : "GameData/UmbraSpaceIndustries"
         }
     ],
     "depends" : [

--- a/NetKAN/USI-MKSLite.netkan
+++ b/NetKAN/USI-MKSLite.netkan
@@ -1,0 +1,25 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "USI-MKSLite",
+    "license": "CC-BY-NC-SA-4.0",
+    "$kref": "#/ckan/kerbalstuff/1184",
+    "$vref": "#/ckan/ksp-avc",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/135640"
+    },
+    "depends": [
+        { "name": "USITools" },
+        { "name": "USI-Core" },
+        { "name": "FirespitterCore" },
+        { "name": "ModuleManager" }
+    ],
+    "conflicts": [
+        { "name": "UKS" }
+    ],
+    "install": [
+        {
+            "find"       : "UmbraSpaceIndustries/MKS-LITE",
+            "install_to" : "GameData/UmbraSpaceIndustries"
+        }
+    ]
+}

--- a/NetKAN/USI-NuclearRockets.netkan
+++ b/NetKAN/USI-NuclearRockets.netkan
@@ -1,0 +1,17 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "USI-NuclearRockets",
+    "license": "CC-BY-NC-SA-4.0",
+    "$kref": "#/ckan/kerbalstuff/1175",
+    "$vref": "#/ckan/ksp-avc",
+    "depends": [
+        { "name": "USI-Tools" },
+        { "name": "USI-Core" }
+    ],
+    "install": [
+        {
+            "find"       : "UmbraSpaceIndustries/Orion",
+            "install_to" : "GameData/UmbraSpaceIndustries"
+        }
+    ]
+}

--- a/NetKAN/USI-SRV.netkan
+++ b/NetKAN/USI-SRV.netkan
@@ -1,13 +1,13 @@
 {
-    "spec_version"   : 1,
+    "spec_version"   : "v1.4",
     "name"           : "USI Survival Pack",
     "identifier"     : "USI-SRV",
     "$kref"          : "#/ckan/github/BobPalmer/SrvPack",
+    "$vref"          : "#/ckan/ksp-avc",
     "author"         : "RoverDude",
     "abstract"       : "Deployable Emergency Reentry Pod (DERP)",
-    "license"        : "CC-BY-NC-SA",
+    "license"        : "CC-BY-NC-SA-4.0",
     "release_status" : "stable",
-	"ksp_version" : "1.0",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/84359"
     },
@@ -31,8 +31,8 @@
     ],
     "install" : [
         {
-            "file"       : "GameData/UmbraSpaceIndustries",
-            "install_to" : "GameData"
+            "find"       : "UmbraSpaceIndustries/SrvPack",
+            "install_to" : "GameData/UmbraSpaceIndustries"
         }
     ]
 }

--- a/NetKAN/USITools.netkan
+++ b/NetKAN/USITools.netkan
@@ -9,7 +9,7 @@
     "license"        : "CC-BY-NC-SA-4.0",
     "release_status" : "stable",
     "resources": {
-        "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/",
+        "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/"
     },
     "provides"       : [ "USI-Tools" ],
     "install" : [


### PR DESCRIPTION
Add USI-Core, USI-MKSLite, USI-NuclearRockets. Change install methods and dependencies of other USI mods as well as make use of their .version files. Epoch bumps to mods that currently conflict with the new `USI-Core` should have users update those mods and avoid issues (hopefully). If that doesn't work then a lot of users will need to be told to remove and re-install UKS and/or Karbonite.

With thanks to @qm3ster and @bobprime for giving me a basis to work from and for pushing me to (finally) get this done.

Closes #2392, closes #2474, closes #2343, closes #2361