### PR TITLE
Add For Science to conflicts list for DMagic Orbital Science

### DIFF
--- a/NetKAN/DMagicOrbitalScience.netkan
+++ b/NetKAN/DMagicOrbitalScience.netkan
@@ -24,6 +24,9 @@
         { "name": "SCANsat" },
         { "name": "CommunityTechTree" }
     ],
+	"conflicts": [
+        { "name": "ForScience" }
+    ],
     "x_netkan_override": [
         {
             "version": "1.0.4",


### PR DESCRIPTION
For Science doesn't properly interact with Orbital Science experiments. This can lead to simply thinking the experiments can't be run, to preventing experiments from being transmitted while using Remote Tech.