### PR TITLE
Update game version of KittopiaTech

### DIFF
--- a/NetKAN/KittopiaTech.netkan
+++ b/NetKAN/KittopiaTech.netkan
@@ -17,7 +17,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/140581-kittopia/"
     },
-    "ksp_version": "1.2",
+    "ksp_version": "1.3.0",
     "depends": [
         { "name" : "Kopernicus", "min_version": "2:release-1.2.0-1" }
     ],


### PR DESCRIPTION
KottopiaTech's latest release is for 1.3.0. It doesn't have a KSP-AVC file.

Discovered during investigation of #6154.