### PR TITLE
Move GPP's conflicting recommends to suggests

### DIFF
--- a/NetKAN/GPP.netkan
+++ b/NetKAN/GPP.netkan
@@ -28,7 +28,7 @@
         {
             "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
             "install_to": "GameData",
-            "comment": "This correctly installs Final Fronteir for GPP"
+            "comment": "This correctly installs Final Frontier for GPP"
         },
         {
             "find": "Optional Mods/LoadingScreen/GameData/LoadingScreenManager",
@@ -57,12 +57,6 @@
     ],
     "recommends": [
         {
-            "name": "GPPCloudsHighRes"
-        },
-        {
-            "name": "GPPCloudsLowRes"
-        },
-        {
             "name": "Strategia"
         },
         {
@@ -77,22 +71,30 @@
         {
             "name": "OPM-Galileo"
         },
-		{
+        {
             "name": "KerbalKonstructs"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "GPPCloudsHighRes"
         },
-		{
+        {
+            "name": "GPPCloudsLowRes"
+        },
+        {
             "name": "Rescale-25"
         },
-		{
+        {
             "name": "Rescale-32"
         },
-		{
+        {
             "name": "Rescale-64"
         },
-		{
+        {
             "name": "Rescale-10"
         },
-		{
+        {
             "name": "Rescale-10625"
         }
     ],

--- a/NetKAN/GPP.netkan
+++ b/NetKAN/GPP.netkan
@@ -103,13 +103,7 @@
             "name": "Rescale-10625"
         }
     ],
-    "conflicts": [
-        {
-            "name": "LoadingScreenManager"
-        }
-    ],
     "provides": [
-        "Scatterer-sunflare",
-        "LoadingScreenManager"
+        "Scatterer-sunflare"
     ]
 }

--- a/NetKAN/GPP.netkan
+++ b/NetKAN/GPP.netkan
@@ -24,11 +24,6 @@
             "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
             "install_to": "GameData",
             "comment": "This correctly installs Final Frontier for GPP"
-        },
-        {
-            "find": "Optional Mods/LoadingScreen/GameData/LoadingScreenManager",
-            "install_to": "GameData",
-            "comment": "This correctly installs LoadingScreenManager for GPP"
         }
     ],
     "version": "1.5.3",

--- a/NetKAN/GPP.netkan
+++ b/NetKAN/GPP.netkan
@@ -79,6 +79,9 @@
     ],
     "suggests": [
         {
+            "name": "SigmaBinary-core"
+        },
+        {
             "name": "GPPCloudsHighRes"
         },
         {

--- a/NetKAN/GPP.netkan
+++ b/NetKAN/GPP.netkan
@@ -63,6 +63,18 @@
         },
         {
             "name": "KerbalKonstructs"
+        },
+        {
+            "name": "SigmaReplacements-Heads"
+        },
+        {
+            "name": "SigmaReplacements-Suits"
+        },
+        {
+            "name": "SigmaReplacements-Skybox"
+        },
+        {
+            "name": "SigmaReplacements-Navigation"
         }
     ],
     "suggests": [

--- a/NetKAN/GPP.netkan
+++ b/NetKAN/GPP.netkan
@@ -21,11 +21,6 @@
             "comment": "This correctly installs KSCSwitcher for GPP"
         },
         {
-            "find": "Optional Mods/GPP_TextureReplacer/GameData/TextureReplacer",
-            "install_to": "GameData",
-            "comment": "This correctly installs TextureReplacer for GPP"
-        },
-        {
             "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
             "install_to": "GameData",
             "comment": "This correctly installs Final Frontier for GPP"


### PR DESCRIPTION
GPP currently recommends a number of mods that conflict with one another.

Cloud packs:
- GPPCloudsHighRes
- GPPCloudsLowRes

Rescales:
- Rescale-25
- Rescale-32
- Rescale-64
- Rescale-10
- Rescale-10625

Currently if you install GPP from the command line, it installs Rescale x2.5, which should probably be something the user chooses rather than the default. And GUI defaults to installing them all:

![image](https://user-images.githubusercontent.com/1559108/33454008-16440694-d5dd-11e7-8d0a-34d5c0b78273.png)

This pull request moves these mods from recommends to suggests, so the user can choose which ones they want, if any.

Pinging @Galileo88 for FYI/feedback. 