### PR TITLE
file/find confusion part deux

### DIFF
--- a/NetKAN/SolarisHypernautics.netkan
+++ b/NetKAN/SolarisHypernautics.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "license": "GPL-3.0",
     "$kref": "#/ckan/spacedock/187",
     "identifier": "SolarisHypernautics",

--- a/NetKAN/SolarisHypernautics.netkan
+++ b/NetKAN/SolarisHypernautics.netkan
@@ -6,7 +6,7 @@
     "x_netkan_epoch": 1,
     "install": [
         {
-            "file"       : "Solaris Hypernautics",
+            "find"       : "Solaris_Hypernautics",
             "install_to" : "GameData"
         }
     ],


### PR DESCRIPTION
[Status page](http://status.ksp-ckan.org/) error: "Module contains no files to install."

Cause: Uses `file` instead of `find`, and the `.netkan` file has a space where the download zip has an underscore

Generates a valid `.ckan` file after this change in my testing.