### PR TITLE
Split concatenated author names for Toolbar

### DIFF
--- a/NetKAN/Toolbar.netkan
+++ b/NetKAN/Toolbar.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version"  	: "v1.4",
     "name"          	: "Toolbar",
-    "author"        	: "blizzy78,linuxgurugamer",
+    "author"        	: ["blizzy78", "linuxgurugamer"],
     "identifier"    	: "Toolbar",
     "abstract"      	: "API for third-party plugins to provide toolbar buttons",
     "license"       	: "BSD-2-clause",


### PR DESCRIPTION
Toolbar lists two authors, but they're combined into one comma-delimited string, and NetKAN supports proper lists of authors.