### PR TITLE
Remove Overdrive conflict from SCANsat

### DIFF
--- a/NetKAN/SCANsat.netkan
+++ b/NetKAN/SCANsat.netkan
@@ -16,8 +16,7 @@
         { "name": "RasterPropMonitor" }
     ],
     "conflicts": [
-        { "name": "ContractConfigurator-ScanSatLite" },
-        { "name": "Overdrive" }
+        { "name": "ContractConfigurator-ScanSatLite" }
     ],
     "resources": {
         "repository": "https://github.com/S-C-A-N/SCANsat"


### PR DESCRIPTION
SCANsat [18.3 no longer conflicts](https://github.com/S-C-A-N/SCANsat/commit/67bb2d30de5e840b8a730aecd1b2361400608566) with Overdrive:

https://github.com/KSP-CKAN/NetKAN/pull/6187#issuecomment-364139701