### PR TITLE
Filter localisations from CAMk3BlockII

### DIFF
--- a/NetKAN/CAMk3BlockII.netkan
+++ b/NetKAN/CAMk3BlockII.netkan
@@ -10,6 +10,7 @@
     "install": [
         {
             "find": "Cormorant Aeronology",
+            "filter": "Localizations",
             "install_to": "GameData"
         }
     ]


### PR DESCRIPTION
ShuttleLiftingBody is a dependency, and it includes the CA localisations for everything.
closes #5998