### PR TITLE
Updated AlphabeticalKerbals to KSP version 1.4

### DIFF
--- a/NetKAN/AlphabeticalKerbals.netkan
+++ b/NetKAN/AlphabeticalKerbals.netkan
@@ -3,7 +3,8 @@
     "identifier"   : "AlphabeticalKerbals",
     "$kref"        : "#/ckan/github/cecilkorik/AlphabeticalKerbals",
     "license"      : "CC0",
-    "ksp_version"  : "1.3.1",
+    "ksp_version_min": "1.3.1",
+    "ksp_version_max": "1.4.99",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/167202-wip-131-alphabeticalkerbals/"
     }


### PR DESCRIPTION
Addon has been tested and doesn't need to be modified, this is just marking it as compatible now that testing is complete.