### PR TITLE
Fix Mk2Expansion dependencies

### DIFF
--- a/NetKAN/Mk2Expansion.netkan
+++ b/NetKAN/Mk2Expansion.netkan
@@ -4,9 +4,7 @@
     "$kref": "#/ckan/spacedock/473",
     "license": "CC-BY-NC-4.0",
     "depends": [
-        { "name": "KlockheedMartian-Gimbal" },
-        { "name": "FirespitterCore" },
-        { "name": "ModuleManager", "min_version": "2.5.3" },
+        { "name": "ModuleManager" },
         { "name": "CommunityResourcePack" },
         { "name": "InterstellarFuelSwitch" }
     ],


### PR DESCRIPTION
No longer depends on Firespitter or Klockheed Martian Gimbal