### PR TITLE
Update NetKAN files for Pood's Skyboxes

### DIFF
--- a/NetKAN/PoodsCalmNebulaSkybox.netkan
+++ b/NetKAN/PoodsCalmNebulaSkybox.netkan
@@ -1,27 +1,27 @@
 {
     "spec_version": 1,
     "name": "Pood's Calm Nebula Skybox",
-    "abstract": "Skybox that presents the Kerbol system within a sparse Nebula. Features a subtle Galaxy star-line and patches of Pink/Blue Nebula proto-Star fields. To the polar South a very energetic solar nursery can be seen.",
+    "abstract": "Skybox that presents the Kerbal Solar System within a sparse Nebula. Features a subtle Galaxy star-line and patches of Pink/Blue Nebula proto-Star fields. To the polar South a very energetic solar nursery can be seen.",
     "author": "Poodmund",
     "identifier": "PoodsCalmNebulaSkybox",
     "$kref": "#/ckan/spacedock/924",
     "license": "CC-BY-NC-ND-4.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/96851-11-texturereplacer-2413-442016/&do=findComment&comment=2388097"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/169919-1"
     },
     "provides": [
         "Skybox"
     ],
-    "conflicts": [
-        { "name": "Skybox" }
-    ],
     "install": [
         {
-            "file": "GameData/TextureReplacer",
+            "file": "GameData/PoodsSkyboxes",
             "install_to": "GameData"
         }
     ],
     "depends": [
-        { "name": "TextureReplacer" }
+        { "name": "SigmaReplacements-SkyBox" }
+    ]
+    "suggests": [
+        { "name": "DistantObject" }
     ]
 }

--- a/NetKAN/PoodsCalmNebulaSkybox.netkan
+++ b/NetKAN/PoodsCalmNebulaSkybox.netkan
@@ -20,7 +20,7 @@
     ],
     "depends": [
         { "name": "SigmaReplacements-SkyBox" }
-    ]
+    ],
     "suggests": [
         { "name": "DistantObject" }
     ]

--- a/NetKAN/PoodsDeepStarMap.netkan
+++ b/NetKAN/PoodsDeepStarMap.netkan
@@ -20,7 +20,7 @@
     ],
     "depends": [
         { "name": "SigmaReplacements-SkyBox" }
-    ]
+    ],
     "suggests": [
         { "name": "DistantObject" }
     ]

--- a/NetKAN/PoodsDeepStarMap.netkan
+++ b/NetKAN/PoodsDeepStarMap.netkan
@@ -7,21 +7,21 @@
     "$kref": "#/ckan/spacedock/925",
     "license": "CC-BY-NC-ND-4.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/96851-11-texturereplacer-2413-442016/&do=findComment&comment=2388097"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/169919-1"
     },
     "provides": [
         "Skybox"
     ],
-    "conflicts": [
-        { "name": "Skybox" }
-    ],
     "install": [
         {
-            "file": "GameData/TextureReplacer",
+            "file": "GameData/PoodsSkyboxes",
             "install_to": "GameData"
         }
     ],
     "depends": [
-        { "name": "TextureReplacer" }
+        { "name": "SigmaReplacements-SkyBox" }
+    ]
+    "suggests": [
+        { "name": "DistantObject" }
     ]
 }

--- a/NetKAN/PoodsMilkyWaySkybox.netkan
+++ b/NetKAN/PoodsMilkyWaySkybox.netkan
@@ -7,21 +7,21 @@
     "$kref": "#/ckan/spacedock/926",
     "license": "CC-BY-NC-ND-4.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/96851-11-texturereplacer-2413-442016/&do=findComment&comment=2388097"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/169919-1"
     },
     "provides": [
         "Skybox"
     ],
-    "conflicts": [
-        { "name": "Skybox" }
-    ],
     "install": [
         {
-            "file": "GameData/TextureReplacer",
+            "file": "GameData/PoodsSkyboxes",
             "install_to": "GameData"
         }
     ],
     "depends": [
-        { "name": "TextureReplacer" }
+        { "name": "SigmaReplacements-SkyBox" }
+    ]
+    "suggests": [
+        { "name": "DistantObject" }
     ]
 }

--- a/NetKAN/PoodsMilkyWaySkybox.netkan
+++ b/NetKAN/PoodsMilkyWaySkybox.netkan
@@ -20,7 +20,7 @@
     ],
     "depends": [
         { "name": "SigmaReplacements-SkyBox" }
-    ]
+    ],
     "suggests": [
         { "name": "DistantObject" }
     ]


### PR DESCRIPTION
Switching from TextureReplacer to Sigma Replacements: Skybox as a dependency and now listing Distant Object Enhancement as a suggested mod.