### PR TITLE
Filter out AirRace from KerbinSide

### DIFF
--- a/NetKAN/KerbinSide.netkan
+++ b/NetKAN/KerbinSide.netkan
@@ -1,10 +1,17 @@
 {
-    "spec_version"   : 1,
+    "spec_version"   : "v1.2",
     "identifier"     : "KerbinSide",
     "$kref"          : "#/ckan/kerbalstuff/77",
     "license"        : "BSD-3-clause",
     "x_netkan_epoch" : "1",
     "depends"        : [
         { "name": "KerbalKonstructs" }
+    ],
+    "install"        : [
+      {
+        "file"  : "GameData/KerbinSide",
+        "install_to" : "GameData",
+        "filter": "AirRace"
+      }
     ]
 }


### PR DESCRIPTION
Closes #2897
AirRace is separate package at Kerbal Stuff and CKAN
It shouldn't be installed by KerbinSide package.