### PR TITLE
OPTSpacePlaneMain: remove ksp_version_min,max; rely on Curse version

### DIFF
--- a/NetKAN/OPTSpacePlaneMain.netkan
+++ b/NetKAN/OPTSpacePlaneMain.netkan
@@ -5,10 +5,9 @@
     "license"      : "CC-BY-NC-SA-4.0",
     "abstract"     : "Over 50 stock-a-like, large space plane oriented parts",
     "resources"    : {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/87956-opt-space-plane-temporary-thread"
+        "homepage" : "http://forum.kerbalspaceprogram.com/index.php?/topic/87956-opt-space-plane-temporary-thread",
+        "spacedock": "https://spacedock.info/mod/1028/OPT%20Space%20Plane"
     },
-    "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.2.2",
     "depends": [
         { "name" : "FirespitterCore" },
         { "name" : "ModuleManager" }


### PR DESCRIPTION
This was blocking the version for KSP 1.3 from getting indexed correctly.
Bonus: add resources.spacedock.