### PR TITLE
New ModuleManager release is targeted at KSP 1.1

### DIFF
--- a/NetKAN/ModuleManager.netkan
+++ b/NetKAN/ModuleManager.netkan
@@ -14,7 +14,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/55219",
         "repository": "https://github.com/sarbian/ModuleManager"
     },
-    "ksp_version": "1.0",
+    "ksp_version": "1.1",
     "install": [
         {
             "find_regexp": "ModuleManager.*\\.dll$",


### PR DESCRIPTION
Fast-tracking to stop people accidentally upgrading to it.