### PR TITLE
Update RCSLandAid to game version 1.3

### DIFF
--- a/NetKAN/RCSLandAid.netkan
+++ b/NetKAN/RCSLandAid.netkan
@@ -1,27 +1,27 @@
 {
-  "spec_version" : 1,
-  "identifier" : "RCSLandAid",
-  "$kref" : "#/ckan/github/SirDiazo/RCSLandAid",
-  "name" : "Horizontal Landing Aid",
-  "abstract" : "Kill your horizontal velocity to land, or hover over a specific point on the ground",
-  "license" : "GPL-3.0",
-  "release_status" : "stable",
-  "ksp_version" : "1.2",
-  "author" : "Diazo",
-  "depends": [
-{ "name": "ModuleManager" }
-],
-  "suggests": [
-    { "name": "Toolbar" }
-  ],
-  "resources": {
-    "homepage": "http://forum.kerbalspaceprogram.com/threads/85838",
-    "repository": "https://github.com/SirDiazo/RCSLandAid"
-  },
-  "install" : [
-    {
-      "file" : "GameData/Diazo",
-      "install_to" : "GameData"
-    }
-  ]
+    "spec_version" : 1,
+    "identifier"   : "RCSLandAid",
+    "$kref"        : "#/ckan/github/SirDiazo/RCSLandAid",
+    "name"         : "Horizontal Landing Aid",
+    "abstract"     : "Kill your horizontal velocity to land, or hover over a specific point on the ground",
+    "license"      : "GPL-3.0",
+    "release_status" : "stable",
+    "ksp_version"  : "1.3",
+    "author"       : "Diazo",
+    "depends" : [
+        { "name": "ModuleManager" }
+    ],
+    "suggests" : [
+        { "name": "Toolbar" }
+    ],
+    "resources" : {
+        "homepage":   "http://forum.kerbalspaceprogram.com/threads/85838",
+        "repository": "https://github.com/SirDiazo/RCSLandAid"
+    },
+    "install" : [
+        {
+            "file"       : "GameData/Diazo",
+            "install_to" : "GameData"
+        }
+    ]
 }


### PR DESCRIPTION
RCSLandAid is updated to KSP 1.3, but we have it as 1.2. It has a plugin but no KSP-AVC file.

Discovered during investigation of #6154.