### PR TITLE
RN naming fix

### DIFF
--- a/NetKAN/RN-SovietSpacecraft.netkan
+++ b/NetKAN/RN-SovietSpacecraft.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version"  : "v1.4",
     "identifier"    : "RN-SovietSpacecraft",
-    "name"          : "Salyut Stations - Soyuz, Progress, Vostok/Voskhod, TKS/VA",
+    "name"          : "Soviet Spacecraft - Soyuz, Progress, Vostok/Voskhod, TKS/VA",
     "author"        : "Raidernick",
     "abstract"      : "Soviet spacecraft pack that contains Soyuz 7K-T, 7K-OKA, 7K-OKP 7K-T-AF and Progress 7K-TG, and Vostok/Voskhod spacecraft, and TKS/VA",
     "comment"       : "Ships installed again",


### PR DESCRIPTION
-Fix naming error in Soviet Spacecraft, it still said salyut, now the
name is correct.