### PR TITLE
Stop hardcoding game version

### DIFF
--- a/NetKAN/PEBKACIndustriesLaunchEscapeSystem.netkan
+++ b/NetKAN/PEBKACIndustriesLaunchEscapeSystem.netkan
@@ -5,7 +5,6 @@
     "$vref": "#/ckan/ksp-avc",
     "license": "restricted",
     "name" : " Launch Escape System",
-    "ksp_version": "1.1.3",
     "abstract" : "The PEBKAC Industries LES (PKI-LES) is designed to more or less simulate the Apollo and Mercury LES's used in real life",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/index.php?/topic/106518-113-pebkac-industries-launch-escape-system-20160706-now-includes-mk1-les/&page=1"


### PR DESCRIPTION
PEBKACIndustriesLaunchEscapeSystem crashes on KSP 1.2.2, because CKAN installs a 1.3.1-only version of the mod, because the version metadata is too broad, because ksp_version is set to 1.1.3 in the netkan.

Now that's removed.

Fixes the netkan for #6148. CKAN-meta PR to follow for older versions.