### PR TITLE
Filter FAR config file

### DIFF
--- a/NetKAN/FerramAerospaceResearch.netkan
+++ b/NetKAN/FerramAerospaceResearch.netkan
@@ -20,7 +20,8 @@
     "install" : [
         {
             "file"       : "GameData/FerramAerospaceResearch",
-            "install_to" : "GameData"
+            "install_to" : "GameData",
+            "filter"     : "config.xml"
         },
         {
             "file"        : "Ships",


### PR DESCRIPTION
Newest version of FAR has the config file in the distribution whereas previous versions didn't. This causes an overwrite conflict on upgrade, so filter it out. @pjf 