### PR TITLE
KerbQuake extended mod.

### DIFF
--- a/NetKAN/KerbQuakeExtended.netkan
+++ b/NetKAN/KerbQuakeExtended.netkan
@@ -10,5 +10,11 @@
 	"install": [{
 		"file": "KerbQuake",
 		"install_to": "GameData"
-	}]
+	}],
+	"name": "KerbQuake Extended",
+	"abstract": "Adds IVA shaking and reentry IVA sound effects!",
+	"license": "BSD-3 clause",
+	"resources": {
+		"homepage": "https://github.com/N70/KerbQuakeExtended"
+	}
 }

--- a/NetKAN/KerbQuakeExtended.netkan
+++ b/NetKAN/KerbQuakeExtended.netkan
@@ -1,0 +1,14 @@
+{
+	"spec_version": 1,
+	"identifier": "KerbQuakeExtended",
+	"$kref": "#/ckan/github/N70/KerbQuakeExtended",
+	"$vref": "#/ckan/ksp-avc",
+	"x_netkan_license_ok": true,
+	"recommends": [{
+		"name": "KSP-AVC"
+	}],
+	"install": [{
+		"file": "KerbQuake",
+		"install_to": "GameData"
+	}]
+}

--- a/NetKAN/KerbQuakeExtended.netkan
+++ b/NetKAN/KerbQuakeExtended.netkan
@@ -3,7 +3,6 @@
 	"identifier": "KerbQuakeExtended",
 	"$kref": "#/ckan/github/N70/KerbQuakeExtended",
 	"$vref": "#/ckan/ksp-avc",
-	"x_netkan_license_ok": true,
 	"recommends": [{
 		"name": "KSP-AVC"
 	}],
@@ -13,7 +12,7 @@
 	}],
 	"name": "KerbQuake Extended",
 	"abstract": "Adds IVA shaking and reentry IVA sound effects!",
-	"license": "BSD-3 clause",
+	"license": "BSD-3-clause",
 	"resources": {
 		"homepage": "https://github.com/N70/KerbQuakeExtended"
 	},

--- a/NetKAN/KerbQuakeExtended.netkan
+++ b/NetKAN/KerbQuakeExtended.netkan
@@ -16,5 +16,6 @@
 	"license": "BSD-3 clause",
 	"resources": {
 		"homepage": "https://github.com/N70/KerbQuakeExtended"
-	}
+	},
+	"author": "N70"
 }


### PR DESCRIPTION
Add my fork of KerbQuake, KerbQuake extended. KerbQuake's original licenses allows for forks, as it uses the [BSD 3-Clause license](https://tldrlegal.com/license/bsd-3-clause-license-(revised)).