### PR TITLE
Update and rename SETI-CommunityTechTree.netkan to SETI-CTT.netkan

### DIFF
--- a/NetKAN/SETI-CTT.netkan
+++ b/NetKAN/SETI-CTT.netkan
@@ -1,6 +1,6 @@
 {
     "spec_version": "v1.2",
-    "identifier": "SETI-CommunityTechTree",
+    "identifier": "SETI-CTT",
     "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Y3mo/SETI-CommunityTechTree/master/SETI-CommunityTechTree.netkan",
     "x_netkan_license_ok": true
 }


### PR DESCRIPTION
Yeah, unfortunately I know about the consequences. But since another modder uses ckan "conflicts" definition to carry out some personal vendetta, I can not use the original identifier anymore.

Sad to see ckan misused like this to the detriment of the users.