### PR TITLE
Deprecate ModuleRCSFX for 1.0.5

### DIFF
--- a/NetKAN/ModuleRCSFX.netkan
+++ b/NetKAN/ModuleRCSFX.netkan
@@ -7,7 +7,7 @@
     "license"        : "CC-BY-SA",
     "author"         : [ "ialdabaoth", "NathanKell" ],
     "release_status" : "stable",
-    "ksp_version"    : "1.0",
+    "ksp_version"    : "1.0.4",
     "resources" : {
         "homepage"   : "http://forum.kerbalspaceprogram.com/threads/92290"
     }

--- a/NetKAN/ModuleRCSFX.netkan
+++ b/NetKAN/ModuleRCSFX.netkan
@@ -6,6 +6,7 @@
     "identifier"     : "ModuleRCSFX",
     "license"        : "CC-BY-SA",
     "author"         : [ "ialdabaoth", "NathanKell" ],
+    "release_status" : "stable",
     "ksp_version_min" : "1.0.0",
     "ksp_version_max" : "1.0.4",
     "resources" : {

--- a/NetKAN/ModuleRCSFX.netkan
+++ b/NetKAN/ModuleRCSFX.netkan
@@ -6,8 +6,8 @@
     "identifier"     : "ModuleRCSFX",
     "license"        : "CC-BY-SA",
     "author"         : [ "ialdabaoth", "NathanKell" ],
-    "release_status" : "stable",
-    "ksp_version"    : "1.0.4",
+    "ksp_version_min" : "1.0.0",
+    "ksp_version_max" : "1.0.4",
     "resources" : {
         "homepage"   : "http://forum.kerbalspaceprogram.com/threads/92290"
     }


### PR DESCRIPTION
According to @NathanKell [here](http://forum.kerbalspaceprogram.com/threads/92290-1-0-4-ModuleRCSFX-v4-2-Aug-23-OBSOLETE-IN-1-0-5?p=2295817&viewfull=1#post2295817), this mod is obsolete for 1.0.5.

This pull request caps the max version to 1.0.4.