### PR TITLE
Mark latest CommunityResourcePack as explicitly compatible with KSP 1.1.2-1.1.99

### DIFF
--- a/NetKAN/CommunityResourcePack.netkan
+++ b/NetKAN/CommunityResourcePack.netkan
@@ -3,5 +3,14 @@
         "spec_version" : "v1.16",
         "identifier" : "CommunityResourcePack",
         "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/CommunityResourcePack.netkan",
-        "x_netkan_license_ok": true
-    }
+        "x_netkan_license_ok": true,
+        "x_netkan_override": [
+            {
+                "version": "0.5.1.0",
+                "override": {
+                    "ksp_version_min": "1.0.0",
+                    "ksp_version_max": "1.1.99"
+                }
+            }
+        ]
+	}


### PR DESCRIPTION
Mark latest CommunityResourcePack as explicitly compatible with KSP
1.1.2-1.1.99.

Hopefully future versions of CRP will have an updated .version file.   The mod contains configs only, so nothing from 1.1.1 to
1.1.2 should break anything.