### PR TITLE
Fix JPL-RSS version overrides format

### DIFF
--- a/NetKAN/JPL-RSS.netkan
+++ b/NetKAN/JPL-RSS.netkan
@@ -17,8 +17,8 @@
             "version": "1.0",
             "delete": [ "ksp_version" ],
             "override": {
-                "ksp_version_min" : "v1.2",
-                "ksp_version_max" : "v1.3"
+                "ksp_version_min" : "1.2",
+                "ksp_version_max" : "1.3"
             }
         }
     ]


### PR DESCRIPTION
The "v" in the ksp_version_min and _max fields confuses the NetKAN bot. Currently causing "JSON deserialization error" at http://status.ksp-ckan.org/, discovered by making that error more verbose in a local fork of netkan.exe.