### PR TITLE
Fix install stanzas for KSPLogiRGB-battlemoose

### DIFF
--- a/NetKAN/KSPLogiRGB-battlemoose.netkan
+++ b/NetKAN/KSPLogiRGB-battlemoose.netkan
@@ -16,8 +16,9 @@
          "install_to": "GameData"
       },
       {
-         "find":       "lib64/LogitechLedEnginesWrapper.dll",
-         "install_to": "GameRoot"
+         "find":               "lib64/LogitechLedEnginesWrapper.dll",
+         "install_to":         "GameRoot",
+         "find_matches_files": true
       }
    ]
 }

--- a/NetKAN/KSPLogiRGB-battlemoose.netkan
+++ b/NetKAN/KSPLogiRGB-battlemoose.netkan
@@ -1,23 +1,23 @@
 {
-   "spec_version":1,
-   "identifier":"KSPLogiRGB-battlemoose",
-   "$kref":"#/ckan/github/battlemoose/ksp-logirgb",
-   "$vref":"#/ckan/ksp-avc",
-   "license":"GPL-3.0",
-   "name":"KSP Logitech RGB Control",
-   "abstract":"Lights up your keyboard to show you all the functions your vessel actually has. Requires a Logitech Full-RGB keyboard to work.",
-   "resources":{
-      "homepage":"https://forum.kerbalspaceprogram.com/index.php?/topic/169895-131-ksp-logitech-rgb-control-v102-2018-01-21",
-      "repository":"https://github.com/battlemoose/ksp-logirgb"
+   "spec_version": "v1.16",
+   "identifier":   "KSPLogiRGB-battlemoose",
+   "name":         "KSP Logitech RGB Control",
+   "abstract":     "Lights up your keyboard to show you all the functions your vessel actually has. Requires a Logitech Full-RGB keyboard to work.",
+   "$kref":        "#/ckan/github/battlemoose/ksp-logirgb",
+   "$vref":        "#/ckan/ksp-avc",
+   "license":      "GPL-3.0",
+   "resources": {
+      "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/169895-131-ksp-logitech-rgb-control-v102-2018-01-21",
+      "repository": "https://github.com/battlemoose/ksp-logirgb"
    },
-   "install":[
+   "install": [
       {
-         "file":"GameData/KSPLogiRGB",
-         "install_to":"GameData"
+         "find":       "GameData/KSPLogiRGB",
+         "install_to": "GameData"
       },
       {
-         "file":"lib64/LogitechLedEnginesWrapper.dll",
-         "install_to":"GameRoot"
+         "find":       "lib64/LogitechLedEnginesWrapper.dll",
+         "install_to": "GameRoot"
       }
    ]
 }


### PR DESCRIPTION
Folder structure changed slightly, need `find` instead of `file` since GameData isn't in the root of the ZIP anymore.