### PR TITLE
Filter out conflicting License and Agencies files

### DIFF
--- a/NetKAN/PicoPort.netkan
+++ b/NetKAN/PicoPort.netkan
@@ -1,18 +1,18 @@
 {
-  "spec_version": "v1.4",
-  "install": [
-    {
-      "install_to": "GameData",
-      "find": "SHED"
-    }
-  ],
-  "depends": [
-    {
-      "name": "ModuleManager"
-    }
-  ],
-  "$kref": "#/ckan/spacedock/1165",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "identifier": "PicoPort",
-  "license": "CC-BY-NC-SA-4.0"
+    "spec_version": "v1.4",
+    "identifier":   "PicoPort",
+    "$kref":        "#/ckan/spacedock/1165",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "CC-BY-NC-SA-4.0",
+    "x_via":        "Automated Linuxgurugamer CKAN script",
+    "install": [
+        {
+            "find":       "SHED",
+            "install_to": "GameData",
+            "filter":     [ "Agencies", "License" ]
+        }
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ]
 }

--- a/NetKAN/REKT.netkan
+++ b/NetKAN/REKT.netkan
@@ -1,19 +1,19 @@
 {
-  "spec_version": "v1.10",
-  "depends": [
-    { "name": "ModuleManager" },
-    { "name": "RetractableLiftingSurface" },
-    { "name": "KSPWheel" }
-  ],
-  "install": [
-    {
-      "install_to": "GameData",
-      "find": "SHED",
-      "filter": "RetractableLiftingSurface"
-    }
-  ],
-  "$vref": "#/ckan/ksp-avc",
-  "$kref": "#/ckan/spacedock/1021",
-  "identifier": "REKT",
-  "license": "CC-BY-NC-SA-4.0"
+    "spec_version": "v1.10",
+    "identifier":   "REKT",
+    "$kref":        "#/ckan/spacedock/1021",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "CC-BY-NC-SA-4.0",
+    "install": [
+        {
+            "find":       "SHED",
+            "install_to": "GameData",
+            "filter":     [ "Agencies", "License", "RetractableLiftingSurface" ]
+        }
+    ],
+    "depends": [
+        { "name": "ModuleManager"             },
+        { "name": "RetractableLiftingSurface" },
+        { "name": "KSPWheel"                  }
+    ]
 }


### PR DESCRIPTION
## Problem

REKT and PicoPort both install:

- SHED/License
- Several files under SHED/Agencies

This causes a conflict where there shouldn't be one.

## Changes

Now the install stanzas filter out these conflicting paths.

In addition, we now use PicoPort's .version file, previously ignored.

Fixes #6413.