### PR TITLE
Updated config files for breaking changes in Custom Asteroids 1.3.

### DIFF
--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -58,5 +58,6 @@
             }
         }
     ],
+                "ksp_version_max": "1.0.5",
     "x_maintained_by": "Starstrider42"
 }

--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -52,9 +52,9 @@
                         "install_to": "GameData",
                         "filter_regexp": "(?<!Basic Asteroids\\.cfg)$"
                     }
-                ],
+                ]
             }
-        },
+        }
     ],
     "x_maintained_by": "Starstrider42"
 }

--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -9,6 +9,7 @@
         {
             "name": "CustomAsteroids",
             "min_version": "1.3",
+            "max_version": "1.99",
             "comment": "Requires beta distribution and new zip layout."
         }
     ],
@@ -43,6 +44,7 @@
                     {
                         "name": "CustomAsteroids",
                         "min_version": "1.0",
+                        "max_version": "1.99",
                         "comment": "Version at which config format stabilized."
                     }
                 ],

--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -4,13 +4,12 @@
     "name": "Custom Asteroids (inner stock system data)",
     "abstract": "Adds asteroids inside orbit of Jool",
     "$kref": "#/ckan/spacedock/210",
-    "$vref" : "#/ckan/ksp-avc",
     "x_netkan_license_ok" : true,
     "depends": [
         {
             "name": "CustomAsteroids",
-            "min_version": "1.0",
-            "comment": "Version at which config format stabilized."
+            "min_version": "1.3",
+            "comment": "Requires beta distribution and new zip layout."
         }
     ],
     "provides": [ "CustomAsteroids-Pops" ],
@@ -23,20 +22,39 @@
     ],
     "install": [
         {
-            "file": "GameData/CustomAsteroids",
+            "file": "Standard Setup",
             "install_to": "GameData",
             "filter_regexp": "(?<!Basic Asteroids\\.cfg)$"
         }
     ],
     "x_netkan_override" : [
         {
-            "version" : [ ">= v1.0", "< v2.0" ],
+            "version" : [ ">= v1.0.0", "< v2.0.0" ],
             "override" : {
                 "comment": "Compatible with any KSP version with the same planets.",
                 "ksp_version_min": "0.18"
             },
             "delete" : [ "ksp_version" ]
-        }
+        },
+        {
+            "version" : "< v1.3.0",
+            "override" : {
+                "depends": [
+                    {
+                        "name": "CustomAsteroids",
+                        "min_version": "1.0",
+                        "comment": "Version at which config format stabilized."
+                    }
+                ],
+                "install": [
+                    {
+                        "file": "GameData/CustomAsteroids",
+                        "install_to": "GameData",
+                        "filter_regexp": "(?<!Basic Asteroids\\.cfg)$"
+                    }
+                ],
+            }
+        },
     ],
     "x_maintained_by": "Starstrider42"
 }

--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -8,8 +8,8 @@
     "depends": [
         {
             "name": "CustomAsteroids",
-            "min_version": "1.3",
-            "max_version": "1.99",
+            "min_version": "v1.3.0",
+            "max_version": "v1.99.99",
             "comment": "Requires beta distribution and new zip layout."
         }
     ],
@@ -43,8 +43,8 @@
                 "depends": [
                     {
                         "name": "CustomAsteroids",
-                        "min_version": "1.0",
-                        "max_version": "1.99",
+                        "min_version": "v1.0.0",
+                        "max_version": "v1.99.99",
                         "comment": "Version at which config format stabilized."
                     }
                 ],

--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -58,6 +58,5 @@
             }
         }
     ],
-                "ksp_version_max": "1.0.5",
     "x_maintained_by": "Starstrider42"
 }

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -4,13 +4,12 @@
     "name": "Custom Asteroids (outer stock system data)",
     "abstract": "Adds comets outside orbit of Jool",
     "$kref": "#/ckan/spacedock/210",
-    "$vref" : "#/ckan/ksp-avc",
     "x_netkan_license_ok" : true,
     "depends": [
         {
             "name": "CustomAsteroids",
-            "min_version": "1.0",
-            "comment": "Version at which config format stabilized."
+            "min_version": "1.3",
+            "comment": "Requires new zip layout."
         }
     ],
     "provides": [ "CustomAsteroids-Pops" ],
