### PR TITLE
Switch WindowShine from DropBox to SpaceDock

### DIFF
--- a/NetKAN/WindowShineTR.netkan
+++ b/NetKAN/WindowShineTR.netkan
@@ -5,11 +5,10 @@
     "abstract": "Stock reflective windows and solar panels + mod support!",
     "author": "Avera9eJoe",
     "license": "CC-BY-NC-4.0",
+    "$kref": "#/ckan/spacedock/1504",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/110080-105"
     },
-    "version": "v12",
-    "ksp_version": "1.1.3",
     "depends": [
         {
             "name": "TextureReplacer"
@@ -20,9 +19,8 @@
     ],
     "install": [
         {
-            "file": "GameData/TextureReplacer",
+            "file": "GameData/WindowShine",
             "install_to": "GameData"
         }
-    ],
-    "download": "https://www.dropbox.com/s/pyvsphdgi86uz6k/WindowShineTR-v12.zip?dl=1"
+    ]
 }


### PR DESCRIPTION
The latest version of this mod is on SpaceDock, and the older DropBox download seems to have been removed, as the bot now errors out on this mod. The internal structure of the zip file changed slightly as well.

https://forum.kerbalspaceprogram.com/index.php?/topic/110080-13-windowshine-v15-toroidal-tank-update-2-october-17/