### PR TITLE
PlanetPacks Overhaul - Part 1

### DIFF
--- a/NetKAN/Asclepius.netkan
+++ b/NetKAN/Asclepius.netkan
@@ -5,10 +5,13 @@
     "identifier": "Asclepius",
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "Kopernicus"}
+        { "name": "Kopernicus", "version": "1:beta-05-2" }
     ],
     "suggests": [
         { "name": "Asclepius-clouds" }
+    ],
+    "provides": [
+        "PlanetPack"
     ],
     "install": [
         {

--- a/NetKAN/Asclepius.netkan
+++ b/NetKAN/Asclepius.netkan
@@ -10,8 +10,8 @@
     "suggests": [
         { "name": "Asclepius-clouds" }
     ],
-    "provides": [
-        "PlanetPack"
+    "conflicts": [
+        { "name": "RealSolarSystem" }
     ],
     "install": [
         {

--- a/NetKAN/Asclepius.netkan
+++ b/NetKAN/Asclepius.netkan
@@ -5,7 +5,7 @@
     "identifier": "Asclepius",
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "Kopernicus", "version": "1:beta-05-2" }
+        { "name": "Kopernicus", "min_version": "1:beta-05-2" }
     ],
     "suggests": [
         { "name": "Asclepius-clouds" }

--- a/NetKAN/ForgottenWorlds.netkan
+++ b/NetKAN/ForgottenWorlds.netkan
@@ -5,7 +5,6 @@
     "spec_version": "v1.4",
 	"depends"		:	[ { "name" : "KopernicusTech" },
 						{ "name" : "ModuleManager" } ],
-	"provides": [ "PlanetPack" ],
 	"conflicts": [ { "name" : "PlanetPack" } ],
 	"install"		:	[ { "find" : "ForgottenWorlds",
 							"install_to" : "GameData" },

--- a/NetKAN/ForgottenWorlds.netkan
+++ b/NetKAN/ForgottenWorlds.netkan
@@ -5,7 +5,6 @@
     "spec_version": "v1.4",
 	"depends"		:	[ { "name" : "KopernicusTech" },
 						{ "name" : "ModuleManager" } ],
-	"conflicts": [ { "name" : "PlanetPack" } ],
 	"install"		:	[ { "find" : "ForgottenWorlds",
 							"install_to" : "GameData" },
 						{ "find" : "KittopiaSpace",

--- a/NetKAN/Insystem.netkan
+++ b/NetKAN/Insystem.netkan
@@ -7,6 +7,7 @@
 					{ "name" : "DDSLoader" },
 					{ "name" : "Kopernicus-Config-Default" },
 					{ "name" : "ModuleManager" } ],
+	"conflicts"	:	[ { "name" : "Kopernicus" } ],
 	"install"		:	[ { "find" : "Insystem",
 						"install_to" : "GameData" } ]
 }

--- a/NetKAN/Insystem.netkan
+++ b/NetKAN/Insystem.netkan
@@ -7,8 +7,6 @@
 					{ "name" : "DDSLoader" },
 					{ "name" : "Kopernicus-Config-Default" },
 					{ "name" : "ModuleManager" } ],
-	"provides": [ "PlanetPack" ],
-	"conflicts": [ { "name" : "PlanetPack" } ],
 	"install"		:	[ { "find" : "Insystem",
 						"install_to" : "GameData" } ]
 }

--- a/NetKAN/KPlus.netkan
+++ b/NetKAN/KPlus.netkan
@@ -20,12 +20,10 @@
         { "name": "PlanetShine" },
         { "name": "TextureReplacer" }
     ],
-    "provides": [
-        "PlanetPack"
+    "conflicts": [
+        { "name": "RealSolarSystem" },
+        { "name": "KerbolPlus" }
     ],
-	"conflicts": [
-		{ "name": "KerbolPlus" }
-	],
     "install": [
         {
             "find": "KPlus",

--- a/NetKAN/KPlus.netkan
+++ b/NetKAN/KPlus.netkan
@@ -13,7 +13,7 @@
     "ksp_version": "1.0.5",
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "Kopernicus", "version": "1:beta-05-2" }
+        { "name": "Kopernicus", "min_version": "1:beta-05-2" }
     ],
     "suggests": [
         { "name": "DistantObject" },

--- a/NetKAN/KPlus.netkan
+++ b/NetKAN/KPlus.netkan
@@ -1,0 +1,35 @@
+{
+    "spec_version"  : "v1.4",
+    "identifier"    : "KPlus",
+    "$kref"         : "#/ckan/github/KillAshley/KPlus",
+    "name"          : "Kerbol Plus Remade",
+    "abstract"      : "Kerbol Plus is a planetary expansion for KSP adding in 6 new planets and 6 moons for players to discover. Note: This version is a revisioned version of KerbolPlus.",
+    "license"       : "CC-BY-NC-SA-4.0",
+    "author"        : [ "KillAshley", "Thomas P." ],
+    "release_status": "stable",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/138438"
+    },
+    "ksp_version": "1.0.5",
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus", "version": "1:beta-05-2" }
+    ],
+    "suggests": [
+        { "name": "DistantObject" },
+        { "name": "PlanetShine" },
+        { "name": "TextureReplacer" }
+    ],
+    "provides": [
+        "PlanetPack"
+    ],
+	"conflicts": [
+		{ "name": "KerbolPlus" }
+	],
+    "install": [
+        {
+            "find": "KPlus",
+            "install_to": "GameData"
+        }
+    ]
+}

--- a/NetKAN/KittopiaTech.netkan
+++ b/NetKAN/KittopiaTech.netkan
@@ -1,0 +1,30 @@
+{
+    "spec_version"  : "v1.4",
+    "identifier"    : "KittopiaTech",
+    "$kref"         : "#/ckan/github/Kopernicus/KittopiaTech",
+    "name"          : "KittopiaTech",
+    "abstract"      : "A Kopernicus visual editor for ingame planet editing and exporting.",
+    "release_status": "development",
+    "license"       : "LGPL-3.0",
+    "author": [
+        "Thomas P.",
+        "BorisBee",
+        "Kragrathea",
+        "KCreator",
+        "Gravitasi",
+        "joedavis"
+    ],
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/129186"
+    },
+    "ksp_version": "1.0.5",
+    "depends": [
+        { "name" : "Kopernicus", "min_version": "1:beta-05-2" }
+    ],
+    "install": [
+        {
+            "find"      : "KittopiaTech",
+            "install_to": "GameData"
+        }
+    ]
+}

--- a/NetKAN/Kopernicus.netkan
+++ b/NetKAN/Kopernicus.netkan
@@ -1,12 +1,12 @@
 {
-    "spec_version": "v1.4",
-    "identifier": "Kopernicus",
-    "$kref": "#/ckan/github/Kopernicus/Kopernicus",
+    "spec_version"  : "v1.4",
+    "identifier"    : "Kopernicus",
+    "$kref"         : "#/ckan/github/Kopernicus/Kopernicus",
     "x_netkan_epoch": "1",
-    "name": "Kopernicus Planetary System Modifier",
-    "abstract": "Allows users to replace the planetary system used by the game.",
+    "name"          : "Kopernicus Planetary System Modifier",
+    "abstract"      : "Allows users to replace the planetary system used by the game.",
     "release_status": "development",
-    "license": "LGPL-3.0",
+    "license"       : "LGPL-3.0",
     "author": [
         "BryceSchroeder",
         "Teknoman117",
@@ -17,16 +17,18 @@
         "KCreator"
     ],
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/114649",
-        "repository": "http://github.com/Kopernicus/Kopernicus"
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/114649"
     },
     "ksp_version": "1.0.5",
-    "depends":	[
+    "depends": [
         { "name" : "ModuleManager", "min_version": "2.6.13" }
+    ],
+    "recommends": [
+        { "name": "PlanetPack" }
     ],
     "install": [
         {
-            "find": "Kopernicus",
+            "find"      : "Kopernicus",
             "install_to": "GameData"
         }
     ]

--- a/NetKAN/Kopernicus.netkan
+++ b/NetKAN/Kopernicus.netkan
@@ -24,7 +24,8 @@
         { "name" : "ModuleManager", "min_version": "2.6.13" }
     ],
     "recommends": [
-        { "name": "PlanetPack" }
+        { "name": "PlanetPack" },
+        { "name": "KittopiaTech" }
     ],
     "install": [
         {

--- a/NetKAN/Kopernicus.netkan
+++ b/NetKAN/Kopernicus.netkan
@@ -24,7 +24,6 @@
         { "name" : "ModuleManager", "min_version": "2.6.13" }
     ],
     "recommends": [
-        { "name": "PlanetPack" },
         { "name": "KittopiaTech" }
     ],
     "install": [

--- a/NetKAN/NewHorizons.netkan
+++ b/NetKAN/NewHorizons.netkan
@@ -1,29 +1,36 @@
 {
-    "$kref"        : "#/ckan/kerbalstuff/661",
-    "spec_version" : "v1.4",
-    "identifier"   : "NewHorizons",
-    "license"      : "CC-BY-NC-SA-4.0",
+    "spec_version"  : "v1.4",
+    "identifier"    : "NewHorizons",
     "x_netkan_epoch": "1",
-    "depends"      : [
-        { "name" : "Kopernicus" },
-        { "name" : "ModuleManager" }
+    "$kref"         : "#/ckan/github/KillAshley/New_Horizons",
+    "name"          : "New Horizons",
+    "abstract"      : "Rearranges the stock system and introduces 19 more bodies to visit and explore.",
+    "license"       : "CC-BY-NC-SA-4.0",
+    "author"        : "KillAshley",
+    "release_status": "stable",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/114092"
+    },
+    "ksp_version": "1.0.5",
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus", "version": "1:beta-05-2" }
     ],
-    "recommends"   : [
-        { "name" : "ADIOS" },
-        { "name" : "RemoteTech" },
-        { "name" : "DeadlyReentry" } 
+    "suggests": [
+        { "name": "ActiveTextureManagement" },
+        { "name": "DMagicOrbitalScience" },
+        { "name": "DistantObject" },
+        { "name": "PlanetShine" },
+        { "name": "ResearchBodies" },
+        { "name": "TextureReplacer" }
     ],
-    "supports"     : [
-        { "name"   : "CommunityResourcePack"}
+    "provides": [
+        "PlanetPack"
     ],
-    "conflicts"    : [
-        { "name" : "KopernicusTech" },
-        { "name" : "RealSolarSystem" }
-    ],
-    "install"      : [
+    "install": [
         {
-            "find" : "New_Horizons",
-            "install_to" : "GameData" 
+            "find": "New_Horizons",
+            "install_to": "GameData"
         }
     ]
 }

--- a/NetKAN/NewHorizons.netkan
+++ b/NetKAN/NewHorizons.netkan
@@ -24,8 +24,8 @@
         { "name": "ResearchBodies" },
         { "name": "TextureReplacer" }
     ],
-    "provides": [
-        "PlanetPack"
+    "conflicts": [
+        { "name": "RealSolarSystem" }
     ],
     "install": [
         {

--- a/NetKAN/NewHorizons.netkan
+++ b/NetKAN/NewHorizons.netkan
@@ -14,7 +14,7 @@
     "ksp_version": "1.0.5",
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "Kopernicus", "version": "1:beta-05-2" }
+        { "name": "Kopernicus", "min_version": "1:beta-05-2" }
     ],
     "suggests": [
         { "name": "ActiveTextureManagement" },

--- a/NetKAN/OuterPlanetsMod.netkan
+++ b/NetKAN/OuterPlanetsMod.netkan
@@ -5,15 +5,14 @@
   "x_netkan_epoch": "1",
   "license": "CC-BY-NC-SA-4.0",
   "depends": [
-    { "name": "ModuleManager", "min_version": "2.6.7" },
-    { "name": "Kopernicus", "min_version": "1:beta-03-3" }
+    { "name": "ModuleManager" },
+    { "name": "Kopernicus", "version": "1:beta-05-2" }
   ],
   "recommends": [
     { "name": "KopernicusExpansion" }
   ],
   "conflicts": [
     { "name": "CustomBiomes" },
-    { "name": "PlanetPack" }
   ],
   "provides": [
     "PlanetPack"
@@ -39,6 +38,9 @@
     { "name": "Karbonite" },
     { "name": "TextureReplacer" }
   ],
+    "provides": [
+        "PlanetPack"
+    ],
   "install" : [
     { "find": "OPM", "install_to" : "GameData" }
   ],

--- a/NetKAN/OuterPlanetsMod.netkan
+++ b/NetKAN/OuterPlanetsMod.netkan
@@ -6,7 +6,7 @@
     "license": "CC-BY-NC-SA-4.0",
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "Kopernicus", "version": "1:beta-05-2" }
+        { "name": "Kopernicus", "min_version": "1:beta-05-2" }
     ],
     "recommends": [
         { "name": "KopernicusExpansion" }

--- a/NetKAN/OuterPlanetsMod.netkan
+++ b/NetKAN/OuterPlanetsMod.netkan
@@ -1,59 +1,57 @@
 {
-  "spec_version": "v1.4",
-  "identifier": "OuterPlanetsMod",
-  "$kref": "#/ckan/kerbalstuff/437",
-  "x_netkan_epoch": "1",
-  "license": "CC-BY-NC-SA-4.0",
-  "depends": [
-    { "name": "ModuleManager" },
-    { "name": "Kopernicus", "version": "1:beta-05-2" }
-  ],
-  "recommends": [
-    { "name": "KopernicusExpansion" }
-  ],
-  "conflicts": [
-    { "name": "CustomBiomes" }
-  ],
-  "provides": [
-    "PlanetPack"
-  ],
-  "suggests": [
-    { "name": "JDiminishingRTG" },
-    { "name": "NearFuturePropulsion" },
-    { "name": "NearFutureElectrical" },
-    { "name": "NearFutureSolar" },
-    { "name": "NearFutureConstruction" },
-    { "name": "NearFutureSpacecraft" },
-    { "name": "TransferWindowPlanner"}
-  ],
-  "supports": [
-    { "name": "PlanetShine" },
-    { "name": "DistantObjectEnhancement" },
-    { "name": "FinalFrontier" },
-    { "name": "AntennaRange" },
-    { "name": "RemoteTech" },
-    { "name": "SCANsat" },
-    { "name": "DeadlyReentry" },
-    { "name": "MunarSurfaceExperimentPackage" },
-    { "name": "Karbonite" },
-    { "name": "TextureReplacer" }
-  ],
-    "provides": [
-        "PlanetPack"
+    "spec_version": "v1.4",
+    "identifier": "OuterPlanetsMod",
+    "$kref": "#/ckan/kerbalstuff/437",
+    "x_netkan_epoch": "1",
+    "license": "CC-BY-NC-SA-4.0",
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus", "version": "1:beta-05-2" }
     ],
-  "install" : [
-    { "find": "OPM", "install_to" : "GameData" }
-  ],
-  "x_netkan_override": [
-    {
-      "version": "<1:1.8",
-      "delete": [ "depends", "recommends" ],
-      "override": {
-        "depends": [
-          { "name": "ModuleManager", "min_version": "2.6.6" },
-          { "name": "Kopernicus", "min_version": "1:beta-01" }
-        ]
-      }
-    }
-  ]
+    "recommends": [
+        { "name": "KopernicusExpansion" }
+    ],
+    "conflicts": [
+        { "name": "RealSolarSystem" },
+        { "name": "CustomBiomes" }
+    ],
+    "suggests": [
+        { "name": "JDiminishingRTG" },
+        { "name": "NearFuturePropulsion" },
+        { "name": "NearFutureElectrical" },
+        { "name": "NearFutureSolar" },
+        { "name": "NearFutureConstruction" },
+        { "name": "NearFutureSpacecraft" },
+        { "name": "TransferWindowPlanner"}
+    ],
+    "supports": [
+        { "name": "PlanetShine" },
+        { "name": "DistantObjectEnhancement" },
+        { "name": "FinalFrontier" },
+        { "name": "AntennaRange" },
+        { "name": "RemoteTech" },
+        { "name": "SCANsat" },
+        { "name": "DeadlyReentry" },
+        { "name": "MunarSurfaceExperimentPackage" },
+        { "name": "Karbonite" },
+        { "name": "TextureReplacer" }
+    ],
+    "install": [
+        {
+            "find": "OPM",
+            "install_to" : "GameData"
+        }
+    ],
+    "x_netkan_override": [
+        {
+            "version": "<1:1.8",
+            "delete": [ "depends", "recommends" ],
+            "override": {
+                "depends": [
+                    { "name": "ModuleManager", "min_version": "2.6.6" },
+                    { "name": "Kopernicus", "min_version": "1:beta-01" }
+                ]
+            }
+        }
+    ]
 }

--- a/NetKAN/OuterPlanetsMod.netkan
+++ b/NetKAN/OuterPlanetsMod.netkan
@@ -12,7 +12,7 @@
     { "name": "KopernicusExpansion" }
   ],
   "conflicts": [
-    { "name": "CustomBiomes" },
+    { "name": "CustomBiomes" }
   ],
   "provides": [
     "PlanetPack"

--- a/NetKAN/RealSolarSystem.netkan
+++ b/NetKAN/RealSolarSystem.netkan
@@ -13,7 +13,7 @@
     },
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "Kopernicus", "version": "1:beta-05-2" },
+        { "name": "Kopernicus", "min_version": "1:beta-05-2" },
         { "name": "RSSTextures" }
     ],
     "recommends": [

--- a/NetKAN/RealSolarSystem.netkan
+++ b/NetKAN/RealSolarSystem.netkan
@@ -22,6 +22,9 @@
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/55145"
     },
+    "provides": [
+        "PlanetPack"
+    ],
     "install" : [
         {
             "find"       : "RealSolarSystem",

--- a/NetKAN/RealSolarSystem.netkan
+++ b/NetKAN/RealSolarSystem.netkan
@@ -1,38 +1,36 @@
 {
-    "spec_version"   : "v1.4",
-    "$kref"          : "#/ckan/github/KSP-RO/RealSolarSystem",
-    "$vref"          : "#/ckan/ksp-avc",
+    "spec_version"    : "v1.4",
+    "$kref"           : "#/ckan/github/KSP-RO/RealSolarSystem",
+    "$vref"           : "#/ckan/ksp-avc",
     "x_netkan_force_v": true,
-    "name"           : "Real Solar System",
-    "identifier"     : "RealSolarSystem",
-    "abstract"       : "Resizes and rearranges the Kerbal system to more closely resemble the Solar System",
-    "license"        : "CC-BY-NC-SA",
-    "release_status" : "stable",
-    "depends" : [
-	{ "name" : "Kopernicus" },
-        { "name" : "RSSTextures" }
-    ],
-    "recommends" : [
-        { "name" : "RealismOverhaul" },
-        { "name" : "KSCSwitcher" }
-    ],
-    "suggests" : [
-        { "name" : "RemoteTech-Config-RSS" }
-    ],
-    "resources" : {
-        "homepage" : "http://forum.kerbalspaceprogram.com/threads/55145"
+    "name"            : "Real Solar System",
+    "identifier"      : "RealSolarSystem",
+    "abstract"        : "Resizes and rearranges the Kerbal system to more closely resemble the Solar System",
+    "license"         : "CC-BY-NC-SA",
+    "release_status"  : "stable",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/55145"
     },
-    "provides": [
-        "PlanetPack"
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus", "version": "1:beta-05-2" },
+        { "name": "RSSTextures" }
     ],
-    "install" : [
+    "recommends": [
+        { "name": "RealismOverhaul" },
+        { "name": "KSCSwitcher" }
+    ],
+    "suggests": [
+        { "name": "RemoteTech-Config-RSS" }
+    ],
+    "install": [
         {
-            "find"       : "RealSolarSystem",
-            "install_to" : "GameData"
+            "find"      : "RealSolarSystem",
+            "install_to": "GameData"
         },
-		{
-			"find"		 : "Cache",
-			"install_to" : "GameData/Kopernicus"
-		}
+        {
+            "find"      : "Cache",
+            "install_to": "GameData/Kopernicus"
+        }
     ]
 }

--- a/NetKAN/TerrestrialPlanetPack.netkan
+++ b/NetKAN/TerrestrialPlanetPack.netkan
@@ -6,8 +6,6 @@
 	"depends" : [ { "name" : "KopernicusTech" },
 					{ "name" : "ModuleManager" },
 					{ "name" : "DDSLoader" } ],
-	"provides": [ "PlanetPack" ],
-	"conflicts": [ { "name" : "PlanetPack" } ],
 	"install" :	[ { "find" : "TerrestrialPlanetPack",
 					"install_to" : "GameData" },
 					{ "find" : "KittopiaSpace",


### PR DESCRIPTION
First step of the Planet Pack overhaul.

* Added KittopiaTech, a visual planet editor plugin for Kopernicus
* Added KPlus
* Added conflicts with other planet packs
* Made the packs only work on a `min_version` of Kopernicus
* Removed the `Provides: PlanetPack` stanza's
* Reformated some files

**NOTE:** For the moment I only added/changed planet packs that are compatible with the current version of Kopernicus (v0.5.2). When a new compatible pack is released, I'll update that file.