### PR TITLE
DmagicOrbitalScience conflict with ForScience

### DIFF
--- a/NetKAN/DMagicOrbitalScience.netkan
+++ b/NetKAN/DMagicOrbitalScience.netkan
@@ -15,6 +15,9 @@
     "recommends": [
         { "name": "ContractsWindowPlus" }
     ],
+    "conflicts": [
+        { "name": "ForScience" }
+    ],
     "suggests": [
         { "name": "CapCom" },
         { "name": "ContractRewardModifier" },


### PR DESCRIPTION
For Science doesn't properly interact with Orbital Science experiments. This can lead to simply thinking the experiments can't be run, to preventing experiments from being transmitted while using Remote Tech.
Closes #4422