### PR TITLE
Update BackInBlack dependencies (fixes #5946)

### DIFF
--- a/NetKAN/BackInBlack.netkan
+++ b/NetKAN/BackInBlack.netkan
@@ -11,7 +11,7 @@
   ],
   "depends": [
     {
-      "name": "InterstellarFuelSwitch"
+      "name": "InterstellarFuelSwitch-Core"
     },
     {
       "name": "ModuleManager"

--- a/NetKAN/BackInBlackTexturePack.netkan
+++ b/NetKAN/BackInBlackTexturePack.netkan
@@ -9,6 +9,11 @@
       "find": "BackInBlack"
     }
   ],
+  "depends": [
+    {
+      "name": "BackInBlack"
+    }
+  ],
   "$kref": "#/ckan/spacedock/1498",
   "x_via": "Automated Linuxgurugamer CKAN script",
   "identifier": "BackInBlackTexturePack",


### PR DESCRIPTION
- Change BackInBlack's dependency from InterstellarFuelSwitch to InterstellarFuelSwitch-Core
- Make BackInBlackTexturePack depend on BackInBlack