### PR TITLE
Force v for AdvancedJetEngine

### DIFF
--- a/NetKAN/AdvancedJetEngine.netkan
+++ b/NetKAN/AdvancedJetEngine.netkan
@@ -18,6 +18,7 @@
     "install": [
         { "find": "GameData/AJE", "install_to": "GameData" }
     ],
+    "x_netkan_force_v": true,
     "comment": "The full path in the mod archive can change. I.e. it was AJE-2.0.3/GameData/AJE at some point. The CKAN needs to deal with this. Hence using 'find'",
     "name": "Advanced Jet Engine",
     "abstract": "Realism for turbojet, turbofans, air-breathing rockets, propellers, and rotors in KSP.",


### PR DESCRIPTION
Latest version has a preceding v after never using one. This will ensure that if it's a mistake or later changes back to having no v that versioning will remain the same.