### PR TITLE
Freeze SoundTrackEditor

### DIFF
--- a/NetKAN/SoundTrackEditor.frozen
+++ b/NetKAN/SoundTrackEditor.frozen
@@ -3,5 +3,6 @@
     "identifier": "SoundTrackEditor",
     "$kref": "#/ckan/spacedock/1480",
     "spec_version": "v1.4",
-    "x_via": "Automated SpaceDock CKAN submission"
+    "x_via": "Automated SpaceDock CKAN submission",
+    "comment": "Frozen due to install impossibility"
 }


### PR DESCRIPTION
SoundTrackEditor cannot be installed by CKAN without a spec change, or a change in the mod's installation folders.
Closes #5953