### PR TITLE
Add SimpleConstruction

### DIFF
--- a/NetKAN/SimpleConstruction.netkan
+++ b/NetKAN/SimpleConstruction.netkan
@@ -1,0 +1,20 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "SimpleConstruction",
+    "$kref": "#/ckan/spacedock/59",
+    "license": "CC-BY-NC-SA-4.0",
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "InterstellarFuelSwitch-Core" },
+    ],
+    "conflicts": [
+        { "name": "ExtraPlanetaryLaunchpads" },
+    ],
+    "install": [
+        {
+            "find": "SimpleConstruction",
+            "install_to": "GameData",
+            "filter": [ "Thumbs.db", "InterstellarFuelSwitch.version" "InterstellarFuelSwitch.dll" ]
+        }
+    ]
+}

--- a/NetKAN/SimpleConstruction.netkan
+++ b/NetKAN/SimpleConstruction.netkan
@@ -14,7 +14,7 @@
         {
             "find": "SimpleConstruction",
             "install_to": "GameData",
-            "filter": [ "Thumbs.db", "InterstellarFuelSwitch.version" "InterstellarFuelSwitch.dll" ]
+            "filter": [ "Thumbs.db", "InterstellarFuelSwitch.version", "InterstellarFuelSwitch.dll" ]
         }
     ]
 }

--- a/NetKAN/SimpleConstruction.netkan
+++ b/NetKAN/SimpleConstruction.netkan
@@ -5,10 +5,10 @@
     "license": "CC-BY-NC-SA-4.0",
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "InterstellarFuelSwitch-Core" },
+        { "name": "InterstellarFuelSwitch-Core" }
     ],
     "conflicts": [
-        { "name": "ExtraPlanetaryLaunchpads" },
+        { "name": "ExtraPlanetaryLaunchpads" }
     ],
     "install": [
         {


### PR DESCRIPTION
Filtering out `InterstellarFuelSwitch.version` and `InterstellarFuelSwitch.dll` because it depends on InterstellarFuelSwitch-Core which includes these files.