### PR TITLE
SufaceMountedLights -> surfacelights in order to give an upgrade path to the existing user base.

### DIFF
--- a/NetKAN/surfacelights.netkan
+++ b/NetKAN/surfacelights.netkan
@@ -1,8 +1,11 @@
 {
-    "identifier": "SurfaceMountedLights",
+    "identifier": "surfacelights",
     "spec_version": "v1.4",
     "$kref": "#/ckan/kerbalstuff/1255",
     "license": "CC-BY-NC-ND-3.0",
+    "conflicts": [
+        { "name": "SurfaceMountedLights" }
+    ],
     "install": [
         {
             "find"       : "SurfaceLights",


### PR DESCRIPTION
SufaceMountedLights was created where surfacelights already existed. They're the same mod. Due to SufaceMountedLights being very recently created I'd like to prioritize the existing install base surfacelights has and deprecate SufaceMountedLights.
Merge before https://github.com/KSP-CKAN/CKAN-meta/pull/804