### PR TITLE
Add glue to index RoverDude's mods from his own metadata

### DIFF
--- a/NetKAN/AlcubierreStandalone.netkan
+++ b/NetKAN/AlcubierreStandalone.netkan
@@ -1,0 +1,5 @@
+{
+    "spec_version": "v1.16",
+    "identifier" : "AlcubierreStandalone",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/AlcubierreStandalone.netkan"
+}

--- a/NetKAN/AlcubierreStandalone.netkan
+++ b/NetKAN/AlcubierreStandalone.netkan
@@ -1,5 +1,7 @@
-{
-    "spec_version": "v1.16",
-    "identifier" : "AlcubierreStandalone",
-    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/AlcubierreStandalone.netkan"
-}
+
+    {
+        "spec_version" : "v1.16",
+        "identifier" : "AlcubierreStandalone",
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/AlcubierreStandalone.netkan",
+        "x_netkan_license_ok": true
+    }

--- a/NetKAN/CommunityResourcePack.netkan
+++ b/NetKAN/CommunityResourcePack.netkan
@@ -2,5 +2,6 @@
     {
         "spec_version" : "v1.16",
         "identifier" : "CommunityResourcePack",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/CommunityResourcePack.netkan"
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/CommunityResourcePack.netkan",
+        "x_netkan_license_ok": true
     }

--- a/NetKAN/CommunityResourcePack.netkan
+++ b/NetKAN/CommunityResourcePack.netkan
@@ -1,0 +1,6 @@
+
+    {
+        "spec_version" : "v1.16",
+        "identifier" : "CommunityResourcePack",
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/CommunityResourcePack.netkan"
+    }

--- a/NetKAN/Karbonite.netkan
+++ b/NetKAN/Karbonite.netkan
@@ -2,5 +2,6 @@
     {
         "spec_version" : "v1.16",
         "identifier" : "Karbonite",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/Karbonite.netkan"
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/Karbonite.netkan",
+        "x_netkan_license_ok": true
     }

--- a/NetKAN/Karbonite.netkan
+++ b/NetKAN/Karbonite.netkan
@@ -1,0 +1,6 @@
+
+    {
+        "spec_version" : "v1.16",
+        "identifier" : "Karbonite",
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/Karbonite.netkan"
+    }

--- a/NetKAN/KarbonitePlus.netkan
+++ b/NetKAN/KarbonitePlus.netkan
@@ -2,5 +2,6 @@
     {
         "spec_version" : "v1.16",
         "identifier" : "KarbonitePlus",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/KarbonitePlus.netkan"
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/KarbonitePlus.netkan",
+        "x_netkan_license_ok": true
     }

--- a/NetKAN/KarbonitePlus.netkan
+++ b/NetKAN/KarbonitePlus.netkan
@@ -1,0 +1,6 @@
+
+    {
+        "spec_version" : "v1.16",
+        "identifier" : "KarbonitePlus",
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/KarbonitePlus.netkan"
+    }

--- a/NetKAN/KaribouExpeditionRover.netkan
+++ b/NetKAN/KaribouExpeditionRover.netkan
@@ -2,5 +2,6 @@
     {
         "spec_version" : "v1.16",
         "identifier" : "KaribouExpeditionRover",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/KaribouExpeditionRover.netkan"
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/KaribouExpeditionRover.netkan",
+        "x_netkan_license_ok": true
     }

--- a/NetKAN/KaribouExpeditionRover.netkan
+++ b/NetKAN/KaribouExpeditionRover.netkan
@@ -1,0 +1,6 @@
+
+    {
+        "spec_version" : "v1.16",
+        "identifier" : "KaribouExpeditionRover",
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/KaribouExpeditionRover.netkan"
+    }

--- a/NetKAN/SoundingRockets.netkan
+++ b/NetKAN/SoundingRockets.netkan
@@ -1,0 +1,6 @@
+
+    {
+        "spec_version" : "v1.16",
+        "identifier" : "SoundingRockets",
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/SoundingRockets.netkan"
+    }

--- a/NetKAN/SoundingRockets.netkan
+++ b/NetKAN/SoundingRockets.netkan
@@ -2,5 +2,6 @@
     {
         "spec_version" : "v1.16",
         "identifier" : "SoundingRockets",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/SoundingRockets.netkan"
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/SoundingRockets.netkan",
+        "x_netkan_license_ok": true
     }

