### PR TITLE
Create HideEmptyTechTreeNodes.netkan

### DIFF
--- a/NetKAN/HideEmptyTechTreeNodes.netkan
+++ b/NetKAN/HideEmptyTechTreeNodes.netkan
@@ -1,0 +1,13 @@
+{
+    "spec_version"   : 1,
+    "identifier"     : "HideEmptyTechTreeNodes",
+    "$kref"          : "#/ckan/spacedock/577",
+    "x_netkan_license_ok": true,
+
+    "depends" : [
+        { "name" : "ModuleManager" }
+    ],
+    "suggests" : [
+	{ "name" : "CommunityTechTree" }
+    ]
+}


### PR DESCRIPTION
This is the mod author. It looks like there's some other pull requests already set up (using the old KerbalStuff netkan file it looks like), but please use this one. I changed the name of the mod slightly, so this file has the correct identifier. It also contains the correct "depends" and "suggests" fields.

It also follows the instructions on your "Adding a mod to CKAN" webpage, so I think is more up to date? For example, the website says to use "spec_version" : 1, but the old netkan file has 1.4. I'm not sure if that matters, but hey.