### PR TITLE
Update SETI-CommunityTechTree.netkan

### DIFF
--- a/NetKAN/SETI-CommunityTechTree.netkan
+++ b/NetKAN/SETI-CommunityTechTree.netkan
@@ -1,34 +1,6 @@
 {
-    "spec_version" : 1,
-    "$kref": "#/ckan/kerbalstuff/748",
-    "$vref" : "#/ckan/ksp-avc",
+    "spec_version": "v1.2",
     "identifier": "SETI-CommunityTechTree",
-    "x_netkan_license_ok" : true,
-    "depends" : [ 
-        { "name": "CommunityTechTree" },
-		{ "name": "KSP-AVC"	},
-        { "name": "ModuleManager" } 
-    ],
-    "recommends": [
-		{ "name": "AdjustableLandingGear" },
-		{ "name": "CustomBarnKit" },
-		{ "name": "Mk3MiniExpansionPack" },
-		{ "name": "StockBugFixModules" },
-		{ "name": "TakeCommand"	},
-		{ "name": "VenStockRevamp" }
-    ],
-	"suggests": [
-		{ "name": "SETI-Contracts" }
-	],
-    "install" : [ { "file" : "SETIctt", "install_to" : "GameData" } ],
-    "x_netkan_override": [
-        {
-            "version": "0.8.4",
-            "delete": [ "ksp_version" ],
-            "override": {
-                "ksp_version_min": "1.0.2",
-                "ksp_version_max": "1.0.4"
-            }
-        }
-    ]
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Y3mo/SETI-CommunityTechTree/master/SETI-CommunityTechTree.netkan",
+    "x_netkan_license_ok": true
 }


### PR DESCRIPTION
Hello,
since the SETI mod complex will undergo a lot of changes from 1.0.4 to 1.0.5 and then again to 1.1, with many changes in between and a move to github in general, I m trying to prepare for it.

To be able to respond faster if (when) issues occur (not only with my mod, but with dependencies/recommendations), I try to externalize the metadata from the netkan respository. I took RealismOverhaul as an example for this. Hopefully I did not miss something.

As this is my first externalization attempt, any feedback on the 2 files (the one inside the netkan respository and the linked file in the SETI-CommunityTechTree repository) is very much appreciated.

Best regards,
Yemo