### PR TITLE
Update DescentMode NetKAN file

### DIFF
--- a/NetKAN/DescentMode.netkan
+++ b/NetKAN/DescentMode.netkan
@@ -15,5 +15,13 @@
     ],
     "conflicts" : [
         { "name" : "RealismOverhaul" }
+    ],
+    "x_netkan_override" : [
+        {
+            "version"  : "v0.2.0",
+            "override" : {
+                "ksp_version" : "1.2.2"
+            }
+        }
     ]
 }

--- a/NetKAN/DescentMode.netkan
+++ b/NetKAN/DescentMode.netkan
@@ -2,8 +2,8 @@
     "spec_version" : 1,
     "identifier"   : "DescentMode",
     "$kref"        : "#/ckan/github/infoman/DescentMode",
+    "$vref"        : "#/ckan/ksp-avc",
     "license"      : "CC-BY-SA-4.0",
-    "ksp_version"  : "1.2.2",
     "author"       : "Eklykti",
     "abstract"     : "Allows you to offset your pod's center of mass to perform a lifting reentry",
     "resources": {


### PR DESCRIPTION
Hello. Please update my netkan file to use KSP-AVC version data instead of hardcoded one. I pushed a prerelease version and it seems to generate a correct .ckan file, and will make it a full release when .netkan is updated, to not break existing 1.2.2 installs