### PR TITLE
Use regex to find correct kRPC

### DIFF
--- a/NetKAN/kRPC.netkan
+++ b/NetKAN/kRPC.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version" : 1,
     "identifier"   : "kRPC",
-    "$kref"        : "#/ckan/github/krpc/krpc",
+    "$kref"        : "#/ckan/github/krpc/krpc/asset_match/krpc-[0-9]\\.[0-9]\\.[0-9]\\.zip",
     "name"         : "kRPC: Remote Procedure Call Server",
     "abstract"     : "kRPC allows you to control the game from external programs. It comes with client libraries for several popular languages including Python, C++, C#, Java and Lua. Programs communicate with the game over a TCP/IP connection, and can be configured to work on just the local machine or even over the wider internet.",
     "license"      : "GPL-3.0",


### PR DESCRIPTION
Only download the zip with the correct contents. In this case it should download `krpc-0.3.8.zip` and **not** `krpc-python-0.3.8.post1.zip`.

This regex code works, but can it be made simpler?

Fixes #5387