### PR TITLE
SeaDragon: remove "quicksearch" recommendation.

### DIFF
--- a/NetKAN/RSSeaDragon.netkan
+++ b/NetKAN/RSSeaDragon.netkan
@@ -9,13 +9,12 @@
         { "name": "ModuleManager" }
     ],
     "recommends": [
-        { "name": "QuickSearch" },
         { "name": "KerbalJointReinforcement" }
     ],
     "suggests": [
-      { "name": "FerramAerospaceResearch" },
-      { "name": "RealSolarSystem" },
-      { "name": "CommunityTechTree" }
+        { "name": "FerramAerospaceResearch" },
+        { "name": "RealSolarSystem" },
+        { "name": "CommunityTechTree" }
     ],
     "install": [
         {


### PR DESCRIPTION
The other PR was closed for being a duplicate, but it was for a different mod's Netkan. Same change, but to a different file.