### PR TITLE
Removes ksp_version from FerramAerospaceResearch.netkan

### DIFF
--- a/NetKAN/FerramAerospaceResearch.netkan
+++ b/NetKAN/FerramAerospaceResearch.netkan
@@ -13,7 +13,6 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/19321-/",
         "repository" : "https://github.com/ferram4/Ferram-Aerospace-Research"
     },
-    "ksp_version"  : "1.0.5",
     "provides"  : [ "AerodynamicModel", "FAR" ],
     "conflicts" : [ { "name" : "AerodynamicModel" } ],
 


### PR DESCRIPTION
FAR v0.15.6 is currently being reported as KSP 1.0.5 only, when it is KSP 1.1.0 only.