### PR TITLE
Make IR parts available

### DIFF
--- a/NetKAN/InfernalRobotics-LegacyParts.netkan
+++ b/NetKAN/InfernalRobotics-LegacyParts.netkan
@@ -1,8 +1,8 @@
 {
     "spec_version": "v1.4",
     "identifier": "InfernalRobotics-LegacyParts",
-    "$kref": "#/ckan/github/MagicSmokeIndustries/InfernalRobotics/asset_match/IR-LegacyParts\\.zip",
-    "ksp_version": "1.1",
+    "$kref": "#/ckan/github/MagicSmokeIndustries/InfernalRobotics/asset_match/.*-Full\\.zip$",
+    "ksp_version": "any",
     "license": "GPL-3.0",
     "name": "Magic Smoke Industries Infernal Robotics - Legacy Parts",
     "abstract": "Making stuff move.",


### PR DESCRIPTION
InfernalRobotics is currently released in a non-functional state, strictly speaking. It consists of a plugin and some parts, but the last time the parts were released was for KSP 1.1.3. Since then, the developers have only been releasing "Core" updates containing just the plugin, including for KSP 1.3.1. Users are expected to assemble the mod themselves by extracting the parts from an earlier release.

In theory, CKAN supports this via the InfernalRobotics-LegacyParts module. However, this package targets an old download file naming scheme (IR-LegacyParts.zip was last released for IR 2.0.0, and after that the naming scheme was changed to IR-version-Final-Full.zip), and was set as only compatible with KSP 1.1 in its netkan. This resulted in frequent confusion for CKAN users, who would install InfernalRobotics and then complain that its parts list was empty (see MagicSmokeIndustries/InfernalRobotics#150 and MagicSmokeIndustries/InfernalRobotics#153).

This pull request updates the InfernalRobotics-LegacyParts module to use the most recent available release and marks it as compatible with all versions of KSP.

Fixes #6131.