### PR TITLE
Updated Custom Asteroids for 1.2 release.

### DIFF
--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -1,4 +1,4 @@
-{
+﻿{
 	"spec_version": 1,
 	"identifier": "CustomAsteroids-Pops-Stock-Inner",
 	"name": "Custom Asteroids (inner stock system data)",
@@ -33,8 +33,7 @@
 			"version" : [ ">= v1.0", "< v2.0" ],
 			"override" : {
 				"comment": "Compatible with any KSP version with the same planets.",
-				"ksp_version_min": "0.18",
-				"ksp_version_max": "1.0.5"
+				"ksp_version_min": "0.18"
 			},
 			"delete" : [ "ksp_version" ]
 		}

--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -4,8 +4,8 @@
 	"name": "Custom Asteroids (inner stock system data)",
 	"abstract": "Adds asteroids inside orbit of Jool",
 	"$kref": "#/ckan/kerbalstuff/251",
-	"release_status": "stable",
-        "x_netkan_license_ok" : true,
+	"$vref" : "#/ckan/ksp-avc",
+	"x_netkan_license_ok" : true,
 	"depends": [ 
 		{
 			"name": "CustomAsteroids",
@@ -18,7 +18,7 @@
 		{ "name" : "AlternisKerbol" }, 
 		{
 			"name": "RealSolarSystem",
-			"comment": "The 6.4Ã— and 10Ã— Kerbol packs are compatible; how to allow them?"
+			"comment": "The 6.4× and 10× Kerbol packs are compatible; how to allow them?"
 		}
 	],
 	"install": [
@@ -28,15 +28,16 @@
 			"filter_regexp": "(?<!Basic Asteroids\\.cfg)$"
 		}
 	],
-    "x_netkan_override" : [
-        {
-            "version" : "v1.1.0",
-            "override" : {
-                "ksp_version_min": "0.25",
-                "ksp_version_max": "1.0.4"
-            },
-            "delete" : [ "ksp_version" ]
-        }
-    ],
+	"x_netkan_override" : [
+		{
+			"version" : [ ">= v1.0", "< v2.0" ],
+			"override" : {
+				"comment": "Compatible with any KSP version with the same planets.",
+				"ksp_version_min": "0.18",
+				"ksp_version_max": "1.1"
+			},
+			"delete" : [ "ksp_version" ]
+		}
+	],
 	"x_maintained_by": "Starstrider42"
 }

--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -34,7 +34,7 @@
 			"override" : {
 				"comment": "Compatible with any KSP version with the same planets.",
 				"ksp_version_min": "0.18",
-				"ksp_version_max": "1.1"
+				"ksp_version_max": "1.0.5"
 			},
 			"delete" : [ "ksp_version" ]
 		}

