### PR TITLE
Telemachus for KSP 1.2

### DIFF
--- a/NetKAN/Telemachus.netkan
+++ b/NetKAN/Telemachus.netkan
@@ -8,8 +8,8 @@
     "resources"    : {
         "homepage" : "http://forum.kerbalspaceprogram.com/index.php?/topic/22623-104-2015-07-04-telemachus"
     },
-    "ksp_version_min" : "1.0.4",
-    "ksp_version_max" : "1.2",
+    "ksp_version_min" : "1.2.0",
+    "ksp_version_max" : "1.2.2",
     "license"      : "restricted",
     "x_netkan_force_v": true
 }

--- a/NetKAN/Telemachus.netkan
+++ b/NetKAN/Telemachus.netkan
@@ -9,7 +9,7 @@
         "homepage" : "http://forum.kerbalspaceprogram.com/index.php?/topic/22623-104-2015-07-04-telemachus"
     },
     "ksp_version_min" : "1.0.4",
-    "ksp_version_max" : "1.0.5",
+    "ksp_version_max" : "1.2",
     "license"      : "restricted",
     "x_netkan_force_v": true
 }


### PR DESCRIPTION
Hello,

This is my first CKAN metadata change, and I'm not very familiar with CKAN, so it's likely I botched this change :)

The latest [Telemachus versions](https://github.com/KSP-Telemachus/Telemachus/releases) seem to support KSP 1.2. Will this change on `NetKAN` also update existing metadata on `CKAN-meta`? Or will it only be applied to new versions?