### PR TITLE
Update required for IXSWarpShipOS release 0.4.0.8

### DIFF
--- a/NetKAN/IXSWarpshipOS.netkan
+++ b/NetKAN/IXSWarpshipOS.netkan
@@ -2,7 +2,7 @@
     "license": "CC-BY-NC-SA-4.0",
     "identifier": "IXSWarpshipOS",
     "$kref": "#/ckan/spacedock/589",
-    "spec_version": "v1.4",
+    "spec_version": "v1.16",
     "depends": [
         { "name": "CommunityResourcePack" },
         { "name": "ModuleManager" }

--- a/NetKAN/IXSWarpshipOS.netkan
+++ b/NetKAN/IXSWarpshipOS.netkan
@@ -23,7 +23,12 @@
         {
             "find"       : "IXSWarpShipOS",
             "install_to" : "GameData",
-            "filter"     : ".DS_Store"
+            "filter"     : [ ".DS_Store", "Example Craft", "old Spacedocks.zip" ]
+        },
+        {
+            "find"               : "IXS01 Warpship Prototype.craft",
+            "install_to"         : "Ships/VAB",
+            "find_matches_files" : true
         }
     ]
 }

--- a/NetKAN/IXSWarpshipOS.netkan
+++ b/NetKAN/IXSWarpshipOS.netkan
@@ -4,11 +4,16 @@
     "$kref": "#/ckan/spacedock/589",
     "spec_version": "v1.4",
     "depends": [
-        { "name": "AlcubierreStandalone" },
-        { "name": "CommunityResourcePack" }
+        { "name": "CommunityResourcePack" },
+        { "name": "ModuleManager" }
+    ],
+    "recommends": [
+        { "name": "WarpDrive" },
+        { "name": "AlcubierreStandalone" }
     ],
     "suggests": [
-    	{ "name": "SpaceDock" }
+        { "name": "SpacedocksRedeployed" },
+        { "name": "CommunityTechTree" }
     ],
     "conflicts": [
         { "name": "WarpShip" },


### PR DESCRIPTION
- changed suggested SpaceDock to SpaceDockRedeployed
- moved Alcubierre Drive from depends to recommends
- added WarpDrive to recommends
- added suggests CommunityTechTree
- added depends ModuleManager

@bartblommaerts, I apologize, I appear to have messed up #6079 beyond my ability to repair. There was a conflict with master because your branch was out of date, and in the process of resolving the conflicts, I erroneously committed instead of `rebase --continue`ing, then pushed to your branch thinking the changes were ready. But git decided to push unchanged master instead, after which your branch had no changes; GitHub decided this meant it should auto-close your PR, and without an open PR, I can no longer push changes to your branch.

The good news is that I do still have the changes and was able to resolve the conflicts properly and push them to my own branch. So while I can't restore your PR, I can create this new one to replace it.