### PR TITLE
Update SXT.netkan

### DIFF
--- a/NetKAN/SXT.netkan
+++ b/NetKAN/SXT.netkan
@@ -3,4 +3,9 @@
   "identifier": "SXT",
   "$kref" : "#/ckan/kerbalstuff/338",
   "license": "CC-BY-NC-SA-4.0"
+  	"depends": [
+		{ "name" : "FirespitterCore" },
+		{ "name" : "FirespitterResourcesConfig"},
+		{ "name" : "ModuleManager"}
+	]
 }

--- a/NetKAN/SXT.netkan
+++ b/NetKAN/SXT.netkan
@@ -2,7 +2,7 @@
   "spec_version": 1,
   "identifier": "SXT",
   "$kref" : "#/ckan/kerbalstuff/338",
-  "license": "CC-BY-NC-SA-4.0"
+  "license": "CC-BY-NC-SA-4.0",
   	"depends": [
 		{ "name" : "FirespitterCore" },
 		{ "name" : "FirespitterResourcesConfig"},


### PR DESCRIPTION
Added FirespitterCore, FirespitterResourcesConfig and ModuleManager as dependencies.

Just found this, so had submitted change to the SXT-23 version just before.

closes KSP-CKAN/CKAN-meta/pull/798