### PR TITLE
Edit regex to match new folder name in KIEFighter

### DIFF
--- a/NetKAN/KIEFighter.netkan
+++ b/NetKAN/KIEFighter.netkan
@@ -8,7 +8,7 @@
     },
     "install": [
         {
-            "find_regexp": "^KIEFighter",
+            "find_regexp": "KIEFighter",
             "install_to": "GameData" 
         }
     ]


### PR DESCRIPTION
Interesting background to this.. the timing of the folder name's change was such that even though a perfectly working .netkan was merged, an update to the mod was issued that broke the .netkan before we ever indexed a version of the mod.