### PR TITLE
Update Kerbalism

### DIFF
--- a/NetKAN/Kerbalism-Profile-Default.netkan
+++ b/NetKAN/Kerbalism-Profile-Default.netkan
@@ -1,0 +1,21 @@
+{
+    "spec_version": "v1.2",
+    "$kref": "#/ckan/spacedock/533",
+    "identifier": "Kerbalism-Profile-Default",
+    "name": "Kerbalism - Default Profile",
+    "abstract": "Default profile for Kerbalism",
+    "license": "public-domain",
+    "provides": [ "Kerbalism-Profile" ],
+    "depends": [
+        { "name": "Kerbalism" }
+    ],
+    "conflicts": [
+        { "name": "Kerbalism-Profile" }
+    ],
+    "install": [
+        {
+            "file": "GameData/Kerbalism/Profiles/Default.cfg",
+            "install_to": "GameData/Kerbalism/Profiles"
+        }
+    ]
+}

--- a/NetKAN/Kerbalism.netkan
+++ b/NetKAN/Kerbalism.netkan
@@ -1,9 +1,36 @@
 {
-    "$kref": "#/ckan/spacedock/533",
     "spec_version": 1,
+    "$kref": "#/ckan/spacedock/533",
     "identifier": "Kerbalism",
     "license": "public-domain",
     "depends": [
-        { "name": "ModuleManager" }
+        { "name": "ModuleManager", "min_version": "2.6.24" }
+    ],
+    "recommends": [
+        { "name": "Kerbalism-Profile" }
+    ],
+    "supports": [
+        { "name": "AntennaRange" },
+        { "name": "CommunityResourcePack" },
+        { "name": "ConnectedLivingSpace" },
+        { "name": "CryoTanks" },
+        { "name": "DangIt" },
+        { "name": "DeepFreeze" },
+        { "name": "KerbalAtomics" },
+        { "name": "KerbalPlanetaryBaseSystems" },
+        { "name": "NearFutureElectrical" },
+        { "name": "NearFutureSolar" },
+        { "name": "NearFutureSpacecraft" },
+        { "name": "origameFoldableAssets" },
+        { "name": "RemoteTech" },
+        { "name": "SCANsat" },
+        { "name": "VenStockRevamp" }
+    ],
+    "install": [
+        {
+            "file": "GameData/Kerbalism",
+            "install_to": "GameData",
+            "filter_regexp": [ "GameData/Kerbalism/Profiles/.+\\.cfg$" ]
+        }
     ]
 }


### PR DESCRIPTION
Updates Kerbalism to account for the new "profiles" setup in 0.9.9.5.

`Kerbalism.netkan` has been updated to *recommend* (a profile isn't required for Kerablism to function) a virtual package `Kerbalism-Profile`. The install has been updated to filter out any profile files that ship in the distribution archive. Also explicitly supported mods have been added.

`Kerablism-Profile-Default.netkan` has been created which *provides* `Kerablism-Profile`, *conflicts* with `Kerablism-Profile`, and installs the `Default.cfg` profile file which ships in the distribution archive.