### PR TITLE
Install TACLS config

### DIFF
--- a/NetKAN/TACLS.netkan
+++ b/NetKAN/TACLS.netkan
@@ -19,8 +19,7 @@
     "install" : [
         {
             "find"          : "GameData/ThunderAerospace",
-            "install_to"    : "GameData",
-            "filter_regexp" : "TacLifeSupport\\/LifeSupport\\.cfg$"
+            "install_to"    : "GameData"
         }
     ],
     "resources" : {


### PR DESCRIPTION
We froze the files in #5330 because RO now uses MM to modify the TACLS config, but the TACLS config wasn't set to install.

Fixes https://github.com/KSP-RO/RealismOverhaul/issues/1621
Fixes https://github.com/KSP-RO/TacLifeSupport/issues/83