### PR TITLE
PlanetPacks Overhaul - Part 2

### DIFF
--- a/NetKAN/AlternisKerbolRekerjiggered.netkan
+++ b/NetKAN/AlternisKerbolRekerjiggered.netkan
@@ -3,8 +3,9 @@
     "spec_version": "v1.4",
     "license": "CC-BY-NC-4.0",
     "$kref": "#/ckan/kerbalstuff/1143",
+    "ksp_version": "1.0.4",
     "depends": [
-        { "name": "Kopernicus" }
+        { "name": "Kopernicus", "version": "1:beta-04" }
     ],
     "recommends": [
         { "name": "DistantObject" },

--- a/NetKAN/AlternisKerbolRekerjiggered.netkan
+++ b/NetKAN/AlternisKerbolRekerjiggered.netkan
@@ -21,5 +21,15 @@
             "find"       : "Kopernicus/Cache",
             "install_to" : "GameData/Kopernicus"
         }
+    ],
+    "x_netkan_override" : [
+        {
+            "version" : "1.4.2",
+            "delete" : [ "ksp_version" ],
+            "override" : {
+                "ksp_version_min" : "1.0.2",
+                "ksp_version_max" : "1.0.4"
+            }
+        }
     ]
 }

--- a/NetKAN/AlternisKerbolRekerjiggered.netkan
+++ b/NetKAN/AlternisKerbolRekerjiggered.netkan
@@ -3,7 +3,6 @@
     "spec_version": "v1.4",
     "license": "CC-BY-NC-4.0",
     "$kref": "#/ckan/kerbalstuff/1143",
-    "ksp_version": "1.0.4",
     "depends": [
         { "name": "Kopernicus", "version": "1:beta-04" }
     ],

--- a/NetKAN/Arkas.netkan
+++ b/NetKAN/Arkas.netkan
@@ -3,8 +3,8 @@
 	"$kref"		:	"#/ckan/kerbalstuff/1158",
 	"spec_version"	:	"v1.4",
 	"license"  	:	"CC-BY-NC-SA-4.0",
-	"comment"	:	"PlanetPack",
-	"depends"	:	[ { "name"	:	"Kopernicus", "min version": "0.4" } ],
+    "ksp_version": "1.0.4",
+	"depends"	:	[ { "name"	:	"Kopernicus", "version": "1:beta-04" } ],
 	"recommends"	:	[ { "name"	:	"Arkas-Clouds" } ],
 	"install"	:	[
 		{

--- a/NetKAN/Arkas.netkan
+++ b/NetKAN/Arkas.netkan
@@ -3,7 +3,6 @@
 	"$kref"		:	"#/ckan/kerbalstuff/1158",
 	"spec_version"	:	"v1.4",
 	"license"  	:	"CC-BY-NC-SA-4.0",
-    "ksp_version": "1.0.4",
 	"depends"	:	[ { "name"	:	"Kopernicus", "version": "1:beta-04" } ],
 	"recommends"	:	[ { "name"	:	"Arkas-Clouds" } ],
 	"install"	:	[

--- a/NetKAN/KSP-64k-12HourDay.netkan
+++ b/NetKAN/KSP-64k-12HourDay.netkan
@@ -12,8 +12,6 @@
         }
     ],
     "depends": [
-        { "name": "ModuleManager", "min_version": "2.6.6" },
-        { "name": "Kopernicus", "min_version": "pre-alpha-07" },
         { "name": "KSP-64k" }
     ]
 }

--- a/NetKAN/KSP-64k.netkan
+++ b/NetKAN/KSP-64k.netkan
@@ -9,7 +9,6 @@
             "install_to": "GameData"
         }
     ],
-    "ksp_version": "1.0.4",
     "depends": [
         { "name": "ModuleManager" },
         { "name": "Kopernicus", "version": "1:beta-04" }

--- a/NetKAN/KSP-64k.netkan
+++ b/NetKAN/KSP-64k.netkan
@@ -9,9 +9,10 @@
             "install_to": "GameData"
         }
     ],
