### PR TITLE
Split dependency into two objects

### DIFF
--- a/NetKAN/CritterCrawler.netkan
+++ b/NetKAN/CritterCrawler.netkan
@@ -7,10 +7,8 @@
     }
   ],
   "depends": [
-    {
-      "name": "KSPWheel",
-      "name": "BDAnimationModules"
-    }
+    { "name": "KSPWheel" },
+    { "name": "BDAnimationModules" }
   ],
   "$vref": "#/ckan/ksp-avc",
   "$kref": "#/ckan/spacedock/1641",


### PR DESCRIPTION
See https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1226-guiana/&do=findComment&comment=3298253

`"depends"` is a JSON array of objects, one object per dependency. CritterCrawler had two `"name"` properties in the same object, when it should be two objects.