### PR TITLE
Specify install folder to omit the license.txt

### DIFF
--- a/NetKAN/HazardTanksTextures.netkan
+++ b/NetKAN/HazardTanksTextures.netkan
@@ -6,8 +6,10 @@
     "spec_version": "v1.4",
     "ksp_version": "any",
     "depends": [
-        { "name": "ProceduralParts" },
         { "name": "VensStylePPTextures" }
+    ],
+    "suggests": [
+            { "name": "ProceduralParts" }
     ],
     "provides": [
         "PPTextures"

--- a/NetKAN/HazardTanksTextures.netkan
+++ b/NetKAN/HazardTanksTextures.netkan
@@ -1,6 +1,7 @@
 {
     "$kref": "#/ckan/spacedock/467",
     "identifier": "HazardTanksTextures",
+    "name": "Procedural Parts - Hazard Tanks Textures",
     "license": "CC-BY-NC-4.0",
     "spec_version": "v1.4",
     "ksp_version": "any",
@@ -13,8 +14,8 @@
      ],
      "install": [
         {
-            "find": "KerbalHacks",
-            "install_to": "GameData",
+            "file"       : "GameData/KerbalHacks/PP_Textures",
+            "install_to" : "GameData/KerbalHacks",
             "filter": "PPVensTankEnds.dds"
         }
     ]


### PR DESCRIPTION
KerbalHacks/license.txt which is included in all my mods was preventing the install if the file existed.