### PR TITLE
Update CrowdSourcedScience to be 1.1.x-compatible

### DIFF
--- a/NetKAN/CrowdSourcedScience.netkan
+++ b/NetKAN/CrowdSourcedScience.netkan
@@ -9,7 +9,8 @@
     "abstract"     : "Provides a nearly inexhaustible supply of science reports in Kerbal Space Program",
     "author"       : "DuoDex",
     "license"      : "CC-BY-NC-SA-4.0",
-    "ksp_version"  : "1.1.2",
+    "ksp_version_min": "1.0.2",
+    "ksp_version_max": "1.1.99",
     "release_status" : "stable",
     "depends" : [
         { "name" : "ModuleManager" }


### PR DESCRIPTION
As CrowdSourcedScience is bascially compatible with almost all versions of KSP, this fix should be safe. According to the changelog this is 1.0.2 until 1.1.x

See also DuoDex/CrowdSourcedScience#49 .