### PR TITLE
Update RetroFuture.netkan

### DIFF
--- a/NetKAN/RetroFuture.netkan
+++ b/NetKAN/RetroFuture.netkan
@@ -1,23 +1,29 @@
 {
     "spec_version"   : 1,
     "identifier"     : "RetroFuture",
-    "$kref"          : "#/ckan/kerbalstuff/111",
+    "$kref"          : "#/ckan/kerbalstuff/1346",
     "license"        : "CC-BY-NC-SA-4.0",
+    "author"         : [ "NohArk", "amankduffers" ],
+    "x_netkan_epoch" : "1",
     "depends" : [
         { "name" : "FirespitterCore" },
-        { "name" : "ModuleManager", "min_version" : "2.5.1" }
+        { "name" : "ModuleManager" }
     ],
     "recommends" : [
         { "name" : "FerramAerospaceResearch" },
         { "name" : "RasterPropMonitor" },
-        { "name" : "BDArmory"},
-        { "name" : "ProceduralDynamics"},
-        { "name" : "SmokeScreen"}
+        { "name" : "ProceduralDynamics" }
+    ],
+    "suggests" : [
+        { "name" : "SmokeScreen" },
+        { "name" : "BDArmory" },
+        { "name" : "TweakScale" }
     ],
     "install" : [
         {
             "file"       : "RetroFuture",
-            "install_to" : "GameData"
+            "install_to" : "GameData",
+            "filter"     : [ "Firespitter.dll", "RetroFuture.ckan" ]
         }
     ]
 }


### PR DESCRIPTION
* New KS link
* Hardcode previous author
* Bump epoch
* Add suggestions
* Filter FS and `.ckan` file

Original license is `CC-BY-NC-SA-4.0` but new author redistributes this mod as `MIT`, which isn't allowed. I pinged amankd to change this

Closes #2812