### PR TITLE
Update PersistentThrust.netkan

### DIFF
--- a/NetKAN/PersistentThrust.netkan
+++ b/NetKAN/PersistentThrust.netkan
@@ -7,7 +7,7 @@
     "license"      : "open-source",
     "author"       : "mrsolarsail",
     "release_status" : "development",
-    "ksp_version"  : "1.0.5",
+    "ksp_version"  : "1.1",
     "resources" : { "homepage" : "http://forum.kerbalspaceprogram.com/threads/133735" },
     "depends" : [ { "name" : "ModuleManager" } ],
     "recommends" : [ { "name" : "SolarSailNavigator" } ],


### PR DESCRIPTION
Even if your submission tested fine locally there are several errors that only the bots will note and reject. This should be expected.
Latest version now works with KSP 1.1