### PR TITLE
Makes EVE Configs NOT required

### DIFF
--- a/NetKAN/EnvironmentalVisualEnhancements.netkan
+++ b/NetKAN/EnvironmentalVisualEnhancements.netkan
@@ -17,7 +17,7 @@
             "install_to" : "GameData"
         }
     ],
-    "depends": [
+    "recommends": [
         { "name": "EnvironmentalVisualEnhancements-Config" }
     ],
     "conflicts": [


### PR DESCRIPTION
so you can install a cloud pack not on CKAN (or make your own) without manually removing it