### PR TITLE
Prevent duplicate files

### DIFF
--- a/NetKAN/SpacetuxSA.netkan
+++ b/NetKAN/SpacetuxSA.netkan
@@ -13,7 +13,8 @@
     "install" : [
         {
             "find"       : "spacetux",
-            "install_to" : "GameData"
+            "install_to" : "GameData",
+            "filter"     : "SharedAssets"
         }
     ],
 	"x_netkan_override" : [


### PR DESCRIPTION
@linuxgurugamer the lastest version (v0.3.7) of SpacetuxSA includes a duplicate of every file in the folder `SharedAssets`.

Previous folder structure:
```
GameData
+ spacetux
   - Agencies
     * spacetux.cfg
     * spacetux.png
     * spacetux_sm.png
   - Flags
     * spacetux_flag.png
   - CHANGELOG
   - License.txt
   - spacetuxgroup.cfg
   - SpacetuxSA.version
```

Current folder structure:
```
GameData
+ spacetux
   - Agencies
     * spacetux.cfg
     * spacetux.png
     * spacetux_sm.png
   - Flags
     * spacetux_flag.png
   - SharedAssets <- this folder has duplicate files
   - CHANGELOG
   - License.txt
   - spacetuxgroup.cfg
   - SpacetuxSA.version
```