### PR TITLE
Fixed configs being installed to wrong folder.

### DIFF
--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.2",
     "identifier": "CustomAsteroids-Pops-Stock-Inner",
     "name": "Custom Asteroids (inner stock system data)",
     "abstract": "Adds asteroids inside orbit of Jool",

--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -24,8 +24,8 @@
     ],
     "install": [
         {
-            "file": "Standard Setup",
-            "install_to": "GameData",
+            "file": "Standard Setup/config",
+            "install_to": "GameData/CustomAsteroids",
             "filter_regexp": "(?<!Basic Asteroids\\.cfg)$"
         }
     ],

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.2",
     "identifier": "CustomAsteroids-Pops-Stock-Outer",
     "name": "Custom Asteroids (outer stock system data)",
     "abstract": "Adds comets outside orbit of Jool",

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -26,8 +26,8 @@
     ],
     "install": [
         {
-            "file": "Standard Setup",
-            "install_to": "GameData",
+            "file": "Standard Setup/config",
+            "install_to": "GameData/CustomAsteroids",
             "filter_regexp": "(?<!Trans-Jool\\.cfg)$"
         }
     ],


### PR DESCRIPTION
This is a fix to a minor issue where installing Custom Asteroids configs would leave the dummy "Standard Setup" folder in GameData. All configs not associated with another mod should go into `GameData/Custom Asteroids/config`.