### PR TITLE
TantaresLV works on KSP 1.3.1

### DIFF
--- a/NetKAN/NewTantaresLV.netkan
+++ b/NetKAN/NewTantaresLV.netkan
@@ -5,7 +5,7 @@
     "identifier"   : "NewTantaresLV",
     "$kref"        : "#/ckan/github/Tantares/TantaresLV",
     "license"      : "CC-BY-NC-SA-4.0",
-    "ksp_version"  : "1.2.2",
+    "ksp_version"  : "1.3.1",
     "abstract"     : "Stockalike N1, Soyuz and more!",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/73686-Tantares"


### PR DESCRIPTION
This mod is labeled as 1.3.1 compatible starting in late October.

https://github.com/Tantares/TantaresLV/releases