### PR TITLE
Use NewTantares instead of old one

### DIFF
--- a/NetKAN/BlacklegIndustriesMMTantaresTACLS.netkan
+++ b/NetKAN/BlacklegIndustriesMMTantaresTACLS.netkan
@@ -19,6 +19,6 @@
     "depends": [
         { "name" : "ModuleManager" },
 		{ "name" : "TACLS" },
-		{ "name" : "Tantares"}
+		{ "name" : "NewTantares"}
     ]
 }

--- a/NetKAN/Contares.netkan
+++ b/NetKAN/Contares.netkan
@@ -4,8 +4,8 @@
     "license": "CC-BY-NC-4.0",
     "$kref": "#/ckan/spacedock/180",
     "depends": [
-        { "name": "Tantares" },
-        { "name": "TantaresLV" },
+        { "name": "NewTantares" },
+        { "name": "NewTantaresLV" },
         { "name": "RealPlume" },
         { "name": "Contares-Common" },
 	{ "name": "RetractableLiftingSurface" }

--- a/NetKAN/ContaresCA1CanadianArrow.netkan
+++ b/NetKAN/ContaresCA1CanadianArrow.netkan
@@ -4,8 +4,8 @@
     "identifier": "ContaresCA1CanadianArrow",
     "license": "CC-BY-NC-4.0",
     "recommends": [
-        { "name": "Tantares" },
-        { "name": "TantaresLV" }
+        { "name": "NewTantares" },
+        { "name": "NewTantaresLV" }
     ],
     "depends": [
         { "name": "RealPlume" },

--- a/NetKAN/ORIONMonkeyBusinessIncParts.netkan
+++ b/NetKAN/ORIONMonkeyBusinessIncParts.netkan
@@ -9,7 +9,7 @@
     "recommends": [
         { "name": "TweakScale" },
         { "name": "InterstellarFuelSwitch-Core" },
-        { "name": "Tantares" },
+        { "name": "NewTantares" },
         { "name": "CommunityResourcePack" },
         { "name": "VenStockRevamp" },
         { "name": "NearFutureConstruction" },

--- a/NetKAN/ShadowWorksStockalikeSLSandMore.netkan
+++ b/NetKAN/ShadowWorksStockalikeSLSandMore.netkan
@@ -5,7 +5,7 @@
     "identifier": "ShadowWorksStockalikeSLSandMore",
     "recommends": [
         { "name": "BaconLabs" },
-        { "name": "Tantares"}
+        { "name": "NewTantares"}
     ],
     "install": [
         {

--- a/NetKAN/SovietConversion.netkan
+++ b/NetKAN/SovietConversion.netkan
@@ -7,8 +7,8 @@
         { "name" : "RemoteTech" } 
     ],
     "depends": [
-        { "name": "Tantares" },
-        { "name": "TantaresLV" },
+        { "name": "NewTantares" },
+        { "name": "NewTantaresLV" },
         { "name": "ABLaunchers" },
         { "name": "Contares", "max_version" : "1.7.4" },
         { "name": "ModuleManager" },

--- a/NetKAN/TantaresFairingExtension.netkan
+++ b/NetKAN/TantaresFairingExtension.netkan
@@ -6,7 +6,7 @@
     "x_netkan_epoch": 1,
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "TantaresLV" }
+        { "name": "NewTantaresLV" }
     ],
     "install": [
         {


### PR DESCRIPTION
Use `NewTantares` instead of the old `Tantares`. This should make some mods available in CKAN that were hold off because of this.

[Reference](http://forum.kerbalspaceprogram.com/index.php?/topic/154922-*/&do=findComment&comment=3045504)