### PR TITLE
Fix install for SpaceshuttleSRB

### DIFF
--- a/NetKAN/SpaceshuttleSRB.netkan
+++ b/NetKAN/SpaceshuttleSRB.netkan
@@ -1,12 +1,17 @@
 {
     "$kref": "#/ckan/spacedock/549",
-    "spec_version": "v1.4",
+    "spec_version": "v1.16",
     "identifier": "SpaceshuttleSRB",
     "license": "MIT",
     "install": [
         {
-            "find"       : "Shuttle SRB",
-            "install_to" : "GameData"
+            "find_regexp": "Not [Ee]n[uo][uo]gh Engines",
+            "install_to": "GameData"
+        },
+        {
+            "find": "Plasma-powerd SSTO.craft",
+            "find_matches_files": true,
+            "install_to" : "Ships/VAB"
         }
     ]
 }

--- a/NetKAN/SpaceshuttleSRB.netkan
+++ b/NetKAN/SpaceshuttleSRB.netkan
@@ -5,7 +5,7 @@
     "license": "MIT",
     "install": [
         {
-            "find_regexp": "Not [Ee]n[uo][uo]gh Engines",
+            "find_regexp": "Not [Ee]n[uo][uo]gh [Ee]ngines",
             "install_to": "GameData"
         },
         {


### PR DESCRIPTION
Explanation of the regex:

The folder name is currently `Not enuogh Engines`.
Ehe capitalization of the `e` in `enuogh` might change to match `Not` and `Engines` so `[Ee]` catches that.

`enuogh` is presumably a typo of the word `enough` so the 2x `[uo]` means the `u` and `o` can be in either position and it'll still catch. 

Lastly `Engines` might be changed to lower case so `[Ee]` allows for both those possibilities.