--- a/NetKAN/UKS.netkan
+++ b/NetKAN/UKS.netkan
@@ -1,0 +1,6 @@
+
+    {
+        "spec_version" : "v1.16",
+        "identifier" : "UKS",
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/UKS.netkan"
+    }

--- a/NetKAN/UKS.netkan
+++ b/NetKAN/UKS.netkan
@@ -2,5 +2,6 @@
     {
         "spec_version" : "v1.16",
         "identifier" : "UKS",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/UKS.netkan"
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/UKS.netkan",
+        "x_netkan_license_ok": true
     }

--- a/NetKAN/USI-ART.netkan
+++ b/NetKAN/USI-ART.netkan
@@ -2,5 +2,6 @@
     {
         "spec_version" : "v1.16",
         "identifier" : "USI-ART",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-ART.netkan"
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-ART.netkan",
+        "x_netkan_license_ok": true
     }

--- a/NetKAN/USI-ART.netkan
+++ b/NetKAN/USI-ART.netkan
@@ -1,0 +1,6 @@
+
+    {
+        "spec_version" : "v1.16",
+        "identifier" : "USI-ART",
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-ART.netkan"
+    }

--- a/NetKAN/USI-Core.netkan
+++ b/NetKAN/USI-Core.netkan
@@ -1,0 +1,6 @@
+
+    {
+        "spec_version" : "v1.16",
+        "identifier" : "USI-Core",
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-Core.netkan"
+    }

--- a/NetKAN/USI-Core.netkan
+++ b/NetKAN/USI-Core.netkan
@@ -2,5 +2,6 @@
     {
         "spec_version" : "v1.16",
         "identifier" : "USI-Core",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-Core.netkan"
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-Core.netkan",
+        "x_netkan_license_ok": true
     }

--- a/NetKAN/USI-EXP.netkan
+++ b/NetKAN/USI-EXP.netkan
@@ -1,0 +1,6 @@
+
+    {
+        "spec_version" : "v1.16",
+        "identifier" : "USI-EXP",
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-EXP.netkan"
+    }

--- a/NetKAN/USI-EXP.netkan
+++ b/NetKAN/USI-EXP.netkan
@@ -2,5 +2,6 @@
     {
         "spec_version" : "v1.16",
         "identifier" : "USI-EXP",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-EXP.netkan"
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-EXP.netkan",
+        "x_netkan_license_ok": true
     }

--- a/NetKAN/USI-FTT.netkan
+++ b/NetKAN/USI-FTT.netkan
@@ -2,5 +2,6 @@
     {
         "spec_version" : "v1.16",
         "identifier" : "USI-FTT",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-FTT.netkan"
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-FTT.netkan",
+        "x_netkan_license_ok": true
     }

--- a/NetKAN/USI-FTT.netkan
+++ b/NetKAN/USI-FTT.netkan
@@ -1,0 +1,6 @@
+
+    {
+        "spec_version" : "v1.16",
+        "identifier" : "USI-FTT",
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-FTT.netkan"
+    }

--- a/NetKAN/USI-LS.netkan
+++ b/NetKAN/USI-LS.netkan
@@ -1,0 +1,6 @@
+
+    {
+        "spec_version" : "v1.16",
+        "identifier" : "USI-LS",
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-LS.netkan"
+    }

--- a/NetKAN/USI-LS.netkan
+++ b/NetKAN/USI-LS.netkan
@@ -2,5 +2,6 @@
     {
         "spec_version" : "v1.16",
         "identifier" : "USI-LS",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-LS.netkan"
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-LS.netkan",
+        "x_netkan_license_ok": true
     }

--- a/NetKAN/USI-MKSLite.netkan
+++ b/NetKAN/USI-MKSLite.netkan
@@ -2,5 +2,6 @@
     {
         "spec_version" : "v1.16",
         "identifier" : "USI-MKSLite",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-MKSLite.netkan"
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-MKSLite.netkan",
+        "x_netkan_license_ok": true
     }

--- a/NetKAN/USI-MKSLite.netkan
+++ b/NetKAN/USI-MKSLite.netkan
@@ -1,0 +1,6 @@
+
+    {
+        "spec_version" : "v1.16",
+        "identifier" : "USI-MKSLite",
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-MKSLite.netkan"
+    }

--- a/NetKAN/USI-NuclearRockets.netkan
+++ b/NetKAN/USI-NuclearRockets.netkan
@@ -1,0 +1,6 @@
+
+    {
+        "spec_version" : "v1.16",
+        "identifier" : "USI-NuclearRockets",
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-NuclearRockets.netkan"
+    }

