### PR TITLE
Stop hardcoding game version for Snacks

### DIFF
--- a/NetKAN/Snacks.netkan
+++ b/NetKAN/Snacks.netkan
@@ -2,6 +2,7 @@
     "spec_version" : "v1.4",
     "identifier"   : "Snacks",
     "$kref"        : "#/ckan/github/Angel-125/Snacks",
+    "$vref"        : "#/ckan/ksp-avc",
     "name"         : "Snacks",
     "abstract"     : "Add a simple life support system based on Snacks!",
     "author"       : [ "tgruetzm", "Angel-125"],
@@ -20,8 +21,11 @@
             "name": "ModuleManager"
         }
     ],
-    "ksp_version": "1.3",
     "x_netkan_override": [
+        {
+            "version": "1.9.0",
+            "delete": [ "ksp_version_min" ]
+        },
         {
             "version": "1.8.0",
             "delete": [ "ksp_version" ],


### PR DESCRIPTION
Snacks has a .version file, but it's currently hard coded to use game version 1.3. This is creating bad metadata for the current version, which is 1.4.1 only.

This pull request updates it to use the .version file. However, the current .version file has KSP_VERSION_MIN without KSP_VERSION_MAX, which indicates compatibility with all future releases. Since that's probably wrong, this pull request also tries to filter out that KSP_VERSION_MIN value.

Fixes #6434 