### PR TITLE
Scatterer Sunflare configuration has moved

### DIFF
--- a/NetKAN/AstronikiSunflareforScatterer.netkan
+++ b/NetKAN/AstronikiSunflareforScatterer.netkan
@@ -12,8 +12,8 @@
     ],
     "install": [
         {
-            "find"       : "sunflare",
-            "install_to" : "GameData/scatterer"
+            "find"       : "Sunflares",
+            "install_to" : "GameData/scatterer/config"
         }
     ]
 }

--- a/NetKAN/Scatterer-sunflare.netkan
+++ b/NetKAN/Scatterer-sunflare.netkan
@@ -13,8 +13,8 @@
     ],
     "install": [
         {
-            "find"       : "sunflare",
-            "install_to" : "GameData/scatterer"
+            "find"       : "Sunflares",
+            "install_to" : "GameData/scatterer/config"
         }
     ]
 }

--- a/NetKAN/Scatterer.netkan
+++ b/NetKAN/Scatterer.netkan
@@ -16,7 +16,7 @@
         {
             "find"       : "scatterer",
             "install_to" : "GameData",
-            "filter"     : "sunflare"
+            "filter"     : "Sunflares"
         }
     ]
 }


### PR DESCRIPTION
SVE Sunflare was fixed in #4712, but the original and Astroniki are broken. 
Scatterer users will likely have to uninstall/reinstall to move file ownership.