### PR TITLE
Fix install for KWRocketry-CommunityFixes and -interstage

### DIFF
--- a/NetKAN/KWRocketry-CommunityFixes-interstage.netkan
+++ b/NetKAN/KWRocketry-CommunityFixes-interstage.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version"  : "v1.2",
+    "spec_version"  : "v1.16",
     "identifier"    : "KWRocketry-CommunityFixes-interstage",
     "$kref"         : "#/ckan/spacedock/51",
     "$vref"         : "#/ckan/ksp-avc",
@@ -11,7 +11,8 @@
     ],
     "install": [
         {
-            "file": "Gamedata/KWCommunityFixes/KWPatch-interstage.cfg",
+            "find": "KWPatch-interstage.cfg",
+            "find_matches_files": true,
             "install_to": "GameData/KWCommunityFixes"
         }
     ],

--- a/NetKAN/KWRocketry-CommunityFixes.netkan
+++ b/NetKAN/KWRocketry-CommunityFixes.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version"  : 1,
+    "spec_version"  : "v1.4",
     "identifier"    : "KWRocketry-CommunityFixes",
     "$kref"         : "#/ckan/spacedock/51",
     "$vref"         : "#/ckan/ksp-avc",
@@ -20,7 +20,7 @@
     ],
     "install": [
         {
-            "file": "Gamedata/KWCommunityFixes",
+            "find": "KWCommunityFixes",
             "install_to": "GameData",
             "filter": "KWPatch-interstage.cfg"
         }


### PR DESCRIPTION
Change in casing for `GameData`, switch from `file` paths to `find`.

@linuxgurugamer I was under the impression `KWRocketry-CommunityFixes` was discontinued in favour of `KWRocketryRedux` but seeing as you're continuing to issue new releases, should we bump the ksp_version compatibility of `KWRocketry-2.7.0-community`?