### PR TITLE
Renaming for spacedock.info

### DIFF
--- a/NetKAN/SETI-BalanceMod.netkan
+++ b/NetKAN/SETI-BalanceMod.netkan
@@ -1,6 +1,0 @@
-{
-    "spec_version": "v1.2",
-    "identifier": "SETI-BalanceMod",
-    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Y3mo/SETI-BalanceMod/master/SETI-BalanceMod.netkan",
-    "x_netkan_license_ok": true
- }

--- a/NetKAN/SETI-Rebalance.netkan
+++ b/NetKAN/SETI-Rebalance.netkan
@@ -1,0 +1,6 @@
+{
+    "spec_version": "v1.2",
+    "identifier": "SETI-Rebalance",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Y3mo/SETI-Rebalance/master/SETI-Rebalance.netkan",
+    "x_netkan_license_ok": true
+ }


### PR DESCRIPTION
SETI-BalanceMod from kerbalstuff renamed to SETI-Rebalance for spacedock.info, I ll adjust my metadata as soon as I have the new spacedock id. 
I can not find any dependencies or references within netkan on the former "SETI-BalanceMod" identifier. 
And with kerbalstuff gone, this is the ideal point in time for a name change.