@@ -25,20 +24,39 @@
     ],
     "install": [
         {
-            "file": "GameData/CustomAsteroids",
+            "file": "Standard Setup",
             "install_to": "GameData",
             "filter_regexp": "(?<!Trans-Jool\\.cfg)$"
         }
     ],
     "x_netkan_override" : [
         {
-            "version" : [ ">= v1.0", "< v2.0" ],
+            "version" : [ ">= v1.0.0", "< v2.0.0" ],
             "override" : {
                 "comment": "Compatible with any KSP version with the same planets.",
                 "ksp_version_min": "0.18.2"
             },
             "delete" : [ "ksp_version" ]
-        }
+        },
+        {
+            "version" : "< v1.3.0",
+            "override" : {
+                "depends": [
+                    {
+                        "name": "CustomAsteroids",
+                        "min_version": "1.0",
+                        "comment": "Version at which config format stabilized."
+                    }
+                ],
+                "install": [
+                    {
+                        "file": "GameData/CustomAsteroids",
+                        "install_to": "GameData",
+                        "filter_regexp": "(?<!Trans-Jool\\.cfg)$"
+                    }
+                ],
+            }
+        },
     ],
     "x_maintained_by": "Starstrider42"
 }

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -9,6 +9,7 @@
         {
             "name": "CustomAsteroids",
             "min_version": "1.3",
+            "max_version": "1.99",
             "comment": "Requires new zip layout."
         }
     ],
@@ -45,6 +46,7 @@
                     {
                         "name": "CustomAsteroids",
                         "min_version": "1.0",
+                        "max_version": "1.99",
                         "comment": "Version at which config format stabilized."
                     }
                 ],

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -60,5 +60,6 @@
             }
         }
     ],
+                "ksp_version_max": "1.0.5",
     "x_maintained_by": "Starstrider42"
 }

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -54,9 +54,9 @@
                         "install_to": "GameData",
                         "filter_regexp": "(?<!Trans-Jool\\.cfg)$"
                     }
-                ],
+                ]
             }
-        },
+        }
     ],
     "x_maintained_by": "Starstrider42"
 }

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -60,6 +60,5 @@
             }
         }
     ],
-                "ksp_version_max": "1.0.5",
     "x_maintained_by": "Starstrider42"
 }

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -8,8 +8,8 @@
     "depends": [
         {
             "name": "CustomAsteroids",
-            "min_version": "1.3",
-            "max_version": "1.99",
+            "min_version": "v1.3.0",
+            "max_version": "v1.99.99",
             "comment": "Requires new zip layout."
         }
     ],
@@ -45,8 +45,8 @@
                 "depends": [
                     {
                         "name": "CustomAsteroids",
-                        "min_version": "1.0",
-                        "max_version": "1.99",
+                        "min_version": "v1.0.0",
+                        "max_version": "v1.99.99",
                         "comment": "Version at which config format stabilized."
                     }
                 ],

--- a/NetKAN/CustomAsteroids.netkan
+++ b/NetKAN/CustomAsteroids.netkan
@@ -10,11 +10,20 @@
         "manual": "http://starstrider42.github.io/Custom-Asteroids/"
     },
     "depends": [
-        { "name": "CustomAsteroids-Pops"}
+        { "name": "CustomAsteroids-Pops"},
+        {
+            "name": "ModuleManager",
+            "min_version": "2.6.14",
+            "comment": "Requires indices."
+        }
     ],
     "recommends": [
+        { "name": "CustomAsteroids-Pops-Stock-Stockalike"},
         { "name": "CustomAsteroids-Pops-Stock-Inner"},
         { "name": "CustomAsteroids-Pops-Stock-Outer"}
+    ],
+    "suggests": [
+        { "name": "CommunityResourcePack"}
     ],
     "install": [
         {
@@ -47,7 +56,19 @@
                     { "name" : "Kopernicus", "min_version": "1:beta-06" }
                 ]
             }
-        }
+        },
+        {
+            "version" : "< v1.3.0",
+            "override" : {
+                "depends": [
+                    { "name": "CustomAsteroids-Pops"}
+                ],
+                "recommends": [
+                    { "name": "CustomAsteroids-Pops-Stock-Inner"},
+                    { "name": "CustomAsteroids-Pops-Stock-Outer"}
+                ],
+            }
+        },
     ],
     "x_maintained_by": "Starstrider42"
 }

--- a/NetKAN/CustomAsteroids.netkan
+++ b/NetKAN/CustomAsteroids.netkan
@@ -66,9 +66,9 @@
                 "recommends": [
                     { "name": "CustomAsteroids-Pops-Stock-Inner"},
                     { "name": "CustomAsteroids-Pops-Stock-Outer"}
-                ],
+                ]
             }
-        },
+        }
     ],
     "x_maintained_by": "Starstrider42"
 }


### PR DESCRIPTION
This config ensures that the upcoming release of Custom Asteroids 1.3 (which among other changes factors the zip file, as requested by two forum users) will not break CKAN, and that the new ModuleManager dependency is recognized right away.

The removal of `$vref` from the population configs is a temporary workaround for KSP-CKAN/CKAN#1674. The line can be restored once a 1.3 zip is on SpaceDock. (I will need to make a second pull request anyway, to upload `CustomAsteroids-Pops-Stock-Stockalike.netkan`; the file cannot be compiled at present due to a "no files to install" error.)