### PR TITLE
Deprecate Stock Bug Fix Modules and Stock Plus

### DIFF
--- a/NetKAN/StockBugFixModules.netkan
+++ b/NetKAN/StockBugFixModules.netkan
@@ -5,7 +5,7 @@
     "name"           : "Stock Bug Fix Modules",
     "abstract"       : "Stand alone fixes for common stock KSP bugs",
     "license"        : "CC-BY-NC-SA-4.0",
-    "ksp_version"    : "1.0",
+    "ksp_version"    : "1.0.4",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/97285",
         "repository" : "https://github.com/ClawKSP/KSP-Stock-Bug-Fix-Modules"

--- a/NetKAN/StockPlus.netkan
+++ b/NetKAN/StockPlus.netkan
@@ -5,7 +5,7 @@
     "name"           : "Stock Plus",
     "abstract"       : "Enhancements of stock functionality",
     "license"        : "CC-BY-NC-SA-4.0",
-    "ksp_version"    : "1.0",
+    "ksp_version"    : "1.0.4",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/97285",
         "repository": "https://github.com/ClawKSP/KSP-Stock-Bug-Fix-Modules"


### PR DESCRIPTION
With pull #2585, Stock Bug Fix Modules and Stock Plus should work up to 1.0.4