### PR TITLE
fix mess with HazardTanksTextures and VensStylePPTextures

### DIFF
--- a/NetKAN/HazardTanksTextures.netkan
+++ b/NetKAN/HazardTanksTextures.netkan
@@ -5,11 +5,12 @@
     "license": "CC-BY-NC-4.0",
     "spec_version": "v1.4",
     "ksp_version": "any",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/134889-KerbalHacks"
+    },
     "depends": [
-        { "name": "VensStylePPTextures" }
-    ],
-    "suggests": [
-            { "name": "ProceduralParts" }
+        { "name": "VensStylePPTextures" },
+        { "name": "ProceduralParts" }
     ],
     "provides": [
         "PPTextures"

--- a/NetKAN/VensStylePPTextures.netkan
+++ b/NetKAN/VensStylePPTextures.netkan
@@ -7,7 +7,7 @@
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/index.php?/topic/134889-KerbalHacks"
     },
-    "suggests": [
+    "depends": [
         { "name": "ProceduralParts" }
     ],
     "install": [


### PR DESCRIPTION
Those mods depends on Procedural Parts. I also added missing resource to HazardTanksTextures.

HazardTanksTextures dependency on VensStylePPTextures is hack since both have one common file that should be extracted to separate package. I'm not sure if it's worth a trouble.