### PR TITLE
KerbalConstructionTime - depend MagiCore, recommend KRASH

### DIFF
--- a/NetKAN/KerbalConstructionTime.netkan
+++ b/NetKAN/KerbalConstructionTime.netkan
@@ -4,15 +4,27 @@
     "$kref"          : "#/ckan/spacedock/222",
     "license"        : "GPL-3.0",
     "recommends" : [
-        { "name" : "StageRecovery" }
+        { 
+			"name" : "StageRecovery" 
+		},
+		{
+			"name" : "KRASH"
+		}
     ],
     "suggests" : [
-        { "name" : "Toolbar" }
+        { 
+			"name" : "Toolbar" 
+		}
     ],
     "install" : [
         {
             "file"       : "GameData/KerbalConstructionTime",
             "install_to" : "GameData"
         }
-    ]
+    ],
+	"depends" : [
+		{
+			"name" : "MagiCore"
+		}
+	]
 }


### PR DESCRIPTION
Even if your submission tested fine locally there are several errors that only the bots will note and reject. This should be expected.
Changes required for KCT 1.3.3.7 for KSP 1.1.2