### PR TITLE
Attempt to fix StockPlus by changing asset match pattern

### DIFF
--- a/NetKAN/StockPlus.netkan
+++ b/NetKAN/StockPlus.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version"   : 1,
     "identifier"     : "StockPlus",
-    "$kref"          : "#/ckan/github/ClawKSP/KSP-Stock-Bug-Fix-Modules/asset_match/StockPlusController\\.zip",
+    "$kref"          : "#/ckan/github/ClawKSP/KSP-Stock-Bug-Fix-Modules/asset_match/StockPlusController",
     "name"           : "Stock Plus",
     "abstract"       : "Enhancements of stock functionality",
     "license"        : "CC-BY-NC-SA-4.0",


### PR DESCRIPTION
Locally this still works (but so does the original) and the hope is that it'll get this mod unstuck from the fail list on http://status.ksp-ckan.org bringing this mod's version to parity with its brother StockBugFixModules