### PR TITLE
Updated dependancy Tweakscale

### DIFF
--- a/NetKAN/KSPInterstellarExtended.netkan
+++ b/NetKAN/KSPInterstellarExtended.netkan
@@ -13,7 +13,7 @@
         { "name"         : "CommunityResourcePack", "min_version" : "0.5.1.1" },
         { "name"         : "Toolbar", "min_version" : "1.7.12" },
         { "name"         : "InterstellarFuelSwitch", "min_version" : "1.29" },
-        { "name"         : "TweakScale", "min_version" : "2.2.9"},
+        { "name"         : "TweakScale", "min_version" : "2.2.10"},
         { "name"         : "ModuleManager", "min_version" : "2.6.24" }
     ],
    "recommends": [


### PR DESCRIPTION
Tweakscale 2.2.10 is needed for KSPI-E to work correctly