### PR TITLE
Set CustomBarnKit, ModularFlightIntegrator, and GCMonitor to use AVC version

### DIFF
--- a/NetKAN/CustomBarnKit.netkan
+++ b/NetKAN/CustomBarnKit.netkan
@@ -2,10 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "CustomBarnKit",
     "$kref": "#/ckan/jenkins/https://ksp.sarbian.com/jenkins/job/CustomBarnKit/",
-    "x_netkan_jenkins": {
-        "use_filename_version": true
-    },
-    "x_netkan_version_edit": "^CustomBarnKit-(?<version>\\d+\\.\\d+\\.\\d+\\.\\d+)\\.zip$",
+    "$vref": "#/ckan/ksp-avc",
     "name": "Custom Barn Kit",
     "abstract": "A small plugin to change a bunch of parameters related to career, science, the buildings upgrade cost and when various features are unlocked.",
     "author": "Sarbian",
@@ -14,7 +11,6 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/121100",
         "repository": "https://github.com/sarbian/CustomBarnKit"
     },
-    "ksp_version": "1.0.5",
     "install": [
         {
             "find": "CustomBarnKit",

--- a/NetKAN/GCMonitor.netkan
+++ b/NetKAN/GCMonitor.netkan
@@ -2,10 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "GCMonitor",
     "$kref": "#/ckan/jenkins/https://ksp.sarbian.com/jenkins/job/GCMonitor/",
-    "x_netkan_jenkins": {
-        "use_filename_version": true
-    },
-    "x_netkan_version_edit": "^GCMonitor-(?<version>\\d+\\.\\d+\\.\\d+\\.\\d+)\\.zip$",
+    "$vref": "#/ckan/ksp-avc",
     "name": "Graphic Memory Monitor",
     "abstract": "This plugin will show you the memory usage of the running KSP installation",
     "author": "Sarbian",
@@ -14,7 +11,6 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/92907",
         "repository": "https://github.com/sarbian/GCMonitor"
     },
-    "ksp_version": "1.1",
     "install": [
         {
             "find": "GCMonitor",

--- a/NetKAN/ModularFlightIntegrator.netkan
+++ b/NetKAN/ModularFlightIntegrator.netkan
@@ -2,10 +2,7 @@
     "spec_version": "v1.16",
     "identifier": "ModularFlightIntegrator",
     "$kref": "#/ckan/jenkins/https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/",
-    "x_netkan_jenkins": {
-        "use_filename_version": true
-    },
-    "x_netkan_version_edit": "^ModularFlightIntegrator-(?<version>\\d+\\.\\d+\\.\\d+\\.\\d+)\\.zip$",
+    "$vref": "#/ckan/ksp-avc",
     "name": "ModularFlightIntegrator",
     "abstract": "This is an amazing addon that will Modularly Integrate your Flight Models.",
     "author": "Sarbian",
@@ -18,36 +15,6 @@
         {
             "find": "ModularFlightIntegrator",
             "install_to": "GameData"
-        }
-    ],
-    "x_netkan_override": [
-        {
-            "version": "<1.1.0.0",
-            "override": {
-                "ksp_version_min": "1.0.0",
-                "ksp_version_max": "1.0.3"
-            }
-        },
-        {
-            "version": [ ">=1.1.0.0" ],
-            "override": {
-                "ksp_version_min": "1.0.4",
-                "ksp_version_max": "1.0.4"
-            }
-        },
-        {
-            "version": ">=1.1.2.0",
-            "override": {
-                "ksp_version_min": "1.0.5",
-                "ksp_version_max": "1.0.5"
-            }
-        },
-        {
-            "version": ">=1.1.3.0",
-            "override": {
-                "ksp_version_min": "1.1.0",
-                "ksp_version_max": "1.1.0"
-            }
         }
     ]
 }


### PR DESCRIPTION
Should fix some issues with their current CKAN listings (1.1 versions
being installed on 1.0.5 etc)