### PR TITLE
Fix CryoTanks vref

### DIFF
--- a/NetKAN/CryoTanks.netkan
+++ b/NetKAN/CryoTanks.netkan
@@ -3,7 +3,7 @@
     "comment": "CryoTanks does not have its own release. Sourced from the KerbalAtomics archive.",
     "identifier": "CryoTanks",
     "$kref": "#/ckan/spacedock/710",
-    "$vref": "#/ckan/ksp-avc/GameData/KerbalAtomics/Versioning/KerbalAtomics.version",
+    "$vref": "#/ckan/ksp-avc",
     "name": "Cryogenic Tanks",
     "abstract": "A set of fuel tanks containing liquid hydrogen, with active cryocooling.",
     "license": "CC-BY-NC-SA-4.0",


### PR DESCRIPTION
I am not quite sure why this broke, but CryoTanks has its own .version
file and running NetKAN confirms that it is finding the correct one

For reference, the error is this:
```
AVC: Invalid path to remote GameData/KerbalAtomics/Versioning/KerbalAtomics.version, doesn't match any of: GameData/CryoTanks/Versioning/CryoTanks.version,
```