### PR TITLE
Filter conflicting files

### DIFF
--- a/NetKAN/Super100ShootingStarSuper67LittleStarCommandPods.netkan
+++ b/NetKAN/Super100ShootingStarSuper67LittleStarCommandPods.netkan
@@ -3,10 +3,14 @@
     "spec_version": "v1.4",
     "license": "CC-BY-4.0",
     "identifier": "Super100ShootingStarSuper67LittleStarCommandPods",
+    "depends": [
+        { "name": "RasterPropMonitor-Core" }
+    ],
     "install": [
         { 
             "find" : "RaptorAerospacial",
-            "install_to" : "GameData"
+            "install_to" : "GameData",
+            "filter": "StockIVA"
         }
     ]
 }


### PR DESCRIPTION
Mod contains two files that conflict with each other. Mod uses an RPM IVA as default but it says in the `Readme.txt`:

> For non-Raster Prop Monitor IVA copy and replace the folders inside "Stock IVA" to the mod location.

So filter out the `StockIVA` and add a dependency for RPM untill the author has fixed this. @politas already mentioned this to the author on the forums.