### PR TITLE
RN updated for ksp 1.2

### DIFF
--- a/NetKAN/AntaresCygnus.netkan
+++ b/NetKAN/AntaresCygnus.netkan
@@ -5,14 +5,14 @@
     "name"          : "Antares-Cygnus",
     "author"        : ["Raidernick","Kartoffelkuchen"],
     "abstract"      : "A joint release between Kartoffelkuchen and Raidernick combining our Cygnus and Antares mods.",
-    "comment"       : "Ships explicitly not installed by author request (he no longer maintains them)",
+    "comment"       : "Ships are installed by default again",
     "resources": {
         "homepage"  : "http://forum.kerbalspaceprogram.com/threads/123578"
     },
     "$kref"         : "#/ckan/github/KSP-RO/Antares-Cygnus",
     "license"       : "CC-BY-NC-ND-3.0",
     "ksp_version_min"   : "1.1.1",
-    "ksp_version_max"   : "1.1.3",
+    "ksp_version_max"   : "1.2",
     "install"       : [
     {
         "find"      : "KK_Antares",

--- a/NetKAN/RN-MiscParts.netkan
+++ b/NetKAN/RN-MiscParts.netkan
@@ -11,7 +11,7 @@
     "$kref"         : "#/ckan/github/KSP-RO/RNMisc",
     "license"       : "CC-BY-NC-ND-3.0",
     "ksp_version_min"   : "1.1.1",
-    "ksp_version_max"   : "1.1.3",
+    "ksp_version_max"   : "1.2",
     "install"       :
     [
       {

--- a/NetKAN/RN-SPP.netkan
+++ b/NetKAN/RN-SPP.netkan
@@ -11,7 +11,7 @@
     "$kref"         : "#/ckan/github/KSP-RO/USSovietSolarPanelsPack",
     "license"       : "CC-BY-NC-ND-3.0",
     "ksp_version_min"   : "1.1.1",
-    "ksp_version_max"   : "1.1.3",
+    "ksp_version_max"   : "1.2",
     "install"       :
     [
       {

--- a/NetKAN/RN-SalyutStations.netkan
+++ b/NetKAN/RN-SalyutStations.netkan
@@ -11,7 +11,7 @@
     "$kref"         : "#/ckan/github/KSP-RO/SalyutStations",
     "license"       : "CC-BY-NC-ND-3.0",
     "ksp_version_min"   : "1.1.1",
-    "ksp_version_max"   : "1.1.3",
+    "ksp_version_max"   : "1.2",
     "install"       : [
     {
         "find"      : "RN_Salyut",
@@ -25,7 +25,7 @@
         { "name"    : "RN-SalyutStations-SoyuzFerries" }
     ],
     "depends"       : [
-        { "name"      : "FirespitterCore"  },
+        { "name"      : "BDAnimationModules"  },
 		{ "name" 	  : "ModuleManager" },
         { "name"      : "TextureReplacer" }
     ],

--- a/NetKAN/RN-SalyutStations.netkan
+++ b/NetKAN/RN-SalyutStations.netkan
@@ -10,7 +10,7 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/SalyutStations",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.1.1",
+    "ksp_version_min"   : "1.2",
     "ksp_version_max"   : "1.2",
     "install"       : [
     {

--- a/NetKAN/RN-Skylab.netkan
+++ b/NetKAN/RN-Skylab.netkan
@@ -4,7 +4,7 @@
     "name"          : "Skylab",
     "author"        : "Raidernick",
     "abstract"      : "This mod comes with everything you need to create your own Skylab, broken solar panels and all!",
-    "comment"       : "Ships explicitly not installed by author request (he no longer maintains them)",
+    "comment"       : "Ships installed again, updated",
     "resources":
     {
         "homepage"  : "http://forum.kerbalspaceprogram.com/threads/86243"
@@ -12,17 +12,20 @@
     "$kref"         : "#/ckan/github/KSP-RO/Skylab",
     "license"       : "CC-BY-NC-ND-3.0",
     "ksp_version_min"   : "1.1.1",
-    "ksp_version_max"   : "1.1.3",
+    "ksp_version_max"   : "1.2",
     "install"       :
     [
       {
         "find"      : "RN_Skylab",
         "install_to": "GameData"
-      }
-    ],
+      },
+    {
+        "file"      : "Ships/VAB",
+        "install_to": "Ships"
+    }],
     "depends"       :
     [
-      { "name"      : "FirespitterCore" },
+      { "name"      : "BDAnimationModules" },
 	  { "name" 	  : "ModuleManager" }
     ]
 }

--- a/NetKAN/RN-Skylab.netkan
+++ b/NetKAN/RN-Skylab.netkan
@@ -11,7 +11,7 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/Skylab",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.1.1",
+    "ksp_version_min"   : "1.2",
     "ksp_version_max"   : "1.2",
     "install"       :
     [

--- a/NetKAN/RN-SovietProbes.netkan
+++ b/NetKAN/RN-SovietProbes.netkan
@@ -11,7 +11,7 @@
     "$kref"         : "#/ckan/github/KSP-RO/SovietProbes",
     "license"       : "CC-BY-NC-ND-3.0",
     "ksp_version_min"   : "1.1.1",
-    "ksp_version_max"   : "1.1.3",
+    "ksp_version_max"   : "1.2",
     "install"       : [
     {
         "find"      : "RN_Soviet_Probes",
@@ -22,7 +22,7 @@
         "install_to": "Ships"
     }],
     "depends"       : [
-        { "name"      : "FirespitterCore"  },
+        { "name"      : "BDAnimationModules"  },
 		{ "name" 	  : "ModuleManager" },
         { "name"      : "TextureReplacer" }
     ],

--- a/NetKAN/RN-SovietProbes.netkan
+++ b/NetKAN/RN-SovietProbes.netkan
@@ -10,7 +10,7 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/SovietProbes",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.1.1",
+    "ksp_version_min"   : "1.2",
     "ksp_version_max"   : "1.2",
     "install"       : [
     {

--- a/NetKAN/RN-SovietRockets.netkan
+++ b/NetKAN/RN-SovietRockets.netkan
@@ -10,7 +10,7 @@
     "$kref"         : "#/ckan/github/KSP-RO/SovietRockets",
     "license"       : "CC-BY-NC-ND-3.0",
     "ksp_version_min"   : "1.1.1",
-    "ksp_version_max"   : "1.1.3",
+    "ksp_version_max"   : "1.2",
     "x_netkan_epoch": "1",
     "install"       : [
     {
@@ -23,7 +23,6 @@
     "depends"       :
     [
 		{ "name"    : "BDAnimationModules" },
-        { "name"    : "FirespitterCore"  },
 		{ "name" 	  : "ModuleManager" },
         { "name"    : "TextureReplacer" }
     ],

--- a/NetKAN/RN-SovietRockets.netkan
+++ b/NetKAN/RN-SovietRockets.netkan
@@ -9,7 +9,7 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/SovietRockets",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.1.1",
+    "ksp_version_min"   : "1.2",
     "ksp_version_max"   : "1.2",
     "x_netkan_epoch": "1",
     "install"       : [

--- a/NetKAN/RN-SovietSpacecraft.netkan
+++ b/NetKAN/RN-SovietSpacecraft.netkan
@@ -11,7 +11,7 @@
     "$kref"         : "#/ckan/github/KSP-RO/SovietSpacecraft",
     "license"       : "CC-BY-NC-ND-3.0",
     "ksp_version_min"   : "1.1.1",
-    "ksp_version_max"   : "1.1.3",
+    "ksp_version_max"   : "1.2",
     "install"       : [
     {
         "find"      : "RN_Soyuz",
@@ -25,8 +25,7 @@
         { "name"    : "RN-SalyutStations-SoyuzFerries" }
     ],
     "depends"       : [
-		{ "name"	  : "AnimatedDecouplers" },
-        { "name"      : "FirespitterCore"  },
+		{ "name"	  : "BDAnimationModules" },
 		{ "name" 	  : "ModuleManager" },
         { "name"      : "TextureReplacer" }
     ],

--- a/NetKAN/RN-SovietSpacecraft.netkan
+++ b/NetKAN/RN-SovietSpacecraft.netkan
@@ -10,7 +10,7 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/SovietSpacecraft",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.1.1",
+    "ksp_version_min"   : "1.2",
     "ksp_version_max"   : "1.2",
     "install"       : [
     {

--- a/NetKAN/RN-USProbesPack.netkan
+++ b/NetKAN/RN-USProbesPack.netkan
@@ -4,14 +4,14 @@
     "name"          : "US Probes Pack",
     "author"        : "Raidernick",
     "abstract"      : "This pack will include pretty much all probes ever launched by NASA and the US military. It is a long term project and I will be adding to it slowly over time.",
-    "comment"       : "Ships explicitly not installed by author request (he no longer maintains them)",
+    "comment"       : "Ships installed again",
     "resources": {
         "homepage"  : "http://forum.kerbalspaceprogram.com/threads/93389"
     },
     "$kref"         : "#/ckan/github/KSP-RO/USProbesPack",
     "license"       : "CC-BY-NC-ND-3.0",
     "ksp_version_min"   : "1.1.1",
-    "ksp_version_max"   : "1.1.3",
+    "ksp_version_max"   : "1.2",
     "install"       :
     [
       {
@@ -26,8 +26,6 @@
     "depends": [
         { "name": "BDAnimationModules" },
         { "name": "TextureReplacer" },
-        { "name": "FirespitterCore" },
-		{ "name": "ModuleManager" },
-        { "name": "SmokeScreen" }
+		{ "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/RN-USProbesPack.netkan
+++ b/NetKAN/RN-USProbesPack.netkan
@@ -10,7 +10,7 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/USProbesPack",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.1.1",
+    "ksp_version_min"   : "1.2",
     "ksp_version_max"   : "1.2",
     "install"       :
     [

--- a/NetKAN/RN-USProbesPack.netkan
+++ b/NetKAN/RN-USProbesPack.netkan
@@ -27,7 +27,7 @@
         { "name": "BDAnimationModules" },
         { "name": "TextureReplacer" },
 		{ "name": "ModuleManager" }
-    ]
+    ],
 	"recommends"    :
     [
         { "name"    : "RN-USRockets" }

--- a/NetKAN/RN-USProbesPack.netkan
+++ b/NetKAN/RN-USProbesPack.netkan
@@ -28,4 +28,8 @@
         { "name": "TextureReplacer" },
 		{ "name": "ModuleManager" }
     ]
+	"recommends"    :
+    [
+        { "name"    : "RN-USRockets" }
+    ]
 }

--- a/NetKAN/RN-USRockets.netkan
+++ b/NetKAN/RN-USRockets.netkan
@@ -10,7 +10,7 @@
     "$kref"         : "#/ckan/github/KSP-RO/USRockets",
     "license"       : "CC-BY-NC-ND-3.0",
     "ksp_version_min"   : "1.1.1",
-    "ksp_version_max"   : "1.1.3",
+    "ksp_version_max"   : "1.2",
     "install"       : [
     {
         "find"      : "RN_US_Rockets",
@@ -21,7 +21,7 @@
         "install_to": "Ships"
     }],
     "depends": [
-		{ "name": "AnimatedDecouplers" },
+		{ "name": "BDAnimationModules" },
         { "name": "TextureReplacer" },
 		{ "name": "ModuleManager" },
         { "name": "SmokeScreen" }

--- a/NetKAN/RN-USRockets.netkan
+++ b/NetKAN/RN-USRockets.netkan
@@ -9,7 +9,7 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/USRockets",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.1.1",
+    "ksp_version_min"   : "1.2",
     "ksp_version_max"   : "1.2",
     "install"       : [
     {

--- a/NetKAN/RN-USRockets.netkan
+++ b/NetKAN/RN-USRockets.netkan
@@ -23,7 +23,11 @@
     "depends": [
 		{ "name": "BDAnimationModules" },
         { "name": "TextureReplacer" },
-		{ "name": "ModuleManager" },
-        { "name": "SmokeScreen" }
+		{ "name": "ModuleManager" }
+    ],
+	"recommends"    :
+    [
+        { "name"    : "SmokeScreen" },
+        { "name"    : "RN-USProbesPack" }
     ]
 }

--- a/NetKAN/TextureReplacer.netkan
+++ b/NetKAN/TextureReplacer.netkan
@@ -1,24 +1,24 @@
 {
     "spec_version" : 1,
     "identifier"   : "TextureReplacer",
-    "$kref"        : "#/ckan/github/ducakar/TextureReplacer",
+    "$kref"        : "#/ckan/github/RangeMachine/TextureReplacer",
     "$vref"        : "#/ckan/ksp-avc",
     "license"      : "CC-BY-NC-SA-4.0",
     "name"         : "TextureReplacer",
     "abstract"     : "Kerbal personalisation, IVA suits on Kerbin and texture replacement and improvements.",
-    "author"       : "shaw",
-    "comment"      : "Plugin is MIT, but some parts CC-BY-NC-SA, and we always specify most restrictive in metadata.",
+    "author"       : [ "shaw", "RangeMachine" ],
+    "comment"      : "Plugin is MIT, but some parts CC-BY-NC-SA, and we always specify most restrictive in metadata. Temporarily moved to maintainer's git until such a time as OP is not MIA.",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/threads/107471",
-        "repository": "https://github.com/ducakar/TextureReplacer"
+        "repository": "https://github.com/RangeMachine/TextureReplacer"
     },
     "x_netkan_override" : [
         {
-            "version" : "v2.4.13",
+            "version" : "v2.5.0",
             "delete" : [ "ksp_version" ],
             "override" : {
-                "ksp_version_min" : "1.1.0",
-                "ksp_version_max" : "1.1.3"
+                "ksp_version_min" : "1.2",
+                "ksp_version_max" : "1.2"
             }
         }
     ]


### PR DESCRIPTION
-Update all mods for ksp 1.2
-Removed all unneeded dependencies, I now only use bahaSP and sometimes
texture replacer for my mods. Firespitter and animated dec are no longer
needed.
- Updated all craft files so they can be installed by default again