### PR TITLE
Update and rename CoatlAerospace.netkan to ProbesPlus.netkan

### DIFF
--- a/NetKAN/ProbesPlus.netkan
+++ b/NetKAN/ProbesPlus.netkan
@@ -1,14 +1,14 @@
 {
-	"spec_version": 1,
-	"identifier": "CoatlAerospace",
+	"spec_version": 0.14,
+	"identifier": "ProbesPlus",
 	"$kref": "#/ckan/spacedock/768",
 	"license": "CC-BY-NC-SA-4.0",
-	"ksp_version": "1.1.2",
+	"ksp_version": "1.1.3",
 	"resources": {"homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/131145-wip-coatl-aerospace-probesplus-dev-thread-v013-beta-61316/",
 				"repository": "https://github.com/raveloda/Coatl-Aerospace"},
 	"depends": [{"name": "DMagicScienceAnimate"},
 		{"name": "DMagicOrbitalScience"},
-		{"name": "ModuleManager"}],
+		{"name": "ModuleManager"}{"name": "Firespitter"}],
 	"suggests": [{"name": "AntennaRange"}, {"name": "RemoteTech"}, {"name": "TweakScale"}],
 	"install": [{"file": "GameData/Coatl Aerospace",
 		"install_to": "GameData"}]

--- a/NetKAN/ProbesPlus.netkan
+++ b/NetKAN/ProbesPlus.netkan
@@ -8,8 +8,13 @@
 				"repository": "https://github.com/raveloda/Coatl-Aerospace"},
 	"depends": [{"name": "DMagicScienceAnimate"},
 		{"name": "DMagicOrbitalScience"},
-		{"name": "ModuleManager"}{"name": "Firespitter"}],
-	"suggests": [{"name": "AntennaRange"}, {"name": "RemoteTech"}, {"name": "TweakScale"}],
+		{"name": "ModuleManager"},
+		{"name": "Firespitter"}],
+	"suggests": [{"name": "AntennaRange"},
+		{"name": "RemoteTech"},
+		{"name": "TweakScale"},
+		("name": "BluedogDB")],
 	"install": [{"file": "GameData/Coatl Aerospace",
 		"install_to": "GameData"}]
+	"conflicts": [{ "name": "CoatlAerospace" }],
 }

--- a/NetKAN/ProbesPlus.netkan
+++ b/NetKAN/ProbesPlus.netkan
@@ -1,9 +1,8 @@
 {
-	"spec_version": 0.14,
+	"spec_version": 1,
 	"identifier": "ProbesPlus",
 	"$kref": "#/ckan/spacedock/768",
 	"license": "CC-BY-NC-SA-4.0",
-	"ksp_version": "1.1.3",
 	"resources": {"homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/131145-wip-coatl-aerospace-probesplus-dev-thread-v013-beta-61316/",
 				"repository": "https://github.com/raveloda/Coatl-Aerospace"},
 	"depends": [{"name": "DMagicScienceAnimate"},
@@ -13,8 +12,8 @@
 	"suggests": [{"name": "AntennaRange"},
 		{"name": "RemoteTech"},
 		{"name": "TweakScale"},
-		("name": "BluedogDB")],
+		{"name": "BluedogDB"}],
 	"install": [{"file": "GameData/Coatl Aerospace",
-		"install_to": "GameData"}]
-	"conflicts": [{ "name": "CoatlAerospace" }],
+		"install_to": "GameData"}],
+	"conflicts": [{ "name": "CoatlAerospace" }]
 }


### PR DESCRIPTION
I looked at the guide and I hope I have the right changes to reflect the change of my mod to the new released version 0.14 . I'd appreciate if someone can help me get my mod updated, or just proofread my code chage. I suggest the name change to "ProbesPlus" because "Coatl Aerospace" is the name of the in-game company for my mods, whereas ProbesPlus is the mod name.

Also, the mod now has a Firespitter dependency. I also don't know what to put in the code to make "Bluedog Design Bureau" a suggested mod. I'll read the guide again.