--- a/NetKAN/USI-NuclearRockets.netkan
+++ b/NetKAN/USI-NuclearRockets.netkan
@@ -2,5 +2,6 @@
     {
         "spec_version" : "v1.16",
         "identifier" : "USI-NuclearRockets",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-NuclearRockets.netkan"
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-NuclearRockets.netkan",
+        "x_netkan_license_ok": true
     }

--- a/NetKAN/USI-SRV.netkan
+++ b/NetKAN/USI-SRV.netkan
@@ -2,5 +2,6 @@
     {
         "spec_version" : "v1.16",
         "identifier" : "USI-SRV",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-SRV.netkan"
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-SRV.netkan",
+        "x_netkan_license_ok": true
     }

--- a/NetKAN/USI-SRV.netkan
+++ b/NetKAN/USI-SRV.netkan
@@ -1,38 +1,6 @@
-{
-    "spec_version"   : "v1.4",
-    "name"           : "USI Survival Pack",
-    "identifier"     : "USI-SRV",
-    "$kref"          : "#/ckan/github/BobPalmer/SrvPack",
-    "$vref"          : "#/ckan/ksp-avc",
-    "author"         : "RoverDude",
-    "abstract"       : "Deployable Emergency Reentry Pod (DERP)",
-    "license"        : "CC-BY-NC-SA-4.0",
-    "release_status" : "stable",
-    "resources" : {
-        "homepage" : "http://forum.kerbalspaceprogram.com/threads/84359"
-    },
-    "depends" : [
-        {
-          "name": "FirespitterCore",
-          "min_version": "7.0.5398.27328"
-        },
-        {
-          "name": "ModuleManager",
-          "min_version": "2.5.1"
-        },
-        {
-          "name": "USITools",
-          "min_version": "0.3.0"
-        },
-        {
-          "name": "CommunityResourcePack",
-          "min_version": "0.3.1"
-        }
-    ],
-    "install" : [
-        {
-            "find"       : "UmbraSpaceIndustries/SrvPack",
-            "install_to" : "GameData/UmbraSpaceIndustries"
-        }
-    ]
-}
+
+    {
+        "spec_version" : "v1.16",
+        "identifier" : "USI-SRV",
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-SRV.netkan"
+    }

--- a/NetKAN/USI-SubPack.netkan
+++ b/NetKAN/USI-SubPack.netkan
@@ -1,0 +1,6 @@
+
+    {
+        "spec_version" : "v1.16",
+        "identifier" : "USI-SubPack",
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-SubPack.netkan"
+    }

--- a/NetKAN/USI-SubPack.netkan
+++ b/NetKAN/USI-SubPack.netkan
@@ -2,5 +2,6 @@
     {
         "spec_version" : "v1.16",
         "identifier" : "USI-SubPack",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-SubPack.netkan"
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-SubPack.netkan",
+        "x_netkan_license_ok": true
     }

--- a/NetKAN/USI-UKS-Shared.netkan
+++ b/NetKAN/USI-UKS-Shared.netkan
@@ -2,5 +2,6 @@
     {
         "spec_version" : "v1.16",
         "identifier" : "USI-UKS-Shared",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-UKS-Shared.netkan"
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-UKS-Shared.netkan",
+        "x_netkan_license_ok": true
     }

--- a/NetKAN/USI-UKS-Shared.netkan
+++ b/NetKAN/USI-UKS-Shared.netkan
@@ -1,0 +1,6 @@
+
+    {
+        "spec_version" : "v1.16",
+        "identifier" : "USI-UKS-Shared",
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-UKS-Shared.netkan"
+    }

--- a/NetKAN/USITools.netkan
+++ b/NetKAN/USITools.netkan
@@ -1,0 +1,6 @@
+
+    {
+        "spec_version" : "v1.16",
+        "identifier" : "USITools",
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USITools.netkan"
+    }

--- a/NetKAN/USITools.netkan
+++ b/NetKAN/USITools.netkan
@@ -2,5 +2,6 @@
     {
         "spec_version" : "v1.16",
         "identifier" : "USITools",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USITools.netkan"
+        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USITools.netkan",
+        "x_netkan_license_ok": true
     }


### PR DESCRIPTION
The `netkan` indexer can use `.netkan` files from other sites, but it
needs glue files to know where to fetch them from. This hange adds that
glue (and is a pretty good reference if we want to do this for other
folks, too).

Tested locally with AlcubierreStandalone and USI-SRV, but I don't have
any reason to expect any of the glue here is incorrect.

Related: #2996, #3009.