### PR TITLE
StockPlus

### DIFF
--- a/NetKAN/StockBugFixModules.netkan
+++ b/NetKAN/StockBugFixModules.netkan
@@ -5,7 +5,8 @@
     "name"           : "Stock Bug Fix Modules",
     "abstract"       : "Stand alone fixes for common stock KSP bugs",
     "license"        : "CC-BY-NC-SA-4.0",
-    "ksp_version"    : "1.0.4",
+    "ksp_version_min": "1.0.3",
+    "ksp_version_max": "1.0.4",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/97285",
         "repository" : "https://github.com/ClawKSP/KSP-Stock-Bug-Fix-Modules"

--- a/NetKAN/StockBugFixPlus.netkan
+++ b/NetKAN/StockBugFixPlus.netkan
@@ -5,7 +5,7 @@
     "name"           : "Stock Bug Fix Modules & StockPlus",
     "abstract"       : "Fixes for common stock KSP bugs. Enhancements of stock functionality",
     "license"        : "CC-BY-NC-SA-4.0",
-    "ksp_version"    : "1.0.5"
+    "ksp_version"    : "1.0.5",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/97285",
         "repository" : "https://github.com/ClawKSP/KSP-Stock-Bug-Fix-Modules"

--- a/NetKAN/StockBugFixPlus.netkan
+++ b/NetKAN/StockBugFixPlus.netkan
@@ -5,11 +5,16 @@
     "name"           : "Stock Bug Fix Modules & StockPlus",
     "abstract"       : "Fixes for common stock KSP bugs. Enhancements of stock functionality",
     "license"        : "CC-BY-NC-SA-4.0",
+    "ksp_version"    : "1.0.5"
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/97285",
         "repository" : "https://github.com/ClawKSP/KSP-Stock-Bug-Fix-Modules"
     },
     "depends" : [
         { "name" : "ModuleManager" }
+    ],
+    "conflicts": [
+        { "name": "StockBugFixModules" },
+        { "name": "StockPlus" }
     ]
 }

--- a/NetKAN/StockPlus.netkan
+++ b/NetKAN/StockPlus.netkan
@@ -5,7 +5,8 @@
     "name"           : "Stock Plus",
     "abstract"       : "Enhancements of stock functionality",
     "license"        : "CC-BY-NC-SA-4.0",
-    "ksp_version"    : "1.0.4",
+    "ksp_version_min": "1.0.3",
+    "ksp_version_max": "1.0.4",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/97285",
         "repository": "https://github.com/ClawKSP/KSP-Stock-Bug-Fix-Modules"


### PR DESCRIPTION
Restrict the old StockPlus to KSP 1.0.4 and conflict with the new version for 1.0.5