### PR TITLE
Update TacSelfDestructContinued.netkan

### DIFF
--- a/NetKAN/TacSelfDestructContinued.netkan
+++ b/NetKAN/TacSelfDestructContinued.netkan
@@ -9,6 +9,7 @@
   "$vref": "#/ckan/ksp-avc",
   "$kref": "#/ckan/spacedock/1135",
   "x_via": "Automated Linuxgurugamer CKAN script",
+  "x_netkan_epoch": "1",
   "identifier": "TacSelfDestructContinued",
   "license": "CC-BY-NC-SA-3.0"
 }


### PR DESCRIPTION
The last version of this mod was named after its license, versiondata was fetched from SD where it is also named like its license so nothing seems wrong on our side. This will make users get the new corrected version as an update.