### PR TITLE
Add manual install advice to abstract

### DIFF
--- a/NetKAN/FerramAerospaceResearch.netkan
+++ b/NetKAN/FerramAerospaceResearch.netkan
@@ -1,6 +1,7 @@
 {
     "spec_version"   : 1,
     "identifier"     : "FerramAerospaceResearch",
+    "abstract"       : "FAR replaces KSP's stock part-centered aerodynamics model with one based on real-life physics. If you experience any problems after installing, please remove under CKAN and try a manual install before seeking assistance.",
     "$kref"          : "#/ckan/kerbalstuff/52",
     "license"        : "GPL-3.0",
     "x_netkan_epoch" : "3",


### PR DESCRIPTION
From discussion on CKAN thread in KSP forums, Ferram has identified that CKAN is causing problems when installing FAR. Let's at least advise users to try a manual install while we sort out the problem.