### PR TITLE
force v for ContractConfigurator-ContractPack-SCANsat

### DIFF
--- a/NetKAN/ContractConfigurator-ContractPack-SCANsat.netkan
+++ b/NetKAN/ContractConfigurator-ContractPack-SCANsat.netkan
@@ -7,6 +7,7 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "author": "DBT85",
+    "x_netkan_force_v": true,
     "$vref": "#/ckan/ksp-avc",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/108097"


### PR DESCRIPTION
Jenkins failure because ksp_version_max is 1.2.0 and dependencies can't be met because of that.