### PR TITLE
Addded recommendation for Tweakscale with minimum version

### DIFF
--- a/NetKAN/InterstellarFuelSwitch-Core.netkan
+++ b/NetKAN/InterstellarFuelSwitch-Core.netkan
@@ -11,4 +11,7 @@
             "install_to" : "GameData/InterstellarFuelSwitch"
         }
     ]
+    "recommends": [
+        { "name"         : "TweakScale", "min_version" : "2.2.10" }
+    ]
 }

--- a/NetKAN/InterstellarFuelSwitch-Core.netkan
+++ b/NetKAN/InterstellarFuelSwitch-Core.netkan
@@ -10,7 +10,7 @@
             "file"       : "GameData/InterstellarFuelSwitch/Plugins",
             "install_to" : "GameData/InterstellarFuelSwitch"
         }
-    ]
+    ],
     "recommends": [
         { "name"         : "TweakScale", "min_version" : "2.2.10" }
     ]


### PR DESCRIPTION
IFS is heavily integrated with Tweakscale and it relies on very specific functionality from Tweakscale to work correctly when installed