### PR TITLE
Set up InsanityAerospace Agency mod and add StockalikeMiningExpansion

### DIFF
--- a/NetKAN/InsanityAerospace.netkan
+++ b/NetKAN/InsanityAerospace.netkan
@@ -8,7 +8,8 @@
     "install":[
 	{
 	    "find": "Mk2Expansion/Agencies",
-	    "install_to": "GameData/Mk2Expansion"
+	    "install_to": "GameData/Mk2Expansion",
+	    "filter": "Thumbs.db"
 	}
     ]
 }

--- a/NetKAN/InsanityAerospace.netkan
+++ b/NetKAN/InsanityAerospace.netkan
@@ -1,0 +1,14 @@
+{
+    "license": "CC-BY-NC-SA-4.0",
+    "$kref": "#/ckan/kerbalstuff/1415",
+    "spec_version": "v1.4",
+    "name": "Insanity Aerospace Agency",
+    "abstract":  "Agency information for mods by SuicidalInsanity",
+    "identifier": "InsanityAerospace",
+    "install":[
+	{
+	    "find": "Mk2Expansion/Agencies",
+	    "install_to": "GameData/Mk2Expansion"
+	}
+    ]
+}

--- a/NetKAN/Mk2Expansion.netkan
+++ b/NetKAN/Mk2Expansion.netkan
@@ -18,7 +18,7 @@
         {
             "find"       : "GameData/Mk2Expansion",
             "install_to" : "GameData",
-            "filter"     : "Agencies"
+            "filter"     : [ "Agencies", "Thumbs.db" ]
         },
         {
             "find"        : "VAB",

--- a/NetKAN/Mk2Expansion.netkan
+++ b/NetKAN/Mk2Expansion.netkan
@@ -8,17 +8,18 @@
         { "name": "FirespitterCore" },
         { "name": "ModuleManager", "min_version": "2.5.3" },
         { "name": "CommunityResourcePack" },
-        { "name": "InterstellarFuelSwitch-Core" },
-	{ "name": "InsanityAerospace" }
+        { "name": "InterstellarFuelSwitch-Core" }
     ],
     "suggests": [
 	{ "name": "FerramAerospaceResearch" }
     ],
+    "provides": [
+	{ "name": "InsanityAerospace" }
+    ],
     "install" : [
         {
             "find"       : "GameData/Mk2Expansion",
-            "install_to" : "GameData",
-	    "filter"     : "Agencies"
+            "install_to" : "GameData"
         },
         {
             "find"        : "VAB",

--- a/NetKAN/Mk2Expansion.netkan
+++ b/NetKAN/Mk2Expansion.netkan
@@ -8,7 +8,8 @@
         { "name": "FirespitterCore" },
         { "name": "ModuleManager", "min_version": "2.5.3" },
         { "name": "CommunityResourcePack" },
-        { "name": "InterstellarFuelSwitch-Core" }
+        { "name": "InterstellarFuelSwitch-Core" },
+	{ "name": "InsanityAerospace" }
     ],
     "suggests": [
 	{ "name": "FerramAerospaceResearch" }
@@ -16,7 +17,8 @@
     "install" : [
         {
             "find"       : "GameData/Mk2Expansion",
-            "install_to" : "GameData"
+            "install_to" : "GameData",
+	    "filter"     : "Agencies"
         },
         {
             "find"        : "VAB",

--- a/NetKAN/Mk2Expansion.netkan
+++ b/NetKAN/Mk2Expansion.netkan
@@ -13,6 +13,9 @@
     "suggests": [
 	{ "name": "FerramAerospaceResearch" }
     ],
+    "conflicts": [
+	{ "name": "InsanityAerospace" }
+    ],
     "provides": [ "InsanityAerospace" ],
     "install" : [
         {

--- a/NetKAN/Mk2Expansion.netkan
+++ b/NetKAN/Mk2Expansion.netkan
@@ -8,19 +8,17 @@
         { "name": "FirespitterCore" },
         { "name": "ModuleManager", "min_version": "2.5.3" },
         { "name": "CommunityResourcePack" },
-        { "name": "InterstellarFuelSwitch-Core" }
+        { "name": "InterstellarFuelSwitch-Core" },
+	{ "name": "InsanityAerospace" }
     ],
     "suggests": [
 	{ "name": "FerramAerospaceResearch" }
     ],
-    "conflicts": [
-	{ "name": "InsanityAerospace" }
-    ],
-    "provides": [ "InsanityAerospace" ],
     "install" : [
         {
             "find"       : "GameData/Mk2Expansion",
-            "install_to" : "GameData"
+            "install_to" : "GameData",
+            "filter"     : "Agencies"
         },
         {
             "find"        : "VAB",

--- a/NetKAN/Mk2Expansion.netkan
+++ b/NetKAN/Mk2Expansion.netkan
@@ -13,9 +13,7 @@
     "suggests": [
 	{ "name": "FerramAerospaceResearch" }
     ],
-    "provides": [
-	{ "name": "InsanityAerospace" }
-    ],
+    "provides": [ "InsanityAerospace" ],
     "install" : [
         {
             "find"       : "GameData/Mk2Expansion",

--- a/NetKAN/StockalikeMiningExtension.netkan
+++ b/NetKAN/StockalikeMiningExtension.netkan
@@ -1,0 +1,21 @@
+{
+    "x_via": "Automated KerbalStuff CKAN submission",
+    "license": "CC-BY-NC-SA-4.0",
+    "$kref": "#/ckan/kerbalstuff/1415",
+    "spec_version": "v1.4",
+    "identifier": "StockalikeMiningExtension",
+    "depends": [
+	{ "name": "InsanityAerospace" }
+    ],
+    "install": [
+	{
+	    "find": "GameData/MiningExpansion",
+	    "install_to": "GameData"
+	},
+	{
+	    "find": "GameData/Mk2Expansion",
+	    "install_to": "GameData",
+	    "filter": "Agencies"
+	}
+    ]
+}


### PR DESCRIPTION
StockalikeMiningExpansion shares some files and a folder with Mk2Expansion. This change pulls the shared files out into a separate dependency, which Mk2Expansion also provides.

Shared folder is /GameData/Mk2Expansion
Shared files are /GameData/Mk2Expansion/Agencies

StockalikeMiningExpansion is a much smaller mod, so I have sourced the Agencies folder from there.

Closes #2941
