### PR TITLE
Update B9AerospaceProceduralParts.netkan

### DIFF
--- a/NetKAN/B9AerospaceProceduralParts.netkan
+++ b/NetKAN/B9AerospaceProceduralParts.netkan
@@ -22,8 +22,8 @@
             "version" : "0.40",
             "delete" : [ "ksp_version" ],
             "override" : {
-                "ksp_version_min" : "1.0.4",
-                "ksp_version_max" : "1.0.5"
+                "ksp_version_min" : "1.0.2",
+                "ksp_version_max" : "1.0.4"
             }
         }
     ]


### PR DESCRIPTION
Downgrade version compatibility. This version doesn't work with 1.0.5 See #2827 for compatibility fork.