### PR TITLE
Update SCANsat netkan for Overdrive incompatibility

### DIFF
--- a/NetKAN/SCANsat.netkan
+++ b/NetKAN/SCANsat.netkan
@@ -17,7 +17,7 @@
     ],
     "conflicts": [
         { "name": "ContractConfigurator-ScanSatLite" },
-		{ "name": "Overdrive" }
+	{ "name": "Overdrive" }
     ],
     "resources": {
         "repository": "https://github.com/S-C-A-N/SCANsat"

--- a/NetKAN/SCANsat.netkan
+++ b/NetKAN/SCANsat.netkan
@@ -16,7 +16,8 @@
         { "name": "RasterPropMonitor" }
     ],
     "conflicts": [
-        { "name": "ContractConfigurator-ScanSatLite" }
+        { "name": "ContractConfigurator-ScanSatLite" },
+		{ "name": "Overdrive" }
     ],
     "resources": {
         "repository": "https://github.com/S-C-A-N/SCANsat"

--- a/NetKAN/SCANsat.netkan
+++ b/NetKAN/SCANsat.netkan
@@ -17,7 +17,7 @@
     ],
     "conflicts": [
         { "name": "ContractConfigurator-ScanSatLite" },
-	{ "name": "Overdrive" }
+        { "name": "Overdrive" }
     ],
     "resources": {
         "repository": "https://github.com/S-C-A-N/SCANsat"


### PR DESCRIPTION
Overdrive changes the stock UI in a way that breaks SCANsat and is therefore incompatible with it.