### PR TITLE
Add ASET Avionics Community Edition

### DIFF
--- a/NetKAN/ASETAvionics-CE.netkan
+++ b/NetKAN/ASETAvionics-CE.netkan
@@ -1,0 +1,23 @@
+{
+    "spec_version": "v1.4",
+    "identifier"  : "ASETAvionics-CE",
+    "$kref"       : "#/ckan/spacedock/1181",
+    "$vref"       : "#/ckan/ksp-avc/GameData/ASET/ASET_Avionics/ASET_Avionics_CE.version",
+    "license"     : "CC-BY-NC-SA-3.0",
+    "author": [
+        "alexustas",
+        "Olympic1"
+    ],
+    "depends": [
+        { "name": "ASETProps-CE" },
+        { "name": "RasterPropMonitor-Core", "min_version" : "1:v0.28.0" }
+    ],
+    "install": [
+        {
+            "find"       : "ASET",
+            "install_to" : "GameData"
+        }
+    ],
+    "provides": [ "ASETAvionics" ],
+    "conflicts": [ { "name": "ASETAvionics" } ]
+}


### PR DESCRIPTION
Community fixes for ASET Avionics.

The only thing I'm thinking about is the dependency on `ASETProps-CE`. All mods that have dependencies for ASETAvionics also depend on ASETProps. Will this cause issues if we depend directly on the CE version or not.