### PR TITLE
Update Telemachus to use SpaceDock

### DIFF
--- a/NetKAN/Telemachus-2.netkan
+++ b/NetKAN/Telemachus-2.netkan
@@ -6,8 +6,10 @@
     "conflicts"    : [
         { "name" : "Telemachus" }
     ],
-    "install"      : [
-        { "file"       : "GameData/Telemachus"},
-        { "install_to" : "GameData" }
+    "install" : [
+        {
+            "file"       : "GameData/Telemachus",
+            "install_to" : "GameData"
+        }
     ]
 }

--- a/NetKAN/Telemachus-2.netkan
+++ b/NetKAN/Telemachus-2.netkan
@@ -1,0 +1,13 @@
+{
+    "spec_version" : 1,
+    "identifier"   : "Telemachus",
+    "$kref"        : "#/ckan/spacedock/742",
+    "license"      : "BSD-4-clause",
+    "conflicts"    : [
+        { "name" : "Telemachus-2" }
+    ],
+    "install"      : [
+        { "file"       : "GameData/Telemachus"},
+        { "install_to" : "GameData" }
+    ]
+}

--- a/NetKAN/Telemachus-2.netkan
+++ b/NetKAN/Telemachus-2.netkan
@@ -1,10 +1,10 @@
 {
     "spec_version" : 1,
-    "identifier"   : "Telemachus",
+    "identifier"   : "Telemachus-2",
     "$kref"        : "#/ckan/spacedock/742",
     "license"      : "BSD-4-clause",
     "conflicts"    : [
-        { "name" : "Telemachus-2" }
+        { "name" : "Telemachus" }
     ],
     "install"      : [
         { "file"       : "GameData/Telemachus"},


### PR DESCRIPTION
Because it's easier to manage SpaceDock NetKANs than GitHub ones.

Alternative to #4189 .

Odd that this fails checks. O.o Works fine for me.