### PR TITLE
Update game version for KerbalWind

### DIFF
--- a/NetKAN/KerbalWind.netkan
+++ b/NetKAN/KerbalWind.netkan
@@ -5,7 +5,7 @@
     "name"         : "Kerbal Wind",
     "abstract"     : "Implements wind and a continuous-gusts model for Ferram Aerospace Research. Provides GUI with settings for wind direction, speed and turbulence magnitude.",
     "license"      : "MIT",
-    "ksp_version"  : "1.1",
+    "ksp_version"  : "1.3",
     "recommends" : [
         { "name" : "Toolbar" }
     ],
@@ -16,10 +16,10 @@
         "homepage" : "http://forum.kerbalspaceprogram.com/threads/107989"
     },
 
-    "comment": "FAR only supports one wind provider at once",
-    "provides" : [ "FARWind" ],
-    "conflicts": [ {"name": "FARWind" } ],
+    "comment"   : "FAR only supports one wind provider at once",
+    "provides"  : [ "FARWind" ],
+    "conflicts" : [ {"name": "FARWind" } ],
 
-    "author" : [ "DaMichel", "silverfox8124" ],
+    "author"    : [ "DaMichel", "silverfox8124" ],
     "release_status" : "stable"
 }


### PR DESCRIPTION
The latest version of KerbalWind is for KSP 1.3, but we have it as 1.1. It doesn't have a KSP-AVC file.

Discovered during investigation of #6154.