### PR TITLE
DeepFreeze: Conflicting life support recommends to suggests

### DIFF
--- a/NetKAN/DeepFreeze.netkan
+++ b/NetKAN/DeepFreeze.netkan
@@ -15,10 +15,12 @@
         { "name" : "BackgroundProcessing" },
         { "name" : "ShipManifest" },
         { "name" : "ConnectedLivingSpace" },
+        { "name" : "AmpYearPowerManager"}
+    ],
+    "suggests": [
         { "name" : "USI-LS" },
         { "name" : "TACLS" },
-        { "name" : "Snacks" },
-        { "name" : "AmpYearPowerManager"}
+        { "name" : "Snacks" }
     ],
     "install": [
         { 


### PR DESCRIPTION
DeepFreeze currently recommends three life support mods, TACLS, USI-LS, and Snacks. Of these, TACLS and USI-LS are marked as conflicting; Snacks isn't, but it's supposed to be a simplified life support mod, so a user wanting to install it probably wouldn't want to deal with the complexity of the other two. In GUI, recommendations are checked by default when prompting for optional dependencies, so the user would have to know that they conflict and then uncheck the ones they don't want.

This pull requests moves these life support mods to "suggests". This way the user can choose whether and which to install rather than having them default to checked in the GUI.