### PR TITLE
Fix install, bump epoch

### DIFF
--- a/NetKAN/Mk3HypersonicSystems.netkan
+++ b/NetKAN/Mk3HypersonicSystems.netkan
@@ -3,6 +3,7 @@
     "license": "CC-BY-NC-SA-4.0",
     "$kref": "#/ckan/spacedock/562",
     "identifier": "Mk3HypersonicSystems",
+    "x_netkan_epoch": "1",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/130548"
     },
@@ -15,7 +16,7 @@
     ],
     "install": [
         {
-            "find"       : "Mk3HypersonicSystems",
+            "find"       : "GameData/Mk3HypersonicSystems",
             "install_to" : "GameData",
             "filter"     : "Thumbs.db"
         },


### PR DESCRIPTION
A quick fix to us installing the base `Mk3HypersonicSystems` folder resulting in its dependencies being double-installed. Pushing this through immediately but would appreciate an after-the-fact review from @politas and/or @Dazpoet 