### PR TITLE
Move nightingale mods to use mod-owned .netkan files.

### DIFF
--- a/NetKAN/ContractConfigurator-AnomalySurveyor.netkan
+++ b/NetKAN/ContractConfigurator-AnomalySurveyor.netkan
@@ -1,30 +1,6 @@
 {
-    "spec_version" : "v1.4",
-    "identifier"   : "ContractConfigurator-AnomalySurveyor",
-    "$kref"        : "#/ckan/github/jrossignol/ContractPack-AnomalySurveyor",
-    "abstract"     : "Contracts to guide you to the various easter eggs in the game.",
-    "name"         : "Contract Pack: Anomaly Surveyor",
-    "license"      : "CC-BY-NC-SA-4.0",
-    "release_status": "stable",
-    "author": "nightingale",
-    "$vref": "#/ckan/ksp-avc",
-    "depends": [
-        { "name": "ContractConfigurator" },
-        { "name": "ModuleManager" }
-    ],
-    "suggests": [
-        { "name": "WaypointManager" },
-        { "name": "SCANsat" }
-    ],
-    "install" : [
-        {
-            "find"       : "AnomalySurveyor",
-            "install_to" : "GameData/ContractPacks"
-        }
-    ],
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/109471",
-        "bugtracker": "https://github.com/jrossignol/ContractPack-AnomalySurveyor/issues",
-        "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-AnomalySurveyor/master/GameData/ContractPacks/AnomalySurveyor/LICENSE.txt"
-    }
+    "spec_version": "v1.16",
+    "identifier": "ContractConfigurator-AnomalySurveyor",
+    "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/jrossignol/ContractPack-AnomalySurveyor/master/ContractConfigurator-AnomalySurveyor.netkan",
+    "x_netkan_license_ok" : true
 }

--- a/NetKAN/ContractConfigurator-FieldResearch.netkan
+++ b/NetKAN/ContractConfigurator-FieldResearch.netkan
@@ -1,30 +1,6 @@
 {
-    "spec_version" : "v1.4",
-    "identifier"   : "ContractConfigurator-FieldResearch",
-    "$kref"        : "#/ckan/github/jrossignol/ContractPack-FieldResearch",
-    "abstract"     : "Do more science!  Receive contracts for performing a variety of experiments under different situations.  Use it to drive the science in your space program, or use it to collect every last bit of science.",
-    "name"         : "Contract Pack: Field Research",
-    "license"      : "CC-BY-NC-SA-4.0",
-    "release_status": "stable",
-    "author": "nightingale",
-    "$vref": "#/ckan/ksp-avc",
-    "depends": [
-        { "name": "ContractConfigurator" },
-        { "name": "ModuleManager" }
-    ],
-    "suggests": [
-        { "name": "CrowdSourcedScience" },
-        { "name": "ScienceAlert" }
-    ],
-    "install" : [
-        {
-            "find"       : "FieldResearch",
-            "install_to" : "GameData/ContractPacks"
-        }
-    ],
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/123892",
-        "bugtracker": "https://github.com/jrossignol/ContractPack-FieldResearch/issues",
-        "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-FieldResearch/master/GameData/ContractPacks/FieldResearch/LICENSE.txt"
-    }
+    "spec_version": "v1.16",
+    "identifier": "ContractConfigurator-FieldResearch",
+    "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/jrossignol/ContractPack-FieldResearch/master/ContractConfigurator-FieldResearch.netkan",
+    "x_netkan_license_ok" : true
 }

--- a/NetKAN/ContractConfigurator-RemoteTech.netkan
+++ b/NetKAN/ContractConfigurator-RemoteTech.netkan
@@ -1,27 +1,6 @@
 {
-    "spec_version" : "v1.4",
-    "identifier"   : "ContractConfigurator-RemoteTech",
-    "$kref"        : "#/ckan/github/jrossignol/ContractPack-RemoteTech",
-    "abstract"     : "A contract pack containing contracts for RemoteTech.",
-    "name"         : "Contract Pack: RemoteTech",
-    "license"      : "CC-BY-NC-SA-4.0",
-    "release_status": "stable",
-    "author": "nightingale",
-    "$vref": "#/ckan/ksp-avc",
-    "depends": [
-        { "name": "ContractConfigurator" },
-        { "name": "RemoteTech" },
-        { "name": "ModuleManager" }
-    ],
-    "install" : [
-        {
-            "find"       : "RemoteTech",
-            "install_to" : "GameData/ContractPacks"
-        }
-    ],
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/106580",
-        "bugtracker": "https://github.com/jrossignol/ContractPack-RemoteTech/issues",
-        "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-RemoteTech/master/GameData/ContractPacks/RemoteTech/LICENSE.txt"
-    }
+    "spec_version": "v1.16",
+    "identifier": "ContractConfigurator-RemoteTech",
+    "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/jrossignol/ContractPack-RemoteTech/master/ContractConfigurator-RemoteTech.netkan",
+    "x_netkan_license_ok" : true
 }

