### PR TITLE
Amended NavballUpDefault due to 1.1 changes

### DIFF
--- a/NetKAN/NavballUpDefault.netkan
+++ b/NetKAN/NavballUpDefault.netkan
@@ -5,7 +5,7 @@
     "name"            : "Navball Up Default",
     "abstract"        : "Triggers the Navball to be up by default in the map view.",
     "license"         : "open-source",
-    "ksp_version_min" : "1.0.2",
+    "ksp_version_min" : "1.1.0",
     "ksp_version_max" : "1.1.0",
     "resources": {
         "homepage": "https://github.com/BrianErikson/KSP/tree/master/HUDTweaks/NavballUpDefault"


### PR DESCRIPTION
KSP 1.1 changes the way the navball is accessed, so any version older than NavballUpDefault-v0.2 (the latest release) will not work on KSP v1.1

