### PR TITLE
Update Historian's install folder

### DIFF
--- a/NetKAN/Historian-expanded.netkan
+++ b/NetKAN/Historian-expanded.netkan
@@ -18,7 +18,7 @@
     ],
     "install": [
         {
-            "file"       : "GameData/KSEA",
+            "file"       : "GameData/Historian",
             "install_to" : "GameData"
         }
     ]


### PR DESCRIPTION
Historian-expanded is erroring out in the NetKAN-bot after its latest update.

https://github.com/Aelfhe1m/Historian-Expanded/releases/tag/v.1.3.1

> BREAKING CHANGE
>
> Move Historian install folder from GameData/KSEA/Historian to GameData/Historian. If upgrading from Historian version 1.2.8 or earlier then any custom layouts must be copied to the new location and the old folder deleted.

This change updates the netkan metadata accordingly.