### PR TITLE
TransferWindowPlanner lacks ksp_version

### DIFF
--- a/NetKAN/TransferWindowPlanner.netkan
+++ b/NetKAN/TransferWindowPlanner.netkan
@@ -7,6 +7,7 @@
     "license": "MIT",
     "release_status": "stable",
     "author": "TriggerAu",
+    "ksp_version": "1.0.5",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/93115",
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",


### PR DESCRIPTION
The latest version is marked on github as 1.0.5 compatible and the forum thread for the mod mentions something about UI changes. People are also asking if the mod will get updated/is working so I'm assuming it is not at this time, user ace22 on irc also mentioned it not working. Might have to add ksp_version to the files in CKAN-meta aswell as to ensure that users don't get a really old version instead.