### PR TITLE
IXSWarpshipOS not showing up in CKAN client

### DIFF
--- a/NetKAN/IXSWarpshipOS.netkan
+++ b/NetKAN/IXSWarpshipOS.netkan
@@ -4,11 +4,19 @@
     "$kref": "#/ckan/spacedock/589",
     "spec_version": "v1.4",
     "depends": [
-        { "name": "AlcubierreStandalone" }
+        { "name": "AlcubierreStandalone" },
+        { "name": "CommunityResourcePack" }
+    ],
+    "suggests": [
+    	{ "name": "SpaceDock" }
+    ],
+    "conflicts": [
+        { "name": "WarpShip" },
+        { "name": "KSPInterstellarExtended" }
     ],
     "install": [
         {
-            "find"       : "WarpShip",
+            "find"       : "IXSWarpShipOS",
             "install_to" : "GameData",
             "filter"     : ".DS_Store"
         }


### PR DESCRIPTION
IXS Warpship OS was not showing up in CKAN anymore. I suspect because it uses the same directory name as its predecessor (Sofia's Warpship mod). Took the opportunity to update dependencies and add KSPInterstellarExtended and the preceding Warpship mod as a conflict.

Summary of the changes:
- Changed mod's directory to be different from its predecessor's (Sofia's Warpship mod)
- Added predecessor's mod as conflicting
- Added KSP Interstellar Extended mod as conflicting, it uses same DLL references.
- Added Fendrin's Spacedock mod as suggestion after removing purely structural spacedock parts from IXSWarpshipOS
- Added Community Resource Pack as a dependency