### PR TITLE
file/find confusion

### DIFF
--- a/NetKAN/SpeedUnitChanger.netkan
+++ b/NetKAN/SpeedUnitChanger.netkan
@@ -5,9 +5,9 @@
     "license": "GPL-3.0",
     "install": [
         {
-            "file": "SpeedUnitChanger",
+            "find": "SpeedUnitChanger",
             "install_to": "GameData",
-            "filter": "Source"
+            "filter": "Sources"
         }
     ]
 }


### PR DESCRIPTION
This one currently says "Module contains no files to install" on the [status page](http://status.ksp-ckan.org/), but the download exists and has mod files in it. If I change `file` to `find`, it generates a valid `.ckan` file. And the Source directory is actually Sources.