### PR TITLE
RN revert changes to 1.3

### DIFF
--- a/NetKAN/AntaresCygnus.netkan
+++ b/NetKAN/AntaresCygnus.netkan
@@ -11,8 +11,8 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/Antares-Cygnus",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.1.1",
-    "ksp_version_max"   : "1.3",
+    "$vref"        : "#/ckan/ksp-avc",
+	"x_netkan_epoch"   : 1,
     "install"       : [
     {
         "find"      : "KK_Antares",

--- a/NetKAN/BDAnimationModules.netkan
+++ b/NetKAN/BDAnimationModules.netkan
@@ -16,5 +16,8 @@
             "find": "BahaSP",
             "install_to": "GameData"
         }
+    ],
+	"depends"       : [
+        { "name"      : "KSP-AVC"  }
     ]
 }

--- a/NetKAN/RN-MiscParts.netkan
+++ b/NetKAN/RN-MiscParts.netkan
@@ -10,8 +10,8 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/RNMisc",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.1.1",
-    "ksp_version_max"   : "1.3",
+    "$vref"        : "#/ckan/ksp-avc",
+	"x_netkan_epoch"   : 1,
     "install"       :
     [
       {

--- a/NetKAN/RN-MiscParts.netkan
+++ b/NetKAN/RN-MiscParts.netkan
@@ -18,5 +18,8 @@
         "find"      : "RN_Misc",
         "install_to": "GameData"
       }
+    ],
+	"depends"       : [
+        { "name"      : "BDAnimationModules"  }
     ]
 }

