### PR TITLE
Future Weapons - remove BDArmory version

### DIFF
--- a/NetKAN/FutureParts.netkan
+++ b/NetKAN/FutureParts.netkan
@@ -4,7 +4,7 @@
     "license": "CC-BY-SA-2.0",
     "identifier": "FutureParts",
     "depends": [
-        { "name": "BDArmory", "min_version": "v0.9.9.1" }
+        { "name": "BDArmory" }
     ],
     "install": [
         {


### PR DESCRIPTION
KSP version compatibilities make the restriction unnecessary.
closes #4898