### PR TITLE
Update New Horizons to KSP 1.1.2

### DIFF
--- a/NetKAN/NewHorizons.netkan
+++ b/NetKAN/NewHorizons.netkan
@@ -11,7 +11,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/114092"
     },
-    "ksp_version": "1.0.5",
+    "ksp_version": "1.1.2",
     "depends": [
         { "name": "ModuleManager" },
         { "name": "Kopernicus", "min_version": "1:beta-05-2" }


### PR DESCRIPTION
Update as per [forum post](http://forum.kerbalspaceprogram.com/index.php?/topic/102776-112-kopernicus-new-horizons-v200-14june2016-out-with-the-old-in-with-the-new/#comment-1792426). Newest version is 2.0.0 for KSP 1.1.2