### PR TITLE
Remove hard coded versions from CustomBarnKit

### DIFF
--- a/NetKAN/CustomBarnKit.netkan
+++ b/NetKAN/CustomBarnKit.netkan
@@ -11,8 +11,6 @@
         "homepage": "http://forum.kerbalspaceprogram.com/threads/121100",
         "repository": "https://github.com/sarbian/CustomBarnKit"
     },
-    "ksp_version_min": "1.2.2",
-    "ksp_version_max": "1.3.90",
     "install": [
         {
             "find": "CustomBarnKit",


### PR DESCRIPTION
@linuxgurugamer noted that this version was showing up as compatible with 1.3.1 even though its .version file says it isn't. Let's try removing the versions from the netkan.

Fixes KSP-CKAN/CKAN#2390.