### PR TITLE
Update Workshop.netkan

### DIFF
--- a/NetKAN/Workshop.netkan
+++ b/NetKAN/Workshop.netkan
@@ -10,12 +10,6 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/97537-11-ose-workshop-kis-addon-v0130-20160426/"
     },
-    "install": [
-        {
-            "file": "GameData/Workshop",
-            "install_to": "GameData"
-        }
-    ],
     "x_netkan_override": [
         {
             "version": "<0.9.0",


### PR DESCRIPTION
Most recent release does not have a top-level `GameData` directory. Just use default install information.