### PR TITLE
Remove dependeny from NearFutureSpacecraft.netkan

### DIFF
--- a/NetKAN/NearFutureSpacecraft.netkan
+++ b/NetKAN/NearFutureSpacecraft.netkan
@@ -4,9 +4,6 @@
     "$kref": "#/ckan/spacedock/708",
     "$vref": "#/ckan/ksp-avc",
     "license": "CC-BY-NC-SA-4.0",
-    "depends":  [
-        { "name" : "NearFutureProps" }
-    ],
     "suggests" : [
         { "name" : "CommunityTechTree" },
         { "name" : "NearFutureConstruction" },


### PR DESCRIPTION
The current version of NearFutureSpacecraft does not seem to rely on this dependency. It runs without installing NearFutureProps, which is not current.