### PR TITLE
Break sunflare from scatterer, add AstronikiSunflareforScatterer

### DIFF
--- a/NetKAN/AstronikiSunflareforScatterer.netkan
+++ b/NetKAN/AstronikiSunflareforScatterer.netkan
@@ -1,0 +1,19 @@
+{
+    "license": "CC-BY-NC-SA-4.0",
+    "identifier": "AstronikiSunflareforScatterer",
+    "$kref": "#/ckan/spacedock/408",
+    "spec_version": "v1.4",
+    "provides": [ "Scatterer-sunflare" ],
+    "conflicts": [
+        { "name": "Scatterer-sunflare" }
+    ],
+    "depends": [
+        { "name": "Scatterer" }
+    ],
+    "install": [
+        {
+            "find"       : "sunflare",
+            "install_to" : "GameData/scatterer"
+        }
+    ]
+}

--- a/NetKAN/Scatterer-sunflare.netkan
+++ b/NetKAN/Scatterer-sunflare.netkan
@@ -1,19 +1,20 @@
 {
-    "identifier": "Scatterer",
+    "identifier": "Scatterer-sunflare",
     "license": "GPL-3.0",
     "release_status": "development",
     "$kref": "#/ckan/spacedock/141",
+    "name": "scatterer - sunflare",
+    "abstract": "The sunflare component of scatterer",
     "x_netkan_force_v": true,
     "spec_version": "v1.4",
     "x_netkan_epoch": "2",
-    "depends": [
+    "conflicts": [
         { "name": "Scatterer-sunflare" }
     ],
     "install": [
         {
-            "find"       : "scatterer",
-            "install_to" : "GameData",
-            "filter"     : "sunflare"
+            "find"       : "sunflare",
+            "install_to" : "GameData/scatterer"
         }
     ]
 }


### PR DESCRIPTION
Testing this is a pain. The easiest way I found is to plop the .ckans into a test repo. https://github.com/KSP-CKAN/CKAN-meta/tree/AstronikiSunflareforScatterer_test includes those .ckans with `Scatterer` bumped to kspver 1.1.2