### PR TITLE
SSRW 1.12 is a 1.2.x release

### DIFF
--- a/NetKAN/SemiSaturatableRW.netkan
+++ b/NetKAN/SemiSaturatableRW.netkan
@@ -15,5 +15,7 @@
             "file"       : "GameData/RW Saturatable",
             "install_to" : "GameData"
         }
-    ]
+    ],
+    "ksp_version_min": "1.2.0",
+    "ksp_version_max": "1.2.8"
 }


### PR DESCRIPTION
There's one update to SSRW that works on 1.2.x

Set the upper bounds to 1.2.8 since 1.2.9 seems to be the
1.3.0 pre-release, dunno if you care, but 1.2.99 now seems
inappropriate...
