### PR TITLE
Move SamBelangerFlags to Spacedock

### DIFF
--- a/NetKAN/SamBelangerFlags.netkan
+++ b/NetKAN/SamBelangerFlags.netkan
@@ -4,7 +4,6 @@
     "name"           : "SamBelanger Flags",
     "$kref"          : "#/ckan/spacedock/1525",
     "abstract"       : "Flags used in SamBelanger's mods",
-    "x_netkan_epoch" : 1,
     "license"        : "MIT",
     "ksp_version"    : "any",
     "comment"        : "flagmod",

--- a/NetKAN/SamBelangerFlags.netkan
+++ b/NetKAN/SamBelangerFlags.netkan
@@ -2,10 +2,11 @@
     "spec_version"   : "v1.4",
     "identifier"     : "SamBelangerFlags",
     "name"           : "SamBelanger Flags",
-    "$kref"          : "#/ckan/spacedock/1525",
+    "$kref"          : "#/ckan/github/SamBelanger/SamBelangerFlags",
     "abstract"       : "Flags used in SamBelanger's mods",
     "license"        : "MIT",
     "ksp_version"    : "any",
+    "x_netkan_epoch" : 1,
     "comment"        : "flagmod",
     "release_status" : "stable",
     "install" : [

--- a/NetKAN/SamBelangerFlags.netkan
+++ b/NetKAN/SamBelangerFlags.netkan
@@ -1,9 +1,10 @@
 {
     "spec_version"   : "v1.4",
     "identifier"     : "SamBelangerFlags",
-    "name"           : "Sam Belanger Flags",
-    "$kref"          : "#/ckan/curse/271783",
+    "name"           : "SamBelanger Flags",
+    "$kref"          : "#/ckan/spacedock/1525",
     "abstract"       : "Flags used in SamBelanger's mods",
+    "x_netkan_epoch" : 1,
     "license"        : "MIT",
     "ksp_version"    : "any",
     "comment"        : "flagmod",


### PR DESCRIPTION
@SamBelanger, I really don't want to force people installing Optional Atmospheres to download the nearly 1GB that is DoubleDouble just to get the flags. If you want to have a SamBelanger Flags that is simply v1.0 and doesn't change, you could make a zip file available anywhere and we could point to that. We don't need a GitHub/Spacedock release to scrape for unchanging mods.