### PR TITLE
Update NSSC.netkan

### DIFF
--- a/NetKAN/NSSC.netkan
+++ b/NetKAN/NSSC.netkan
@@ -19,8 +19,5 @@
      ],
     "recommends"     : [
         {"name" : "KAS"}
-    ],
-    "conflicts": [
-        { "name": "ExtraPlanetaryLaunchpads" }
     ]
 }


### PR DESCRIPTION
I added `"provides"  : [ "ExtraPlanetaryLaunchpads" ]` to SC (#4999) and completely forgot that NSSC has 
```
"conflicts": [
    { "name": "ExtraPlanetaryLaunchpads" }
]
```
So NSSC became incompatible with SimpleConstruction. Fixing it on NSSC side.