### PR TITLE
Fix regex for version numbers for kRPC

### DIFF
--- a/NetKAN/kRPC.netkan
+++ b/NetKAN/kRPC.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version" : 1,
     "identifier"   : "kRPC",
-    "$kref"        : "#/ckan/github/krpc/krpc/asset_match/krpc-[0-9]\\.[0-9]\\.[0-9]\\.zip",
+    "$kref"        : "#/ckan/github/krpc/krpc/asset_match/krpc-[0-9]+\\.[0-9]+\\.[0-9]+\\.zip",
     "name"         : "kRPC: Remote Procedure Call Server",
     "abstract"     : "kRPC allows you to control the game from external programs. It comes with client libraries for several popular languages including Python, C++, C#, Java and Lua. Programs communicate with the game over a TCP/IP connection, and can be configured to work on just the local machine or even over the wider internet.",
     "license"      : "GPL-3.0",


### PR DESCRIPTION
The github asset regex wasn't picking up new versions 0.3.10 and 0.3.11 for the kRPC mod. I've tweaked the regex to fix this.