### PR TITLE
DestructionEffects fixup

### DIFF
--- a/NetKAN/DestructionEffects-SemiContinued.netkan
+++ b/NetKAN/DestructionEffects-SemiContinued.netkan
@@ -1,0 +1,24 @@
+{
+    "spec_version"      : 1,
+    "identifier"        : "DestructionEffects-SemiContinued",
+    "$kref"             : "#/ckan/github/Wicloz/DestructionEffects-Semi-Continued",
+    "name"              : "Destruction Effects Semi-Continued",
+    "abstract"          : "This mod adds flames and smoke to certain parts' joint break event.",
+    "license"           : "CC0",
+    "ksp_version_min"   : "1.1.0",
+    "ksp_version_max"   : "1.1.99",
+    "resources": {
+        "homepage"      : "http://forum.kerbalspaceprogram.com/index.php?/topic/99088-10xdestruction-effects-flames-and-smoke-on-joint-breaks",
+        "repository"    : "https://github.com/Wicloz/DestructionEffects-Semi-Continued"
+    },
+    "conflicts": [
+        { "name": "DestructionEffects" }
+    ],
+    "install": [
+        {
+            "file":"DestructionEffects",
+            "install_to": "GameData"
+        }
+    ]
+    
+}

--- a/NetKAN/DestructionEffects.netkan
+++ b/NetKAN/DestructionEffects.netkan
@@ -1,14 +1,18 @@
 {
     "spec_version"      : 1,
     "identifier"        : "DestructionEffects",
-    "$kref"             : "#/ckan/github/Wicloz/DestructionEffects-Semi-Continued",
-    "name"              : "Destruction Effects Semi-Continued",
+    "$kref"             : "#/ckan/github/jrodrigv/DestructionEffects",
+    "name"              : "Destruction Effects",
     "abstract"          : "This mod adds flames and smoke to certain parts' joint break event.",
     "license"           : "CC0",
     "ksp_version_min"   : "1.1.0",
     "ksp_version_max"   : "1.1.99",
+    "x_netkan_epoch"    : 1,
+    "conflicts": [
+        { "name": "DestructionEffects-SemiContinued" }
+    ],
     "resources": {
         "homepage"      : "http://forum.kerbalspaceprogram.com/index.php?/topic/99088-10xdestruction-effects-flames-and-smoke-on-joint-breaks",
-        "repository"    : "https://github.com/Wicloz/DestructionEffects-Semi-Continued"
+        "repository"    : "https://github.com/Wicloz/DestructionEffects"
     }
 }


### PR DESCRIPTION
Following advice [here](http://forum.kerbalspaceprogram.com/index.php?/topic/99088-10xdestruction-effects-flames-and-smoke-on-joint-breaks/&do=findComment&comment=2622536).
Replaces the current DestructionEffects with a pure continuation.
Makes DestructionEffects-SemiContinued a separate, conflicting mod.
The Spacedock release appears to be someone re-releasing the DestructionEffects here without giving credit. (CC-0, so they can do that, but this source seems better.)
Replaces #4192