### PR TITLE
Add DSSHU life support patches

### DIFF
--- a/NetKAN/DeepSpaceSurfaceHabitatUnitPack.netkan
+++ b/NetKAN/DeepSpaceSurfaceHabitatUnitPack.netkan
@@ -31,6 +31,18 @@
             "find":       "DSSHU-Tweakscale.cfg",
             "install_to": "GameData/DSSHU",
             "find_matches_files": true
+        }, {
+            "find":       "DSSHU-Snacks.cfg",
+            "install_to": "GameData/DSSHU",
+            "find_matches_files": true
+        }, {
+            "find":       "DSSHU-TACLS.cfg",
+            "install_to": "GameData/DSSHU",
+            "find_matches_files": true
+        }, {
+            "find":       "DSSHU-USILifeSupport.cfg",
+            "install_to": "GameData/DSSHU",
+            "find_matches_files": true
         } 
     ]
 }


### PR DESCRIPTION
These configs were previously applied unconditionally and incompatible, so we weren't installing them. The author has updated them to use NEEDS clauses, so now we'll install them all.