### PR TITLE
Switch to find_regexp

### DIFF
--- a/NetKAN/PolishTranslation.netkan
+++ b/NetKAN/PolishTranslation.netkan
@@ -2,11 +2,11 @@
     "x_via": "Automated SpaceDock CKAN submission",
     "$kref": "#/ckan/spacedock/1390",
     "license": "GPL-2.0",
-    "spec_version": "v1.4",
+    "spec_version": "v1.10",
     "identifier": "PolishTranslation",
     "install": [
         {
-            "find": "Spolszczenie",
+            "find_regexp": "KSP Localization PL.*",
             "install_to": "GameData"
         }
     ]


### PR DESCRIPTION
This mod includes the version number in the directory internal to the zip, and the `find` property in the netkan doesn't match the zip.

Current [status page](http://status.ksp-ckan.org/) error: "Could not find Spolszczenie entry in zipfile to install"

Example file:

```
  Length      Date    Time    Name
---------  ---------- -----   ----
   659516  2017-07-15 09:26   KSP Localization PL - Alpha 1.45/dictionary.cfg
```