### PR TITLE
add ForScience KSP 1.2.x version

### DIFF
--- a/NetKAN/ForScience.netkan
+++ b/NetKAN/ForScience.netkan
@@ -6,12 +6,13 @@
     "author": [
         "WaveFunctionP"
     ],
-    "license": "restricted",
+    "license": "CC-BY-SA-4.0",
     "resources": {
         "homepage": "http://kerbal.curseforge.com/projects/for-science"
     },
-    "version": "v1.3",
-    "ksp_version": "1.1",
+    "version": "v1.4.1",
+    "ksp_version_min": "1.2.0",
+    "ksp_version_max": "1.2.8",
     "install": [
         {
             "file": "GameData/ForScience",
@@ -19,5 +20,5 @@
             "filter": "Thumbs.db"
         }
     ],
-    "download": "http://addons-origin.cursecdn.com/files/2295/65/ForScience%20v1.3.zip"
+    "download": "https://addons-origin.cursecdn.com/files/2336/379/ForScience%20v1.4.1.zip"
 }


### PR DESCRIPTION
this was updated for KSP 1.2.x but apparently nobody updated the
metadata.

also updated the license per the link on the top post in the
forum thread:

http://forum.kerbalspaceprogram.com/index.php?/topic/107803-12-forscience-v141-your-science-autopilot/&

