### PR TITLE
Create PoodsOPMVO.netkan

### DIFF
--- a/NetKAN/PoodsOPMVO.netkan
+++ b/NetKAN/PoodsOPMVO.netkan
@@ -13,7 +13,7 @@
 		{ "name"     : "Kopernicus", "min_version" : "2:release-1.2.2-5" },
 		{ "name"     : "OuterPlanetsMod", "min_version" : "1:2.1" },
 		{ "name"     : "EnvironmentalVisualEnhancements", "min_version" : "2:EVE-1.2-2" },
-		{ "name"     : "scatterer", "min_version" : "2:v0.0300" }
+		{ "name"     : "Scatterer", "min_version" : "2:v0.0300" }
 	],
 	"install"        : [
 		{ "find"     : "PoodsOPMVO", "install_to" : "GameData" }

--- a/NetKAN/PoodsOPMVO.netkan
+++ b/NetKAN/PoodsOPMVO.netkan
@@ -12,7 +12,7 @@
         { "name"     : "ModuleManager" },
 		{ "name"     : "Kopernicus", "min_version" : "2:release-1.2.2-5" },
 		{ "name"     : "OuterPlanetsMod", "min_version" : "1:2.1" },
-		{ "name"     : "EnvironmentalVisualEnhancements", "min_version" : "2:EVE-1.2.2" },
+		{ "name"     : "EnvironmentalVisualEnhancements", "min_version" : "2:EVE-1.2-2" },
 		{ "name"     : "scatterer", "min_version" : "2:v0.0300" }
 	],
 	"install"        : [

--- a/NetKAN/PoodsOPMVO.netkan
+++ b/NetKAN/PoodsOPMVO.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version"   : 1,
+    "spec_version"   : "v1.4",
     "identifier"     : "PoodsOPMVO",
     "$kref"          : "#/ckan/github/Poodmund/PoodsOPMVO",
     "license"        : "restricted",

--- a/NetKAN/PoodsOPMVO.netkan
+++ b/NetKAN/PoodsOPMVO.netkan
@@ -14,7 +14,10 @@
 		{ "name"     : "OuterPlanetsMod", "min_version" : "1:2.1" },
 		{ "name"     : "EnvironmentalVisualEnhancements", "min_version" : "2:EVE-1.2.2" },
 		{ "name"     : "scatterer", "min_version" : "2:v0.0300" }
-    ],
+	],
+	"install"        : [
+		{ "find"     : "PoodsOPMVO", "install_to" : "GameData" }
+	],
 	"resources"      : {
         "homepage"   : "http://forum.kerbalspaceprogram.com/index.php?/topic/126375-1",
 		"repository" : "https://github.com/Poodmund/PoodsOPMVO/"

--- a/NetKAN/PoodsOPMVO.netkan
+++ b/NetKAN/PoodsOPMVO.netkan
@@ -1,0 +1,22 @@
+{
+    "spec_version"   : 1,
+    "identifier"     : "PoodsOPMVO",
+    "$kref"          : "#/ckan/github/Poodmund/PoodsOPMVO",
+    "license"        : "restricted",
+    "$vref"          : "#/ckan/ksp-avc",
+	"name"           : "Outer Planets Mod - Visual Overhaul",
+	"author"         : "Poodmund",
+	"release_status" : "development",
+	"abstract"       : "Pood's OPM-VO is a graphical overhaul modification for Kerbal Space Program's additional planet/moon mod, Outer Planets Mod, that builds upon the OPM mod by adding additional atmospheric and cloud effects using original artwork.",
+	"depends"        : [
+        { "name"     : "ModuleManager" },
+		{ "name"     : "Kopernicus", "min_version" : "2:release-1.2.2-5" },
+		{ "name"     : "OuterPlanetsMod", "min_version" : "1:2.1" },
+		{ "name"     : "EnvironmentalVisualEnhancements", "min_version" : "2:EVE-1.2.2" },
+		{ "name"     : "scatterer", "min_version" : "2:v0.0300" }
+    ],
+	"resources"      : {
+        "homepage"   : "http://forum.kerbalspaceprogram.com/index.php?/topic/126375-1",
+		"repository" : "https://github.com/Poodmund/PoodsOPMVO/"
+    }
+}


### PR DESCRIPTION
.netkan file for Pood's Outer Planets Mod - Visual Overhaul.

I did notice that the Outer Planets Mod is currently listed as KSP Max Version 1.2.1 and my mod states a requirement of 1.2.2. Outer Planets Mod works fine and is compatible with KSP 1.2.2 and should be updated to reflect this. I will raise a separate issue.