### PR TITLE
Sigma split

### DIFF
--- a/NetKAN/SigmaBinary-DunaIke.netkan
+++ b/NetKAN/SigmaBinary-DunaIke.netkan
@@ -6,6 +6,7 @@
     "abstract"     : "Contains a Duna + Ike binary system.",
     "license"      : "CC-BY-NC-SA-4.0",
     "author"       : "Sigma88",
+    "ksp_version"  : "1.0",
     "depends": [
         { "name": "SigmaBinary-core" }
     ],
@@ -17,5 +18,7 @@
             "find": "DunaIke Binary",
             "install_to": "GameData/Sigma/Binary"
         }
-    ]
+    ],
+    "x_netkan_epoch": "1",
+    "comment": "This mod used to be packaged differently but is now repackaged to allow an upgrade path."
 }

--- a/NetKAN/SigmaBinary-DunaIke.netkan
+++ b/NetKAN/SigmaBinary-DunaIke.netkan
@@ -1,17 +1,22 @@
 {
-    "spec_version": "v1.4",
-    "license": "CC-BY-NC-SA-4.0",
-    "$kref": "#/ckan/github/Sigma88/Sigma-Binary",
-    "identifier": "SigmaBinary-DunaIke",
-    "name"        : "Sigma Binary - Duna + Ike Binary",
-    "abstract"    : "Contains a Duna + Ike binary system.",
+    "spec_version" : "v1.4",
+    "identifier"   : "SigmaBinary-DunaIke",
+    "$kref"        : "#/ckan/github/Sigma88/Sigma-Binary",
+    "$vref"        : "#/ckan/ksp-avc",
+    "name"         : "Sigma Binary - Duna + Ike Binary",
+    "abstract"     : "Contains a Duna + Ike binary system.",
+    "license"      : "CC-BY-NC-SA-4.0",
+    "author"       : "Sigma88",
     "depends": [
-        { "name": "SigmaBinary-core"}
+        { "name": "SigmaBinary-core" }
     ],
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/127820"
+    },
     "install": [
         {
-            "find"       : "DunaIke Binary",
-            "install_to" : "GameData/Sigma/Binary"
+            "find": "DunaIke Binary",
+            "install_to": "GameData/Sigma"
         }
     ]
 }

--- a/NetKAN/SigmaBinary-DunaIke.netkan
+++ b/NetKAN/SigmaBinary-DunaIke.netkan
@@ -2,7 +2,6 @@
     "spec_version" : "v1.4",
     "identifier"   : "SigmaBinary-DunaIke",
     "$kref"        : "#/ckan/github/Sigma88/Sigma-Binary",
-    "$vref"        : "#/ckan/ksp-avc",
     "name"         : "Sigma Binary - Duna + Ike Binary",
     "abstract"     : "Contains a Duna + Ike binary system.",
     "license"      : "CC-BY-NC-SA-4.0",
@@ -16,7 +15,7 @@
     "install": [
         {
             "find": "DunaIke Binary",
-            "install_to": "GameData/Sigma"
+            "install_to": "GameData/Sigma/Binary"
         }
     ]
 }

--- a/NetKAN/SigmaBinary-core.netkan
+++ b/NetKAN/SigmaBinary-core.netkan
@@ -1,22 +1,26 @@
 {
-    "spec_version": "v1.4",
-    "license": "CC-BY-NC-SA-4.0",
-    "$kref": "#/ckan/github/Sigma88/Sigma-Binary",
-    "$vref" : "#/ckan/ksp-avc",
-    "identifier": "SigmaBinary-core",
-    "name"        : "Sigma Binary",
-    "abstract"    : "This mod enables the creation of binary systems but does not contain any binary systems itself.",
+    "spec_version" : "v1.4",
+    "identifier"   : "SigmaBinary-core",
+    "$kref"        : "#/ckan/github/Sigma88/Sigma-Binary",
+    "$vref"        : "#/ckan/ksp-avc",
+    "name"         : "Sigma Binary",
+    "abstract"     : "This mod will let you turn custom and/or stock bodies into binary systems, without the need to do all the calculations yourself.",
+    "license"      : "CC-BY-NC-SA-4.0",
+    "author"       : "Sigma88",
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "Kopernicus"}
+        { "name": "Kopernicus "}
     ],
     "suggests": [
         { "name": "SigmaBinary-DunaIke" }
     ],
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/127820"
+    },
     "install": [
         {
-            "find"       : "Sigma",
-            "install_to" : "GameData"
+            "find": "Binary",
+            "install_to": "GameData/Sigma"
         }
     ]
 }

