### PR TITLE
Make UnchartedLands version-independent

### DIFF
--- a/NetKAN/UnchartedLands.netkan
+++ b/NetKAN/UnchartedLands.netkan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/120111-ul/"
     },
-    "ksp_version": "1.3.0",
+    "ksp_version"   : "any",
     "x_netkan_force_v": true,
     "depends": [
         { "name": "ModuleManager" },
@@ -30,7 +30,7 @@
     ],
     "install": [
         {
-            "find": "UnchartedLands",
+            "find":       "UnchartedLands",
             "install_to": "GameData"
         }
     ]

--- a/NetKAN/UnchartedLands.netkan
+++ b/NetKAN/UnchartedLands.netkan
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/120111-ul/"
     },
-    "ksp_version"   : "any",
+    "ksp_version"   : "1.3",
     "x_netkan_force_v": true,
     "depends": [
         { "name": "ModuleManager" },


### PR DESCRIPTION
UnchartedLands is marked as 1.3.1 compatible on its forum page, but we have it as 1.3.0. According to discussion on its forum thread, it works with both. It has no KSP-AVC file.

Discovered during investigation of #6154.