### PR TITLE
FAR Override bad AVC info for 0.15.9

### DIFF
--- a/NetKAN/FerramAerospaceResearch.netkan
+++ b/NetKAN/FerramAerospaceResearch.netkan
@@ -35,11 +35,11 @@
     ],
     "x_netkan_override": [
         {
-            "version": "3:0.15.8",
+            "version": "3:0.15.9",
             "delete": [ "ksp_version" ],
             "override": {
-                "ksp_version_min": "1.2.0",
-                "ksp_version_max": "1.2.2"
+                "ksp_version_min": "1.3.0",
+                "ksp_version_max": "1.3.99"
             }
         }
     ]


### PR DESCRIPTION
Makes KSP-CKAN/CKAN-meta#1288 permanent