### PR TITLE
Add KSPChromaControl

### DIFF
--- a/NetKAN/KSPChromaControl.netkan
+++ b/NetKAN/KSPChromaControl.netkan
@@ -1,0 +1,13 @@
+{
+    "spec_version" : 1,
+    "identifier" : "KSPChromaControl",
+    "$kref" : "#/ckan/github/cguckes/ksp-chroma",
+    "license" : "GPL-3.0",
+    "name" : "KSP Chroma Control",
+    "abstract" : "Lights up your keyboard to show you all the functions your vessel actually has. Requires a Razer Chroma Keyboard or Keypad along with Razer Synapse installed to work.",
+    "ksp_version" : "1.1.0",
+    "resources" : {
+        "homepage" : "https://github.com/cguckes/ksp-chroma",
+        "repository"  : "https://github.com/cguckes/ksp-chroma"
+    }
+}


### PR DESCRIPTION
Copied (with some small revisions) from and closes https://github.com/KSP-CKAN/CKAN-meta/issues/1056. Pinging @Dazpoet to see if there's any precedent on how to handle these types of mods.

I'm also of 2 minds regarding `link2source.txt`. I could see someone making the argument that it's a source and should be filtered, but I could also make the argument that it's in the same vein as a "readme" which we include.

