### PR TITLE
Update Stock Bug Fix Modules & StockPlus

### DIFF
--- a/NetKAN/StockBugFixPlus.netkan
+++ b/NetKAN/StockBugFixPlus.netkan
@@ -5,10 +5,16 @@
     "name": "Stock Bug Fix Modules & StockPlus",
     "abstract": "Stand alone fixes for common stock KSP bugs.",
     "license": "CC-BY-NC-SA-4.0",
-    "ksp_version": "1.1.2",
+    "ksp_version": "1.1.3",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/index.php?/topic/87737-/"
     },
+    "install": [
+        {
+            "file": "StockBugFixControllerPlus",
+            "install_to": "GameData"
+        }
+    ],
     "conflicts": [
         { "name": "StockBugFixModules" },
         { "name": "StockPlus" }


### PR DESCRIPTION
This is my first time editing NetKAN.

The name of the zip, and folder within, changed from "StockBugFixPlus" to "StockBugFixControllerPlus". Should it be handled as I have done, or should the netkan file be renamed?