### PR TITLE
Update TACLS.netkan, add CRP dependency

### DIFF
--- a/NetKAN/TACLS.netkan
+++ b/NetKAN/TACLS.netkan
@@ -9,6 +9,7 @@
     "depends" : [
         {   "name" : "ModuleManager" },
         {   "name" : "TACLS-Config" }
+        {   "name" : "CommunityResourcePack" }
     ],
     "suggests" : [
         {   "name" : "KSP-AVC" }


### PR DESCRIPTION
We removed TACLS's organic resource definition in favor of CRP dependency.