### PR TITLE
Changed "UpgradesUIExtensions" plugin name to "UpgradesGUI"

### DIFF
--- a/NetKAN/UpgradesGUI.netkan
+++ b/NetKAN/UpgradesGUI.netkan
@@ -1,9 +1,9 @@
 {
   "spec_version" : "v1.20",
-  "identifier"   : "UpgradesUIextensions",
+  "identifier"   : "UpgradesGUI",
   "$kref"        : "#/ckan/github/gotmachine/UpgradesUIExtensions",
   "license"      : "Unlicense",
-  "abstract"     : "VAB/SPH & TechTree interface tweaks for modules/part upgrades",
+  "abstract"     : "GUI tweaks to show upgraded stats in VAB/SPH part tooltips. Also allow to customize which upgrades are enabled.",
   "$vref"        : "#/ckan/ksp-avc",
   "resources"    : 
   {

--- a/NetKAN/UpgradesGUI.netkan
+++ b/NetKAN/UpgradesGUI.netkan
@@ -1,6 +1,6 @@
 {
   "spec_version" : "v1.20",
-  "identifier"   : "UpgradesGUI",
+  "identifier"   : "UpgradesUIExtensions",
   "$kref"        : "#/ckan/github/gotmachine/UpgradesUIExtensions",
   "license"      : "Unlicense",
   "abstract"     : "GUI tweaks to show upgraded stats in VAB/SPH part tooltips. Also allow to customize which upgrades are enabled.",


### PR DESCRIPTION
I changed my plugin name (I know, messy idea...) from "UpgradesUIExtensions" to "UpgradesGUI".