### PR TITLE
Add LightFixer!

### DIFF
--- a/NetKAN/LightFixer.netkan
+++ b/NetKAN/LightFixer.netkan
@@ -1,0 +1,16 @@
+{
+    "license": "CC-BY-SA",
+    "$kref": "#/ckan/spacedock/874",
+    "spec_version": "v1.4",
+    "identifier": "LightFixer",
+    "depends": [
+        { "name": "Kopernicus" },
+        { "name": "ModuleManager" }
+    ],
+    "install": [
+        {
+            "file": "LightFixer!",
+            "install_to": "GameData"
+        }
+    ]
+}


### PR DESCRIPTION
The mod is just a `Config.cfg` which edits Kopernicus using ModuleManager, which is why I added ModuleManager as a hard dependency, rather than getting it transitively through Kopernicus.

Closes #4482