### PR TITLE
B9-PWings-Fork: do not depend on CrossFeedEnabler

### DIFF
--- a/NetKAN/B9-PWings-Fork.netkan
+++ b/NetKAN/B9-PWings-Fork.netkan
@@ -11,9 +11,6 @@
     },
     "x_licence_code": "MIT",
     "x_licence_assets": "CC-BY-NC-SA-4.0",
-    "depends": [
-        { "name": "CrossFeedEnabler" }
-    ],
     "conflicts": [
 	{ "name": "B9AerospaceProceduralParts" }
     ],


### PR DESCRIPTION
CrossFeedEnabler is stock as of 1.0.5

**Apparently, CrossFeedEnabler mod should not be installed at all in 1.0.5**
Instead they should patch Physics.cfg (as RO does) to enable surface-attach crossfeed.