### PR TITLE
SVE Override broken AVC KSP versions

### DIFF
--- a/NetKAN/SVE-HighResolution.netkan
+++ b/NetKAN/SVE-HighResolution.netkan
@@ -34,5 +34,14 @@
             "find"       : "GameData/StockVisualEnhancements",
             "install_to" : "GameData"
         }
+    ],
+    "x_netkan_override": [
+        {
+            "version": "2:1.1.4",
+            "delete": [ "ksp_version_min", "ksp_version_max" ],
+            "override": {
+                "ksp_version" : "1.2"
+            }
+        }
     ]
 }

--- a/NetKAN/SVE-LowResolution.netkan
+++ b/NetKAN/SVE-LowResolution.netkan
@@ -34,5 +34,14 @@
             "find"       : "GameData/StockVisualEnhancements",
             "install_to" : "GameData"
         }
+    ],
+    "x_netkan_override": [
+        {
+            "version": "2:1.1.4",
+            "delete": [ "ksp_version_min", "ksp_version_max" ],
+            "override": {
+                "ksp_version" : "1.2"
+            }
+        }
     ]
 }

--- a/NetKAN/SVE-MediumResolution.netkan
+++ b/NetKAN/SVE-MediumResolution.netkan
@@ -34,5 +34,14 @@
             "find"       : "GameData/StockVisualEnhancements",
             "install_to" : "GameData"
         }
+    ],
+    "x_netkan_override": [
+        {
+            "version": "2:1.1.4",
+            "delete": [ "ksp_version_min", "ksp_version_max" ],
+            "override": {
+                "ksp_version" : "1.2"
+            }
+        }
     ]
 }


### PR DESCRIPTION
The AVC .version files in the current releases have ksp_min as 1.2 and ksp_max as 1.2.1, so for 1.2.2 we're offering the previous release which has been removed from GitHub. 