### PR TITLE
Added dependancy to KSPInterstellarExtended

### DIFF
--- a/NetKAN/InterstellarFuelSwitch.netkan
+++ b/NetKAN/InterstellarFuelSwitch.netkan
@@ -16,7 +16,7 @@
         { "name" : "ModuleManager" }
     ],
     "recommends": [
-        { "name"         : "KSPInterstellarExtended }
+        { "name"         : "KSPInterstellarExtended" }
     ],
     "abstract" : "Library that enables switching the contents, meshes, and textures of tanks.",
     "resources" : {

--- a/NetKAN/InterstellarFuelSwitch.netkan
+++ b/NetKAN/InterstellarFuelSwitch.netkan
@@ -15,11 +15,11 @@
         { "name" : "InterstellarFuelSwitch-Core", "min_version" : "1.28" },
         { "name" : "ModuleManager" }
     ],
+    "recommends": [
+        { "name"         : "KSPInterstellarExtended, "min_version" : "1.8.16" }
+    ],
     "abstract" : "Library that enables switching the contents, meshes, and textures of tanks.",
     "resources" : {
         "bugtracker"   : "https://github.com/sswelm/KSP-Interstellar-Extended/issues"
-    },
-    "recommends": [
-        { "name"         : "KSPInterstellarExtended, "min_version" : "1.8.16" }
-    ]
+    }
 }

--- a/NetKAN/InterstellarFuelSwitch.netkan
+++ b/NetKAN/InterstellarFuelSwitch.netkan
@@ -16,7 +16,7 @@
         { "name" : "ModuleManager" }
     ],
     "recommends": [
-        { "name"         : "KSPInterstellarExtended, "min_version" : "1.8.16" }
+        { "name"         : "KSPInterstellarExtended }
     ],
     "abstract" : "Library that enables switching the contents, meshes, and textures of tanks.",
     "resources" : {

--- a/NetKAN/InterstellarFuelSwitch.netkan
+++ b/NetKAN/InterstellarFuelSwitch.netkan
@@ -18,5 +18,8 @@
     "abstract" : "Library that enables switching the contents, meshes, and textures of tanks.",
     "resources" : {
         "bugtracker"   : "https://github.com/sswelm/KSP-Interstellar-Extended/issues"
-    }
+    },
+    "recommends": [
+        { "name"         : "KSPInterstellarExtended, "min_version" : "1.8.16" }
+    ]
 }


### PR DESCRIPTION
Interstellar Fuel switcher can optionaly use KSP Interstelar Extended crygenic module for boiloff