### PR TITLE
Fixes up WindowShine's CKAN

### DIFF
--- a/NetKAN/WindowShineTR.netkan
+++ b/NetKAN/WindowShineTR.netkan
@@ -27,7 +27,7 @@
 	}],
 	"x_netkan_override": [{
 		"version": "v15",
-		"delete" : [ "ksp_version" ],
+		"delete": ["ksp_version"],
 		"override": {
 			"ksp_version_min": "1.3",
 			"ksp_version_max": "1.3.99"

--- a/NetKAN/WindowShineTR.netkan
+++ b/NetKAN/WindowShineTR.netkan
@@ -1,26 +1,35 @@
 {
-    "spec_version": 1,
-    "identifier": "WindowShineTR",
-    "name": "WindowShine",
-    "abstract": "Stock reflective windows and solar panels + mod support!",
-    "author": "Avera9eJoe",
-    "license": "CC-BY-NC-4.0",
-    "$kref": "#/ckan/spacedock/1504",
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/110080-105"
-    },
-    "depends": [
-        {
-            "name": "TextureReplacer"
-        },
-        {
-            "name": "ModuleManager"
-        }
-    ],
-    "install": [
-        {
-            "file": "GameData/WindowShine",
-            "install_to": "GameData"
-        }
-    ]
+	"spec_version": 1,
+	"identifier": "WindowShineTR",
+	"name": "WindowShine",
+	"abstract": "Stock reflective windows and solar panels + mod support!",
+	"author": "Avera9eJoe",
+	"license": "CC-BY-NC-4.0",
+	"$kref": "#/ckan/spacedock/1504",
+	"resources": {
+		"homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/110080-105"
+	},
+	"depends": [{
+			"name": "TextureReplacer",
+			"max_version": "v12"
+		},
+		{
+			"name": "TextureReplacerReplaced",
+			"min_version": "v15"
+		},
+		{
+			"name": "ModuleManager"
+		}
+	],
+	"install": [{
+		"file": "GameData/WindowShine",
+		"install_to": "GameData"
+	}],
+	"x_netkan_override": [{
+		"version": "v15",
+		"override": {
+			"ksp_version_min": "1.3",
+			"ksp_version_max": "1.3.99"
+		}
+	}]
 }

--- a/NetKAN/WindowShineTR.netkan
+++ b/NetKAN/WindowShineTR.netkan
@@ -27,6 +27,7 @@
 	}],
 	"x_netkan_override": [{
 		"version": "v15",
+		"delete": "ksp_version",
 		"override": {
 			"ksp_version_min": "1.3",
 			"ksp_version_max": "1.3.99"

--- a/NetKAN/WindowShineTR.netkan
+++ b/NetKAN/WindowShineTR.netkan
@@ -10,12 +10,7 @@
 		"homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/110080-105"
 	},
 	"depends": [{
-			"name": "TextureReplacer",
-			"max_version": "v12"
-		},
-		{
-			"name": "TextureReplacerReplaced",
-			"min_version": "v15"
+			"name": "TextureReplacerReplaced"
 		},
 		{
 			"name": "ModuleManager"
@@ -26,11 +21,24 @@
 		"install_to": "GameData"
 	}],
 	"x_netkan_override": [{
-		"version": "v15",
-		"delete": ["ksp_version"],
-		"override": {
-			"ksp_version_min": "1.3",
-			"ksp_version_max": "1.3.99"
+			"version": "v15",
+			"delete": ["ksp_version"],
+			"override": {
+				"ksp_version_min": "1.3",
+				"ksp_version_max": "1.3.99"
+			}
+		},
+		{
+			"version": ["v11", "v12"],
+			"override": {
+				"depends": [{
+						"name": "TextureReplacer"
+					},
+					{
+						"name": "ModuleManager"
+					}
+				]
+			}
 		}
-	}]
+	]
 }

--- a/NetKAN/WindowShineTR.netkan
+++ b/NetKAN/WindowShineTR.netkan
@@ -27,7 +27,7 @@
 	}],
 	"x_netkan_override": [{
 		"version": "v15",
-		"delete": "ksp_version",
+		"delete" : [ "ksp_version" ],
 		"override": {
 			"ksp_version_min": "1.3",
 			"ksp_version_max": "1.3.99"


### PR DESCRIPTION
Ensures post-v12 versions require TextureReplacerReplaced, not TextureReplacer.