### PR TITLE
Fix install Kosmodrome

### DIFF
--- a/NetKAN/Kosmodrome.netkan
+++ b/NetKAN/Kosmodrome.netkan
@@ -6,7 +6,7 @@
   "depends" : [
     { "name": "KerbalKonstructs" }
   ],
-  "Install" : [ {
+  "install" : [ {
     "find" : "Kosmodrome",
     "install_to" : "GameData",
     "filter" : "Thumbs.db"


### PR DESCRIPTION
`Install` to `install`
https://github.com/KSP-CKAN/CKAN-meta/pull/1175