### PR TITLE
Add @TheWhiteGuardian's mods

### DIFF
--- a/NetKAN/INSTANTIATOR.netkan
+++ b/NetKAN/INSTANTIATOR.netkan
@@ -1,0 +1,15 @@
+{
+	"spec_version": "v1.16",
+	"identifier":   "INSTANTIATOR",
+	"$kref":        "#/ckan/spacedock/1624",
+	"license":      "MIT",
+	"resources": {
+		"homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/168992-*",
+		"repository": "https://github.com/TheWhiteGuardian/Unofficial_INSTANTIATOR"
+	},
+	"install": [ {
+		"find":       "INSTANTIATOR",
+		"install_to": "GameData",
+		"filter":     [ "ExampleConfig.cfg" ]
+	} ]
+}

--- a/NetKAN/KS3P.netkan
+++ b/NetKAN/KS3P.netkan
@@ -1,0 +1,9 @@
+{
+	"spec_version": "v1.16",
+	"identifier":   "KS3P",
+	"$kref":        "#/ckan/spacedock/1618",
+	"license":      "MIT",
+	"resources": {
+		"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/168763-*"
+	}
+}


### PR DESCRIPTION
This pull request adds mods by @TheWhiteGuardian to CKAN:

- KS3P, a post-processing visual mod
- INSTANTIATOR, also a visual mod

They are pretty straightforwardly packaged, with an identifier-matching directory containing the files.

The only complication is that INSTANTIATOR includes an example config file that looks like it would not be good to have installed, since it includes statements like "Body = X" that probably are not valid since X is not a planet, so we filter that file out. Modders who need that file can and should download the mod outside of CKAN.

Permission of author:

- https://forum.kerbalspaceprogram.com/index.php?/topic/168992-13x-instantiator/&do=findComment&comment=3303409
- https://forum.kerbalspaceprogram.com/index.php?/topic/168763-13x-ks3p/&do=findComment&comment=3303410

This is needed so we can include these mods as dependencies of GPO in #6285.