### PR TITLE
Change IndicatorLightsCommunityExtensions relationships from recommends to supports

### DIFF
--- a/NetKAN/IndicatorLightsCommunityExtensions.netkan
+++ b/NetKAN/IndicatorLightsCommunityExtensions.netkan
@@ -6,7 +6,7 @@
     "depends": [
         { "name": "IndicatorLights" }
     ],
-    "recommends": [
+    "supports": [
         { "name": "VenStockRevamp" },
         { "name": "ImpossibleInnovations" }
     ]


### PR DESCRIPTION
I think `supports` is the more appropriate relationship here over `recommends` since users installing this mod may not even care or be interested in any of the mods it supports except maybe one or two. It's basically a set of compatibility patches, it doesn't encourage using any particular mod.