### PR TITLE
DRE override no longer needed

### DIFF
--- a/NetKAN/DeadlyReentry.netkan
+++ b/NetKAN/DeadlyReentry.netkan
@@ -19,14 +19,5 @@
             "install_to": "GameData"
         }
     ],
-    "x_netkan_override" : [
-        {
-            "version" : "v7.4.5.1",
-            "override"  : {
-                "ksp_version_min" : "1.1.2",
-                "ksp_version_max" : "1.1.3"
-            }
-        }
-    ],
     "x_netkan_force_v": true
 }


### PR DESCRIPTION
With the release of 7.4.7 for 1.1.3, we don't need the override.