### PR TITLE
Fix IFS

### DIFF
--- a/NetKAN/InterstellarFuelSwitch.netkan
+++ b/NetKAN/InterstellarFuelSwitch.netkan
@@ -7,7 +7,7 @@
         {
             "find" : "InterstellarFuelSwitch",
             "install_to" : "GameData",
-            "filter" : "Plugins"
+            "filter" : [ "Plugins", "Resources" ]
         }
     ],
     "depends" : [


### PR DESCRIPTION
InterstellarFuelSwitch-Core now also install the `Resources` folder, so we need to filter that too.

Fixes #5587
Fixes #5588