### PR TITLE
InfernalRobotics update to v1.16 of the CKAN spec.

### DIFF
--- a/NetKAN/InfernalRobotics.netkan
+++ b/NetKAN/InfernalRobotics.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.16",
     "identifier": "InfernalRobotics",
     "$kref": "#/ckan/github/MagicSmokeIndustries/InfernalRobotics/asset_match/IR-2.0.0-Final-Core\\.zip",
     "$vref": "#/ckan/ksp-avc",


### PR DESCRIPTION
The `ksp_version_strict` field requires at least v1.16 of the CKAN spec.
This updates the .netkan file appropriately.