### PR TITLE
Update KerbCam to KSP 1.2-1.3

### DIFF
--- a/NetKAN/KerbCam-Continued.netkan
+++ b/NetKAN/KerbCam-Continued.netkan
@@ -4,13 +4,14 @@
     "$kref"        : "#/ckan/github/cartman09/kerbcam",
     "name"         : "KerbCam Continued",
     "author"       : "cartman09",
-    "abstract"     : "Update and continuation of huin's Kerbcam for KSP 1.1",
+    "abstract"     : "Update and continuation of huin's Kerbcam for KSP",
     "license"      : "BSD-2-clause",
-    "ksp_version"  : "1.1",
+    "ksp_version_min" : "1.2",
+    "ksp_version_max" : "1.3",
     "install": [
     {
-            "file"       : "KerbCam",
-            "install_to" : "GameData"
+        "file"       : "KerbCam",
+        "install_to" : "GameData"
     }
     ],
     "resources": {


### PR DESCRIPTION
KerbCam's latest release was built for 1.2 and is reported by its author to work on 1.3, but we have it as 1.1. It doesn't have a KSP-AVC file.

Discovered during investigation of #6154.