### PR TITLE
Add KSP version override for ABLaunchers

### DIFF
--- a/NetKAN/ABLaunchers.netkan
+++ b/NetKAN/ABLaunchers.netkan
@@ -8,5 +8,15 @@
             "find"       : "GameData/AB_Launchers",
             "install_to" : "GameData"
         }
+    ],
+    "x_netkan_override": [
+        {
+            "version": "1.2",
+            "delete": [ "ksp_version" ],
+            "override": {
+                "ksp_version_min" : "1.1.0",
+                "ksp_version_max" : "1.1.99"
+            }
+        }
     ]
 }


### PR DESCRIPTION
Forum thread describes the current release as being ok for all of KSP 1.1
Will fix dependency required by #4599 