### PR TITLE
Add MainSailor's Procedural Parts Texture packs from Spacedock

### DIFF
--- a/NetKAN/GammaTextures.netkan
+++ b/NetKAN/GammaTextures.netkan
@@ -1,0 +1,25 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "GammaTextures",
+    "ksp_version": "any",
+    "$kref": "#/ckan/spacedock/487",
+    "name": "Procedural Parts - MainSailor's Procedural Textures - Gamma Textures",
+    "license": "CC-BY-NC-SA-4.0",
+    "abstract": "Procedural Parts textures by MainSailor in a sci fi inspired look",
+    "depends": [
+        { "name": "ProceduralParts" },
+        { "name": "MainSailorTextures-Essentials" }
+    ],
+    "conflicts": [
+        { "name": "MainSailorTextures-Complete" }
+    ],
+    "provides": [
+        "PPTextures"
+    ],
+    "install": [
+        {
+            "file": "MainSailor/Gamma",
+            "install_to": "GameData/MainSailor"
+        }
+    ]
+}

--- a/NetKAN/MainSailorTextures-Complete.netkan
+++ b/NetKAN/MainSailorTextures-Complete.netkan
@@ -1,0 +1,23 @@
+{
+    "spec_version": 1,
+    "identifier": "MainSailorTextures-Complete",
+    "ksp_version": "any",
+    "$kref": "#/ckan/spacedock/487",
+    "name": "Procedural Parts - MainSailor's Procedural Textures - Complete Texture Pack",
+    "license": "CC-BY-NC-SA-4.0",
+    "abstract": "Procedural Parts textures by MainSailor - Includes Gamma, Historical, Theta and Fairings packs",
+    "depends": [
+        { "name": "ProceduralParts" },
+        { "name": "MainSailorTextures-Essentials" }
+    ],
+    "provides": [
+        "PPTextures"
+    ],
+    "install": [
+        {
+            "file": "MainSailor",
+            "install_to": "GameData",
+            "filter": [ "Essentials", "Flags" ]
+        }
+    ]
+}

--- a/NetKAN/MainSailorTextures-Essentials.netkan
+++ b/NetKAN/MainSailorTextures-Essentials.netkan
@@ -1,6 +1,6 @@
 {
     "spec_version": "v1.4",
-    "identifier": "MainSailorTextures-Essential",
+    "identifier": "MainSailorTextures-Essentials",
     "ksp_version": "any",
     "$kref": "#/ckan/spacedock/487",
     "name": "Procedural Parts - MainSailor's Procedural Textures - Essential Textures and Flag",

--- a/NetKAN/MainSailorTextures-Essentials.netkan
+++ b/NetKAN/MainSailorTextures-Essentials.netkan
@@ -1,0 +1,25 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "MainSailorTextures-Essential",
+    "ksp_version": "any",
+    "$kref": "#/ckan/spacedock/487",
+    "name": "Procedural Parts - MainSailor's Procedural Textures - Essential Textures and Flag",
+    "license": "CC-BY-NC-SA-4.0",
+    "abstract": "Procedural Parts textures required for all MainSailor Texture packs",
+    "depends": [
+        { "name": "ProceduralParts" }
+    ],
+    "provides": [
+        "PPTextures"
+    ],
+    "install": [
+        {
+            "file": "MainSailor/Essentials",
+            "install_to": "GameData/MainSailor"
+        },
+        {
+            "file": "MainSailor/Flags",
+            "install_to": "GameData/MainSailor"
+        }
+    ]
+}

--- a/NetKAN/MainSailorTextures-Fairings.netkan
+++ b/NetKAN/MainSailorTextures-Fairings.netkan
@@ -1,0 +1,25 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "MainSailorTextures-Fairings",
+    "ksp_version": "any",
+    "$kref": "#/ckan/spacedock/487",
+    "name": "Procedural Parts - MainSailor's Procedural Textures - Gamma Textures",
+    "license": "CC-BY-NC-SA-4.0",
+    "abstract": "Procedural Parts complementary textures by MainSailor for fairings",
+    "depends": [
+        { "name": "ProceduralParts" },
+        { "name": "MainSailorTextures-Essentials" }
+    ],
+    "conflicts": [
+        { "name": "MainSailorTextures-Complete" }
+    ],
+    "provides": [
+        "PPTextures"
+    ],
+    "install": [
+        {
+            "file": "MainSailor/Fairings",
+            "install_to": "GameData/MainSailor"
+        }
+    ]
+}

--- a/NetKAN/MainSailorTextures-Historical.netkan
+++ b/NetKAN/MainSailorTextures-Historical.netkan
@@ -1,0 +1,25 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "MainSailorTextures-Historical",
+    "ksp_version": "any",
+    "$kref": "#/ckan/spacedock/487",
+    "name": "Procedural Parts - MainSailor's Procedural Textures - Historic Textures",
+    "license": "CC-BY-NC-SA-4.0",
+    "abstract": "Procedural Parts textures by MainSailor with a simple, historically-inspired look",
+    "depends": [
+        { "name": "ProceduralParts" },
+        { "name": "MainSailorTextures-Essentials" }
+    ],
+    "conflicts": [
+        { "name": "MainSailorTextures-Complete" }
+    ],
+    "provides": [
+        "PPTextures"
+    ],
+    "install": [
+        {
+            "file": "MainSailor/Historical",
+            "install_to": "GameData/MainSailor"
+        }
+    ]
+}

--- a/NetKAN/MainSailorTextures-Theta.netkan
+++ b/NetKAN/MainSailorTextures-Theta.netkan
@@ -1,0 +1,25 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "MainSailorTextures-Theta",
+    "ksp_version": "any",
+    "$kref": "#/ckan/spacedock/487",
+    "name": "Procedural Parts - MainSailor's Procedural Textures - Gamma Textures",
+    "license": "CC-BY-NC-SA-4.0",
+    "abstract": "Procedural Parts textures by MainSailor - a look at What-if?",
+    "depends": [
+        { "name": "ProceduralParts" },
+        { "name": "MainSailorTextures-Essentials" }
+    ],
+    "conflicts": [
+        { "name": "MainSailorTextures-Complete" }
+    ],
+    "provides": [
+        "PPTextures"
+    ],
+    "install": [
+        {
+            "file": "MainSailor/Theta",
+            "install_to": "GameData/MainSailor"
+        }
+    ]
+}


### PR DESCRIPTION
Splits out individual packs for those that don't want everything.
PPTextures mods, so KSP version compatibility can be controlled by the dependency's availability.
Closes #3557
Closes KSP-CKAN/CKAN-meta#1045