### PR TITLE
Update ColorfulFuelLines.netkan

### DIFF
--- a/NetKAN/ColorfulFuelLines.netkan
+++ b/NetKAN/ColorfulFuelLines.netkan
@@ -9,7 +9,7 @@
     },
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "InterstellarFuelSwitch-Core" }
+        { "name": "FirespitterCore" }
     ],
     "install": [
         {


### PR DESCRIPTION
Switching back to Firespitter for now, since InterstellarFuelSwitch is AWOL in the CKAN index.