### PR TITLE
Update name from "Astronomer's Visual Pack"

### DIFF
--- a/NetKAN/AstronomersPack.frozen
+++ b/NetKAN/AstronomersPack.frozen
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.2",
     "identifier": "AstronomersPack",
-    "name": "Astronomer's Visual Pack",
+    "name": "Astronomer's Visual Pack (deprecated)",
     "abstract": "Meta-package for Astronomer's Visual Pack and its options",
     "license": "restricted",
     "ksp_version_min": "0.25",


### PR DESCRIPTION
To possibly fix the disappearance of the updated version of the same name, and prevent conflict. Name changed to "Astronomer's Visual Pack (deprecated)", can be changed at will.