### PR TITLE
Use KSP-AVC file for GPP side mods

### DIFF
--- a/NetKAN/GPPCloudsHighRes.netkan
+++ b/NetKAN/GPPCloudsHighRes.netkan
@@ -23,7 +23,7 @@
             "name": "GPPCloudsLowRes"
         }
     ],
-    "version": "1.5.3",
+    "$vref": "#/ckan/ksp-avc",
     "ksp_version": "1.3.1",
     "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack",
     "identifier": "GPPCloudsHighRes",

--- a/NetKAN/GPPCloudsLowRes.netkan
+++ b/NetKAN/GPPCloudsLowRes.netkan
@@ -23,7 +23,7 @@
             "name": "GPPCloudsHighRes"
         }
     ],
-    "version": "1.5.3",
+    "$vref": "#/ckan/ksp-avc",
     "ksp_version": "1.3.1",
     "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack",
     "identifier": "GPPCloudsLowRes",

--- a/NetKAN/GPPSecondary.netkan
+++ b/NetKAN/GPPSecondary.netkan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-ksp-13-galileos-planet-pack-v151-8-sept-2017/"
     },
-    "version": "1.5.3",
+    "$vref": "#/ckan/ksp-avc",
     "ksp_version": "1.3.1",
     "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack",
     "identifier": "GPPSecondary",


### PR DESCRIPTION
These mods are currently installing version 1.5.88 while CKAN displays 1.5.3.

Switching to AVC $vref since the download contains a valid version file.