### PR TITLE
Taerobee is just parts, mark it as version independent

### DIFF
--- a/NetKAN/Taerobee.netkan
+++ b/NetKAN/Taerobee.netkan
@@ -1,11 +1,11 @@
 {
     "spec_version": "v1.4",
-    "identifier": "Taerobee",
-    "$kref": "#/ckan/github/Tantares/Taerobee",
-    "license": "CC-BY-NC-SA-4.0",
-    "name": "Taerobee - Stockalike X-1 & More",
-    "abstract": "Stockalike Historic (Pre-Sputnik) Rocket and Aircraft Parts.",
-    "ksp_version": "1.2.2",
+    "identifier":   "Taerobee",
+    "$kref":        "#/ckan/github/Tantares/Taerobee",
+    "license":      "CC-BY-NC-SA-4.0",
+    "name":         "Taerobee - Stockalike X-1 & More",
+    "abstract":     "Stockalike Historic (Pre-Sputnik) Rocket and Aircraft Parts.",
+    "ksp_version":  "any",
     "x_netkan_version_edit": "^[vV]?(?<version>.+)$",
     "x_netkan_epoch": "1",
     "resources": {
@@ -13,7 +13,7 @@
     },
     "install": [
         {
-            "find": "Taerobee",
+            "find":       "Taerobee",
             "install_to": "GameData"
         }
     ],


### PR DESCRIPTION
Taerobee's forum thread says it supports 1.3.1, but we have it as 1.2.2. The latest release is older than KSP 1.3, so I took a look, and it's just a parts/config mod, so it makes sense to mark it compatible with any game version.

Discovered during investigation of #6154.