### PR TITLE
Remove RoverDude's merged mods

### DIFF
--- a/NetKAN/KaribouExpeditionRover.netkan
+++ b/NetKAN/KaribouExpeditionRover.netkan
@@ -1,7 +1,0 @@
-
-    {
-        "spec_version" : "v1.16",
-        "identifier" : "KaribouExpeditionRover",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/KaribouExpeditionRover.netkan",
-        "x_netkan_license_ok": true
-    }

--- a/NetKAN/USI-SRV.netkan
+++ b/NetKAN/USI-SRV.netkan
@@ -1,7 +1,0 @@
-
-    {
-        "spec_version" : "v1.16",
-        "identifier" : "USI-SRV",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-SRV.netkan",
-        "x_netkan_license_ok": true
-    }

--- a/NetKAN/USI-SubPack.netkan
+++ b/NetKAN/USI-SubPack.netkan
@@ -1,7 +1,0 @@
-
-    {
-        "spec_version" : "v1.16",
-        "identifier" : "USI-SubPack",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/USI-SubPack.netkan",
-        "x_netkan_license_ok": true
-    }


### PR DESCRIPTION
> Yup!  Sub pack and Srv-Pack are now part of the expedition pack.  KER is now part of MKS.  So those mods should be removed from CKAN.