### PR TITLE
Fix NearFutureProps vref

### DIFF
--- a/NetKAN/NearFutureProps.netkan
+++ b/NetKAN/NearFutureProps.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier": "NearFutureProps",
     "$kref": "#/ckan/spacedock/708",
-    "$vref": "#/ckan/ksp-avc/GameData/NearFutureSpacecraft/Versioning/NearFutureSpacecraft.version",
+    "$vref": "#/ckan/ksp-avc",
     "name": "Near Future IVA Props",
     "abstract": "Props used to build IVA spaces in various mods by Nertea.",
     "license": "CC-BY-NC-SA-4.0",


### PR DESCRIPTION
again not quite sure why this broke, but NearFutureProps has its own .version
file and running NetKAN confirms that it is finding the correct one