### PR TITLE
Update StockVisualEnhancements.netkan

### DIFF
--- a/NetKAN/StockVisualEnhancements.netkan
+++ b/NetKAN/StockVisualEnhancements.netkan
@@ -7,11 +7,9 @@
     "x_netkan_epoch" : "1",
     "conflicts": [
         {
-            "name": "SVE-Textures"
+            "name": "SVE-Textures",
+            "name": "EnvironmentalVisualEnhancements"
         }
-    ],
-    "depends": [
-        { "name": "EnvironmentalVisualEnhancements" }
     ],
     "recommends": [
         { "name": "Kopernicus" },


### PR DESCRIPTION
Fixes current SpaceDock download. I'm hoping to persuade @Nhawks1717 to switch to a more CKAN-friendly distribution method soon as right now the EVE files are bundled. 