### PR TITLE
Update NetKAN files for my mods to use new forum URLs.

### DIFF
--- a/NetKAN/AGroupOnStage.netkan
+++ b/NetKAN/AGroupOnStage.netkan
@@ -28,7 +28,7 @@
 	],
 	"resources"			:
 	{
-		"homepage"		: "http://forum.kerbalspaceprogram.com/threads/93259",
+		"homepage"		: "http://forum.kerbalspaceprogram.com/index.php?/topic/84134-agos/",
 		"repository"	: "https://github.com/iPeer/AGroupOnStage",
 		"bugtracker"	: "https://github.com/iPeer/AGroupOnStage/issues"
 	}

--- a/NetKAN/AGroupOnStage.netkan
+++ b/NetKAN/AGroupOnStage.netkan
@@ -28,7 +28,7 @@
 	],
 	"resources"			:
 	{
-		"homepage"		: "http://forum.kerbalspaceprogram.com/index.php?/topic/84134-agos/",
+		"homepage"		: "http://forum.kerbalspaceprogram.com/index.php?/topic/84134-/",
 		"repository"	: "https://github.com/iPeer/AGroupOnStage",
 		"bugtracker"	: "https://github.com/iPeer/AGroupOnStage/issues"
 	}

--- a/NetKAN/ClampsBeGone.netkan
+++ b/NetKAN/ClampsBeGone.netkan
@@ -17,7 +17,7 @@
 	],
 	"resources"			:
 	{
-		"homepage"		: "http://forum.kerbalspaceprogram.com/index.php?/topic/116945-cbg/",
+		"homepage"		: "http://forum.kerbalspaceprogram.com/index.php?/topic/116945-/",
 		"repository"	: "https://github.com/iPeer/ClampsBeGone",
 		"bugtracker"	: "https://github.com/iPeer/ClampsBeGone/issues"
 	}

--- a/NetKAN/ClampsBeGone.netkan
+++ b/NetKAN/ClampsBeGone.netkan
@@ -6,6 +6,7 @@
 	"$kref"				: "#/ckan/github/iPeer/ClampsBeGone",
 	"license"      		: "GPL-3.0",
 	"$vref"				: "#/ckan/ksp-avc",
+	"ksp_version_max"	: "1.0.4",
 	"install"			:
 	[
 		{
@@ -16,7 +17,7 @@
 	],
 	"resources"			:
 	{
-		"homepage"		: "http://forum.kerbalspaceprogram.com/threads/129870",
+		"homepage"		: "http://forum.kerbalspaceprogram.com/index.php?/topic/116945-cbg/",
 		"repository"	: "https://github.com/iPeer/ClampsBeGone",
 		"bugtracker"	: "https://github.com/iPeer/ClampsBeGone/issues"
 	}

--- a/NetKAN/InFlightFlagSwitcher.netkan
+++ b/NetKAN/InFlightFlagSwitcher.netkan
@@ -22,7 +22,7 @@
 	],
 	"resources"			:
 	{
-		"homepage"		: "http://forum.kerbalspaceprogram.com/index.php?/topic/115192-iffs/",
+		"homepage"		: "http://forum.kerbalspaceprogram.com/index.php?/topic/115192-/",
 		"repository"	: "https://github.com/iPeer/InFlightFlagSwitcher",
 		"bugtracker"	: "https://github.com/iPeer/InFlightFlagSwitcher/issues"
 	}

--- a/NetKAN/InFlightFlagSwitcher.netkan
+++ b/NetKAN/InFlightFlagSwitcher.netkan
@@ -22,7 +22,7 @@
 	],
 	"resources"			:
 	{
-		"homepage"		: "http://forum.kerbalspaceprogram.com/threads/127902",
+		"homepage"		: "http://forum.kerbalspaceprogram.com/index.php?/topic/115192-iffs/",
 		"repository"	: "https://github.com/iPeer/InFlightFlagSwitcher",
 		"bugtracker"	: "https://github.com/iPeer/InFlightFlagSwitcher/issues"
 	}


### PR DESCRIPTION
Also added `ksp_version_max` to ClampsBeGone.netkan as it's not longer supported/needed as of 1.0.5.