+    "ksp_version": "1.0.4",
     "depends": [
-        { "name": "ModuleManager", "min_version": "2.6.6" },
-        { "name": "Kopernicus", "min_version": "pre-alpha-07" }
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus", "version": "1:beta-04" }
     ],
     "suggests": [
         { "name": "ProceduralParts" },

--- a/NetKAN/KerbolPlus.netkan
+++ b/NetKAN/KerbolPlus.netkan
@@ -1,23 +1,29 @@
 {
-    "$kref"        : "#/ckan/github/Amarius1/Kerbol-Plus",
+    "$kref"       : "#/ckan/github/Amarius1/Kerbol-Plus",
     "spec_version": "v1.4",
-    "identifier": "KerbolPlus",
-    "license": "CC-BY-NC-SA",
-    "name"         : "Kerbol Plus",
-    "abstract"     : "This mod aims to expand the stock kerbol system with 2 more gas giants and lots of moons.",
-    "ksp_version"  : "1.0.4",
-	"depends"	:	[ { "name" : "Kopernicus" },
-					{ "name" : "ModuleManager" } ],
-	"provides": [ "PlanetPack" ],
-	"conflicts"	:	[ { "name" : "Kopernicus" },
-					{ "name" : "KittopiaTech" },
-					{ "name" : "PlanetPack" }
-					],
-	"install"		:	[ { "find" : "KerbolPlus",
-						"install_to" : "GameData" },
-						{ "find" : "Kopernicus/Cache",
-						"install_to" : "GameData/Kopernicus"
-						} 
-					],
+    "identifier"  : "KerbolPlus",
+    "license"     : "CC-BY-NC-SA-4.0",
+    "name"        : "Kerbol Origins",
+    "abstract"    : "This mod aims to expand the stock Kerbol System with 2 more gas giants and lots of moons.",
+    "ksp_version" : "1.0.4",
+	"depends": [
+		{ "name" : "Kopernicus", "version": "1:beta-04" },
+		{ "name" : "ModuleManager" }
+	],
+	"conflicts": [
+		{ "name" : "KPlus" },
+		{ "name" : "RealSolarSystem" }
+	],
+	"install": [
+		{
+			"find"      : "KerbolPlus",
+			"install_to": "GameData"
+		},
+		{
+			"find"      : "Kopernicus/Cache",
+			"install_to": "GameData/Kopernicus"
+		} 
+    ],
+    "x_netkan_epoch": "1",
     "x_netkan_force_v": true
 }

--- a/NetKAN/KopernicusExpansion.netkan
+++ b/NetKAN/KopernicusExpansion.netkan
@@ -12,6 +12,6 @@
     },
     "ksp_version": "1.0.4",
     "depends":	[
-        { "name" : "Kopernicus", "min_version": "1:beta-03" }
+        { "name" : "Kopernicus", "version": "1:beta-04" }
     ]
 }

--- a/NetKAN/Kronkus.netkan
+++ b/NetKAN/Kronkus.netkan
@@ -4,7 +4,6 @@
     "$kref"        : "#/ckan/kerbalstuff/1152",
     "license"      : "CC0",
     "x_netkan_license_ok": true,
-    "ksp_version": "1.0.4",
     "depends": [
         { "name": "Kopernicus", "version": "1:beta-04" },
         { "name": "ModuleManager" }

--- a/NetKAN/Kronkus.netkan
+++ b/NetKAN/Kronkus.netkan
@@ -4,8 +4,9 @@
     "$kref"        : "#/ckan/kerbalstuff/1152",
     "license"      : "CC0",
     "x_netkan_license_ok": true,
+    "ksp_version": "1.0.4",
     "depends": [
-        { "name": "Kopernicus" },
+        { "name": "Kopernicus", "version": "1:beta-04" },
         { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/Ktolemy.netkan
+++ b/NetKAN/Ktolemy.netkan
@@ -6,7 +6,6 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/137299"
     },
-    "ksp_version": "1.0.4",
     "depends": [
         { "name": "Kopernicus", "version": "1:beta-04" }
     ]

--- a/NetKAN/Ktolemy.netkan
+++ b/NetKAN/Ktolemy.netkan
@@ -6,7 +6,8 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/137299"
     },
+    "ksp_version": "1.0.4",
     "depends": [
-        { "name": "Kopernicus" }
+        { "name": "Kopernicus", "version": "1:beta-04" }
     ]
 }

--- a/NetKAN/NebiaAndShomma.netkan
+++ b/NetKAN/NebiaAndShomma.netkan
@@ -3,8 +3,10 @@
     "spec_version": "v1.4",
     "$kref": "#/ckan/kerbalstuff/1219",
     "license": "CC-BY-NC-SA-4.0",
