### PR TITLE
Move PartCommander to SpaceDock

### DIFF
--- a/NetKAN/PartCommander.netkan
+++ b/NetKAN/PartCommander.netkan
@@ -1,6 +1,6 @@
 {
     "spec_version": 1,
     "license": "GPL-3.0",
-    "$kref": "#/ckan/kerbalstuff/965",
+    "$kref": "#/ckan/spacedock/615",
     "identifier": "PartCommander"
 }


### PR DESCRIPTION
I've released a new version with KSP 1.1 support via SpaceDock and would like to get CKAN updated.  Thanks!