### PR TITLE
RealFuels: Remove CrossFeedEnabler

### DIFF
--- a/NetKAN/RealFuels.netkan
+++ b/NetKAN/RealFuels.netkan
@@ -29,9 +29,6 @@
         { "name" : "StockFuelSwitch" },
         { "name" : "EngineIgnitor" }
     ],
-    "recommends" : [
-        { "name" : "CrossFeedEnabler" }
-    ],
     "x_netkan_override" : [
         {
             "version" : "<=rf-v10.4.9",


### PR DESCRIPTION
It's not a 1.0.5 mod.