### PR TITLE
Add CriticalTemperatureGauge.netkan

### DIFF
--- a/NetKAN/CriticalTemperatureGauge.netkan
+++ b/NetKAN/CriticalTemperatureGauge.netkan
@@ -1,0 +1,11 @@
+{
+  "spec_version" : 1,
+  "identifier"   : "CriticalTemperatureGauge",
+  "$kref"        : "#/ckan/github/formicant/CriticalTemperatureGauge",
+  "$vref"        : "#/ckan/ksp-avc",
+  "name"         : "Critical Temperature Gauge",
+  "author"       : [ "Ravien", "Teilnehmer" ],
+  "abstract"     : "A plugin showing a temperature gauge and which part is going to blow up first",
+  "license"      : "GPL-3.0",
+  "resources"    : { "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/146239-113-critical-temperature-gauge-continued" }
+}


### PR DESCRIPTION
An official continuation of Ravien’s CriticalTemperatureGauge mod with a new GitHub repo.