### PR TITLE
Redirect InfernalRobotics-Sequencer from SpaceDock to GitHub

### DIFF
--- a/NetKAN/InfernalRobotics-Sequencer.netkan
+++ b/NetKAN/InfernalRobotics-Sequencer.netkan
@@ -3,7 +3,7 @@
     "license": "GPL-3.0",
     "$kref": "#/ckan/github/MagicSmokeIndustries/IR-Sequencer",
     "$vref": "#/ckan/ksp-avc",
-    "spec_version": "1.4",
+    "spec_version": "v1.4",
     "depends" : [
         { "name" : "InfernalRobotics", "min_version" : "0.21.3" },
         { "name" : "ModuleManager" }

--- a/NetKAN/InfernalRobotics-Sequencer.netkan
+++ b/NetKAN/InfernalRobotics-Sequencer.netkan
@@ -3,7 +3,7 @@
     "license": "GPL-3.0",
     "$kref": "#/ckan/github/MagicSmokeIndustries/IR-Sequencer",
     "$vref": "#/ckan/ksp-avc",
-    "spec_version": "1",
+    "spec_version": "1.4",
     "depends" : [
         { "name" : "InfernalRobotics", "min_version" : "0.21.3" },
         { "name" : "ModuleManager" }

--- a/NetKAN/InfernalRobotics-Sequencer.netkan
+++ b/NetKAN/InfernalRobotics-Sequencer.netkan
@@ -1,8 +1,9 @@
 {
     "identifier": "InfernalRobotics-Sequencer",
     "license": "GPL-3.0",
-    "$kref": "#/ckan/spacedock/72",
-    "spec_version": "v1.4",
+    "$kref": "#/ckan/github/MagicSmokeIndustries/IR-Sequencer",
+    "$vref": "#/ckan/ksp-avc",
+    "spec_version": "1",
     "depends" : [
         { "name" : "InfernalRobotics", "min_version" : "0.21.3" },
         { "name" : "ModuleManager" }

--- a/NetKAN/InfernalRobotics-Sequencer.netkan
+++ b/NetKAN/InfernalRobotics-Sequencer.netkan
@@ -4,12 +4,12 @@
     "$kref": "#/ckan/github/MagicSmokeIndustries/IR-Sequencer",
     "name": "Sequencer for Infernal Robotics",
     "author": "ZiwKerman",
-    "abstract": "This add-on serves as an example on how to use Infernal Robotics's API. With this mod you can create and play sequences of servo movement commands and special commands, like GoTo, Toggle ActionGroup, Delay and Wait."
+    "abstract": "This add-on serves as an example on how to use Infernal Robotics's API. With this mod you can create and play sequences of servo movement commands and special commands, like GoTo, Toggle ActionGroup, Delay and Wait.",
     "$vref": "#/ckan/ksp-avc",
     "spec_version": "v1.4",
     "resources": { 
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/104547-113-ir-sequencer-v100-add-on-to-infernal-robotics-updated-09072016/"
-    }
+    },
     "depends" : [
         { "name" : "InfernalRobotics", "min_version" : "0.21.3" },
         { "name" : "ModuleManager" }

--- a/NetKAN/InfernalRobotics-Sequencer.netkan
+++ b/NetKAN/InfernalRobotics-Sequencer.netkan
@@ -7,6 +7,9 @@
     "abstract": "This add-on serves as an example on how to use Infernal Robotics's API. With this mod you can create and play sequences of servo movement commands and special commands, like GoTo, Toggle ActionGroup, Delay and Wait."
     "$vref": "#/ckan/ksp-avc",
     "spec_version": "v1.4",
+    "resources": { 
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/104547-113-ir-sequencer-v100-add-on-to-infernal-robotics-updated-09072016/"
+    }
     "depends" : [
         { "name" : "InfernalRobotics", "min_version" : "0.21.3" },
         { "name" : "ModuleManager" }

--- a/NetKAN/InfernalRobotics-Sequencer.netkan
+++ b/NetKAN/InfernalRobotics-Sequencer.netkan
@@ -2,6 +2,9 @@
     "identifier": "InfernalRobotics-Sequencer",
     "license": "GPL-3.0",
     "$kref": "#/ckan/github/MagicSmokeIndustries/IR-Sequencer",
+    "name": "Sequencer for Infernal Robotics",
+    "author": "ZiwKerman",
+    "abstract": "This add-on serves as an example on how to use Infernal Robotics's API. With this mod you can create and play sequences of servo movement commands and special commands, like GoTo, Toggle ActionGroup, Delay and Wait."
     "$vref": "#/ckan/ksp-avc",
     "spec_version": "v1.4",
     "depends" : [


### PR DESCRIPTION
SpaceDock hasn't been upgraded since IRS version 0.6.0, but the mod is
up to 1.0.0 on GitHub (and Sequencer versions each require the matching IR version).  I've checked with the mod authors and they've OK'd this update.