### PR TITLE
 Add missing B9PartSwitch dependency to BDB

### DIFF
--- a/NetKAN/BluedogDB.netkan
+++ b/NetKAN/BluedogDB.netkan
@@ -8,7 +8,7 @@
         { "name": "ModuleManager" },
         { "name": "CommunityResourcePack" },
         { "name": "DMagicScienceAnimate" },
-	{ "name": "B9PartSwitch" }
+        { "name": "B9PartSwitch" }
     ],
     "supports": [
         { "name": "HullcamVDS" },

--- a/NetKAN/BluedogDB.netkan
+++ b/NetKAN/BluedogDB.netkan
@@ -1,12 +1,14 @@
 {
-    "license": "CC-BY-NC-SA-4.0",
-    "identifier": "BluedogDB",
-    "$kref": "#/ckan/spacedock/442",
     "spec_version": "v1.4",
+    "identifier":   "BluedogDB",
+    "$kref":        "#/ckan/spacedock/442",
+    "license":      "CC-BY-NC-SA-4.0",
     "x_netkan_force_v": true,
     "depends": [
+        { "name": "ModuleManager" },
         { "name": "CommunityResourcePack" },
-        { "name": "DMagicScienceAnimate" }
+        { "name": "DMagicScienceAnimate" },
+	{ "name": "B9PartSwitch" }
     ],
     "supports": [
         { "name": "HullcamVDS" },
@@ -21,7 +23,7 @@
     ],
     "install": [
         {
-            "find": "Bluedog_DB",
+            "find":       "Bluedog_DB",
             "install_to": "GameData"
         }
     ]


### PR DESCRIPTION
This is bundled in the download but wasn't mentioned on the forum thread. As per: 

- https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1226-guiana/&do=findComment&comment=3279133