### PR TITLE
Add conflict relationships to jatwaa's mods

### DIFF
--- a/NetKAN/Ballistanks.netkan
+++ b/NetKAN/Ballistanks.netkan
@@ -1,12 +1,16 @@
 {
-    "identifier": "Ballistanks",
     "spec_version": "v1.4",
-    "$kref": "#/ckan/spacedock/341",
-    "license": "MIT",
+    "identifier":   "Ballistanks",
+    "$kref":        "#/ckan/spacedock/341",
+    "license":      "MIT",
     "install": [
         {
-            "find"       : "JatwaaDemolitionsCo",
-            "install_to" : "GameData"
+            "find":       "JatwaaDemolitionsCo",
+            "install_to": "GameData"
         }
+    ],
+    "conflicts": [
+        { "name": "JDBallisback"     },
+        { "name": "JDLiquidFuelCell" }
     ]
 }

--- a/NetKAN/JDBallisback.netkan
+++ b/NetKAN/JDBallisback.netkan
@@ -12,5 +12,9 @@
            "file": "JatwaaDemolitionsCo",
            "install_to": "GameData"
         }
-    ] 
+    ],
+    "conflicts": [
+        { "name": "Ballistanks" },
+        { "name": "JDLiquidFuelCell" }
+    ]
 }

--- a/NetKAN/JDBallisback.netkan
+++ b/NetKAN/JDBallisback.netkan
@@ -1,8 +1,8 @@
 {
-    "license": "MIT",
-    "$kref": "#/ckan/spacedock/849",
     "spec_version": "v1.4",
-    "identifier": "JDBallisback",
+    "identifier":   "JDBallisback",
+    "$kref":        "#/ckan/spacedock/849",
+    "license":      "MIT",
     "recommends": [
         { "name": "KAS" },
         { "name": "KIS" }
@@ -14,7 +14,7 @@
         }
     ],
     "conflicts": [
-        { "name": "Ballistanks" },
+        { "name": "Ballistanks"      },
         { "name": "JDLiquidFuelCell" }
     ]
 }

--- a/NetKAN/JDLiquidFuelCell.netkan
+++ b/NetKAN/JDLiquidFuelCell.netkan
@@ -1,16 +1,20 @@
 {
-    "identifier": "JDLiquidFuelCell",
-    "license": "MIT",
     "spec_version": "v1.4",
-    "$kref": "#/ckan/spacedock/665",
+    "identifier":   "JDLiquidFuelCell",
+    "$kref":        "#/ckan/spacedock/665",
+    "license":      "MIT",
     "depends": [
         { "name": "FirespitterCore" },
-        { "name": "ModuleManager" }
+        { "name": "ModuleManager"   }
     ],
     "install": [
         {
-            "file"       : "JatwaaDemolitionsCo",
-            "install_to" : "GameData"
+            "file":       "JatwaaDemolitionsCo",
+            "install_to": "GameData"
         }
+    ],
+    "conflicts": [
+        { "name": "Ballistanks"  },
+        { "name": "JDBallisback" }
     ]
 }


### PR DESCRIPTION
These mods all try to install `GameData/JatwaaDemolitionsCo/Resources.cfg`:
- Ballistanks
- JDLiquidFuelCell
- JDBallisback

The contents of the file are different for each mod, so there's no prospect of reconciling them via a common dependency.

This PR marks them all as conflicting.

Fixes #6224.