### PR TITLE
Proc Parts metadata updates for 1.2.x

### DIFF
--- a/NetKAN/ProceduralParts.netkan
+++ b/NetKAN/ProceduralParts.netkan
@@ -34,8 +34,16 @@
             "version": "v1.1.7",
             "delete" : [ "ksp_version" ],
             "override": {
-                    "ksp_version_min" : "1.0.4",
+                "ksp_version_min" : "1.0.4",
                 "ksp_version_max" : "1.0.5"
+            }
+        }
+        {
+            "version": "v1.2.8",
+            "delete" : [ "ksp_version" ],
+            "override": {
+                "ksp_version_min" : "1.2.0",
+                "ksp_version_max" : "1.2.8"
             }
         }
     ]

--- a/NetKAN/ProceduralParts.netkan
+++ b/NetKAN/ProceduralParts.netkan
@@ -37,7 +37,7 @@
                 "ksp_version_min" : "1.0.4",
                 "ksp_version_max" : "1.0.5"
             }
-        }
+        },
         {
             "version": "v1.2.8",
             "delete" : [ "ksp_version" ],


### PR DESCRIPTION
ProcParts has a 1.2.1 release and this expands that to 1.2.x