### PR TITLE
Open up KSP compatibility for PilotAssistant

### DIFF
--- a/NetKAN/PilotAssistant.netkan
+++ b/NetKAN/PilotAssistant.netkan
@@ -14,5 +14,15 @@
             "file"       : "GameData/Pilot Assistant",
             "install_to" : "GameData"
         }
+    ],
+    "x_netkan_override" [
+        {
+            "version": "v1.12.5",
+            "delete": [ "ksp_version" ],
+            "override": {
+                "ksp_version_min": "1.1.0",
+                "ksp_version_max": "1.1.2"
+            }
+        }
     ]
 }

--- a/NetKAN/PilotAssistant.netkan
+++ b/NetKAN/PilotAssistant.netkan
@@ -15,7 +15,7 @@
             "install_to" : "GameData"
         }
     ],
-    "x_netkan_override" [
+    "x_netkan_override": [
         {
             "version": "v1.12.5",
             "delete": [ "ksp_version" ],


### PR DESCRIPTION
All the text shows the author's intent was to make the latest version more generally compatible as "1.1", even though the .version file says "1.1.0". Limiting to released versions to be conservative, though.

I have reached out to the author to get the .version file updated.