### PR TITLE
Update RoverSpeed.netkan

### DIFF
--- a/NetKAN/RoverSpeed.netkan
+++ b/NetKAN/RoverSpeed.netkan
@@ -3,7 +3,17 @@
     "identifier"   : "RoverSpeed",
     "$kref"        : "#/ckan/kerbalstuff/936",
     "x_netkan_license_ok": true,
-	"depends": [
+    "x_netkan_override" : [
+	{
+	    "version" : "0.9.2",
+	    "delete" : [ "ksp_version" ],
+	    "override" : {
+		"ksp_version_min" : "1.0.4",
+		"ksp_version_max" : "1.0.5"
+	     }
+	}
+    ],
+    "depends": [
         { "name": "ModuleManager", "min_version": "2.6.0" }
     ]
 }


### PR DESCRIPTION
Override KSP version for current release. No reason for this mod not to continue working on 1.0.5