--- a/NetKAN/SigmaBinary-core.netkan
+++ b/NetKAN/SigmaBinary-core.netkan
@@ -9,7 +9,7 @@
     "author"       : "Sigma88",
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "Kopernicus "}
+        { "name": "Kopernicus" }
     ],
     "suggests": [
         { "name": "SigmaBinary-DunaIke" }

--- a/NetKAN/SigmaBinary-core.netkan
+++ b/NetKAN/SigmaBinary-core.netkan
@@ -22,5 +22,7 @@
             "find": "Binary",
             "install_to": "GameData/Sigma"
         }
-    ]
+    ],
+    "x_netkan_epoch": "1",
+    "comment": "This mod used to be packaged differently but is now repackaged to allow an upgrade path."
 }

--- a/NetKAN/SigmaJoolRecolor.netkan
+++ b/NetKAN/SigmaJoolRecolor.netkan
@@ -9,7 +9,7 @@
     "author"       : "Sigma88",
     "depends": [
         { "name": "ModuleManager" },
-		{ "name": "Kopernicus "}
+        { "name": "Kopernicus "}
     ],
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/112095"

--- a/NetKAN/SigmaJoolRecolor.netkan
+++ b/NetKAN/SigmaJoolRecolor.netkan
@@ -9,7 +9,7 @@
     "author"       : "Sigma88",
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "Kopernicus "}
+        { "name": "Kopernicus" }
     ],
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/112095"

--- a/NetKAN/SigmaJoolRecolor.netkan
+++ b/NetKAN/SigmaJoolRecolor.netkan
@@ -1,0 +1,23 @@
+{
+    "spec_version" : "v1.4",
+    "identifier"   : "SigmaJoolRecolor",
+    "$kref"        : "#/ckan/github/Sigma88/Sigma-JoolRecolor",
+    "$vref"        : "#/ckan/ksp-avc",
+    "name"         : "Sigma: Jool Recolor",
+    "abstract"     : "This mod changes the color of Jool to make it more similar to Jupiter.",
+    "license"      : "CC-BY-NC-SA-4.0",
+    "author"       : "Sigma88",
+    "depends": [
+        { "name": "ModuleManager" },
+		{ "name": "Kopernicus "}
+    ],
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/112095"
+    },
+    "install": [
+        {
+            "find": "JoolRecolor",
+            "install_to": "GameData/Sigma"
+        }
+    ]
+}

--- a/NetKAN/SigmaModExpansions.netkan
+++ b/NetKAN/SigmaModExpansions.netkan
@@ -1,27 +1,28 @@
 {
-    "spec_version": 1,
-    "identifier": "SigmaModExpansions",
-    "$kref": "#/ckan/kerbalstuff/816",
-    "license": "CC-BY-NC-SA-4.0",
-    "provides": [
-        "SigmaOPMExpansion",
-        "SigmaRTExpansion"
-    ],
+    "spec_version" : "v1.4",
+    "identifier"   : "SigmaModExpansions",
+    "$kref"        : "#/ckan/github/Sigma88/Sigma-OuterSpaceComms",
+    "$vref"        : "#/ckan/ksp-avc",
+    "name"         : "Sigma: OuterSpaceComms",
+    "abstract"     : "A set of 3 antennas designed to probe deep into outer space.",
+    "license"      : "CC-BY-NC-SA-4.0",
+    "author"       : "Sigma88",
     "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "OuterPlanetsMod" },
+        { "name": "ModuleManager" },
         { "name": "RemoteTech" }
+	],
+    "recommends": [
+        { "name": "OuterPlanetsMod" }
     ],
-    "conflicts": [
-        { "name": "SigmaOPMExpansion" },
-        { "name": "SigmaRTExpansion" }
-    ],
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/112095"
+    },
     "install": [
         {
-            "file": "GameData/Sigma",
-            "install_to": "GameData"
+            "file": "OuterSpaceComms",
+            "install_to": "GameData/Sigma"
         }
-    ]
+    ],
+    "x_netkan_epoch": "1",
+    "comment": "This mod used to be packaged differently but is now repackaged to allow an upgrade path."
 }

--- a/NetKAN/SigmaModExpansions.netkan
+++ b/NetKAN/SigmaModExpansions.netkan
@@ -19,7 +19,7 @@
     },
     "install": [
         {
-            "file": "OuterSpaceComms",
+            "find": "OuterSpaceComms",
             "install_to": "GameData/Sigma"
         }
     ],

--- a/NetKAN/SigmaModExpansions.netkan
+++ b/NetKAN/SigmaModExpansions.netkan
@@ -11,7 +11,7 @@
         { "name": "ModuleManager" },
         { "name": "RemoteTech" }
     ],
