### PR TITLE
FuelEfficientPilots.netkan

### DIFF
--- a/NetKAN/FuelEfficientPilots.netkan
+++ b/NetKAN/FuelEfficientPilots.netkan
@@ -1,0 +1,12 @@
+{
+	"spec_version": "v1.4",
+	"depends":
+	[
+		{
+			"name": "ModuleManager"
+		}
+	],
+	"$kref": "#/ckan/spacedock/1466",
+	"identifier": "FuelEfficientPilots",
+	"license": "CC-BY-NC-SA-4.0"
+}


### PR DESCRIPTION
Mod details:
name = /mod/1466/FuelEfficientPilots
author = packetshepherd
abstract = Give Pilots better fuel efficiency based on experience
license = CC-BY-NC-SA 4.0
Homepage =
description = Pilots have the ability to get better fuel efficiency through experience, so now your five-star pilot can give you better bang for your buck!
