### PR TITLE
Replace OptionalAtm with OptionalAtmospheresRevamped

### DIFF
--- a/NetKAN/OptionalAtm.netkan
+++ b/NetKAN/OptionalAtm.netkan
@@ -1,31 +1,33 @@
 {
-    "spec_version"   : "v1.4",
+    "spec_version"   : "v1.16",
     "identifier"     : "OptionalAtm",
-    "$kref"          : "#/ckan/spacedock/1525",
+    "$kref"          : "#/ckan/github/DeltaDizzy/OptionalAtmospheresRevamped",
     "$vref"          : "#/ckan/ksp-avc",
-    "abstract"       : "Adds atmospheres to those planets and moons which don't have atmospheres of the kerbol system",
+    "abstract"       : "Adds atmospheres to those planets and moons which don't have atmospheres of the Kerbol system",
     "license"        : "MIT",
     "release_status" : "stable",
+    "x_netkan_epoch" : 1,
+    "ksp_version_min" : "1.3.0",
+    "ksp_version_max" : "1.3.1",
     "resources" : {
-        "homepage"     : "http://forum.kerbalspaceprogram.com/index.php?/topic/163142-wip-130-optionalatmosphere-oa-v14",
-        "repository"   : "https://github.com/SamBelanger/OptionalAtmosphere"
+        "homepage"   : "https://forum.kerbalspaceprogram.com/index.php?/topic/167316-13113optional-atmospheres-revampedoar",
+        "repository" : "https://github.com/DeltaDizzy/OptionalAtmospheresRevamped"
     },
     "install" : [
         {
-            "find"       : "OptionalAtmospheres",
-            "install_to" : "GameData/SamBelanger"
+            "find"       : "OptionalAtmospheresRevamped",
+            "install_to" : "GameData"
         }
     ],
     "depends" : [
-        { "name" : "Kopernicus", "min_version" : "2:release-1.3.0-4" },
-        { "name" : "ModuleManager", "min_version" : "2.8.0" },
-        { "name" : "ModularFlightIntegrator", "min_version" : "1.2.4.0" },
+        { "name" : "Kopernicus",              "min_version" : "2:release-1.3.0-4" },
+        { "name" : "ModuleManager",           "min_version" : "2.8.0"             },
+        { "name" : "ModularFlightIntegrator", "min_version" : "1.2.4.0"           },
         { "name" : "CommunityResourcePack" },
-        { "name" : "SamBelangerFlags" }
+        { "name" : "SamBelangerFlags"      }
     ],
     "recommends" : [
-        { "name" : "BetterTimeWarpContinued" },
-        { "name" : "KSP-AVC" }
+        { "name" : "BetterTimeWarpContinued" }
     ],
     "x_netkan_override": [
         {
@@ -38,9 +40,9 @@
             "version": "1.4.9.1",
             "override": {
                 "depends" : [
-                    { "name" : "Kopernicus", "min_version" : "2:release-1.3.0-4" },
-                    { "name" : "ModuleManager", "min_version" : "2.8.0" },
-                    { "name" : "ModularFlightIntegrator", "min_version" : "1.2.4.0" }
+                    { "name" : "Kopernicus",              "min_version" : "2:release-1.3.0-4" },
+                    { "name" : "ModuleManager",           "min_version" : "2.8.0"             },
+                    { "name" : "ModularFlightIntegrator", "min_version" : "1.2.4.0"           }
                 ],
                 "install" : [
                     {

--- a/NetKAN/OptionalAtm.netkan
+++ b/NetKAN/OptionalAtm.netkan
@@ -1,6 +1,7 @@
 {
     "spec_version"   : "v1.16",
     "identifier"     : "OptionalAtm",
+    "author"         : [ "DeltaDizzy", "SamBelanger" ],
     "$kref"          : "#/ckan/github/DeltaDizzy/OptionalAtmospheresRevamped",
     "abstract"       : "Adds atmospheres to those planets and moons which don't have atmospheres of the Kerbol system",
     "license"        : "MIT",

--- a/NetKAN/OptionalAtm.netkan
+++ b/NetKAN/OptionalAtm.netkan
@@ -2,7 +2,6 @@
     "spec_version"   : "v1.16",
     "identifier"     : "OptionalAtm",
     "$kref"          : "#/ckan/github/DeltaDizzy/OptionalAtmospheresRevamped",
-    "$vref"          : "#/ckan/ksp-avc",
     "abstract"       : "Adds atmospheres to those planets and moons which don't have atmospheres of the Kerbol system",
     "license"        : "MIT",
     "release_status" : "stable",


### PR DESCRIPTION
OptionalAtmospheres was recently removed from SpaceDock, and now lives on GitHub. 
@SamBelanger has transferred ownership to @DeltaDizzy.
The download no longer has a KSP-AVC file.

Fixes #6105.