### PR TITLE
DCK: update directories and dependencies

### DIFF
--- a/NetKAN/DCKDavincisCombatKit.netkan
+++ b/NetKAN/DCKDavincisCombatKit.netkan
@@ -5,21 +5,20 @@
     "$kref": "#/ckan/spacedock/1524",
     "x_via": "Automated SpaceDock CKAN submission",
     "depends": [
-        { "name": "ModuleManager" },
-        { "name": "BDArmoryContinued" },
-        { "name": "TweakScale" }
+        { "name": "ModuleManager" }
     ],
     "recommends": [
-        { "name": "FerramAerospaceResearch" },
-        { "name": "BDynamicsMk22Cockpits" },
-        { "name": "Mk2Expansion" },
+        { "name": "BDArmoryContinued"         },
+        { "name": "TweakScale"                },
+        { "name": "FerramAerospaceResearch"   },
+        { "name": "BDynamicsMk22Cockpits"     },
+        { "name": "Mk2Expansion"              },
         { "name": "QuizTechAeroPackContinued" }
     ],
     "install": [
-        {
-            "find": "DCK",
-            "install_to": "GameData",
-            "filter": ".git"
-        }
+        { "find": "DCKinc",             "install_to": "GameData" },
+        { "find": "DCK_AirplanePlus",   "install_to": "GameData" },
+        { "find": "DCK_AviatorArsenal", "install_to": "GameData" },
+        { "find": "DCK_QuizTech",       "install_to": "GameData" }
     ]
 }


### PR DESCRIPTION
- The DCK folder is now DCKinc
- The release announcement says only ModuleManager is required, so other depends moved to recommends
- Other supplemental folders added

https://forum.kerbalspaceprogram.com/index.php?/topic/159310-13x-dck-v030-part-textures-rims-transparent-aircraft-armor-energy-shields-stealth-coating-and-other-goodies-for-ksp-stock-bdac-bdmk22-sm_afvs-m2x-kax-ap-badtprops-quiztech-procedural-parts11052017/&do=findComment&comment=3211388