### PR TITLE
Path Change - USAFOrion

### DIFF
--- a/NetKAN/NyrathsUSAFOrion.netkan
+++ b/NetKAN/NyrathsUSAFOrion.netkan
@@ -7,7 +7,7 @@
     "$kref"     : "#/ckan/spacedock/73",
     "install"   : [
         {
-            "find"       : "Nyrath",
+            "find"       : "USAFOrion",
             "install_to" : "GameData"
         }
     ],


### PR DESCRIPTION
For reasons I've yet to determine, this mod's plugin fails to work with the existing folder structure.  Fixing the mod required moving it's install location.  Which, from a netkan point of view is a giant pain in the posterior.