--- a/NetKAN/RN-SPP.netkan
+++ b/NetKAN/RN-SPP.netkan
@@ -10,8 +10,8 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/USSovietSolarPanelsPack",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.1.1",
-    "ksp_version_max"   : "1.3",
+    "$vref"        : "#/ckan/ksp-avc",
+	"x_netkan_epoch"   : 1,
     "install"       :
     [
       {

--- a/NetKAN/RN-SalyutStations.netkan
+++ b/NetKAN/RN-SalyutStations.netkan
@@ -10,8 +10,8 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/SalyutStations",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.2.0",
-    "ksp_version_max"   : "1.2.2",
+    "$vref"        : "#/ckan/ksp-avc",
+	"x_netkan_epoch"   : 1,
     "install"       : [
     {
         "find"      : "RN_Salyut",

--- a/NetKAN/RN-SalyutStations.netkan
+++ b/NetKAN/RN-SalyutStations.netkan
@@ -10,8 +10,8 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/SalyutStations",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.3",
-    "ksp_version_max"   : "1.3",
+    "ksp_version_min"   : "1.2.0",
+    "ksp_version_max"   : "1.2.2",
     "install"       : [
     {
         "find"      : "RN_Salyut",

--- a/NetKAN/RN-Skylab.netkan
+++ b/NetKAN/RN-Skylab.netkan
@@ -11,8 +11,8 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/Skylab",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.2.0",
-    "ksp_version_max"   : "1.2.2",
+    "$vref"        : "#/ckan/ksp-avc",
+	"x_netkan_epoch"   : 1,
     "install"       :
     [
       {

--- a/NetKAN/RN-Skylab.netkan
+++ b/NetKAN/RN-Skylab.netkan
@@ -11,8 +11,8 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/Skylab",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.3",
-    "ksp_version_max"   : "1.3",
+    "ksp_version_min"   : "1.2.0",
+    "ksp_version_max"   : "1.2.2",
     "install"       :
     [
       {

--- a/NetKAN/RN-SovietProbes.netkan
+++ b/NetKAN/RN-SovietProbes.netkan
@@ -10,8 +10,8 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/SovietProbes",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.2.0",
-    "ksp_version_max"   : "1.2.2",
+    "$vref"        : "#/ckan/ksp-avc",
+	"x_netkan_epoch"   : 1,
     "install"       : [
     {
         "find"      : "RN_Soviet_Probes",

--- a/NetKAN/RN-SovietProbes.netkan
+++ b/NetKAN/RN-SovietProbes.netkan
@@ -10,8 +10,8 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/SovietProbes",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.3",
-    "ksp_version_max"   : "1.3",
+    "ksp_version_min"   : "1.2.0",
+    "ksp_version_max"   : "1.2.2",
     "install"       : [
     {
         "find"      : "RN_Soviet_Probes",

--- a/NetKAN/RN-SovietRockets.netkan
+++ b/NetKAN/RN-SovietRockets.netkan
@@ -9,9 +9,8 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/SovietRockets",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.2.0",
-    "ksp_version_max"   : "1.2.2",
-    "x_netkan_epoch": "1",
+    "$vref"        : "#/ckan/ksp-avc",
+	"x_netkan_epoch"   : 2,
     "install"       : [
     {
         "find"      : "RN_Soviet_Rockets",

--- a/NetKAN/RN-SovietRockets.netkan
+++ b/NetKAN/RN-SovietRockets.netkan
@@ -9,8 +9,8 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/SovietRockets",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.3",
-    "ksp_version_max"   : "1.3",
+    "ksp_version_min"   : "1.2.0",
+    "ksp_version_max"   : "1.2.2",
     "x_netkan_epoch": "1",
     "install"       : [
     {

--- a/NetKAN/RN-SovietSpacecraft.netkan
+++ b/NetKAN/RN-SovietSpacecraft.netkan
@@ -10,8 +10,8 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/SovietSpacecraft",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.2.0",
-    "ksp_version_max"   : "1.2.2",
+    "$vref"        : "#/ckan/ksp-avc",
+	"x_netkan_epoch"   : 1,
     "install"       : [
     {
         "find"      : "RN_Soyuz",

--- a/NetKAN/RN-SovietSpacecraft.netkan
+++ b/NetKAN/RN-SovietSpacecraft.netkan
@@ -10,8 +10,8 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/SovietSpacecraft",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.3",
-    "ksp_version_max"   : "1.3",
+    "ksp_version_min"   : "1.2.0",
+    "ksp_version_max"   : "1.2.2",
     "install"       : [
     {
         "find"      : "RN_Soyuz",

--- a/NetKAN/RN-USProbesPack.netkan
+++ b/NetKAN/RN-USProbesPack.netkan
@@ -10,8 +10,8 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/USProbesPack",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.2.0",
-    "ksp_version_max"   : "1.2.2",
+    "$vref"        : "#/ckan/ksp-avc",
+	"x_netkan_epoch"   : 1,
     "install"       :
     [
       {

--- a/NetKAN/RN-USProbesPack.netkan
+++ b/NetKAN/RN-USProbesPack.netkan
@@ -10,8 +10,8 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/USProbesPack",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.3",
-    "ksp_version_max"   : "1.3",
+    "ksp_version_min"   : "1.2.0",
+    "ksp_version_max"   : "1.2.2",
     "install"       :
     [
       {

--- a/NetKAN/RN-USRockets.netkan
+++ b/NetKAN/RN-USRockets.netkan
@@ -9,8 +9,8 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/USRockets",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.2.0",
-    "ksp_version_max"   : "1.2.2",
+    "$vref"        : "#/ckan/ksp-avc",
+	"x_netkan_epoch"   : 1,
     "install"       : [
     {
         "find"      : "RN_US_Rockets",

--- a/NetKAN/RN-USRockets.netkan
+++ b/NetKAN/RN-USRockets.netkan
@@ -9,8 +9,8 @@
     },
     "$kref"         : "#/ckan/github/KSP-RO/USRockets",
     "license"       : "CC-BY-NC-ND-3.0",
-    "ksp_version_min"   : "1.3",
-    "ksp_version_max"   : "1.3",
+    "ksp_version_min"   : "1.2.0",
+    "ksp_version_max"   : "1.2.2",
     "install"       : [
     {
         "find"      : "RN_US_Rockets",


### PR DESCRIPTION
-Remove the changes to 1.3 because of it breaking ckan and my mod/the
game from loading.
@linuxgurugamer This needs to go hand in hand with removing those
metadata files I mentionned in the forum PM. Once all that is deleted I will quickly remove the releases for 1.3.