### PR TITLE
Update Kopernicus.netkan

### DIFF
--- a/NetKAN/Kopernicus.netkan
+++ b/NetKAN/Kopernicus.netkan
@@ -19,7 +19,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/140580-Kopernicus"
     },
-    "ksp_version": "1.2.1",
+    "ksp_version": "1.2.2",
     "x_netkan_staging": true,
     "depends": [
         { "name": "ModuleManager", "min_version": "2.6.16" },


### PR DESCRIPTION
@techman83 Is staging working correctly? `Kopernicus` has `x_netkan_staging` set to `true` because it has manually specified KSP version information but it seems like the most recent update was automatically [comitted](https://github.com/KSP-CKAN/CKAN-meta/commit/1259de3d40c52e8c297635b7c5c9a930a8ec7512) rather than staged.

@KSP-CKAN/wranglers 

