### PR TITLE
Update SDHI Strobe-O-Matic compat to KSP 1.1.2

### DIFF
--- a/NetKAN/SDHI-StrobeOMatic.netkan
+++ b/NetKAN/SDHI-StrobeOMatic.netkan
@@ -5,7 +5,7 @@
     "name"         : "SDHI Strobe-O-Matic Warning Rotator Lights",
     "abstract"     : "Small surface-mounted or stack-attached rotating warning lights in various colors. 100% Plugin Free.",
     "license"      : "CC-BY-SA-4.0",
-    "ksp_version"  : "1.1.0",
+    "ksp_version"  : "1.1.2",
     "resources"    : {
         "homepage"   : "http://forum.kerbalspaceprogram.com/index.php?/topic/137804-11-sdhi-strobe-o-matic-warning-rotator-lights-v10-23-april-2016/",
         "repository" : "https://github.com/sumghai/SDHI_StrobeOMatic"


### PR DESCRIPTION
This only uses stock part modules, therefore no plugin compatibility issues. Should be able to be updated ASAP.