### PR TITLE
Mark KWRocketryRedux and KWRocketryRebalanced as conflicting

### DIFF
--- a/NetKAN/KWRocketryRebalanced.netkan
+++ b/NetKAN/KWRocketryRebalanced.netkan
@@ -9,22 +9,23 @@
     "resources" : {
         "homepage"  :   "http://forum.kerbalspaceprogram.com/index.php?/topic/137762-kw-rocketry-redux/"
     },
-    "depends": [
+    "depends" : [
         { "name" : "ModuleManager" }
     ],
     "conflicts" : [
         { "name" : "KWRocketry" },
+        { "name" : "KWRocketryRedux" },
         { "name" : "KWRocketry-CommunityFixes" },
         { "name" : "KWRocketry-CommunityFixes-interstage"  }
     ],
-    "recommends": [ 
+    "recommends" : [ 
        { "name": "SimpleAdjustableFairings-KWRocketry" }, 
        { "name": "Patchmanager" },
        { "name": "JanitorsCloset" } 
     ],
-    "install"     : [
+    "install" : [
         {
-            "find"    : "KWRocketryRebalanced/GameData/KWRocketry",
+            "find"      : "KWRocketryRebalanced/GameData/KWRocketry",
             "install_to": "GameData"
         }
     ]

--- a/NetKAN/KWRocketryRebalanced.netkan
+++ b/NetKAN/KWRocketryRebalanced.netkan
@@ -7,7 +7,7 @@
     "name"          : "KW Rocketry Rebalanced",
     "abstract"      : "This is the full KW Rocketry with the tanks rebalanced to better values",
     "resources" : {
-        "homepage"  :   "http://forum.kerbalspaceprogram.com/index.php?/topic/137762-kw-rocketry-redux/"
+        "homepage"  : "http://forum.kerbalspaceprogram.com/index.php?/topic/137762-kw-rocketry-redux/"
     },
     "depends" : [
         { "name" : "ModuleManager" }
@@ -16,17 +16,17 @@
         { "name" : "KWRocketry" },
         { "name" : "KWRocketryRedux" },
         { "name" : "KWRocketry-CommunityFixes" },
-        { "name" : "KWRocketry-CommunityFixes-interstage"  }
+        { "name" : "KWRocketry-CommunityFixes-interstage" }
     ],
     "recommends" : [ 
-       { "name": "SimpleAdjustableFairings-KWRocketry" }, 
-       { "name": "Patchmanager" },
-       { "name": "JanitorsCloset" } 
+        { "name" : "SimpleAdjustableFairings-KWRocketry" }, 
+        { "name" : "Patchmanager" },
+        { "name" : "JanitorsCloset" } 
     ],
     "install" : [
         {
-            "find"      : "KWRocketryRebalanced/GameData/KWRocketry",
-            "install_to": "GameData"
+            "find"       : "KWRocketryRebalanced/GameData/KWRocketry",
+            "install_to" : "GameData"
         }
     ]
 }

--- a/NetKAN/KWRocketryRedux.netkan
+++ b/NetKAN/KWRocketryRedux.netkan
@@ -17,11 +17,11 @@
         { "name" : "KWRocketry" },
         { "name" : "KWRocketryRebalanced" },
         { "name" : "KWRocketry-CommunityFixes" },
-        { "name" : "KWRocketry-CommunityFixes-interstage"  }
+        { "name" : "KWRocketry-CommunityFixes-interstage" }
     ],
     "recommends" : [ 
-       { "name" : "SimpleAdjustableFairings-KWRocketry" }, 
-       { "name" : "JanitorsCloset" } 
+        { "name" : "SimpleAdjustableFairings-KWRocketry" }, 
+        { "name" : "JanitorsCloset" } 
     ],
     "install" : [
         {

--- a/NetKAN/KWRocketryRedux.netkan
+++ b/NetKAN/KWRocketryRedux.netkan
@@ -2,30 +2,31 @@
     "spec_version"  : "v1.4",
     "identifier"    : "KWRocketryRedux",
     "$kref"         : "#/ckan/github/linuxgurugamer/KWRocketryRedux",
-    "$vref"           : "#/ckan/ksp-avc",
+    "$vref"         : "#/ckan/ksp-avc",
     "license"       : "CC-BY-SA-3.0",
     "name"          : "KW Rocketry Redux",
     "abstract"      : "This is the full KW Rocketry with the Community Fixes included.  Repackaged so that the power configs are selecteable in CKAN",
     "resources" : {
-        "homepage"  :   "http://forum.kerbalspaceprogram.com/index.php?/topic/137762-kw-rocketry-redux/"
+        "homepage"  : "http://forum.kerbalspaceprogram.com/index.php?/topic/137762-kw-rocketry-redux/"
     },
-    "depends": [
+    "depends" : [
         { "name" : "ModuleManager" },
         { "name" : "KWRocketryRedux-power" }
     ],
     "conflicts" : [
         { "name" : "KWRocketry" },
+        { "name" : "KWRocketryRebalanced" },
         { "name" : "KWRocketry-CommunityFixes" },
         { "name" : "KWRocketry-CommunityFixes-interstage"  }
     ],
-    "recommends": [ 
-       { "name": "SimpleAdjustableFairings-KWRocketry" }, 
-       { "name": "JanitorsCloset" } 
+    "recommends" : [ 
+       { "name" : "SimpleAdjustableFairings-KWRocketry" }, 
+       { "name" : "JanitorsCloset" } 
     ],
-    "install"     : [
+    "install" : [
         {
-            "find"    : "KWRocketry/GameData/KWRocketry",
-            "install_to": "GameData"
+            "find"       : "KWRocketry/GameData/KWRocketry",
+            "install_to" : "GameData"
         }
     ]
 }


### PR DESCRIPTION
These are nearly the same mod, but it's currently possible to attempt to install both:

```
$ ckan install KWRocketryRedux KWRocketryRebalanced
1) KWRocketryRedux-GraduatedPwr (KW Rocketry Redux - Graduated Power Response Configs)
2) KWRocketryRedux-InstantPwr (KW Rocketry Redux - Instant Power Response Configs)
Enter a number between 1 and 2 (To cancel press "c" or "n".): 
2 
About to install...

 * KW Rocketry Redux 3.1.4 (cached)
 * KW Rocketry Rebalanced 3.2.3 (cached)
 * KW Rocketry Redux - Instant Power Response Configs 3.1.4 (cached)
 * Module Manager 3.0.1 (cached)
 * Simple Adjustable Fairings - KW Rocketry Pack v1.0.1 (cached)
 * Simple Adjustable Fairings - Plugin v1.0.1 (cached)
 * The Janitor's Closet 0.3.2 (cached)
 * Filter Extensions - Plugin 3.0.4 (cached)
 * Filter Extensions - Default Configuration 3.0.4 (cached)
 * KSP AVC 1.1.6.2 (cached)

Continue? [Y/n] 


Installing mod "KWRocketryRedux 3.1.4"
Installing mod "KWRocketryRebalanced 3.2.3"
Oh no! We tried to overwrite a file owned by another mod!
Please try a `ckan update` and try again.

If this problem re-occurs, then it maybe a packaging bug.
Please report it at:

https://github.com/KSP-CKAN/NetKAN/issues/new

Please including the following information in your report:

File           : GameData/KWRocketry/Flags/KWFlag01.png
Installing Mod : KWRocketryRebalanced 3.2.3
Owning Mod     : KWRocketryRedux
CKAN Version   : v1.24.0-PRE+c54020bc44a0

Your GameData has been returned to its original state.
```

Now they're marked as conflicting.

Fixes #6138.