### PR TITLE
Get kRPC version info from ksp-avc

### DIFF
--- a/NetKAN/kRPC.netkan
+++ b/NetKAN/kRPC.netkan
@@ -5,7 +5,7 @@
     "name"         : "kRPC: Remote Procedure Call Server",
     "abstract"     : "kRPC allows you to control the game from external programs. It comes with client libraries for several popular languages including Python, C++, C#, Java and Lua. Programs communicate with the game over a TCP/IP connection, and can be configured to work on just the local machine or even over the wider internet.",
     "license"      : "GPL-3.0",
-    "ksp_version"  : "1.0.5",
+    "$vref"        : "#/ckan/ksp-avc",
     "resources": {
         "homepage": "http://krpc.github.io/krpc"
     }


### PR DESCRIPTION
kRPC 0.2.2 was released with a ```kRPC.version``` file. Adding vref field.