### PR TITLE
Fix install for ItsTheLittleThings

### DIFF
--- a/NetKAN/ItsTheLittleThings.netkan
+++ b/NetKAN/ItsTheLittleThings.netkan
@@ -1,11 +1,11 @@
 {
     "identifier": "ItsTheLittleThings",
-    "spec_version": 1,
+    "spec_version": "v1.10",
     "$kref": "#/ckan/spacedock/462",
     "license": "CC-BY-SA-2.0",
     "install": [
         {
-            "file": "its the little things/game data/Its the little things",
+            "find_regexp": "[Gg]ame\\s{0,1}[Dd]ata/It'{0,1}s\\s{0,1}[Tt]he\\s{0,1}[Ll]ittle\\s{0,1}[Tt]hings",
             "install_to": "GameData"
         }
     ]

--- a/NetKAN/ItsTheLittleThings.netkan
+++ b/NetKAN/ItsTheLittleThings.netkan
@@ -5,7 +5,7 @@
     "license": "CC-BY-SA-2.0",
     "install": [
         {
-            "find_regexp": "[Gg]ame\\s{0,1}[Dd]ata/It'{0,1}s\\s{0,1}[Tt]he\\s{0,1}[Ll]ittle\\s{0,1}[Tt]hings",
+            "find_regexp": "(?i)game\\s*data/it'?s\\s*the\\s*little\\s*things",
             "install_to": "GameData"
         }
     ]


### PR DESCRIPTION
Another convoluted regex to cover all kinds of capitalization changes.

In this case the folder went from `Its the little things` to `Its the little Things`

This regex covers all cases of caps changing as well as spaces between words and the addition of an apostrophe `'` to `Its`.

I'm a regex scrub so there are probably 100 more efficient ways to do this.