+	"name": "Keridani",
+    "ksp_version": "1.0.4",
     "depends": [
-        { "name": "Kopernicus" }
+        { "name": "Kopernicus", "version": "1:beta-04" }
     ],
     "recommends": [
         { "name": "EnvironmentalVisualEnhancements" }
@@ -17,5 +19,6 @@
             "find"       : "Planets",
             "install_to" : "GameData"
         }
-    ]
+    ],
+    "x_netkan_epoch": "1"
 }

--- a/NetKAN/NebiaAndShomma.netkan
+++ b/NetKAN/NebiaAndShomma.netkan
@@ -4,7 +4,6 @@
     "$kref": "#/ckan/kerbalstuff/1219",
     "license": "CC-BY-NC-SA-4.0",
 	"name": "Keridani",
-    "ksp_version": "1.0.4",
     "depends": [
         { "name": "Kopernicus", "version": "1:beta-04" }
     ],

--- a/NetKAN/RhatssPlanetpack.netkan
+++ b/NetKAN/RhatssPlanetpack.netkan
@@ -3,7 +3,6 @@
     "$kref": "#/ckan/kerbalstuff/1074",
     "license": "MIT",
     "identifier": "RhatssPlanetpack",
-    "ksp_version": "1.0.4",
     "depends": [
         { "name": "Kopernicus", "version": "1:beta-02-4" }
     ],
@@ -11,6 +10,16 @@
         {
             "find"       : "RPM",
             "install_to" : "GameData"
+        }
+    ],
+    "x_netkan_override" : [
+        {
+            "version" : "1.2",
+            "delete" : [ "ksp_version" ],
+            "override" : {
+                "ksp_version_min" : "1.0.2",
+                "ksp_version_max" : "1.0.4"
+            }
         }
     ]
 }

--- a/NetKAN/RhatssPlanetpack.netkan
+++ b/NetKAN/RhatssPlanetpack.netkan
@@ -3,8 +3,9 @@
     "$kref": "#/ckan/kerbalstuff/1074",
     "license": "MIT",
     "identifier": "RhatssPlanetpack",
+    "ksp_version": "1.0.4",
     "depends": [
-        { "name": "Kopernicus"}
+        { "name": "Kopernicus", "version": "1:beta-02-4" }
     ],
     "install": [
         {

--- a/NetKAN/SentarExpansion.netkan
+++ b/NetKAN/SentarExpansion.netkan
@@ -3,7 +3,6 @@
     "identifier"    : "SentarExpansion",
     "$kref"         : "#/ckan/kerbalstuff/1029",
     "license"       : "GPL-2.0",
-    "ksp_version": "1.0.4",
 	"depends": [
         { "name": "Kopernicus", "version": "1:beta-03-3" },
         { "name" : "ModuleManager" }

--- a/NetKAN/SentarExpansion.netkan
+++ b/NetKAN/SentarExpansion.netkan
@@ -3,8 +3,9 @@
     "identifier"    : "SentarExpansion",
     "$kref"         : "#/ckan/kerbalstuff/1029",
     "license"       : "GPL-2.0",
+    "ksp_version": "1.0.4",
 	"depends": [
-        { "name": "Kopernicus", "min_version": "1:beta-02-4"},
-        { "name" : "ModuleManager", "min_version": "2.6.6" }
+        { "name": "Kopernicus", "version": "1:beta-03-3" },
+        { "name" : "ModuleManager" }
     ]
 }

--- a/NetKAN/SigmaBinary-core.netkan
+++ b/NetKAN/SigmaBinary-core.netkan
@@ -9,7 +9,7 @@
     "author"       : "Sigma88",
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "Kopernicus" }
+        { "name": "Kopernicus", "version": "1:beta-05-2" }
     ],
     "suggests": [
         { "name": "SigmaBinary-DunaIke" }

--- a/NetKAN/SigmaOPMExpansion.netkan
+++ b/NetKAN/SigmaOPMExpansion.netkan
@@ -10,7 +10,7 @@
     "depends": [
         { "name": "ModuleManager" },
         { "name": "OuterPlanetsMod" },
-        { "name": "Kopernicus" }
+        { "name": "Kopernicus", "version": "1:beta-04" }
     ],
     "suggests": [
         { "name": "SigmaOPMRecolor" }

--- a/NetKAN/SigmaOPMRecolor.netkan
+++ b/NetKAN/SigmaOPMRecolor.netkan
@@ -10,7 +10,7 @@
     "depends": [
         { "name": "ModuleManager" },
         { "name": "OuterPlanetsMod" },
-        { "name": "Kopernicus" }
+        { "name": "Kopernicus", "version": "1:beta-04" }
     ],
     "suggests": [
         { "name": "SigmaOPMExpansion" }

--- a/NetKAN/SigmaPluronKhato.netkan
+++ b/NetKAN/SigmaPluronKhato.netkan
@@ -9,7 +9,7 @@
     "author"       : "Sigma88",
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "Kopernicus" }
+        { "name": "Kopernicus", "version": "1:beta-04" }
     ],
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/112095"

--- a/NetKAN/SigmaStockRecolor.netkan
+++ b/NetKAN/SigmaStockRecolor.netkan
@@ -9,7 +9,7 @@
     "author"       : "Sigma88",
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "Kopernicus" }
+        { "name": "Kopernicus", "version": "1:beta-04" }
     ],
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/112095"

