### PR TITLE
Give B9 props a separate name

### DIFF
--- a/NetKAN/B9-props.netkan
+++ b/NetKAN/B9-props.netkan
@@ -1,6 +1,7 @@
 {
     "spec_version" : "v1.2",
     "identifier"   : "B9-props",
+    "name"         : "B9 Aerospace Props",
     "$kref"        : "#/ckan/kerbalstuff/132",
     "license"      : "CC-BY-NC-SA-3.0",
     "depends" : [


### PR DESCRIPTION
The B9 props pack shows up with the same name as the main B9 pack currently.  This prevents it from being installed by itself and prevents it from being removed once installed (except via command line).  This also reduces confusion when looking at mods to be installed.