### PR TITLE
Update USI mods

### DIFF
--- a/NetKAN/USI-Core.netkan
+++ b/NetKAN/USI-Core.netkan
@@ -5,14 +5,17 @@
     "name"           : "USI Core",
     "author"         : "RoverDude",
     "identifier"     : "USI-Core",
-    "abstract"       : "Kontainers and Reactors and shared tools for USI mods",
+    "abstract"       : "Kontainers, Reactors and shared tools for USI mods",
     "license"        : "CC-BY-NC-SA-4.0",
     "release_status" : "stable",
     "resources": {
         "homepage": "http://bobpalmer.github.io/UmbraSpaceIndustries/"
     },
     "depends" : [
-        { "name" : "USITools" }
+        { "name" : "USITools" },
+        { "name" : "CommunityResourcePack" },
+        { "name" : "FirespitterCore" },
+        { "name" : "ModuleManager" }
     ],
     "install" : [
         {

--- a/NetKAN/USI-EXP.netkan
+++ b/NetKAN/USI-EXP.netkan
@@ -15,8 +15,7 @@
         { "name": "FirespitterCore", "min_version": "7.0.5398.27328" },
         { "name": "ModuleManager", "min_version": "2.5.1" },
         { "name": "USITools", "min_version": "0.4.0" },
-        { "name": "CommunityResourcePack", "min_version": "0.2.3" },
-        { "name": "ModuleRCSFX" }
+        { "name": "CommunityResourcePack", "min_version": "0.2.3" }
     ],
     "install" : [
         {


### PR DESCRIPTION
USI-EXP: As of v0.4.3.0 it doesn't need a dependancy on `ModuleRCSFX` anymore.

USI-Core: As of v0.1.1.0 it depends on `USITools`, `CommunityResourcePack`, `FirespitterCore` and `ModuleManager`.