### PR TITLE
FoxDefenseContracts got moved into GameData

### DIFF
--- a/NetKAN/FoxDefenseContracts.netkan
+++ b/NetKAN/FoxDefenseContracts.netkan
@@ -9,7 +9,7 @@
     ],
     "install": [
         {
-            "file": "FoxDefenseContracts",
+            "find": "FoxDefenseContracts",
             "install_to": "GameData"
         }
     ]


### PR DESCRIPTION
Slight structural change in this download, the folder is the same but now it's under a GameData folder.