### PR TITLE
Revert SVE to old regex

### DIFF
--- a/NetKAN/SVE-HighResolution.netkan
+++ b/NetKAN/SVE-HighResolution.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version"   : "v1.4",
-    "$kref"          : "#/ckan/github/Galileo88/StockVisualEnhancements/asset_match/SVE\\.HR\\.1\\.1",
-    "$vref"          : "#/ckan/ksp-avc/SVE HR 1.1.1/StockVisualEnhancements.version",
+    "$kref"          : "#/ckan/github/Galileo88/StockVisualEnhancements/asset_match/SVE.HR.*.zip",
+    "$vref"          : "#/ckan/ksp-avc/SVE HR 1.1.2/GameData/StockVisualEnhancements/StockVisualEnhancements.version",
     "identifier"     : "SVE-HighResolution",
     "abstract"       : "A visual enhancement pack using EVE and Scatterer for the stock planets. ",
     "license"        : "CC-BY-NC-SA",

--- a/NetKAN/SVE-LowResolution.netkan
+++ b/NetKAN/SVE-LowResolution.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version"   : "v1.4",
-    "$kref"          : "#/ckan/github/Galileo88/StockVisualEnhancements/asset_match/SVE\\.LR\\.1\\.1",
-    "$vref"          : "#/ckan/ksp-avc/SVE LR 1.1.1/StockVisualEnhancements.version",
+    "$kref"          : "#/ckan/github/Galileo88/StockVisualEnhancements/asset_match/SVE.LR.*.zip",
+    "$vref"          : "#/ckan/ksp-avc/SVE LR 1.1.2/GameData/StockVisualEnhancements/StockVisualEnhancements.version",
     "identifier"     : "SVE-LowResolution",
     "abstract"       : "A visual enhancement pack using EVE and Scatterer for the stock planets. ",
     "license"        : "CC-BY-NC-SA",

--- a/NetKAN/SVE-MediumResolution.netkan
+++ b/NetKAN/SVE-MediumResolution.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version"   : "v1.4",
-    "$kref"          : "#/ckan/github/Galileo88/StockVisualEnhancements/asset_match/SVE\\.MR\\.1\\.1",
-    "$vref"          : "#/ckan/ksp-avc/SVE MR 1.1.1/StockVisualEnhancements.version",
+    "$kref"          : "#/ckan/github/Galileo88/StockVisualEnhancements/asset_match/SVE.MR.*.zip",
+    "$vref"          : "#/ckan/ksp-avc/SVE MR 1.1.2/GameData/StockVisualEnhancements/StockVisualEnhancements.version",
     "identifier"     : "SVE-MediumResolution",
     "abstract"       : "A visual enhancement pack using EVE and Scatterer for the stock planets. ",
     "license"        : "CC-BY-NC-SA",

--- a/NetKAN/SVE-Sunflare.netkan
+++ b/NetKAN/SVE-Sunflare.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version"   : "v1.10",
-    "$kref"          : "#/ckan/github/Galileo88/StockVisualEnhancements/asset_match/SVE\\.LR\\.1\\.1",
-    "$vref"          : "#/ckan/ksp-avc/SVE LR 1.1.1/StockVisualEnhancements.version",
+    "$kref"          : "#/ckan/github/Galileo88/StockVisualEnhancements/asset_match/SVE.LR.*.zip",
+    "$vref"          : "#/ckan/ksp-avc/SVE LR 1.1.2/GameData/StockVisualEnhancements/StockVisualEnhancements.version",
     "identifier"     : "SVE-Sunflare",
     "abstract"       : "A visual enhancement pack using EVE and Scatterer for the stock planets. ",
     "name"           : "Stock Visual Enhancements: Sunflare",


### PR DESCRIPTION
Switched back to the old kref regex.

Question: Is there a way to include regex inside a vref, because with this way we'll always need update it with every release. If it isn't possible, I'll switch back to using `ksp_version`.