### PR TITLE
Remove suggested mod from Kopernicus.netkan

### DIFF
--- a/NetKAN/Kopernicus.netkan
+++ b/NetKAN/Kopernicus.netkan
@@ -25,9 +25,6 @@
         { "name": "ModuleManager", "min_version": "2.6.16" },
         { "name": "ModularFlightIntegrator" }
     ],
-    "suggests": [
-        { "name": "KittopiaTech" }
-    ],
     "install": [
         {
             "find"      : "Kopernicus",


### PR DESCRIPTION
KittopiaTech is discontinued and out of date. Removing suggestion from code.