### PR TITLE
Update licenses for Snark's mods

### DIFF
--- a/NetKAN/BetterBurnTime.netkan
+++ b/NetKAN/BetterBurnTime.netkan
@@ -2,5 +2,5 @@
     "identifier": "BetterBurnTime",
     "$kref": "#/ckan/spacedock/21",
     "spec_version": "v1.4",
-    "license": "MIT"
+    "license": "CC-BY-NC-ND-4.0"
 }

--- a/NetKAN/BetterCrewAssignment.netkan
+++ b/NetKAN/BetterCrewAssignment.netkan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier": "BetterCrewAssignment",
     "$kref": "#/ckan/spacedock/22",
-    "license": "MIT",
+    "license": "CC-BY-NC-ND-4.0",
     "depends": [
         { "name": "ModuleManager" }
     ]

--- a/NetKAN/DefaultActionGroups.netkan
+++ b/NetKAN/DefaultActionGroups.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier": "DefaultActionGroups",
     "$kref": "#/ckan/spacedock/24",
-    "license": "MIT",
+    "license": "CC-BY-NC-ND-4.0",
     "depends": [
         { "name": "ModuleManager" }
     ],

--- a/NetKAN/IndicatorLights.netkan
+++ b/NetKAN/IndicatorLights.netkan
@@ -2,7 +2,7 @@
     "$kref": "#/ckan/spacedock/566",
     "spec_version": "v1.4",
     "identifier": "IndicatorLights",
-    "license": "MIT",
+    "license": "CC-BY-NC-SA-4.0",
     "depends": [
         { "name": "ModuleManager" }
     ]

--- a/NetKAN/IndicatorLightsCommunityExtensions.netkan
+++ b/NetKAN/IndicatorLightsCommunityExtensions.netkan
@@ -6,7 +6,7 @@
     "depends": [
         { "name": "IndicatorLights" }
     ],
-    "supports": [        
+    "supports": [
         { "name": "ImpossibleInnovations" },
         { "name": "Mk1CabinHatch" },
         { "name": "PartOverhauls" },

--- a/NetKAN/VectorRepurposed.netkan
+++ b/NetKAN/VectorRepurposed.netkan
@@ -1,7 +1,7 @@
 {
     "$kref": "#/ckan/spacedock/27",
     "spec_version": "v1.4",
-    "license": "CC-BY-NC-SA-4.0",
+    "license": "MIT",
     "identifier": "VectorRepurposed",
     "depends"      : [
         { "name" : "ModuleManager" }


### PR DESCRIPTION
I'm not exactly sure when these licenses were changed. Sometime around October last year, apparently.
@techman83, do we have any way to fix incorrect licenses on files we've mirrored to the Internet Archive?