### PR TITLE
Update folder path for FASA

### DIFF
--- a/NetKAN/FASALaunchClampsContinued.netkan
+++ b/NetKAN/FASALaunchClampsContinued.netkan
@@ -2,7 +2,7 @@
 	"spec_version": "v1.4",
 	"install"	  : [
 	{
-		"file": "FASA",
+		"file": "GameData/FASA",
 		"install_to": "GameData"
 	}
 	],


### PR DESCRIPTION
This mod previously shipped a FASA folder, and now it's nested in a GameData folder. This change updates the netkan to account for that.