### PR TITLE
Remove incorrect Aviation Lights 3.13 compat override.

### DIFF
--- a/NetKAN/AviationLights.netkan
+++ b/NetKAN/AviationLights.netkan
@@ -14,7 +14,7 @@
             "version": "v3.13",
             "delete": [ "ksp_version" ],
             "override": {
-                "ksp_version" : "1.3"
+                "ksp_version" : "1.2.2"
             }
         }
     ]


### PR DESCRIPTION
PR-5529 added an override for 3.13 of Aviation Lights. But as per the author's response at http://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1223-mahia/&do=findComment&comment=3087187 this is incorrect.

I'm not sure if just removing the override at this point will have the desired effect. But figure that changing the override to point to the intended version would work as intended.