### PR TITLE
TooManyOrbits to 1.2

### DIFF
--- a/NetKAN/TooManyOrbits.netkan
+++ b/NetKAN/TooManyOrbits.netkan
@@ -2,5 +2,11 @@
     "spec_version" : 1,
     "identifier"   : "TooManyOrbits",
     "$kref"        : "#/ckan/spacedock/1340",
-    "license"      : "MIT"
+    "license"      : "MIT",
+    "x_netkan_override": [
+        {
+            "version": "1.1.0",
+            "override": { "ksp_version": "1.2.2" }
+        }
+    ]
 }


### PR DESCRIPTION
Mod is not compatible with 1.3 so overriding back to 1.2