### PR TITLE
Update StageRecovery.netkan

### DIFF
--- a/NetKAN/StageRecovery.netkan
+++ b/NetKAN/StageRecovery.netkan
@@ -24,7 +24,7 @@
         "version": "1.5.6",
         "override": {
             "ksp_version_min": "1.0.2",
-            "ksp_version_max": "1.0.4"
+            "ksp_version_max": "1.0.5"
         }
     }]
 }


### PR DESCRIPTION
Update ksp_version_max override since the newest version supports KSP 1.0.5.