### PR TITLE
Remove Snacks cfg from DeepSpaceSurfaceHabitatUnitPack

### DIFF
--- a/NetKAN/DeepSpaceSurfaceHabitatUnitPack.netkan
+++ b/NetKAN/DeepSpaceSurfaceHabitatUnitPack.netkan
@@ -32,14 +32,6 @@
             "install_to": "GameData/DSSHU",
             "find_matches_files": true
         }, {
-            "find":       "DSSHU-Snacks.cfg",
-            "install_to": "GameData/DSSHU",
-            "find_matches_files": true
-        }, {
-            "find":       "DSSHU-TACLS.cfg",
-            "install_to": "GameData/DSSHU",
-            "find_matches_files": true
-        }, {
             "find":       "DSSHU-USILifeSupport.cfg",
             "install_to": "GameData/DSSHU",
             "find_matches_files": true


### PR DESCRIPTION
Two of this mod's optional configs have been removed.