### PR TITLE
Add ModuleManager - Test

### DIFF
--- a/NetKAN/ModuleManager.netkan
+++ b/NetKAN/ModuleManager.netkan
@@ -1,0 +1,25 @@
+{
+    "spec_version": "v1.16",
+    "identifier": "ModuleManager",
+    "$kref": "#/ckan/jenkins/https://ksp.sarbian.com/jenkins/job/ModuleManager/",
+    "x_netkan_jenkins": {
+        "use_filename_version": true
+    },
+    "x_netkan_version_edit": "^ModuleManager-(?<version>\\d+\\.\\d+\\.\\d+)\\.zip$",
+    "name": "Module Manager",
+    "abstract": "Modify KSP configs without conflict",
+    "author": [ "ialdabaoth", "Sarbian" ],
+    "license": "CC-BY-SA",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
+        "repository": "https://github.com/sarbian/ModuleManager"
+    },
+    "ksp_version": "1.0",
+    "install": [
+        {
+            "find_regexp": "ModuleManager.*\\.dll$",
+            "find_matches_files": true,
+            "install_to": "GameData"
+        }
+    ]
+}


### PR DESCRIPTION
Trying out the new Jenkins support from KSP-CKAN/CKAN/pull/1512. This `.netkan` file generates the following `.ckan`:

```
{
    "spec_version": "v1.16",
    "identifier": "ModuleManager",
    "name": "Module Manager",
    "abstract": "Modify KSP configs without conflict",
    "author": [
        "ialdabaoth",
        "Sarbian"
    ],
    "license": "CC-BY-SA",
    "resources": {
        "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
        "repository": "https://github.com/sarbian/ModuleManager",
        "ci": "https://ksp.sarbian.com/jenkins/job/ModuleManager/"
    },
    "version": "2.6.13",
    "ksp_version": "1.0",
    "install": [
        {
            "find_regexp": "ModuleManager.*\\.dll$",
            "find_matches_files": true,
            "install_to": "GameData"
        }
    ],
    "download": "https://ksp.sarbian.com/jenkins/job/ModuleManager/101/artifact/ModuleManager-2.6.13.zip",
    "download_size": 28055,
    "x_generated_by": "netkan"
}
```