### PR TITLE
Add KSP versions to override for ModularFlightIntegrator

### DIFF
--- a/NetKAN/ModularFlightIntegrator.netkan
+++ b/NetKAN/ModularFlightIntegrator.netkan
@@ -14,11 +14,40 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/118088",
         "repository": "https://github.com/sarbian/ModularFlightIntegrator"
     },
-    "ksp_version": "1.0.5",
     "install": [
         {
             "find": "ModularFlightIntegrator",
             "install_to": "GameData"
+        }
+    ],
+    "x_netkan_override": [
+        {
+            "version": "<1.1.0.0",
+            "override": {
+                "ksp_version_min": "1.0.0",
+                "ksp_version_max": "1.0.3"
+            }
+        },
+        {
+            "version": [ ">=1.1.0.0" ],
+            "override": {
+                "ksp_version_min": "1.0.4",
+                "ksp_version_max": "1.0.4"
+            }
+        },
+        {
+            "version": ">=1.1.2.0",
+            "override": {
+                "ksp_version_min": "1.0.5",
+                "ksp_version_max": "1.0.5"
+            }
+        },
+        {
+            "version": ">=1.1.3.0",
+            "override": {
+                "ksp_version_min": "1.1.0",
+                "ksp_version_max": "1.1.0"
+            }
         }
     ]
 }


### PR DESCRIPTION
`1.1.3.0` should only be compatible with KSP 1.1.0.