### PR TITLE
Remove absent install path

### DIFF
--- a/NetKAN/YongeTechTreesPlugin-Revived.netkan
+++ b/NetKAN/YongeTechTreesPlugin-Revived.netkan
@@ -19,10 +19,6 @@
         {
             "find"       : "GameData/YongeTech_TechTreesPlugin",
             "install_to" : "GameData"
-        },
-                {
-            "find"       : "GameData/YongeTech_TechTreeConverter",
-            "install_to" : "GameData"
         }
     ],
     "suggests":[


### PR DESCRIPTION
There's no Converter path of any kind in this zip. There's a YongeTech_TechTreesPlugin folder, and there's ETT in another folder in the same archive (which has its own `.netkan` file sharing this SpaceDock link).

Current [status page](http://status.ksp-ckan.org/) error: "Could not find GameData/YongeTech_TechTreeConverter entry in zipfile to install"