### PR TITLE
Fix repo URL for SpudMoon

### DIFF
--- a/NetKAN/SpudMoon.netkan
+++ b/NetKAN/SpudMoon.netkan
@@ -2,7 +2,7 @@
 {
     "spec_version"  : "v1.4",
     "identifier"    : "SpudMoon",
-    "$kref"         : "#/ckan/github/MrChumley/Kronkus",
+    "$kref"         : "#/ckan/github/MrChumley/Spud",
     "x_netkan_epoch": "2",
     "name"          : "SpudMoon",
     "abstract"      : "Dres was once a lonely planet and then Spud showed up",


### PR DESCRIPTION
This mod currently has the wrong Github repo in its $kref, causing "Could not find Spud entry in zipfile to install" on the status page.