### PR TITLE
Update DiverseKerbalHeads.netkan

### DIFF
--- a/NetKAN/DiverseKerbalHeads.netkan
+++ b/NetKAN/DiverseKerbalHeads.netkan
@@ -1,29 +1,18 @@
 {
-    "spec_version": 1,
+    "spec_version": 1.4,
     "identifier": "DiverseKerbalHeads",
-    "name": "Diverse Kerbal Heads",
-    "abstract": "Texture pack to provide racial and gender diversity to kerbonauts. Requires TextureReplacer.",
+    "$kref": "#/ckan/spacedock/1579",
     "author": [
         "Sylith",
         "shaw",
-        "IOI655362"
+        "IOI655362",
+        "klgraham1013"
     ],
     "license": "CC-BY-4.0",
-    "resources": {
-        "homepage": "https://kerbal.curseforge.com/projects/diverse-kerbal-heads-1-0"
-    },
-    "version": "1.0",
     "ksp_version": "any",
     "depends": [
         {
-            "name": "TextureReplacer"
+            "name": "TextureReplacerReplaced"
         }
-    ],
-    "install": [
-        {
-            "file": "GameData/TextureReplacer",
-            "install_to": "GameData"
-        }
-    ],
-    "download": "https://kerbal.curseforge.com/projects/diverse-kerbal-heads-1-0/files/latest"
+    ]
 }

--- a/NetKAN/DiverseKerbalHeads.netkan
+++ b/NetKAN/DiverseKerbalHeads.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1.4,
+    "spec_version": "v1.4",
     "identifier": "DiverseKerbalHeads",
     "$kref": "#/ckan/spacedock/1579",
     "author": [


### PR DESCRIPTION
Diverse Kerbal Heads now has new maintainer and is modified to be compatible with [Texture Replacer Replaced](https://forum.kerbalspaceprogram.com/index.php?/topic/167229-131-trr-diverse-kerbal-heads-v11-11052017/). I've contacted the author and he granted permissions for mod to be indexed by CKAN:
<img width="960" alt="screen" src="https://user-images.githubusercontent.com/2231969/32440653-5505bd2c-c31e-11e7-884f-41a929a17d1f.png">
