### PR TITLE
switch to find_regexp

### DIFF
--- a/NetKAN/NorthKerbinDynamics.netkan
+++ b/NetKAN/NorthKerbinDynamics.netkan
@@ -10,7 +10,7 @@
     ],
     "install": [
         {
-            "file"       : "North Kerbin Weaponry",
+            "find_regexp": "North Kerbin Weaponry.*",
             "install_to" : "GameData"
         }
     ]

--- a/NetKAN/NorthKerbinDynamics.netkan
+++ b/NetKAN/NorthKerbinDynamics.netkan
@@ -2,7 +2,7 @@
     "license": "CC-BY-SA-4.0",
     "identifier": "NorthKerbinDynamics",
     "$kref": "#/ckan/spacedock/214",
-    "spec_version": "v1.4",
+    "spec_version": "v1.10",
     "depends": [
         { "name": "CommunityAmmunitionLibrary" },
         { "name": "ModuleManager" },


### PR DESCRIPTION
This mod includes the version in the directory internal to the zip, so a regexp is needed to match.

E.g.:

```
  Length      Date    Time    Name
---------  ---------- -----   ----
     1636  2016-06-11 08:23   North Kerbin Weaponry v0.83/effects/Explosion_150.mu
```

Current [status page](http://status.ksp-ckan.org/) error: "Module contains no files to install."