### PR TITLE
KASAssembledAreobrakingShield to spacedock

### DIFF
--- a/NetKAN/KASAssembledAreobrakingShield.netkan
+++ b/NetKAN/KASAssembledAreobrakingShield.netkan
@@ -1,5 +1,5 @@
 {
-    "$kref": "#/ckan/kerbalstuff/1378",
+    "$kref": "#/ckan/spacedock/243",
     "spec_version": "v1.4",
     "license": "BSD-3-clause",
     "identifier": "KASAssembledAreobrakingShield",


### PR DESCRIPTION
So this one is a bit odd.. The author uploaded version 1 to spacedock but not (or instead of) version 2 which we have a .ckan for (and a working download as well). Version 2 *is* the superior version per the ksp forum thread

> OK, I just released an update to this mod.
Changelog-
Fixed spelling (Thanks, parameciumkid!)
Converted textures to .dds.

With that in mind, I'm not adding an epoch to this netkan as I think we should be offering v2, however once the author re-releases v2 I think we should have a netkan in place to catch that.

I poked the author in http://forum.kerbalspaceprogram.com/index.php?/topic/129047-105-kas-assembled-aerobraking-shield/ to see what's up.

Closes https://github.com/KSP-CKAN/NetKAN/pull/3280