### PR TITLE
AdjustableLandingGear

### DIFF
--- a/NetKAN/AdjustableLandingGear.netkan
+++ b/NetKAN/AdjustableLandingGear.netkan
@@ -12,7 +12,7 @@
             "delete" : [ "ksp_version" ],
             "override" : {
                 "ksp_version_min" : "1.0.2",
-                "ksp_version_max" : "1.0.4"
+                "ksp_version_max" : "1.0.5"
             }
         }
     ]

--- a/NetKAN/BahamutoDynamicsPartsPack.netkan
+++ b/NetKAN/BahamutoDynamicsPartsPack.netkan
@@ -20,7 +20,7 @@
             "delete": [ "ksp_version" ],
             "override": {
                 "ksp_version_min": "1.0.2",
-                "ksp_version_max": "1.0.4"
+                "ksp_version_max": "1.0.5"
             }
         }
     ]

--- a/NetKAN/CameraTools.netkan
+++ b/NetKAN/CameraTools.netkan
@@ -9,7 +9,7 @@
             "delete": [ "ksp_version" ],
             "override": {
                 "ksp_version_min": "1.0.2",
-                "ksp_version_max": "1.0.4"
+                "ksp_version_max": "1.0.5"
             }
         }
     ],


### PR DESCRIPTION
AdjustableLandingGear and CameraTools work with 1.0.5 according to the KS pages. BahamutoDynamicsPartsPack works fine because it uses the `BDAnimationModules.dll`, the same dll that is used for AdjustableLandingGear.

This dll can be updated by merging in KSP-CKAN/CKAN-meta/pull/831