### PR TITLE
Custom Asteroids updates

### DIFF
--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -3,7 +3,7 @@
 	"identifier": "CustomAsteroids-Pops-Stock-Inner",
 	"name": "Custom Asteroids (inner stock system data)",
 	"abstract": "Adds asteroids inside orbit of Jool",
-	"$kref": "#/ckan/kerbalstuff/251",
+	"$kref": "#/ckan/spacedock/210",
 	"$vref" : "#/ckan/ksp-avc",
 	"x_netkan_license_ok" : true,
 	"depends": [ 

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -3,7 +3,7 @@
 	"identifier": "CustomAsteroids-Pops-Stock-Outer",
 	"name": "Custom Asteroids (outer stock system data)",
 	"abstract": "Adds comets outside orbit of Jool",
-	"$kref": "#/ckan/kerbalstuff/251",
+	"$kref": "#/ckan/spacedock/210",
 	"$vref" : "#/ckan/ksp-avc",
 	"x_netkan_license_ok" : true,
 	"depends": [ 

--- a/NetKAN/CustomAsteroids.netkan
+++ b/NetKAN/CustomAsteroids.netkan
@@ -16,9 +16,6 @@
 		{ "name": "CustomAsteroids-Pops-Stock-Inner"}, 
 		{ "name": "CustomAsteroids-Pops-Stock-Outer"}
 	],
-	"conflicts": [
-		{ "name" : "Kopernicus", "min_version": "1:beta-06" }
-	],
 	"install": [
 		{
 			"file": "GameData/CustomAsteroids",
@@ -42,6 +39,14 @@
 				"ksp_version_max": "1.0.5"
 			},
 			"delete" : [ "ksp_version" ]
+		},
+		{
+			"version" : "< v1.2.0",
+			"override" : {
+				"conflicts": [
+					{ "name" : "Kopernicus", "min_version": "1:beta-06" }
+				]
+			}
 		}
 	],
 	"x_maintained_by": "Starstrider42"

--- a/NetKAN/CustomAsteroids.netkan
+++ b/NetKAN/CustomAsteroids.netkan
@@ -1,7 +1,7 @@
 {
 	"spec_version": 1,
 	"identifier": "CustomAsteroids",
-	"$kref": "#/ckan/kerbalstuff/251",
+	"$kref": "#/ckan/spacedock/210",
 	"$vref" : "#/ckan/ksp-avc",
 	"x_netkan_license_ok" : true,
 	"resources": {


### PR DESCRIPTION
This PR moves Custom Asteroids' krefs from KerbalStuff to SpaceDock. In addition, it fixes a mistake I made in the NetKAN file regarding which versions are incompatible with Kopernicus.