### PR TITLE
Force GPP hash recalc

### DIFF
--- a/NetKAN/GPP.netkan
+++ b/NetKAN/GPP.netkan
@@ -1,6 +1,6 @@
 {
-	"spec_version": "v1.4",
-	"identifier": "GPP",
-	"$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Galileo88/Galileos-Planet-Pack/master/CKAN/GPP.netkan",
-	"x_netkan_license_ok": true
+    "spec_version": "v1.4",
+    "identifier":   "GPP",
+    "$kref":        "#/ckan/netkan/https://raw.githubusercontent.com/Galileo88/Galileos-Planet-Pack/master/CKAN/GPP.netkan",
+    "x_netkan_license_ok": true
 }

--- a/NetKAN/GPPCloudsHighRes.netkan
+++ b/NetKAN/GPPCloudsHighRes.netkan
@@ -1,6 +1,6 @@
 {
-	"spec_version": "v1.4",
-	"identifier": "GPPCloudsHighRes",
-	"$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Galileo88/Galileos-Planet-Pack/master/CKAN/GPPCloudsHighRes.netkan",
-	"x_netkan_license_ok": true
+    "spec_version": "v1.4",
+    "identifier":   "GPPCloudsHighRes",
+    "$kref":        "#/ckan/netkan/https://raw.githubusercontent.com/Galileo88/Galileos-Planet-Pack/master/CKAN/GPPCloudsHighRes.netkan",
+    "x_netkan_license_ok": true
 }

--- a/NetKAN/GPPCloudsLowRes.netkan
+++ b/NetKAN/GPPCloudsLowRes.netkan
@@ -1,6 +1,6 @@
 {
-	"spec_version": "v1.4",
-	"identifier": "GPPCloudsLowRes",
-	"$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Galileo88/Galileos-Planet-Pack/master/CKAN/GPPCloudsLowRes.netkan",
-	"x_netkan_license_ok": true
+    "spec_version": "v1.4",
+    "identifier":   "GPPCloudsLowRes",
+    "$kref":        "#/ckan/netkan/https://raw.githubusercontent.com/Galileo88/Galileos-Planet-Pack/master/CKAN/GPPCloudsLowRes.netkan",
+    "x_netkan_license_ok": true
 }

--- a/NetKAN/GPPSecondary.netkan
+++ b/NetKAN/GPPSecondary.netkan
@@ -1,6 +1,6 @@
 {
-	"spec_version": "v1.4",
-	"identifier": "GPPSecondary",
-	"$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Galileo88/Galileos-Planet-Pack/master/CKAN/GPPSecondary.netkan",
-	"x_netkan_license_ok": true
+    "spec_version": "v1.4",
+    "identifier":   "GPPSecondary",
+    "$kref":        "#/ckan/netkan/https://raw.githubusercontent.com/Galileo88/Galileos-Planet-Pack/master/CKAN/GPPSecondary.netkan",
+    "x_netkan_license_ok": true
 }


### PR DESCRIPTION
GPP had a new release, then replaced the same download URL with a ZIP with an updated KSP-AVC file.

The metadata hash doesn't match the current download, which causes errors at installation, but the netkan bot refuses to re-index the download:

![image](https://user-images.githubusercontent.com/1559108/36785763-9bbf2314-1c49-11e8-961e-4fe125bc4b09.png)

This must mean the original file is still in the bot's cache. This pull request makes whitespace-only changes to the affected netkans, so their CKAN-meta entries will be regenerated by Jenkins.