### PR TITLE
Remove SPH folder from TianGong

### DIFF
--- a/NetKAN/ChineseTianGongScienceSpaceStation.netkan
+++ b/NetKAN/ChineseTianGongScienceSpaceStation.netkan
@@ -9,10 +9,6 @@
             "install_to" : "GameData"
         },
         {
-            "find"       : "SPH",
-            "install_to" : "Ships"
-        },
-        {
             "find"       : "VAB",
             "install_to" : "Ships"
         }


### PR DESCRIPTION
It was empty in the old downloads anyway, and it's absent in the latest ones.