### PR TITLE
FASA: Move TR from depends to recommends

### DIFF
--- a/NetKAN/FASA.netkan
+++ b/NetKAN/FASA.netkan
@@ -12,17 +12,16 @@
     "license"       : "CC-BY-SA",
     "ksp_version_min"   : "1.2.0",
     "ksp_version_max"   : "1.3",
-    "install"       : [
-    {
+    "install"       : [{
         "find"      : "FASA",
         "install_to": "GameData"
     }],
     "depends"       : [
-		{ "name" 	  : "ModuleManager" },
-        { "name"      : "TextureReplacer" }
+        { "name" : "ModuleManager" }
     ],
-	"recommends" : [
-        { "name" : "RasterPropMonitor" }
+    "recommends" : [
+        { "name" : "RasterPropMonitor" },
+        { "name" : "TextureReplacer"   }
     ],
     "conflicts" : [
         { "name": "FASALaunchClamps" }


### PR DESCRIPTION
FASA currently depends on TextureReplacer, which is not available for KSP 1.3.1. This causes FASA to be hidden completely for KSP 1.3.1 (see KSP-CKAN/CKAN#1695). However, manual users of FASA report that it works without TextureReplacer, so it's more appropriately marked as an optional dependency:

https://forum.kerbalspaceprogram.com/index.php?/topic/22888-105-fasa-544/&do=findComment&comment=3244692

This PR changes that dependency to a recommendation, so FASA will be available to install without TextureReplacer on KSP 1.3.1.