### PR TITLE
RSS should no longer suggest the RT2 config

### DIFF
--- a/NetKAN/RealSolarSystem.netkan
+++ b/NetKAN/RealSolarSystem.netkan
@@ -20,9 +20,6 @@
         { "name": "RealismOverhaul" },
         { "name": "KSCSwitcher" }
     ],
-    "suggests": [
-        { "name": "RemoteTech-Config-RSS" }
-    ],
     "install": [
         {
             "find"      : "RealSolarSystem",


### PR DESCRIPTION
It's obsolete to do so; RSS includes it itself now.