### PR TITLE
Update MagiCore to work on 1.1.2/3 both

### DIFF
--- a/NetKAN/MagiCore.netkan
+++ b/NetKAN/MagiCore.netkan
@@ -26,5 +26,15 @@
             "find_matches_files": true,
             "install_to": "GameData"
         }
-    ]
+    ],
+    "x_netkan_override" : [
+        {
+            "version" : "1.1.1",
+            "delete" : [ "ksp_version" ],
+            "override" : {
+                "ksp_version_min" : "1.1.2",
+                "ksp_version_max" : "1.1.3"
+            }
+        }
+   ]
 }


### PR DESCRIPTION
Can be reverted once https://github.com/magico13/MagiCore/pull/2 is accepted. As of now nothing that depends on MagiCore (KCT, mods that req KCT) will show in CkAN due to this mismatch.

Hopefully @magico13 can get to the PR soon, but I see no harm in doing this until then.