### PR TITLE
Deleted ModuleManager dependency

### DIFF
--- a/NetKAN/StockPlugins.netkan
+++ b/NetKAN/StockPlugins.netkan
@@ -4,8 +4,15 @@
     "$kref" : "#/ckan/spacedock/112",
     "$vref" : "#/ckan/ksp-avc",
     "license": "public-domain",
-    "depends": [
-        { "name": "ModuleManager", "min_version": "2.6.0" }
+    "install" : [
+        {
+            "file"       : "GameData/StockPlugins",
+            "install_to" : "GameData"
+        },
+        {
+            "file"       : "GameData/ModuleManager.2.6.25.dll",
+            "install_to" : "GameData"
+        },
     ],
     "suggests": [
         { "name": "DeadlyReentry" },

--- a/NetKAN/StockPlugins.netkan
+++ b/NetKAN/StockPlugins.netkan
@@ -12,7 +12,7 @@
         {
             "file"       : "GameData/ModuleManager.2.6.25.dll",
             "install_to" : "GameData"
-        },
+        }
     ],
     "suggests": [
         { "name": "DeadlyReentry" },


### PR DESCRIPTION
Hello, I've followed the "flame war" against CKAN, I understand why they do this, but I don't like how they do it. 

I don't like that some of my tiny mods can be used by the best and the hugest dependency of KSP for this "war". For this, I pull this request. I don't think it's a good way, I don't think it's need, I don't think you need to accept this pull. Perhaps the meta are broken here.

You have done a good work on CKAN, huge thanks for this, I don't use it because I don't need it, but I support it, because many of my friends don't know how to install a mod, as each mods have different install instruction, they don't want to lose their time to learn how to install each mod.

Ferram4, RoverDude, Sarbian and other are angry because of CKAN policy, I'm angry because of their policy to them.