--- a/NetKAN/ContractConfigurator-Tourism.netkan
+++ b/NetKAN/ContractConfigurator-Tourism.netkan
@@ -1,29 +1,6 @@
 {
-    "spec_version" : "v1.4",
-    "identifier"   : "ContractConfigurator-Tourism",
-    "$kref"        : "#/ckan/github/jrossignol/ContractPack-Tourism",
-    "abstract"     : "Better tourism! A richer tourism experience than stock.  Take tourists to space and to visit the stations and bases that you've already created. Build new tourist attractions like the space casino mega-project.  15 new contracts for tourism.",
-    "name"         : "Contract Pack: Tourism Plus",
-    "license"      : "CC-BY-NC-SA-4.0",
-    "release_status": "stable",
-    "author": "nightingale",
-    "$vref": "#/ckan/ksp-avc",
-    "depends": [
-        { "name": "ContractConfigurator" },
-        { "name": "ModuleManager" }
-    ],
-    "suggests": [
-        { "name": "WaypointManager" }
-    ],
-    "install" : [
-        {
-            "find"       : "Tourism",
-            "install_to" : "GameData/ContractPacks"
-        }
-    ],
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/113621",
-        "bugtracker": "https://github.com/jrossignol/ContractPack-Tourism/issues",
-        "license": "https://raw.githubusercontent.com/jrossignol/ContractPack-Tourism/master/GameData/ContractPacks/Tourism/LICENSE.txt"
-    }
+    "spec_version": "v1.16",
+    "identifier": "ContractConfigurator-Tourism",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/jrossignol/ContractPack-Tourism/master/ContractConfigurator-Tourism.netkan",
+    "x_netkan_license_ok": true
 }

--- a/NetKAN/ContractConfigurator.netkan
+++ b/NetKAN/ContractConfigurator.netkan
@@ -1,27 +1,6 @@
 {
     "spec_version": "v1.16",
     "identifier": "ContractConfigurator",
-    "$kref": "#/ckan/github/jrossignol/ContractConfigurator",
-    "name": "Contract Configurator",
-    "abstract": "A config-file based solution for creating new contracts!",
-    "license": "MIT",
-    "release_status": "stable",
-    "author": "nightingale",
-    "$vref": "#/ckan/ksp-avc",
-    "description": "A config-file based solution for creating new contracts!",
-    "ksp_version_strict" : true,
-    "suggests": [
-        { "name": "CoherentContracts" },
-        { "name": "ContractsWindowPlus" },
-        { "name": "WiderContractsApp" }
-    ],
-    "recommends": [
-        { "name": "WaypointManager" }
-    ],
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/101604",
-        "bugtracker": "https://github.com/jrossignol/ContractConfigurator/issues",
-        "license": "https://raw.githubusercontent.com/jrossignol/ContractConfigurator/master/LICENSE.txt",
-        "manual": "https://github.com/jrossignol/ContractConfigurator/wiki"
-    }
+    "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/jrossignol/ContractConfigurator/master/ContractConfigurator.netkan",
+    "x_netkan_license_ok" : true
 }

--- a/NetKAN/WaypointManager.netkan
+++ b/NetKAN/WaypointManager.netkan
@@ -1,23 +1,6 @@
 {
-    "spec_version": 1,
+    "spec_version" : "v1.16",
     "identifier": "WaypointManager",
-    "$kref": "#/ckan/github/jrossignol/WaypointManager",
-    "name": "Waypoint Manager",
-    "abstract": "Display waypoints while in flight, create custom waypoints.",
-    "license": "MIT",
-    "release_status": "stable",
-    "author": "nightingale",
-    "$vref": "#/ckan/ksp-avc",
-    "description": "Display waypoints while in flight, create custom waypoints.",
-    "install": [
-        {
-            "file"       : "GameData/WaypointManager",
-            "install_to" : "GameData"
-        }
-    ],
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/threads/104758",
-        "bugtracker": "https://github.com/jrossignol/WaypointManager/issues",
-        "license": "https://raw.githubusercontent.com/jrossignol/WaypointManager/master/LICENSE.txt"
-    }
+    "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/jrossignol/WaypointManager/master/WaypointManager.netkan",
+    "x_netkan_license_ok" : true
 }


### PR DESCRIPTION
Most of the old-style KSP forum links broken and I needed to fix them.  I figured this was a good opportunity to move everything in the netkans into my own repos to make this type of change easier in future.