### PR TITLE
Fix ksp_version_min for OPM 2.1

### DIFF
--- a/NetKAN/OuterPlanetsMod.netkan
+++ b/NetKAN/OuterPlanetsMod.netkan
@@ -58,6 +58,7 @@
         {
             "version": "1:2.1",
             "override": {
+                "ksp_version_min" : "1.2.1",
                 "ksp_version_max" : "1.2.2"
             }
         }


### PR DESCRIPTION
See https://github.com/KSP-CKAN/CKAN-meta/pull/1306; this pull request sets up a version override in the NetKAN to fix the problem of OPM 2.1 trying to install on the incompatible 1.1.x KSP releases.