### PR TITLE
InterstellarFuelSwitch 2.0.4 is now recommended

### DIFF
--- a/NetKAN/KSPInterstellarExtended.netkan
+++ b/NetKAN/KSPInterstellarExtended.netkan
@@ -12,7 +12,7 @@
     "depends" : [
         { "name"         : "CommunityResourcePack", "min_version" : "0.5.1.1" },
         { "name"         : "Toolbar", "min_version" : "1.7.12" },
-        { "name"         : "InterstellarFuelSwitch", "min_version" : "1.29" },
+        { "name"         : "InterstellarFuelSwitch", "min_version" : "2.0.4" },
         { "name"         : "TweakScale", "min_version" : "2.2.10"},
         { "name"         : "ModuleManager", "min_version" : "2.6.24" }
     ],


### PR DESCRIPTION
InterstellarFuelSwitch 2.0.4 also depends on Tweakscale 2.2.10
