### PR TITLE
Update KOSMOS-SSPP.netkan

### DIFF
--- a/NetKAN/KOSMOS-SSPP.netkan
+++ b/NetKAN/KOSMOS-SSPP.netkan
@@ -5,13 +5,11 @@
     "abstract"      : "Contains station parts and solar panels for older soviet style spacecraft.",
     "$kref"         : "#/ckan/github/raidernick/KOSMOS",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version"   : "1.0.5",
+    "ksp_version_min"   : "1.0.5",
+    "ksp_version_max"   : "1.1.0",
     "resources": {
         "homepage"  : "https://github.com/raidernick/KOSMOS"
     },
-    "depends" : [
-        { "name" : "FirespitterCore" }
-    ],
     "install" : [
         {
             "find" : "KOSMOS",


### PR DESCRIPTION
Removes Firespitter as a dependency.  The SSPP is not dependent on it. 

Clarifies that SSPP works with KSP 1.0.5 and 1.1.0.