### PR TITLE
Update licensing on SCANsat.netkan

### DIFF
--- a/NetKAN/SCANsat.netkan
+++ b/NetKAN/SCANsat.netkan
@@ -3,8 +3,7 @@
     "identifier": "SCANsat",
     "$kref": "#/ckan/spacedock/129",
     "$vref": "#/ckan/ksp-avc",
-    "license": [ "BSD-3-clause", "restricted", "CC0", "public-domain", "MIT", "Apache-2.0", "CC-BY-SA-3.0", "CC-BY-NC-SA-4.0" ],
-    "x_netkan_license_ok": true,
+    "license": "restricted",
 	"x_netkan_force_v": true,
 	"depends": [
         { "name": "ModuleManager" }


### PR DESCRIPTION
When multiple licenses exist we always default to the most restrictive one as per the spec.

Could we put the entire licensearray into a seperate `"licenses"` field perhaps? I'm not sure how netkan handles such a thing nowadays.

Also removed the x_netkan_license_ok so we hardcode the most restrictive one.