### PR TITLE
Add kerbalsimpit

### DIFF
--- a/NetKAN/KerbalSimpit.netkan
+++ b/NetKAN/KerbalSimpit.netkan
@@ -1,0 +1,5 @@
+{
+  "spec_version": "v1.16",
+  "identifier": "KerbalSimpit",
+  "$kref": "#/ckan/netkan/https://bitbucket.org/pjhardy/kerbalsimpit/downloads/KerbalSimpit.netkan"
+}

--- a/NetKAN/KerbalSimpit.netkan
+++ b/NetKAN/KerbalSimpit.netkan
@@ -4,3 +4,4 @@
   "$kref": "#/ckan/netkan/https://bitbucket.org/pjhardy/kerbalsimpit/downloads/KerbalSimpit.netkan",
   "x_netkan_license_ok": true
 }
+

--- a/NetKAN/KerbalSimpit.netkan
+++ b/NetKAN/KerbalSimpit.netkan
@@ -4,4 +4,3 @@
   "$kref": "#/ckan/netkan/https://bitbucket.org/pjhardy/kerbalsimpit/downloads/KerbalSimpit.netkan",
   "x_netkan_license_ok": true
 }
-

--- a/NetKAN/KerbalSimpit.netkan
+++ b/NetKAN/KerbalSimpit.netkan
@@ -1,5 +1,6 @@
 {
   "spec_version": "v1.16",
   "identifier": "KerbalSimpit",
-  "$kref": "#/ckan/netkan/https://bitbucket.org/pjhardy/kerbalsimpit/downloads/KerbalSimpit.netkan"
+  "$kref": "#/ckan/netkan/https://bitbucket.org/pjhardy/kerbalsimpit/downloads/KerbalSimpit.netkan",
+  "x_netkan_license_ok": true
 }


### PR DESCRIPTION
Adds my Kerbal Simpit mod.

I couldn't find any docs on what the `x_netkan_license_ok` field is expected to do, but all of the metanetkan entries I've checked have it, and my mod is licensed under simplified BSD so hopefully that's OK too.