### PR TITLE
Create USISubmarinePack.netkan

### DIFF
--- a/NetKAN/USI-Submarine.netkan
+++ b/NetKAN/USI-Submarine.netkan
@@ -2,10 +2,14 @@
     "$kref": "#/ckan/kerbalstuff/1361",
     "spec_version": "v1.4",
     "license": "CC-BY-NC-SA-4.0",
-    "identifier": "USISubmarinePack",
+    "identifier": "USI-Submarine",
     "install": [
       {
-        "find" : ["FX", "SubPack"],
+        "find" : "FX",
+        "install_to" : "GameData/UmbraSpaceIndustries"
+      },
+      {
+        "find" : "SubPack",
         "install_to" : "GameData/UmbraSpaceIndustries"
       }
     ],

--- a/NetKAN/USISubmarinePack.netkan
+++ b/NetKAN/USISubmarinePack.netkan
@@ -1,0 +1,18 @@
+{
+    "$kref": "#/ckan/kerbalstuff/1361",
+    "spec_version": "v1.4",
+    "license": "CC-BY-NC-SA-4.0",
+    "identifier": "USISubmarinePack",
+    "install": [
+      {
+        "find" : ["FX", "SubPack"],
+        "install_to" : "GameData/UmbraSpaceIndustries"
+      }
+    ],
+    "depends" : [
+      { "name" : "USITools", "min_version": "0.5.5.0"  },
+      { "name": "FirespitterCore", "min_version": "v7.1.5" },
+      { "name": "ModuleManager", "min_version": "2.6.2" },
+      { "name": "CommunityResourcePack", "min_version": "0.4.8.0" }
+    ]
+}


### PR DESCRIPTION
Fix #2856.  Note that this depends on a version of USITools that hasn't been properly released yet, but is included in the zip. Should mean this mod does not initially appear as available. Should I do a hand-wrought USITools-0.5.5.0.ckan sourcing from this download?