### PR TITLE
TextureReplacerReplaced, don't provide yourself

### DIFF
--- a/NetKAN/TextureReplacerReplaced.netkan
+++ b/NetKAN/TextureReplacerReplaced.netkan
@@ -13,7 +13,6 @@
 							"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/161898-*",
 							"repository": "https://github.com/HaArLiNsH/TextureReplacerReplaced"
 						},
-	"provides": ["TextureReplacerReplaced"],
 	"conflicts": [ { "name": "TextureReplacer" } ],
 	"install"  : [
 						{


### PR DESCRIPTION
TRR currently provides itself. This is redundant and confuses the installer; the user is asked to choose between the same mod twice when installing a dependent mod:

![image](https://user-images.githubusercontent.com/1559108/33461543-86b596c0-d5f8-11e7-8d1d-62af79f79d39.png)

This pull requests removes that provides directive.