### PR TITLE
Add Toolbar dependency to ScienceAlert

### DIFF
--- a/NetKAN/ScienceAlert.netkan
+++ b/NetKAN/ScienceAlert.netkan
@@ -2,5 +2,8 @@
     "spec_version": "v1.4",
     "identifier":   "ScienceAlert",
     "$kref":        "#/ckan/spacedock/1690",
-    "license":      "GPL-3.0"
+    "license":      "GPL-3.0",
+    "depends": [
+        { "name": "Toolbar" }
+    ]
 }


### PR DESCRIPTION
Toolbar is required for ScienceAlert. I think this was added to the thread after it was added to CKAN (and it's still not mentioned on SpaceDock).