### PR TITLE
Switch from find to file

### DIFF
--- a/NetKAN/KerbalTubes.netkan
+++ b/NetKAN/KerbalTubes.netkan
@@ -9,7 +9,7 @@
     ],
     "install": [
         {
-            "find"       : "KerbalTubes",
+            "file"       : "KerbalTubes",
             "install_to" : "GameData"
         }
     ]

--- a/NetKAN/KerbalTubes.netkan
+++ b/NetKAN/KerbalTubes.netkan
@@ -5,7 +5,7 @@
     "spec_version": "v1.4",
     "$kref": "#/ckan/spacedock/34",
     "depends": [
-        { "name": "HullCamVDS" }
+        { "name": "HullcamVDS" }
     ],
     "install": [
         {


### PR DESCRIPTION
I don't quite understand why this is erroring out, but changing `find` to `file` generates a valid `.ckan` file in my testing.

Current [status page](http://status.ksp-ckan.org/) error: "Could not find KerbalTubes entry in zipfile to install"

Example file:

```
  Length      Date    Time    Name
---------  ---------- -----   ----
     1439  2017-07-31 22:33   KerbalTubes/Parts/Coupling/DockingIrisMax/DockingIrisMax.cfg
```