### PR TITLE
Fix name of REKT's AVC file

### DIFF
--- a/NetKAN/REKT.netkan
+++ b/NetKAN/REKT.netkan
@@ -11,7 +11,7 @@
       "filter": "RetractableLiftingSurface"
     }
   ],
-  "$vref": "#/ckan/ksp-avc/rekt.version",
+  "$vref": "#/ckan/ksp-avc/RecoverableEmergencyKerbalTransport.version",
   "$kref": "#/ckan/spacedock/1021",
   "x_via": "Automated Linuxgurugamer CKAN script",
   "identifier": "REKT",


### PR DESCRIPTION
This mod's $vref says to look for rekt.version, but the mod ships RecoverableEmergencyKerbalTransport.version instead, currently causing "AVC: Invalid path to remote rekt.version, doesn't match ..." on http://status.ksp-ckan.org/

To confirm, see: https://github.com/steedcrugeon/REKT/blob/master/SHED/REKT/RecoverableEmergencyKerbalTransport.version