### PR TITLE
Add Trim Indicator

### DIFF
--- a/NetKAN/TrimIndicator.netkan
+++ b/NetKAN/TrimIndicator.netkan
@@ -1,0 +1,13 @@
+{
+  "spec_version" : 1,
+  "identifier"   : "TrimIndicator",
+  "$kref"        : "#/ckan/github/formicant/TrimIndicator",
+  "$vref"        : "#/ckan/ksp-avc",
+  "name"         : "Trim Indicator",
+  "author"       : [ "Teilnehmer" ],
+  "abstract"     : "A minimalistic add-on displaying trim values inside the control gauges.",
+  "license"      : "GPL-3.0",
+  "resources"    : {
+    "homepage"   : "https://forum.kerbalspaceprogram.com/index.php?/topic/164522-trim-indicator"
+  }
+}


### PR DESCRIPTION
A minimalistic add-on displaying trim values inside the control gauges.