### PR TITLE
Remove version hardcoding for GPP

### DIFF
--- a/NetKAN/GPP.netkan
+++ b/NetKAN/GPP.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier": "GPP",
     "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack",
+    "$vref": "#/ckan/ksp-avc",
     "name": "Galileo's Planet Pack",
     "abstract": "Galileo's Planet Pack is an all new solar system. With high quality planets to explore, and more challeging gameplay than the stock game, GPP will give even the most accomplished KSPer hours of fun. GPP removes the stock planetary system and will corrupt stock system game saves.",
     "author": "Galileo88",
@@ -26,7 +27,6 @@
             "comment": "This correctly installs Final Frontier for GPP"
         }
     ],
-    "version": "1.5.3",
     "ksp_version": "1.3.1",
     "depends": [
         {


### PR DESCRIPTION
GPP updated from 1.5.3 to 1.5.88, but the version was hardcoded in the netkan, so the new version overwrote the old.

GPP ships a valid AVC file, though, so we can just $vref it.