### PR TITLE
Split concatenated author names for PreciseNode

### DIFF
--- a/NetKAN/PreciseNode.netkan
+++ b/NetKAN/PreciseNode.netkan
@@ -5,7 +5,7 @@
     "name"           : "Precise Node",
     "identifier"     : "PreciseNode",
     "abstract"       : "Provides a more precise widget for maneuver node editing",
-    "author"         : "blizzy78,linuxgurugamer",
+    "author"         : ["blizzy78", "linuxgurugamer"],
     "license"        : "BSD-2-clause",
     "release_status" : "stable",
     "resources" : {


### PR DESCRIPTION
PreciseNode lists two authors, but they're combined into one comma-delimited string, and NetKAN supports proper lists of authors.