### PR TITLE
Update HeatControl's license

### DIFF
--- a/NetKAN/HeatControl.netkan
+++ b/NetKAN/HeatControl.netkan
@@ -4,7 +4,7 @@
     "$kref"          : "#/ckan/spacedock/537",
     "$vref"          : "#/ckan/ksp-avc",
     "release_status" : "stable",
-    "license"        : "CC-BY-NC-SA-4.0",
+    "license"        : ["CC-BY-NC-SA-4.0", "restricted"],
     "depends" : [
         { "name" : "ModuleManager" }
     ],

--- a/NetKAN/HeatControl.netkan
+++ b/NetKAN/HeatControl.netkan
@@ -4,7 +4,7 @@
     "$kref"          : "#/ckan/spacedock/537",
     "$vref"          : "#/ckan/ksp-avc",
     "release_status" : "stable",
-    "license"        : ["CC-BY-NC-SA-4.0", "restricted"],
+    "license"        : "restricted",
     "depends" : [
         { "name" : "ModuleManager" }
     ],


### PR DESCRIPTION
This mod's code is CC-BY-NC-SA-4.0, but its models are All Rights Reserved.

(That is the reason for #6037.)