### PR TITLE
MemGraph 1.1.0.3 works on both KSP 1.2 and 1.3

### DIFF
--- a/NetKAN/MemGraph.netkan
+++ b/NetKAN/MemGraph.netkan
@@ -5,7 +5,8 @@
     "name"         : "MemGraph",
     "abstract"     : "This is a simple plugin to display of graph of memory allocation and garbage collection. It is intended as a troubleshooting and development aid rather than for general use.",
     "license"      : "MIT",
-    "ksp_version"  : "1.2",
+    "ksp_version_min"  : "1.2",
+    "ksp_version_max"  : "1.3",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/139128-memgraph"
     }


### PR DESCRIPTION
Update MemGraph metadata to correctly reflect compatible versions.

Mod thread link for convenience:
http://forum.kerbalspaceprogram.com/index.php?/topic/139128-12x13-memgraph-1103-with-stutter-reduction/