-    "recommends": [
+    "suggests": [
         { "name": "OuterPlanetsMod" }
     ],
     "resources": {

--- a/NetKAN/SigmaModExpansions.netkan
+++ b/NetKAN/SigmaModExpansions.netkan
@@ -10,7 +10,7 @@
     "depends": [
         { "name": "ModuleManager" },
         { "name": "RemoteTech" }
-	],
+    ],
     "recommends": [
         { "name": "OuterPlanetsMod" }
     ],

--- a/NetKAN/SigmaRTExpansion.netkan
+++ b/NetKAN/SigmaRTExpansion.netkan
@@ -8,7 +8,9 @@
     "license"      : "CC-BY-NC-SA-4.0",
     "author"       : "Sigma88",
     "depends": [
-        { "name": "ModuleManager" },
+        { "name": "ModuleManager" }
+    ],
+    "suggests": [
         { "name": "RemoteTech" }
     ],
     "resources": {

--- a/NetKAN/SigmaRTExpansion.netkan
+++ b/NetKAN/SigmaRTExpansion.netkan
@@ -1,16 +1,25 @@
 {
-    "spec_version": 1,
-    "identifier": "SigmaRTExpansion",
-    "$kref": "#/ckan/kerbalstuff/914",
-    "license": "CC-BY-NC-SA-4.0",
+    "spec_version" : "v1.4",
+    "identifier"   : "SigmaRTExpansion",
+    "$kref"        : "#/ckan/github/Sigma88/Sigma-Antennas",
+    "$vref"        : "#/ckan/ksp-avc",
+    "name"         : "Sigma: Antennas",
+    "abstract"     : "A set of 4 antennas, recolored and resized versions of the stock Comms DTS-M1 because color coding is fun!",
+    "license"      : "CC-BY-NC-SA-4.0",
+    "author"       : "Sigma88",
     "depends": [
         { "name": "ModuleManager" },
         { "name": "RemoteTech" }
     ],
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/112095"
+    },
     "install": [
         {
-            "file": "GameData/Sigma",
-            "install_to": "GameData"
+            "find": "Antennas",
+            "install_to": "GameData/Sigma"
         }
-    ]
+    ],
+    "x_netkan_epoch": "1",
+    "comment": "This mod used to be packaged differently but is now repackaged to allow an upgrade path."
 }

--- a/NetKAN/SigmaStockRecolor.netkan
+++ b/NetKAN/SigmaStockRecolor.netkan
@@ -9,7 +9,7 @@
     "author"       : "Sigma88",
     "depends": [
         { "name": "ModuleManager" },
-		{ "name": "Kopernicus "}
+        { "name": "Kopernicus "}
     ],
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/112095"

--- a/NetKAN/SigmaStockRecolor.netkan
+++ b/NetKAN/SigmaStockRecolor.netkan
@@ -9,7 +9,7 @@
     "author"       : "Sigma88",
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "Kopernicus "}
+        { "name": "Kopernicus" }
     ],
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/112095"

--- a/NetKAN/SigmaStockRecolor.netkan
+++ b/NetKAN/SigmaStockRecolor.netkan
@@ -1,15 +1,25 @@
 {
-    "spec_version": "v1.4",
-    "$kref": "#/ckan/kerbalstuff/1067",
-    "license": "CC-BY-NC-SA-4.0",
-    "identifier": "SigmaStockRecolor",
+    "spec_version" : "v1.4",
+    "identifier"   : "SigmaStockRecolor",
+    "$kref"        : "#/ckan/github/Sigma88/Sigma-EveRecolor",
+    "$vref"        : "#/ckan/ksp-avc",
+    "name"         : "Sigma: Eve Recolor",
+    "abstract"     : "This mod changes the color of Eve to make it more similar to Venus.",
+    "license"      : "CC-BY-NC-SA-4.0",
+    "author"       : "Sigma88",
     "depends": [
-        { "name": "ModuleManager"}
+        { "name": "ModuleManager" },
+		{ "name": "Kopernicus "}
     ],
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/112095"
+    },
     "install": [
         {
-            "find"       : "StockRecolor",
-            "install_to" : "GameData/Sigma"
+            "find": "EveRecolor",
+            "install_to": "GameData/Sigma"
         }
-    ]
+    ],
+    "x_netkan_epoch": "1",
+    "comment": "This mod used to be packaged differently but is now repackaged to allow an upgrade path."
 }


### PR DESCRIPTION
* `SigmaStockRecolor` was split into `Jool Recolor` (new) and `Eve Recolor` (holds identifier).
* `SigmaRTExpansion` was moved to github and renamed to `Sigma: Antennas` (holds identifier).
* `SigmaModExpansions` was moved to github and renamed to `Sigma: OuterSpaceComms` (holds identifier).
* `SigmaBinary` was split into `SigmaBinary-core` and `SigmaBinary-DunaIke` (both hold there identifier).