### PR TITLE
Move KSP-64K to Spacedock

### DIFF
--- a/NetKAN/KSP-64k.netkan
+++ b/NetKAN/KSP-64k.netkan
@@ -16,7 +16,7 @@
     ],
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "Kopernicus", "version": "1:beta-04" }
+        { "name": "Kopernicus" }
     ],
     "suggests": [
         { "name": "ProceduralParts" },

--- a/NetKAN/KSP-64k.netkan
+++ b/NetKAN/KSP-64k.netkan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "KSP-64k",
     "$kref": "#/ckan/spacedock/719",
-    "$vref": "#/ckan/ksp-avc"
+    "$vref": "#/ckan/ksp-avc",
     "license": "CC-BY-NC-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/87284-",

--- a/NetKAN/KSP-64k.netkan
+++ b/NetKAN/KSP-64k.netkan
@@ -1,20 +1,16 @@
 {
     "spec_version": 1,
     "identifier": "KSP-64k",
-    "$kref": "#/ckan/github/KSP-64k/64k",
+    "$kref": "#/ckan/spacedock/719",
+    "$vref": "#/ckan/ksp-avc"
     "license": "CC-BY-NC-4.0",
-    "name": "64K",
-    "abstract": "KSP 6.4x bigger!  Added challenge for FAR and NEAR users.",
-    "author": "Paul_Kingtiger",
     "resources": {
-        "homepage": "http://www.kingtiger.co.uk/kingtiger/wordpress/64k/",
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/87284-",
         "repository": "https://github.com/KSP-64k/64k"
     },
-    "ksp_version_min": "1.0.4",
-    "ksp_version_max": "1.0.5",
     "install": [
         {
-            "file": "64k/GameData/64k",
+            "file": "GameData/KScale64",
             "install_to": "GameData"
         }
     ],
@@ -24,9 +20,6 @@
     ],
     "suggests": [
         { "name": "ProceduralParts" },
-        { "name": "ImageViewer" },
-        { "name": "KSP-64k-12HourDay" },
-        { "name": "KSP-64k-imgviewer" },
         { "name": "RemoteTech" }
     ]
 }

--- a/NetKAN/KSP-64k.netkan
+++ b/NetKAN/KSP-64k.netkan
@@ -20,6 +20,8 @@
     ],
     "suggests": [
         { "name": "ProceduralParts" },
-        { "name": "RemoteTech" }
+        { "name": "RemoteTech" },
+        { "name": "DeadlyReentry" },
+        { "name": "SCANSat" }
     ]
 }


### PR DESCRIPTION
Set homepage to forum link since both Spacedock and forum thread have a prominent link to kingtiger.co.uk, but kingtiger.co.uk has no link to forum thread, and is outdated. Forum thread has been updated with new release details.
64K - 12 hour & Delta-V ImageViewer optional installs appear to have been dropped.
Closes #4125