### PR TITLE
Change Depends on RPM to Recomments

### DIFF
--- a/NetKAN/DockingPortAlignmentIndicator.netkan
+++ b/NetKAN/DockingPortAlignmentIndicator.netkan
@@ -8,10 +8,10 @@
         {
             "name": "ModuleManager",
             "min_version": "2.5.1"
-        },
-        {
-            "name": "RasterPropMonitor"
         }
+    ],
+    "recommends": [
+        { "name": "RasterPropMonitor" }
     ],
     "install": [
         {


### PR DESCRIPTION
DPAI is not dependent on RPM, it can work standalone and adds a new screen if RPM is installed.