### PR TITLE
KerbinSideGAP mod dependencies updating

### DIFF
--- a/NetKAN/KerbinSideGAP.netkan
+++ b/NetKAN/KerbinSideGAP.netkan
@@ -7,8 +7,9 @@
     "license": "CC-BY-NC-4.0",
 
     "depends": [
+        {"name": "KerbinSide-virt"},
         {"name": "ContractConfigurator", "min_version": "1.9.6"},
-        {"name": "KerbinSide"}
+        {"name": "ContractConfigurator-KerbinSideJobs", "min_version": "2.0"}
     ],
     "recommends": [
         {"name": "NavUtilities"},
@@ -24,7 +25,7 @@
     },
     "install" : [
         {
-            "find_regexp": "Kerbin.?Side.?GAP",
+            "file": "KerbinSideGAP",
             "install_to": "GameData/ContractPacks"
         },
         {


### PR DESCRIPTION
I've updated dependencies to fit new packages structure that AlphaAsh had introduced.

Am I right, that this affects only further releases of my mod, while current ones (v1.0-v1.2) remains as they are and so they will be still available for KSP 1.0.5 users?