### PR TITLE
NF Propulsion Extra deprecated in KSP 1.0.5+

### DIFF
--- a/NetKAN/NearFuturePropulsionExtras.netkan
+++ b/NetKAN/NearFuturePropulsionExtras.netkan
@@ -8,7 +8,7 @@
     "release_status" : "stable",
     "license"        : "CC-BY-NC-SA-4.0",
     "depends" : [
-        { "name" : "CommunityResourcePack" }
+        { "name" : "CommunityResourcePack", "max_version" : "4.3.0" }
     ],
     "recommends" : [
         { "name" : "NearFuturePropulsion" }


### PR DESCRIPTION
This optional config file is no longer being shipped with the mod nowadays. Metadata tweaked to only allow it to install in 1.0.4 or prior.