### PR TITLE
Moved TakeCommand from Kerbstuff to SpaceDock

### DIFF
--- a/NetKAN/TakeCommand.netkan
+++ b/NetKAN/TakeCommand.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version" : 1,
     "identifier"   : "TakeCommand",
-    "$kref"        : "#/ckan/kerbalstuff/776",
+    "$kref"        : "#/ckan/spacedock/585",
     "x_netkan_license_ok": true,
     "depends": [
         { "name": "ModuleManager" }


### PR DESCRIPTION
I've released a new version of TakeCommand for KSP 1.1, and it's now being hosted on SpaceDock so I'd like to get CKAN updated to point at the new location.