### PR TITLE
Add conflict, bump epoch for RN-SovietRockets

### DIFF
--- a/NetKAN/RN-SovietRockets.netkan
+++ b/NetKAN/RN-SovietRockets.netkan
@@ -25,7 +25,7 @@
         "install_to": "GameData"
     }],
     "conflicts": [
-        { "name": "FASA" }
+        { "name": "ReflectionPlugin" }
     ],
     "depends"       :
     [

--- a/NetKAN/RN-SovietRockets.netkan
+++ b/NetKAN/RN-SovietRockets.netkan
@@ -10,6 +10,7 @@
     "$kref"         : "#/ckan/github/KSP-RO/SovietRockets",
     "license"       : "CC-BY-NC-ND-3.0",
     "ksp_version"   : "1.1.2",
+    "x_netkan_epoch": "1",
     "install"       : [
     {
         "find"      : "RN_Proton",
@@ -23,6 +24,9 @@
         "find"      : "RN_Zenit",
         "install_to": "GameData"
     }],
+    "conflicts": [
+        { "name": "FASA" }
+    ],
     "depends"       :
     [
         { "name"    : "FirespitterCore"  },
@@ -31,7 +35,7 @@
     "recommends"    :
     [
         { "name"    : "RN-SalyutStations" },
-		{ "name"    : "RN-SovietSpacecraft" },
-        { "name"    : "RN-SovietProbes"                }
+        { "name"    : "RN-SovietSpacecraft" },
+        { "name"    : "RN-SovietProbes" }
     ]
 }


### PR DESCRIPTION
This will add a conflict to `FASA` and add an epoch. The epoch bump will appear to the CKAN client as if there's a new version of `RN-SovietRockets` so users who want to upgrade will have to remove FASA.