### PR TITLE
remove epoch again

### DIFF
--- a/NetKAN/GravityTurnContinued.netkan
+++ b/NetKAN/GravityTurnContinued.netkan
@@ -7,7 +7,6 @@
     "abstract": "Automated highly efficient launches",
     "ksp_version": "1.2",
     "license": "GPL-3.0",
-    "x_netkan_epoch": 1,
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/148448-12161-gravityturn-continued-automated-efficient-launches/",
         "repository": "https://github.com/AndyMt/GravityTurn/"


### PR DESCRIPTION
Unintentionally used a "V" prefix in version 1.7.1.
Latest Version 1.7.2 doesn't have it as "most" earlier versions.
I promise to not use a "V" prefix again.