### PR TITLE
Add SMURFF-Extras-VenStockRevamp

### DIFF
--- a/NetKAN/SMURFF-Extras-VenStockRevamp.netkan
+++ b/NetKAN/SMURFF-Extras-VenStockRevamp.netkan
@@ -1,0 +1,24 @@
+{
+    "spec_version": "v1.2",
+    "identifier": "SMURFF-Extras-VenStockRevamp",
+    "$kref": "#/ckan/github/Kerbas-ad-astra/SMURFF",
+    "$vref": "#/ckan/ksp-avc/GameData/SMURFF/SMURFF.version",
+    "x_netkan_version_edit": "^[vV]?(?<version>.+)$",
+    "name": "SMURFF Extras - Ven Stock Revamp",
+    "abstract": "Extra SMURFF patches for Ven Stock Revamp.",
+    "license": "Apache-2.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/117992-/"
+    },
+    "depends": [
+        { "name": "SMURFF" },
+        { "name": "VenStockRevamp" },
+        { "name": "ModuleManager", "min_version": "2.6.16" }
+    ],
+    "install": [
+        {
+            "file": "Extras/VSR_CryoX_SoftTanks.cfg",
+            "install_to": "GameData/SMURFF/Extras"
+        }   
+    ]
+}

--- a/NetKAN/SMURFF.netkan
+++ b/NetKAN/SMURFF.netkan
@@ -14,6 +14,7 @@
         { "name": "ModuleManager", "min_version": "2.6.16" }
     ],
     "suggests": [
+        { "name": "SMURFF-Extras-VenStockRevamp" },
         { "name": "AntennaRange" },
         { "name": "BehemothAerospaceEngineeringLargeParts" },
         { "name": "CryoEngines" },


### PR DESCRIPTION
SMURFF now comes with optional patches in its `Extras` directory. This adds a package for the only one so far: `SMURFF-Extras-VenStockRevamp`. For future extensibility I figure its best to group the patches by mod/general functionality. If that does not prove to be granular enough we can split them in the future.