### PR TITLE
Update CoherentContracts.netkan

### DIFF
--- a/NetKAN/CoherentContracts.netkan
+++ b/NetKAN/CoherentContracts.netkan
@@ -6,14 +6,4 @@
     "depends" : [
         { "name" : "ModuleManager" }
     ],
-    "x_netkan_override": [
-        {
-            "version": "1.02",
-            "delete": [ "ksp_version" ],
-            "override": {
-                "ksp_version_min": "1.0.2",
-                "ksp_version_max": "1.0.4"
-            }
-        }
-    ]
 }


### PR DESCRIPTION
Now references the KS API. Probably, this is a pre-CKAN mod and I don't know how to mark it CKAN-compat in KS.