### PR TITLE
New KS page

### DIFF
--- a/NetKAN/A6Intruder.netkan
+++ b/NetKAN/A6Intruder.netkan
@@ -1,5 +1,5 @@
 {
-    "$kref": "#/ckan/kerbalstuff/839",
+    "$kref": "#/ckan/kerbalstuff/1243",
     "license": "WTFPL",
     "spec_version": 1,
     "identifier": "A6Intruder",


### PR DESCRIPTION
This mod got removed from KerbalStuff, causing a 404, and then got back added to KerbalStuff but with a new page.

This happened also with`AircraftIVAHelmet` and `Area21SCraft`, but didn't got back added to KerbalStuff.