### PR TITLE
Copy CareerManager.netkan

### DIFF
--- a/NetKAN/CareerManager.netkan
+++ b/NetKAN/CareerManager.netkan
@@ -1,6 +1,8 @@
 {
-    "spec_version": "v1.2",
-    "identifier": "CareerManager",
-    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/bananashavings/CareerManager/master/CareerManager.netkan",
+    "spec_version" : 1,
+    "identifier"   : "CareerManager",
+    "$kref"        : "#/ckan/spacedock/424",
+    "$vref" : "#/ckan/ksp-avc",
+    "license": "GPL-3.0",
     "x_netkan_license_ok": true
 }


### PR DESCRIPTION
Verbatim copy of https://github.com/bananashavings/CareerManager/blob/febcc185cb345f099a96e62cf5e823948caf8133/CareerManager.netkan

Courtesy ping @bananashavings in case you weren't aware that https://github.com/bananashavings/CareerManager/commit/4f2d10008db7feebc5f631047b472eec9b4d4395 deleted your .netkan.