### PR TITLE
Revert "UKS isn't supported on CKAN anymore, so remove it as a dependency."

### DIFF
--- a/NetKAN/UKS-Kerbalism-Patch.netkan
+++ b/NetKAN/UKS-Kerbalism-Patch.netkan
@@ -6,6 +6,7 @@
     "x_netkan_license_ok": true,
     "depends": [
         { "name": "ModuleManager" },
+        { "name": "UKS" },
         { "name": "Kerbalism", "min_version": "1.0.0" }
     ],
     "recommends": [


### PR DESCRIPTION
Reverts KSP-CKAN/NetKAN#4282