### PR TITLE
Asteroid Day as dependency

### DIFF
--- a/NetKAN/RP-0.netkan
+++ b/NetKAN/RP-0.netkan
@@ -17,6 +17,7 @@
         { "name" : "DeadlyReentry" },
         { "name" : "VenStockRevamp" },
         { "name" : "CommunityTechTree" }
+        { "name" : "AsteroidDay" }
     ],
     "recommends" : [
         { "name" : "KerbalConstructionTime" },


### PR DESCRIPTION
The new antenna stats require the Asteroid Day antenna for the mariner role.