### PR TITLE
Remove VAB folder from Fenrir

### DIFF
--- a/NetKAN/Fenrir.netkan
+++ b/NetKAN/Fenrir.netkan
@@ -10,10 +10,6 @@
         {
             "find":"Mythological-Space-Administration",
             "install_to": "GameData"
-        },
-        {
-            "find":"VAB",
-            "install_to": "Ships"
         }
     ]
 }


### PR DESCRIPTION
Author confirms that this folder is intentionally removed and will no longer be shipped:

https://forum.kerbalspaceprogram.com/index.php?/topic/166821-wip-fenrir-launcher-pack/&do=findComment&comment=3210124