### PR TITLE
allow WarpEverywhere on KSP v1.2.x

### DIFF
--- a/NetKAN/WarpEverywhere.netkan
+++ b/NetKAN/WarpEverywhere.netkan
@@ -9,5 +9,7 @@
       "install_to": "GameData"
     }
   ],
+  "ksp_version_min": "1.2.0",
+  "ksp_version_max": "1.2.99",
   "spec_version": "v1.4"
 }


### PR DESCRIPTION
this mod is simple, works on 1.2.0/1.2.1/1.2.2 and is likely to not
need recompiles for patch revs of KSP.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>