### PR TITLE
Fix TACLS dependencies

### DIFF
--- a/NetKAN/TACLS.netkan
+++ b/NetKAN/TACLS.netkan
@@ -9,7 +9,7 @@
     "depends" : [
         {   "name" : "ModuleManager" },
         {   "name" : "CommunityResourcePack" },
-        {   "name" : "BackGroundResources" }
+        {   "name" : "BackgroundResources" }
     ],
     "suggests" : [
         {   "name" : "KSP-AVC" }


### PR DESCRIPTION
BackgroundResources was mistyped in the dependencies, preventing the install of TACLS.