--- a/NetKAN/ToySolarSystem.netkan
+++ b/NetKAN/ToySolarSystem.netkan
@@ -3,7 +3,8 @@
     "spec_version": "v1.4",
     "identifier": "ToySolarSystem",
     "license": "MIT",
+    "ksp_version" : "1.0.4",
     "depends": [
-        { "name": "Kopernicus" }
+        { "name": "Kopernicus", "version": "1:beta-04" }
     ]
 }

--- a/NetKAN/ToySolarSystem.netkan
+++ b/NetKAN/ToySolarSystem.netkan
@@ -3,8 +3,17 @@
     "spec_version": "v1.4",
     "identifier": "ToySolarSystem",
     "license": "MIT",
-    "ksp_version" : "1.0.4",
     "depends": [
         { "name": "Kopernicus", "version": "1:beta-04" }
+    ],
+    "x_netkan_override" : [
+        {
+            "version" : "1.0",
+            "delete" : [ "ksp_version" ],
+            "override" : {
+                "ksp_version_min" : "1.0.2",
+                "ksp_version_max" : "1.0.4"
+            }
+        }
     ]
 }

--- a/NetKAN/sidosUraniaSystem.netkan
+++ b/NetKAN/sidosUraniaSystem.netkan
@@ -3,15 +3,14 @@
     "$kref"     : "#/ckan/kerbalstuff/1185",
     "spec_version"  : "v1.4",
     "license"   : "CC-BY-NC-SA",
-    "comment"   : "PlanetPack",
     "resources" : 
     {
         "homepage"  : "http://forum.kerbalspaceprogram.com/threads/66882"
     },
-
+    "ksp_version": "1.0.4",
     "depends" : 
     [
-        { "name"    : "Kopernicus", "min version": "0.4" },
+        { "name"    : "Kopernicus", "version": "1:beta-04" },
         { "name"    : "EnvironmentalVisualEnhancements" }
     ],
     "install" : 

--- a/NetKAN/sidosUraniaSystem.netkan
+++ b/NetKAN/sidosUraniaSystem.netkan
@@ -7,7 +7,6 @@
     {
         "homepage"  : "http://forum.kerbalspaceprogram.com/threads/66882"
     },
-    "ksp_version": "1.0.4",
     "depends" : 
     [
         { "name"    : "Kopernicus", "version": "1:beta-04" },
@@ -25,5 +24,15 @@
         { "name" : "EnvironmentalVisualEnhancements-LR" },
         { "name" : "EnvironmentalVisualEnhancements-HR" },
         { "name" : "SentarExpansion" } 
+    ],
+    "x_netkan_override" : [
+        {
+            "version" : "0.8",
+            "delete" : [ "ksp_version" ],
+            "override" : {
+                "ksp_version_min" : "1.0.2",
+                "ksp_version_max" : "1.0.4"
+            }
+        }
     ]
 }


### PR DESCRIPTION
Second step of the Planet Pack overhaul.

Restricted all planet packs to 1.0.4 that were listed working for 1.0.5. By doing this I also needed to force the packs to use Koperncius 0.4