### PR TITLE
Remove extra comma in SmokeScreen.netkan

### DIFF
--- a/NetKAN/SmokeScreen.netkan
+++ b/NetKAN/SmokeScreen.netkan
@@ -27,7 +27,7 @@
             "version": "2.7.6.1",
             "override": {
                 "ksp_version_min": "1.3.0",
-                "ksp_version_max": "1.3.90",
+                "ksp_version_max": "1.3.90"
             }
         },
         {


### PR DESCRIPTION
I think Sarbian edits these without the aid of the pull request validation scripts, and this one has a syntax error that's breaking #6324.