### PR TITLE
Set RSSTextures to be 1.1-compatible

### DIFF
--- a/NetKAN/RSSTextures2048.netkan
+++ b/NetKAN/RSSTextures2048.netkan
@@ -5,7 +5,7 @@
     "identifier"    :   "RSSTextures2048",
     "$kref"         :   "#/ckan/github/KSP-RO/RSS-Textures/asset_match/2048",
     "abstract"      :   "Textures for Real Solar Systems",
-    "ksp_version"   :   "1.0",
+    "ksp_version"   :   "1.1",
     "release_status":   "stable",
     "resources"     :   { "repository" : "https://github.com/KSP-RO/RSS-Textures" },
     "provides"      :   [ "RSSTextures" ],

--- a/NetKAN/RSSTextures4096.netkan
+++ b/NetKAN/RSSTextures4096.netkan
@@ -5,7 +5,7 @@
     "identifier"    :   "RSSTextures4096",
     "$kref"         :   "#/ckan/github/KSP-RO/RSS-Textures/asset_match/4096",
     "abstract"      :   "Textures for Real Solar Systems",
-    "ksp_version"   :   "1.0",
+    "ksp_version"   :   "1.1",
     "release_status":   "stable",
     "resources"     :   { "repository" : "https://github.com/KSP-RO/RSS-Textures" },
     "provides"      :   [ "RSSTextures" ],

--- a/NetKAN/RSSTextures8192.netkan
+++ b/NetKAN/RSSTextures8192.netkan
@@ -5,7 +5,7 @@
     "identifier"    :   "RSSTextures8192",
     "$kref"         :   "#/ckan/github/KSP-RO/RSS-Textures/asset_match/8192",
     "abstract"      :   "Textures for Real Solar Systems",
-    "ksp_version"   :   "1.0",
+    "ksp_version"   :   "1.1",
     "release_status":   "stable",
     "resources"     :   { "repository" : "https://github.com/KSP-RO/RSS-Textures" },
     "provides"      :   [ "RSSTextures" ],


### PR DESCRIPTION
RSS has been released for 1.1, and there aren't any texture changes, so
the textures for 1.0 should also work for 1.1