### PR TITLE
Update PlanetWiki-OPM.netkan

### DIFF
--- a/NetKAN/PlanetWiki-OPM.netkan
+++ b/NetKAN/PlanetWiki-OPM.netkan
@@ -6,8 +6,6 @@
     "depends": [
         { "name": "OuterPlanetsMod" }
     ],
-    "ksp_version_min": "1.1.0",
-    "ksp_version_max": "1.1.99",
     "x_netkan_staging": true,
     "comment": "Staging turned on to check overridden KSP version",
     "install": [


### PR DESCRIPTION
Removed max and min KSP versions since this mod has been updated to KSP version 1.2.1. Removing these restrictions will allow this mod to update automatically. PlanetWiki.netkan does not have these restrictions, so it can update on its own.