### PR TITLE
Make OPM recommend, not require, CBK.

### DIFF
--- a/NetKAN/OuterPlanetsMod.netkan
+++ b/NetKAN/OuterPlanetsMod.netkan
@@ -8,8 +8,7 @@
     "depends": [
         { "name": "CommunityTerrainTexturePack" },
         { "name": "ModuleManager" },
-        { "name": "Kopernicus", "min_version": "2:release-1.2.1-1" },
-        { "name": "CustomBarnKit" }
+        { "name": "Kopernicus", "min_version": "2:release-1.2.1-1" }
     ],
     "provides": [ "CustomAsteroids-Pops" ],
     "recommends": [
@@ -17,7 +16,8 @@
         { "name": "SigmaOPMRecolor" },
         { "name": "SigmaOPMExpansion" },
         { "name": "CustomAsteroids" },
-        { "name": "SigmaBinary-core", "min_version": "1:v1.3.2" }
+        { "name": "SigmaBinary-core", "min_version": "1:v1.3.2" },
+        { "name": "CustomBarnKit" }
     ],
     "conflicts": [
         { "name": "BilliardsPlanetPack" },


### PR DESCRIPTION
Custom Barn Kit is not compatible with some other mods and is not strictly required for gameplay, so it should be recommended, not required. CBK is needed only to increase the communication range of the tracking station in order to reach the outer planets. The same goal can be accomplished by using mods like [Extended Antenna Progression](https://github.com/LouisB3/KSP-ExtendedAntennaProgression), or just building a really overpowered relay satellite.

Pinging @CaptRobau, since the final decision should be his.