### PR TITLE
Switch to find_regexp

### DIFF
--- a/NetKAN/ReworkedStockSystem.netkan
+++ b/NetKAN/ReworkedStockSystem.netkan
@@ -1,9 +1,9 @@
 {
-  "spec_version": "v1.4",
+  "spec_version": "v1.10",
   "install": [
     {
       "install_to": "GameData",
-      "find": "ReSS_V1.0.1"
+      "find_regexp": "ReSS_.*"
     }
   ],
   "depends": [

--- a/NetKAN/ReworkedStockSystem.netkan
+++ b/NetKAN/ReworkedStockSystem.netkan
@@ -3,7 +3,7 @@
   "install": [
     {
       "install_to": "GameData",
-      "find_regexp": "ReSS_.*"
+      "find": "ReSS"
     }
   ],
   "depends": [


### PR DESCRIPTION
`.netkan` was hard coded to version 1.0.1, which didn't work so well once version 1.0.2 came out. But there's also a nested `gameData` folder, which looks like it should be the true root of the tree.

Current [status page](http://status.ksp-ckan.org/) error: "Could not find ReSS_V1.0.1 entry in zipfile to install"

Example file:

```
  Length      Date    Time    Name
---------  ---------- -----   ----
     2074  2017-08-27 15:11   ReSS_V1.0.2/gameData/ReSS/Bop/cfg/Bop.cfg
```