### PR TITLE
Mk2.5 Spaceplane Parts to SpaceDock, closes #3198

### DIFF
--- a/NetKAN/RaginCaucasian.netkan
+++ b/NetKAN/RaginCaucasian.netkan
@@ -2,10 +2,7 @@
     "license": "MIT",
     "identifier": "RaginCaucasian",
     "spec_version": "v1.4",
-    "$kref": "#/ckan/kerbalstuff/1450",
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/131513-update-25m-flat-bottom-spaceplane-parts/"
-    },
+    "$kref": "#/ckan/spacedock/194",
     "install": [
         {
             "find": "GameData/RaginCaucasian",


### PR DESCRIPTION
I don't know why the `identifier` `RaginCaucasian` was chosen.