### PR TITLE
Filter empty PluginData folder in DistantObject-default (fixes #6065)

### DIFF
--- a/NetKAN/DistantObject-default.netkan
+++ b/NetKAN/DistantObject-default.netkan
@@ -14,7 +14,7 @@
     "install": [{
         "file": "GameData/DistantObject",
         "install_to": "GameData",
-        "filter": ["DistantObject.dll", "Flare", "Icons", "Settings.cfg", "DistantObject.version"]
+        "filter": ["DistantObject.dll", "Flare", "Icons", "Settings.cfg", "DistantObject.version", "PluginData"]
     }],
     "provides": ["DistantObject-config"],
     "conflicts": [


### PR DESCRIPTION
DistantObject-default currently installs an empty GameData/DistantObject/PluginData folder, which causes conflicts with DistantObject at uninstallation (see #6065). This pull request removes the empty folder.