### PR TITLE
Update TacFuelBalancer ksp version override

### DIFF
--- a/NetKAN/TacFuelBalancer.netkan
+++ b/NetKAN/TacFuelBalancer.netkan
@@ -28,7 +28,7 @@
             "delete" : [ "ksp_version" ],
             "override" : {
                 "ksp_version_min" : "1.0.2",
-                "ksp_version_max" : "1.0.4"
+                "ksp_version_max" : "1.0.5"
             }
         }
     ]


### PR DESCRIPTION
Reports seem positive for this continuing to work in 1.0.5