### PR TITLE
Historian-expanded add force_v

### DIFF
--- a/NetKAN/Historian-expanded.netkan
+++ b/NetKAN/Historian-expanded.netkan
@@ -6,6 +6,7 @@
     "author"       : "Aelfhe1m",
     "abstract"     : "Adds fully configurable and dynamic captions and overlay graphics to screenshots to better describe the context of screenshots and record your Kerbal adventures.",
     "license"      : "GPL-3.0",
+    "x_netkan_force_v": true,
     "ksp_version"  : "1.1.2",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/138848-112-historian-expanded/"


### PR DESCRIPTION
Not sure what happened, exactly, but we need the "v" now.
As per [forum post](http://forum.kerbalspaceprogram.com/index.php?/topic/90246-the-comprehensive-kerbal-archive-network-ckan-package-manager-v1161-13-mar-2016/&do=findComment&comment=2629757)