### PR TITLE
Re-add deleted netkans as frozen

### DIFF
--- a/NetKAN/AxisSystem.frozen
+++ b/NetKAN/AxisSystem.frozen
@@ -1,0 +1,10 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "AxisSystem",
+    "$kref":        "#/ckan/spacedock/1438",
+    "license":      "MIT",
+    "depends": [ 
+        { "name": "Kopernicus"    },
+        { "name": "ModuleManager" }
+    ]
+}

--- a/NetKAN/RejuvenatedDuna.frozen
+++ b/NetKAN/RejuvenatedDuna.frozen
@@ -1,0 +1,17 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "RejuvenatedDuna",
+    "$kref":        "#/ckan/spacedock/894",
+    "license":      "CC-BY-NC-SA-4.0",
+    "x_via":        "Automated SpaceDock CKAN submission",
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus"    }
+    ],
+    "install": [
+        {
+            "find":       "RejuvenatedDuna",
+            "install_to": "GameData"
+        }
+    ]
+}

--- a/NetKAN/rt-config-by-ippo.frozen
+++ b/NetKAN/rt-config-by-ippo.frozen
@@ -1,0 +1,25 @@
+{
+    "spec_version": "v1.2",
+    "identifier":   "rt-config-by-ippo",
+    "name":         "Ippo's configuration for Remote Tech",
+    "abstract":     "This settings file for Remote Tech makes it both more realistic and a bit easier by giving nearly infinite range to the ground stations. Manually delete RemoteTech/RemoteTech_Settings.cfg first or this will not install.",
+    "$kref":        "#/ckan/github/Ippo343/rt-config",
+    "license":      "public-domain",
+    "ksp_version_min": "0.25",
+    "resources": {
+        "homepage": "https://github.com/Ippo343/rt-config"
+    },
+    "install": [
+        {
+            "file": "GameData/RemoteTech/RemoteTech_Settings.cfg",
+            "install_to": "GameData/RemoteTech"
+        }
+    ],
+    "depends": [
+        { "name": "RemoteTech" }
+    ],
+    "provides": [ "RemoteTech-Config" ],
+    "conflicts": [
+        { "name" : "RemoteTech-Config" }
+    ]
+}


### PR DESCRIPTION
## Problems

Early in my CKAN career, I was eager to eliminate all errors from http://status.ksp-ckan.org/, several of which were due to mods that had been removed from their host sites. In three instances I addressed this by deleting the .netkan files, which I found out in #5975 is a no-no; we should rename them to .frozen instead.

| Pull request | File |
| --- | --- |
| #5842 | AxisSystem.netkan |
| #5843 | RejuvenatedDuna.netkan |
| #5864 | rt-config-by-ippo.netkan |

@Olympic1, next time please tell the clueless new person about freezing. :wink: 

## Changes

These files are now retrieved from the repo archive and re-added as .frozen as they should have been.