### PR TITLE
Add epoch.

### DIFF
--- a/NetKAN/Taerobee.netkan
+++ b/NetKAN/Taerobee.netkan
@@ -7,6 +7,7 @@
     "abstract": "Stockalike Historic (Pre-Sputnik) Rocket and Aircraft Parts.",
     "ksp_version": "1.1.0",
     "x_netkan_version_edit": "^[vV]?(?<version>.+)$",
+    "x_netkan_epoch": "1",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/119858-/"
     },


### PR DESCRIPTION
According to https://github.com/Tantares/Taerobee/releases the release is only hours old, but we have a version `2.3` indexed as compatible with `1.0.5`. This may be the same file re-released in which case an override would be accurate, but in the event that the file is different users on `1.0.5` end up installing an incorrect version. An epoch allows us to have both `2.3` with individual compatibilities.