### PR TITLE
Address TACLS version inconsistencies

### DIFF
--- a/NetKAN/TACLS.netkan
+++ b/NetKAN/TACLS.netkan
@@ -1,10 +1,12 @@
 {
     "spec_version"   : "v1.4",
     "identifier"     : "TACLS",
-    "author"         : ["KSP-RO Group/danfarnsy", "Taranis Elsu" ],
+    "author"         : [ "Jplrepo", "KSP-RO Group/danfarnsy", "Taranis Elsu" ],
     "name"           : "TAC Life Support (TACLS)",
     "$kref"          : "#/ckan/github/KSP-RO/TacLifeSupport",
     "$vref"          : "#/ckan/ksp-avc",
+    "x_netkan_epoch" : 1,
+    "x_netkan_version_edit": "^[vV]?(?<version>.+)$",
     "license"        : "CC-BY-NC-SA-3.0",
     "depends" : [
         {   "name" : "ModuleManager" },


### PR DESCRIPTION
TACLS has changed hands a couple of times this year, and as a result the versioning for it is a bit of a mess. A quick grep of my up-to-date registry.json shows these versions:

* "v0.12.2"
* "v0.12.1"
* "v0.12.0"
* "v0.11.3"
* "V0.12.3" (note capitalised V)
* "0.12.2"
* "0.12.1"

The most recent release was V0.12.3 a few days ago, but it's getting put well down the ordered version list.

At this point I figured the best approach is to just increase the epoch and strip the V from the start. But would be happy to be corrected.

Bonus sly change: Added current author to authors field.