### PR TITLE
ShipEffects update 1 of 2

### DIFF
--- a/NetKAN/ShipEffects.netkan
+++ b/NetKAN/ShipEffects.netkan
@@ -7,7 +7,7 @@
     "license": "CC-BY-NC-SA-4.0",
     "release_status": "stable",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/132289-1-0-4-ShipEffects-Sound-Mod-Dynamic-Sound-Effects-(Maintenance)-v1-0-1-08-23-2015",
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/132289-1-0-4-ShipEffects-Sound-Mod-Dynamic-Sound-Effects-(Maintenance)-v1-0-1-08-23-2015"
     },
     "version": "1.0.5",
     "ksp_version_min": "1.0.4",

--- a/NetKAN/ShipEffects.netkan
+++ b/NetKAN/ShipEffects.netkan
@@ -1,0 +1,24 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "ShipEffects",
+    "name": "ShipEffects-Sound-Mod: Dynamic Sound Effects (Maintenance)",
+    "abstract": "Dynamic IVA Sound Effects, add drama to your IVAs and hear your ship's fuselage Shake, Rattle and Rumble!",
+    "author": [ "ensouensou", "CoriW", "Fwiffo"],
+    "license": "CC-BY-NC-SA-4.0",
+    "release_status": "stable",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/threads/132289-1-0-4-ShipEffects-Sound-Mod-Dynamic-Sound-Effects-(Maintenance)-v1-0-1-08-23-2015",
+    },
+    "version": "1.0.5",
+    "ksp_version_min": "1.0.4",
+    "ksp_version_max": "1.1.99",
+    "install": [
+        {
+            "find": "ShipEffects",
+            "install_to": "GameData",
+            "filter": "Source"
+        }
+    ],
+    "download": "https://rawgit.com/rkagerer/KSP-Fwiffo-Repository/master/Mods/ShipEffects/ShipEffects-Sound-Mod-1.0.5.zip",
+    "x_generated_by": "Fwiffo"
+}

--- a/NetKAN/ShipEffects.netkan
+++ b/NetKAN/ShipEffects.netkan
@@ -1,24 +1,5 @@
 {
-    "spec_version": "v1.4",
-    "identifier": "ShipEffects",
-    "name": "ShipEffects-Sound-Mod: Dynamic Sound Effects (Maintenance)",
-    "abstract": "Dynamic IVA Sound Effects, add drama to your IVAs and hear your ship's fuselage Shake, Rattle and Rumble!",
-    "author": [ "ensouensou", "CoriW", "Fwiffo"],
-    "license": "CC-BY-NC-SA-4.0",
-    "release_status": "stable",
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/132289-1-0-4-ShipEffects-Sound-Mod-Dynamic-Sound-Effects-(Maintenance)-v1-0-1-08-23-2015"
-    },
-    "version": "1.0.5",
-    "ksp_version_min": "1.0.4",
-    "ksp_version_max": "1.1.99",
-    "install": [
-        {
-            "find": "ShipEffects",
-            "install_to": "GameData",
-            "filter": "Source"
-        }
-    ],
-    "download": "https://rawgit.com/rkagerer/KSP-Fwiffo-Repository/master/Mods/ShipEffects/ShipEffects-Sound-Mod-1.0.5.zip",
-    "x_generated_by": "Fwiffo"
+    "spec_version"   : "v1.4",
+    "identifier"     : "ShipEffects",
+    "$kref"          : "#/ckan/netkan/https://raw.githubusercontent.com/rkagerer/KSP-Fwiffo-Repository/master/CKAN-meta-fwiffo/ShipEffects/ShipEffects-1.0.5.ckan"
 }

--- a/NetKAN/ShipEffects.netkan
+++ b/NetKAN/ShipEffects.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version"   : "v1.4",
-    "identifier"     : "ShipEffects",
-    "$kref"          : "#/ckan/netkan/https://raw.githubusercontent.com/rkagerer/KSP-Fwiffo-Repository/master/CKAN-meta-fwiffo/ShipEffects/ShipEffects-1.0.5.ckan"
+    "spec_version"   :  "v1.4",
+    "identifier"     :  "ShipEffects",
+    "$kref"          :  "#/ckan/netkan/https://raw.githubusercontent.com/rkagerer/KSP-Fwiffo-Repository/master/CKAN-meta-fwiffo/ShipEffects/ShipEffects-1.0.5.ckan"
 }


### PR DESCRIPTION
This is a NetKAN file for a KSP-1.1.3 compatible ShipEffects that is newer than the one presently in the repository.

I am hoping this pull request generates CKAN-meta/ShipEffects/ShipEffects-1.0.5.ckan

After it has been picked up I will do another PR with a new version of ShipEffects.netkan to generate CKAN-meta/ShipEffects/ShipEffects-1.0.7.ckan which is for KSP 1.2.

Confused yet?  I am.