### PR TITLE
Update SimpleConstruction.netkan

### DIFF
--- a/NetKAN/SimpleConstruction.netkan
+++ b/NetKAN/SimpleConstruction.netkan
@@ -19,11 +19,11 @@
     "install" : [
         {
             "find": "SimpleConstruction",
-            "install_to": "GameData",
+            "install_to": "GameData"
         },
         {
             "find": "ExtraplanetaryLaunchpads",
-            "install_to": "GameData",
+            "install_to": "GameData"
         }
     ]
 }

--- a/NetKAN/SimpleConstruction.netkan
+++ b/NetKAN/SimpleConstruction.netkan
@@ -3,12 +3,27 @@
     "identifier": "SimpleConstruction",
     "$kref": "#/ckan/spacedock/59",
     "license": "MIT",
-    "x_netkan_epoch": 1,
+    "x_netkan_version_edit": {
+        "find": "[Version_]?",
+        "replace": "",
+        "strict": false
+    },
     "depends": [
         { "name": "ModuleManager" },
         { "name": "InterstellarFuelSwitch-Core" }
     ],
     "conflicts": [
         { "name": "ExtraPlanetaryLaunchpads" }
+    ],
+    "provides"  : [ "ExtraPlanetaryLaunchpads" ],
+    "install" : [
+        {
+            "find": "SimpleConstruction",
+            "install_to": "GameData",
+        },
+        {
+            "find": "ExtraplanetaryLaunchpads",
+            "install_to": "GameData",
+        }
     ]
 }

--- a/NetKAN/SimpleConstruction.netkan
+++ b/NetKAN/SimpleConstruction.netkan
@@ -2,20 +2,12 @@
     "spec_version": "v1.4",
     "identifier": "SimpleConstruction",
     "$kref": "#/ckan/spacedock/59",
-    "license": "CC-BY-NC-SA-4.0",
-    "x_netkan_force_v": true,
+    "license": "MIT",
     "depends": [
         { "name": "ModuleManager" },
         { "name": "InterstellarFuelSwitch-Core" }
     ],
     "conflicts": [
         { "name": "ExtraPlanetaryLaunchpads" }
-    ],
-    "install": [
-        {
-            "find": "SimpleConstruction",
-            "install_to": "GameData",
-            "filter": [ "Thumbs.db", "InterstellarFuelSwitch.version", "InterstellarFuelSwitch.dll" ]
-        }
     ]
 }

--- a/NetKAN/SimpleConstruction.netkan
+++ b/NetKAN/SimpleConstruction.netkan
@@ -3,6 +3,7 @@
     "identifier": "SimpleConstruction",
     "$kref": "#/ckan/spacedock/59",
     "license": "MIT",
+    "x_netkan_epoch": 1,
     "depends": [
         { "name": "ModuleManager" },
         { "name": "InterstellarFuelSwitch-Core" }


### PR DESCRIPTION
- Updated license
- Removed `x_netkan_force_v` to avoid odd version numbering
- Removed installation directives.