### PR TITLE
Update Scatterer.netkan

### DIFF
--- a/NetKAN/Scatterer.netkan
+++ b/NetKAN/Scatterer.netkan
@@ -37,6 +37,7 @@
             "version": "2:v0.0329_for_1.4.2",
             "override": {
                 "ksp_version" : "1.4.2"
+            }
         }
     ]
 }

--- a/NetKAN/Scatterer.netkan
+++ b/NetKAN/Scatterer.netkan
@@ -32,6 +32,11 @@
             "override": {
                 "ksp_version" : "1.3"
             }
+        },
+        {
+            "version": "2:v0.0329_for_1.4.2",
+            "override": {
+                "ksp_version" : "1.4.2"
         }
     ]
 }


### PR DESCRIPTION
Version override for 1.4.2 as SpaceDock has not included 1.4.2 in their versions list yet (scatterer is listed as 1.4.1)