### PR TITLE
Update ModuleRCSFX.netkan

### DIFF
--- a/NetKAN/ModuleRCSFX.netkan
+++ b/NetKAN/ModuleRCSFX.netkan
@@ -9,7 +9,7 @@
     "release_status" : "stable",
     "ksp_version_min" : "1.0.0",
     "ksp_version_max" : "1.0.4",
-    "ksp_version_strict" : "true",
+    "ksp_version_strict" : true,
     "resources" : {
         "homepage"   : "http://forum.kerbalspaceprogram.com/threads/92290"
     }

--- a/NetKAN/ModuleRCSFX.netkan
+++ b/NetKAN/ModuleRCSFX.netkan
@@ -9,6 +9,7 @@
     "release_status" : "stable",
     "ksp_version_min" : "1.0.0",
     "ksp_version_max" : "1.0.4",
+    "ksp_version_strict" : "true",
     "resources" : {
         "homepage"   : "http://forum.kerbalspaceprogram.com/threads/92290"
     }

--- a/NetKAN/ModuleRCSFX.netkan
+++ b/NetKAN/ModuleRCSFX.netkan
@@ -1,16 +1,16 @@
 {
-    "spec_version"   : 1,
-    "name"           : "ModuleRCSFX",
-    "$kref"          : "#/ckan/github/NathanKell/ModuleRCSFX",
-    "abstract"       : "A fixed version of the stock RCS module",
-    "identifier"     : "ModuleRCSFX",
-    "license"        : "CC-BY-SA",
-    "author"         : [ "ialdabaoth", "NathanKell" ],
-    "release_status" : "stable",
-    "ksp_version_min" : "1.0.0",
-    "ksp_version_max" : "1.0.4",
-    "ksp_version_strict" : true,
-    "resources" : {
+    "spec_version"          : "v1.16",
+    "name"                  : "ModuleRCSFX",
+    "$kref"                 : "#/ckan/github/NathanKell/ModuleRCSFX",
+    "abstract"              : "A fixed version of the stock RCS module",
+    "identifier"            : "ModuleRCSFX",
+    "license"               : "CC-BY-SA",
+    "author"                : [ "ialdabaoth", "NathanKell" ],
+    "release_status"        : "stable",
+    "ksp_version_min"       : "1.0.0",
+    "ksp_version_max"       : "1.0.4",
+    "ksp_version_strict"    : true,
+    "resources"             : {
         "homepage"   : "http://forum.kerbalspaceprogram.com/threads/92290"
     }
 }


### PR DESCRIPTION
NathanKell has announced that ModuleRCSFX has been rolled into stock as of 1.0.5, and should not be installed.
http://forum.kerbalspaceprogram.com/index.php?/topic/83259-104-modulercsfx-v42-aug-23-obsolete-in-105/&do=findComment&comment=2278629