### PR TITLE
Add KSPSerialIO cross platform fork

### DIFF
--- a/NetKAN/KSPSerialIOcrossplatform.netkan
+++ b/NetKAN/KSPSerialIOcrossplatform.netkan
@@ -1,0 +1,26 @@
+{
+  "spec_version": "1",
+  "identifier": "KSPSerialIOcrossplatform",
+  "$kref": "#/ckan/spacedock/850",
+  "license": "CC-BY",
+
+  "install": [
+    {
+      "file": "KSPSerialIO/KSPSerialIO.dll",
+      "install_to": "GameData/KSPSerialIO"
+    },
+    {
+      "file": "KSPSerialIO/PsimaxSerial.dll",
+      "install_to": "GameData/KSPSerialIO"
+    },
+    { "file": "KSPSerialIO/PluginData/KSPSerialIO/config.xml",
+      "install_to": "GameData/KSPSerialIO/PluginData/KSPSerialIO"
+    }
+  ],
+
+  "conflicts": [
+    {
+      "name": "SerialIO"
+    }
+  ]
+}

--- a/NetKAN/KSPSerialIOcrossplatform.netkan
+++ b/NetKAN/KSPSerialIOcrossplatform.netkan
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1",
+  "spec_version": "1.4",
   "identifier": "KSPSerialIOcrossplatform",
   "$kref": "#/ckan/spacedock/850",
   "license": "CC-BY",

--- a/NetKAN/KSPSerialIOcrossplatform.netkan
+++ b/NetKAN/KSPSerialIOcrossplatform.netkan
@@ -1,5 +1,5 @@
 {
-  "spec_version": "1.4",
+  "spec_version": "v1.4",
   "identifier": "KSPSerialIOcrossplatform",
   "$kref": "#/ckan/spacedock/850",
   "license": "CC-BY",

--- a/NetKAN/SerialIO.netkan
+++ b/NetKAN/SerialIO.netkan
@@ -12,7 +12,7 @@
 
 	"conflicts": [
 		{
-			"name": "SerialIO-MacLinuxWin"
+			"name": "KSPSerialIOcrossplatform"
 		}
 	]
 }

--- a/NetKAN/SerialIO.netkan
+++ b/NetKAN/SerialIO.netkan
@@ -12,7 +12,7 @@
 
 	"conflicts": [
 		{
-			"name": "KSPSerialIOcrossplatform"
+			"name": "SerialIO-MacLinuxWin"
 		}
 	]
 }


### PR DESCRIPTION
There's a little bit of hairiness here, sorry.

* This mod conflicts with `SerialIO` (the mod it's forked from - I hope to eventually merge them, but this is where we are now). I've gone ahead and updated the netkan for `SerialIO` to reflect this.
* It's functionality equivalent, but a separate implementation, to the `SerialIO-MacLinuxWin`, which existed on kerbalstuff but hasn't been maintained for quite some time and isn't currently listed anywhere. That's why I replaced it in the `SerialIO` conflicts. But didn't want to flat-out remove the netkan for it.
* This mod installs a DLL that's a duplicate of the `PsimaxSerialLibrary` netkan. But, again, that's a listing that hasn't been kept up to date - the package doesn't exist on spacedock at all.

I'm not sure what the policy is on those sorts of abandoned netkan files, so I've just opened up this PR to get some feedback. I reached out to the `SerialIO-MacLinuxWin` and `PsimaxSerialLibrary` author on the KSP forum a week ago regarding picking up that code, but haven't heard anything back. I guess I'd be happy to split out the serial library I'm using to a separate netkan entry, either replacing the existing PsimaxSerial one or a new one. Whichever the CKAN folk think would be appropriate.