### PR TITLE
Comprehensive CryoEngines & KerbalAtomics update

### DIFF
--- a/NetKAN/CryoEngines-SurfaceAttach.netkan
+++ b/NetKAN/CryoEngines-SurfaceAttach.netkan
@@ -1,0 +1,15 @@
+{
+    "spec_version"   : "v1.4",
+    "identifier"     : "CryoEngines-SurfaceAttach",
+    "$kref"          : "#/ckan/kerbalstuff/717",
+    "name"           : "Cryogenic Engines Extras: Surface Attachment",
+    "abstract"       : "Optional patch to make the engines surface attaching.",
+    "release_status" : "stable",
+    "license"        : "CC-BY-NC-SA-4.0",
+    "depends" : [
+        { "name" : "CryoEngines" }
+    ],
+    "install" : [
+        { "find" : "CryoEnginesSurfaceAttach", "install_to" : "GameData/CryoEngines/Extras" }
+    ]
+}

--- a/NetKAN/CryoEngines.netkan
+++ b/NetKAN/CryoEngines.netkan
@@ -20,7 +20,7 @@
         { "name" : "KerbalAtomics" }
     ],
     "supports" : [
-        { "name" : "CryoEngines-LFO" }
+        { "name" : "CryoEngines-LFO" },
         { "name" : "CryoEngines-SurfaceAttach" }
     ],
     "install" : [

--- a/NetKAN/CryoEngines.netkan
+++ b/NetKAN/CryoEngines.netkan
@@ -2,20 +2,26 @@
     "spec_version"   : "v1.4",
     "identifier"     : "CryoEngines",
     "$kref"          : "#/ckan/kerbalstuff/717",
+    "name"           : "Cryogenic Engines",
+    "abstract"       : "Several new rocket engines, running on liquid hydrogen/oxygen mix. High Isp, comes with simple boiloff mechanics. Extras available.",
     "release_status" : "stable",
     "license"        : "CC-BY-NC-SA-4.0",
-    "x_netkan_epoch": "1",
-    "depends" : [
-        { "name" : "InterstellarFuelSwitch-Core", "min_version" : "1.5" },
+    "depends": [
         { "name" : "CommunityResourcePack" },
-        { "name" : "BDAnimationModules" },
+        { "name" : "CryoTanks" },
+        { "name" : "DeployableEngines" },
+        { "name" : "InterstellarFuelSwitch-Core" },
         { "name" : "ModuleManager" }
     ],
-    "suggests" : [
+    "recommends" : [
         { "name" : "CommunityTechTree" }
+    ],
+    "suggests" : [
+        { "name" : "KerbalAtomics" }
     ],
     "supports" : [
         { "name" : "CryoEngines-LFO" }
+        { "name" : "CryoEngines-SurfaceAttach" }
     ],
     "install" : [
         { "find" : "CryoEngines", "install_to" : "GameData" }

--- a/NetKAN/CryoTanks.netkan
+++ b/NetKAN/CryoTanks.netkan
@@ -1,0 +1,20 @@
+{
+    "spec_version"   : "v1.4",
+    "identifier"     : "CryoTanks",
+    "$kref"          : "#/ckan/kerbalstuff/1422",
+    "name"           : "Cryogenic Tanks",
+    "abstract"       : "A set of fuel tanks containing liquid hydrogen, with active cryocooling. Used by some of Nertea's mods.",
+    "release_status" : "stable",
+    "license"        : "CC-BY-NC-SA-4.0",
+    "depends": [
+        { "name" : "CommunityResourcePack" },
+        { "name" : "ModuleManager" }
+    ],
+    "supports" : [
+        { "name" : "KerbalAtomics" },
+        { "name" : "CryoEngines" }
+    ],
+    "install" : [
+        { "find" : "CryoTanks", "install_to" : "GameData" }
+    ]
+}

--- a/NetKAN/DeployableEngines.netkan
+++ b/NetKAN/DeployableEngines.netkan
@@ -1,0 +1,16 @@
+{
+    "spec_version"   : "v1.4",
+    "identifier"     : "DeployableEngines",
+    "$kref"          : "#/ckan/kerbalstuff/1422",
+    "name"           : "Deployable Engines Plugin",
+    "abstract"       : "A plugin to manage extending/retracting engine nozzles. This package is merely a resource and does nothing by itself.",
+    "release_status" : "stable",
+    "license"        : "CC-BY-NC-SA-4.0",
+    "supports" : [
+        { "name" : "KerbalAtomics" },
+        { "name" : "CryoEngines" }
+    ],
+    "install" : [
+        { "find" : "DeployableEngines", "install_to" : "GameData" }
+    ]
+}

--- a/NetKAN/KerbalAtomics.netkan
+++ b/NetKAN/KerbalAtomics.netkan
@@ -1,0 +1,30 @@
+{
+    "spec_version"   : "v1.4",
+    "identifier"     : "KerbalAtomics",
+    "$kref"          : "#/ckan/kerbalstuff/1422",
+    "name"           : "Kerbal Atomics",
+    "abstract"       : "Several new nuclear thermal rockets, running on liquid hydrogen tanks with simple boiloff mechanics. ATTENTION: Will convert all other NTRs it finds to use this fuel!",
+    "release_status" : "stable",
+    "license"        : "CC-BY-NC-SA-4.0",
+    "depends": [
+        { "name" : "CommunityResourcePack" },
+        { "name" : "CryoTanks" },
+        { "name" : "DeployableEngines" },
+        { "name" : "InterstellarFuelSwitch-Core" },
+        { "name" : "ModuleManager" }
+    ],
+    "recommends" : [
+        { "name" : "CommunityTechTree" }
+    ],
+    "suggests" : [
+        { "name" : "CryoEngines" },
+        { "name" : "NearFutureConstruction" },
+        { "name" : "NearFutureElectrical" },
+        { "name" : "NearFuturePropulsion" },
+        { "name" : "NearFutureSolar" },
+        { "name" : "NearFutureSpacecraft" }
+    ],
+    "install" : [
+        { "find" : "KerbalAtomics", "install_to" : "GameData" }
+    ]
+}


### PR DESCRIPTION
Introduces new mod "Kerbal Atomics" by Nertea. Decouples two submodule dependencies that it shares with CryoEngines, to avoid duplicate installs. Updates CryoEngines to latest version. Finally, adds missing optional extra for CryoEngines.