### PR TITLE
Case sensitivity in dependency identifier

### DIFF
--- a/NetKAN/AstronomersVisualPack.netkan
+++ b/NetKAN/AstronomersVisualPack.netkan
@@ -13,7 +13,7 @@
         { "name": "ModuleManager" },
         { "name": "AVP-Textures" },
         { "name": "Kopernicus" },
-        { "name": "scatterer" },
+        { "name": "Scatterer" },
 	    { "name": "LoadingScreenManager" },
 		{ "name": "EnvironmentalVisualEnhancements" }
 	],


### PR DESCRIPTION
Case sensitivity with the identifier for the Scatterer mod was preventing AVP from installing. I changed it in my local registry, and AVP upgraded without issue. This should allow others to upgrade.