### PR TITLE
Added KSP-AVC support of my StockMods

### DIFF
--- a/NetKAN/StockNoContracts.netkan
+++ b/NetKAN/StockNoContracts.netkan
@@ -1,6 +1,7 @@
 {
     "spec_version": 1,
     "$kref": "#/ckan/spacedock/111",
+    "$vref" : "#/ckan/ksp-avc",
     "identifier": "StockNoContracts",
     "license": "public-domain",
     "depends": [

--- a/NetKAN/StockPlugins.netkan
+++ b/NetKAN/StockPlugins.netkan
@@ -2,6 +2,7 @@
     "spec_version" : 1,
     "identifier" : "StockPlugins",
     "$kref" : "#/ckan/spacedock/112",
+    "$vref" : "#/ckan/ksp-avc",
     "license": "public-domain",
     "depends": [
         { "name": "ModuleManager", "min_version": "2.6.0" }
@@ -14,6 +15,7 @@
         { "name": "kOS" },
         { "name": "MechJeb2" },
         { "name": "Protractor" },
-        { "name": "Telemachus" }
+        { "name": "Telemachus" },
+        { "name": "RocketWatch" }
     ]
 }

--- a/NetKAN/StockRT.netkan
+++ b/NetKAN/StockRT.netkan
@@ -1,7 +1,8 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": 1,
     "identifier": "StockRT",
     "$kref": "#/ckan/spacedock/113",
+    "$vref" : "#/ckan/ksp-avc",
     "license": "public-domain",
     "depends": [
         { "name": "ModuleManager", "min_version": "2.6.0" },

--- a/NetKAN/StockRT.netkan
+++ b/NetKAN/StockRT.netkan
@@ -6,7 +6,7 @@
     "license": "public-domain",
     "depends": [
         { "name": "ModuleManager", "min_version": "2.6.0" },
-        { "name": "RemoteTech", "min_version": "1.6.0" }
+        { "name": "RemoteTech", "min_version": "v1.6.0" }
     ],
     "supports": [
         { "name": "RealSolarSystem" },

--- a/NetKAN/StockSCANsat.netkan
+++ b/NetKAN/StockSCANsat.netkan
@@ -1,11 +1,12 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": 1,
     "identifier": "StockSCANsat",
     "$kref": "#/ckan/spacedock/114",
+    "$vref" : "#/ckan/ksp-avc",
     "license": "public-domain",
     "depends": [
         { "name": "ModuleManager", "min_version": "2.6.0" },
-        { "name": "SCANsat", "min_version": "v14.0"}
+        { "name": "SCANsat", "min_version": "v16.0"}
     ],
     "supports": [
         { "name": "ContractConfigurator-ContractPack-SCANsat" },


### PR DESCRIPTION
Hello, I've added support of KSP-AVC on my mods. I don't know why but at this time, I don't see StockRT on the CKAN list, perhaps something goes wrong? As I can see, my last StockRT update is indexed on the metadata, I don't know what I can do to correct this.

Thanks :)