### PR TITLE
Update BWA-X-ROMBUS.netkan

### DIFF
--- a/NetKAN/BWA-X-ROMBUS.netkan
+++ b/NetKAN/BWA-X-ROMBUS.netkan
@@ -7,7 +7,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/141153-112-bwa-x-rombus-pack/",
         "repository": "https://github.com/Lupinarius/BWA-X/"
     },
-    "ksp_version_min": "1.0",
+    "ksp_version_min": "1.0.5",
 	"ksp_version_max": "1.1.2",
     "depends": [
         { "name": "ModuleManager" },


### PR DESCRIPTION
CKAN still shows this as incompatible with 1.05, so I'm guessing the .5 is needed after the 1.0 in the ksp_version_min statement. I thought that the lower 1.0 version number would be inclusive of versions in between but maybe not? If you can see any other reason this shows up as not compatible with KSP-1.0.5, please let me know so I can fix it, thank you and sorry about any extra work this has caused.