### PR TITLE
Fixup RSS / KSP version oddity.

### DIFF
--- a/NetKAN/RealSolarSystem.netkan
+++ b/NetKAN/RealSolarSystem.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version"    : "v1.4",
+    "spec_version"    : "v1.12",
     "$kref"           : "#/ckan/github/KSP-RO/RealSolarSystem",
     "$vref"           : "#/ckan/ksp-avc",
     "x_netkan_force_v": true,
@@ -24,6 +24,14 @@
         {
             "find"      : "RealSolarSystem",
             "install_to": "GameData"
+        }
+    ],
+    "x_netkan_override" : [
+        {
+            "version" : "v11.0.0",
+            "override" : {
+                "ksp_version" : "1.1"
+            }
         }
     ]
 }


### PR DESCRIPTION
The KSP-AVC spec isn't really clear on whether KSP versions should
always have three parts. Our code assumes that it does. The RSS .version
version file doesn't. This results in a file being emitted targetting
KSP "1.1." (with a trailing dot) which causes validation to fail.

This override forces the version to "1.1", which will work with both
1.1.0 and 1.1.1 (which is arriving soon).

For @NathanKell.