### PR TITLE
Change kdex to use `find`

### DIFF
--- a/NetKAN/KDEX.netkan
+++ b/NetKAN/KDEX.netkan
@@ -13,7 +13,7 @@
 	},
 	"install": [
 		{
-			"file"       : "GameData/masTerTorch",
+			"find"       : "masTerTorch",
 			"install_to" : "GameData"
 		}
 	],


### PR DESCRIPTION
The format of this zip has been changing in its past few releases.

1.04:
```
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  2014-11-15 15:45   GameData/
        0  2014-11-15 17:30   GameData/masTerTorch/
      978  2014-11-15 15:46   GameData/masTerTorch/license.txt
        0  2014-11-15 15:44   GameData/masTerTorch/Parts/
```

1.10:
```
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  2017-10-17 05:54   kdex-1.10/
        0  2017-10-17 05:54   kdex-1.10/GameData/
        0  2017-10-17 05:54   kdex-1.10/GameData/masTerTorch/
        0  2017-10-17 05:54   kdex-1.10/GameData/masTerTorch/Parts/
```

1.10.1:
```
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  2017-10-19 11:03   kdex-1.10.1/
        0  2017-10-19 11:03   kdex-1.10.1/GameData/
        0  2017-10-19 11:03   kdex-1.10.1/GameData/masTerTorch/
        0  2017-10-19 11:03   kdex-1.10.1/GameData/masTerTorch/Parts/
```

... which isn't good for a `file`-based netkan. A `find` clause would work for all of them, though.