--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -18,7 +18,7 @@
 		{ "name" : "AlternisKerbol" }, 
 		{
 			"name": "RealSolarSystem",
-			"comment": "The 6.4× and 10× Kerbol packs are compatible; how to allow them?"
+			"comment": "The 6.4Ã— and 10Ã— Kerbol packs are compatible; how to allow them?"
 		}
 	],
 	"install": [

--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -1,4 +1,4 @@
-﻿{
+{
 	"spec_version": 1,
 	"identifier": "CustomAsteroids-Pops-Stock-Inner",
 	"name": "Custom Asteroids (inner stock system data)",

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -36,7 +36,7 @@
 			"override" : {
 				"comment": "Compatible with any KSP version with the same planets.",
 				"ksp_version_min": "0.18.2",
-				"ksp_version_max": "1.1"
+				"ksp_version_max": "1.0.5"
 			},
 			"delete" : [ "ksp_version" ]
 		}

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -20,7 +20,7 @@
 		{ "name" : "PlanetFactoryCE" }, 
 		{
 			"name": "RealSolarSystem",
-			"comment": "The 6.4× and 10× Kerbol packs are compatible; how to select for them?"
+			"comment": "The 6.4Ã— and 10Ã— Kerbol packs are compatible; how to select for them?"
 		}
 	],
 	"install": [

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -4,7 +4,8 @@
 	"name": "Custom Asteroids (outer stock system data)",
 	"abstract": "Adds comets outside orbit of Jool",
 	"$kref": "#/ckan/kerbalstuff/251",
-	"release_status": "stable",
+	"$vref" : "#/ckan/ksp-avc",
+	"x_netkan_license_ok" : true,
 	"depends": [ 
 		{
 			"name": "CustomAsteroids",
@@ -19,7 +20,7 @@
 		{ "name" : "PlanetFactoryCE" }, 
 		{
 			"name": "RealSolarSystem",
-			"comment": "The 6.4Ã— and 10Ã— Kerbol packs are compatible; how to select for them?"
+			"comment": "The 6.4× and 10× Kerbol packs are compatible; how to select for them?"
 		}
 	],
 	"install": [
@@ -29,16 +30,16 @@
 			"filter_regexp": "(?<!Trans-Jool\\.cfg)$"
 		}
 	],
-    "x_netkan_override" : [
-        {
-            "version" : "v1.1.0",
-            "override" : {
-                "ksp_version_min": "0.25",
-                "ksp_version_max": "1.0.4"
-            },
-            "delete" : [ "ksp_version" ]
-        }
-    ],
-	"x_maintained_by": "Starstrider42",
-        "x_netkan_license_ok" : true
+	"x_netkan_override" : [
+		{
+			"version" : [ ">= v1.0", "< v2.0" ],
+			"override" : {
+				"comment": "Compatible with any KSP version with the same planets.",
+				"ksp_version_min": "0.18.2",
+				"ksp_version_max": "1.1"
+			},
+			"delete" : [ "ksp_version" ]
+		}
+	],
+	"x_maintained_by": "Starstrider42"
 }

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -1,4 +1,4 @@
-{
+﻿{
 	"spec_version": 1,
 	"identifier": "CustomAsteroids-Pops-Stock-Outer",
 	"name": "Custom Asteroids (outer stock system data)",
@@ -35,8 +35,7 @@
 			"version" : [ ">= v1.0", "< v2.0" ],
 			"override" : {
 				"comment": "Compatible with any KSP version with the same planets.",
-				"ksp_version_min": "0.18.2",
-				"ksp_version_max": "1.0.5"
+				"ksp_version_min": "0.18.2"
 			},
 			"delete" : [ "ksp_version" ]
 		}

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -1,4 +1,4 @@
-﻿{
+{
 	"spec_version": 1,
 	"identifier": "CustomAsteroids-Pops-Stock-Outer",
 	"name": "Custom Asteroids (outer stock system data)",

--- a/NetKAN/CustomAsteroids.netkan
+++ b/NetKAN/CustomAsteroids.netkan
@@ -2,8 +2,8 @@
 	"spec_version": 1,
 	"identifier": "CustomAsteroids",
 	"$kref": "#/ckan/kerbalstuff/251",
-	"release_status": "stable",
-        "x_netkan_license_ok" : true,
+	"$vref" : "#/ckan/ksp-avc",
+	"x_netkan_license_ok" : true,
 	"resources": {
 		"repository": "https://github.com/Starstrider42/Custom-Asteroids",
 		"bugtracker": "https://github.com/Starstrider42/Custom-Asteroids/issues",
@@ -16,6 +16,9 @@
 		{ "name": "CustomAsteroids-Pops-Stock-Inner"}, 
 		{ "name": "CustomAsteroids-Pops-Stock-Outer"}
 	],
+	"conflicts": [
+		{ "name" : "Kopernicus", "min_version": "1:beta-06" }
+	],
 	"install": [
 		{
 			"file": "GameData/CustomAsteroids",
@@ -23,17 +26,23 @@
 			"filter": "config"
 		}
 	],
-	"name": "Custom Asteroids",
-	"abstract": "Custom Asteroids is a mod for KSP that expands the stock asteroid functionality. Under Custom Asteroids most asteroids will not be on a flyby course for Kerbin. Instead, the mod places asteroids in specific populations throughout the stock kerbol system.",
-    "x_netkan_override" : [
-        {
-            "version" : "v1.1.0",
-            "override" : {
-                "ksp_version_min": "0.25",
-                "ksp_version_max": "1.0.4"
-            },
-            "delete" : [ "ksp_version" ]
-        }
-    ],
+	"x_netkan_override" : [
+		{
+			"version" : "v1.1.0",
+			"override" : {
+				"ksp_version_min": "0.25",
+				"ksp_version_max": "1.0.4"
+			},
+			"delete" : [ "ksp_version" ]
+		},
+		{
+			"version" : "v1.2.0",
+			"override" : {
+				"ksp_version_min": "1.0.0",
+				"ksp_version_max": "1.0.5"
+			},
+			"delete" : [ "ksp_version" ]
+		}
+	],
 	"x_maintained_by": "Starstrider42"
 }

--- a/NetKAN/CustomAsteroids.netkan
+++ b/NetKAN/CustomAsteroids.netkan
@@ -1,4 +1,4 @@
-{
+﻿{
 	"spec_version": 1,
 	"identifier": "CustomAsteroids",
 	"$kref": "#/ckan/kerbalstuff/251",

--- a/NetKAN/CustomAsteroids.netkan
+++ b/NetKAN/CustomAsteroids.netkan
@@ -1,4 +1,4 @@
-﻿{
+{
 	"spec_version": 1,
 	"identifier": "CustomAsteroids",
 	"$kref": "#/ckan/kerbalstuff/251",

--- a/NetKAN/CustomAsteroids.netkan
+++ b/NetKAN/CustomAsteroids.netkan
@@ -38,8 +38,7 @@
 		{
 			"version" : "v1.2.0",
 			"override" : {
-				"ksp_version_min": "1.0.0",
-				"ksp_version_max": "1.0.5"
+				"ksp_version_min": "1.0.0"
 			},
 			"delete" : [ "ksp_version" ]
 		}

--- a/NetKAN/CustomAsteroids.netkan
+++ b/NetKAN/CustomAsteroids.netkan
@@ -38,7 +38,8 @@
 		{
 			"version" : "v1.2.0",
 			"override" : {
-				"ksp_version_min": "1.0.0"
+				"ksp_version_min": "1.0.0",
+				"ksp_version_max": "1.0.5"
 			},
 			"delete" : [ "ksp_version" ]
 		}


### PR DESCRIPTION
Version override mirrors the "if it doesn't crash KSP, it works" policy expressed in #2762. Custom Asteroids is incompatible with Kopernicus after the latter added its own asteroid feature (compatibility may be restored later; is there a way to express that only a specific version of CA has a conflict?). Other changes should be self-explanatory.