### PR TITLE
Create SETI-ModPack-Basic.netkan

### DIFF
--- a/NetKAN/SETI-ModPack-Basic.netkan
+++ b/NetKAN/SETI-ModPack-Basic.netkan
@@ -1,0 +1,7 @@
+{
+    "kind": "metapackage",
+    "spec_version": "v1.6",
+    "identifier": "SETI-ModPack-Basic",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Y3mo/SETI-ModPacks/master/SETI-ModPack-Basic.netkan",
+    "x_netkan_license_ok": true
+ }


### PR DESCRIPTION
This is my first time attempting to transfer a meta-package to netkan, I ll try to work on it until it does not fail checks.

It is the ModPack-1-Basic distributed as a ckan file in the SETI thread, with extensions.
In the referenced github file, I temporarily set the KSP version to 1.0.4, so I can test it before people with with the current version 1.0.5 can see it.

I just read on the CKAN forum thread that such a metapackage can work, but I m not aware of any so far (even RealismOverhaul has some download content in it). If anyone has an example of a netkan metapackage, I would really appreciate learning from it.

Thank you very much,
Yemo