### PR TITLE
Make CTT 1.1-1.1.2 compatible

### DIFF
--- a/NetKAN/CommunityTechTree.netkan
+++ b/NetKAN/CommunityTechTree.netkan
@@ -21,6 +21,14 @@
                 "ksp_version_min" : "1.0.4",
                 "ksp_version_max" : "1.0.5"
             }
+        },
+        {
+            "version" : "2.4",
+            "delete" : [ "ksp_version" ],
+            "override" : {
+                "ksp_version_min" : "1.1.0",
+                "ksp_version_max" : "1.1.2"
+            }
         }
     ]
 }


### PR DESCRIPTION
CTT had explicit 1.1.0 metadata from spacedock; this changes current release to min/max to work in 1.1.2. @nertea you might want to update on spacedock too :)