### PR TITLE
Update KSP versions for NewTantares

### DIFF
--- a/NetKAN/NewTantares.netkan
+++ b/NetKAN/NewTantares.netkan
@@ -5,7 +5,8 @@
     "identifier"   : "NewTantares",
     "$kref"        : "#/ckan/github/Tantares/Tantares",
     "license"      : "CC-BY-NC-SA-4.0",
-    "ksp_version"  : "1.2.2",
+    "ksp_version_min" : "1.3.0",
+    "ksp_version_max" : "1.3.8",
     "abstract"     : "Stockalike Soyuz, LK and more!",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/73686-Tantares"


### PR DESCRIPTION
Version is hard coded to 1.2.2 in the netkan, but this mod has been 1.3 compatible since June:

https://github.com/Tantares/Tantares/releases

It doesn't specify 1.3.0 or 1.3.1, so I went with both.