### PR TITLE
Add B9-props

### DIFF
--- a/NetKAN/B9-props.netkan
+++ b/NetKAN/B9-props.netkan
@@ -1,0 +1,19 @@
+{
+    "spec_version" : "v1.2",
+    "identifier"   : "B9-props",
+    "$kref"        : "#/ckan/kerbalstuff/132",
+    "license"      : "CC-BY-NC-SA-3.0",
+    "depends" : [
+        { "name": "RasterPropMonitor-Core" },
+        { "name": "FirespitterCore" }
+    ],
+    "recommends": [
+        { "name": "B9" }
+    ],
+    "install" : [
+        {
+            "file"       : "GameData/B9_Aerospace/Props",
+            "install_to" : "GameData/B9_Aerospace"
+        }
+    ]
+}

--- a/NetKAN/B9-props.netkan
+++ b/NetKAN/B9-props.netkan
@@ -15,5 +15,15 @@
             "file"       : "GameData/B9_Aerospace/Props",
             "install_to" : "GameData/B9_Aerospace"
         }
+    ],
+    "x_netkan_override": [
+        {
+            "version": "R5.2.8",
+            "delete": [ "ksp_version" ],
+            "override": {
+                "ksp_version_min": "1.0.0",
+                "ksp_version_max": "1.0.5"
+            }
+        }
     ]
 }

--- a/NetKAN/B9.netkan
+++ b/NetKAN/B9.netkan
@@ -4,12 +4,11 @@
   "$kref"        : "#/ckan/kerbalstuff/132",
   "license"      : "CC-BY-NC-SA-3.0",
   "depends" : [
+    { "name" : "B9-props" },
     { "name" : "CrossFeedEnabler" },
-    { "name" : "FirespitterCore" },
     { "name" : "KineTechAnimation" },
     { "name" : "KlockheedMartian-Gimbal" },
     { "name" : "ModuleManager", "min_version" : "2.5.1" },
-    { "name" : "RasterPropMonitor-Core" },
     { "name" : "ResGen" },
     { "name" : "VirginKalactic-NodeToggle" }
   ],
@@ -20,7 +19,8 @@
   "install" : [
     {
       "file"       : "GameData/B9_Aerospace",
-      "install_to" : "GameData"
+      "install_to" : "GameData",
+      "filter"     : "Props"
     },
     {
       "file"        : "Ships",

--- a/NetKAN/B9.netkan
+++ b/NetKAN/B9.netkan
@@ -5,16 +5,20 @@
   "license"      : "CC-BY-NC-SA-3.0",
   "depends" : [
     { "name" : "B9-props" },
-    { "name" : "CrossFeedEnabler" },
-    { "name" : "KineTechAnimation" },
+    { "name" : "FirespitterCore" },
     { "name" : "KlockheedMartian-Gimbal" },
-    { "name" : "ModuleManager", "min_version" : "2.5.1" },
-    { "name" : "ResGen" },
-    { "name" : "VirginKalactic-NodeToggle" }
+    { "name" : "ModuleManager", "min_version" : "2.6.13" },
+    { "name" : "RasterPropMonitor-Core" },
+    { "name" : "SmokeScreen" },
+    { "name" : "B9AnimationModules" }
   ],
   "recommends" : [
-    { "name" : "HotRockets" },
+    { "name" : "AdjustableLandingGear" },
+    { "name" : "B9AerospaceProceduralParts" },
     { "name" : "AerodynamicModel" }
+  ],
+  "conflicts" : [
+    { "name" : "VirginKalactic-NodeToggle" }
   ],
   "install" : [
     {
@@ -23,10 +27,8 @@
       "filter"     : "Props"
     },
     {
-      "file"        : "Ships",
-      "install_to"  : "Ships",
-      "optional"    : true,
-      "description" : "B9 example crafts"
+      "file"       : "GameData/Virgin Kalactic",
+      "install_to" : "GameData"
     }
   ]
 }


### PR DESCRIPTION
Part of #2748 so that it doesn't need to install the whole `B9` mod but only the `Props` folder.

Filter out the `Props` folder in B9 and depend on `B9-props`. Also removed dependency on `FirespitterCore` and `RasterPropMonitor-Core` because these are required for `B9-props`.