### PR TITLE
Switch ShowFPS to a proper kref

### DIFF
--- a/NetKAN/ShowFPS.netkan
+++ b/NetKAN/ShowFPS.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "ShowFPS",
-    "ksp_version": "1.1",
+    "$kref": "#/ckan/curse/220663",
     "resources": 
     {
         "homepage": "http://www.curse.com/ksp-mods/kerbal/220663-showfps"
@@ -10,8 +10,6 @@
     "license": "LGPL-3.0",
     "abstract": "Simple framerate counter, enable with F8.",
     "author": "m4v",
-    "version": "v1.1",
-    "download": "http://kerbal.curseforge.com/projects/showfps/files/2297168/download",
     "install": [
         { 
             "file" : "ShowFPS",

--- a/NetKAN/ShowFPS.netkan
+++ b/NetKAN/ShowFPS.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier": "ShowFPS",
-    "ksp_version_min": "1.1",
+    "ksp_version": "1.1",
     "resources": 
     {
         "homepage": "http://www.curse.com/ksp-mods/kerbal/220663-showfps"


### PR DESCRIPTION
ShowFPS is marked as compatible with all game versions 1.1 and later, but it doesn't work on 1.2.

This pull request sets it to use a proper `$kref` property so the actual version info will be pulled from Curse. This not only fixes the current problem but ensures that any future uploads, if there are any, will work properly.

See KSP-CKAN/CKAN-meta#1333.