### PR TITLE
Update Realistic Atmospheres

### DIFF
--- a/NetKAN/RealisticAtmospheres.netkan
+++ b/NetKAN/RealisticAtmospheres.netkan
@@ -10,6 +10,12 @@
         { "name": "Kopernicus" },
         { "name": "ModuleManager" }
     ],
+    "install": [
+        {
+            "file": "GameData/RealisticAtmospheres",
+            "install_to": "GameData"
+        }
+    ],
     "x_netkan_license_ok": true,
     "x_netkan_override": [
         {


### PR DESCRIPTION
Turns out there's a bug in the automatic `install` directive code that will cause it to fail if there are no files directly under the mod root (in this case `GameData/RealisticAtmospheres`). Explicitly specify the install directive as a workaround until I get that sorted.