### PR TITLE
Aviation Lights v4.0.0+ now supports KSP 1.4.x - Upping version number.

### DIFF
--- a/NetKAN/AviationLights.netkan
+++ b/NetKAN/AviationLights.netkan
@@ -5,7 +5,7 @@
     "name": "Aviation Lights",
     "license": "CC-BY-NC-SA-4.0",
     "author": [ "MOARdV", "BigNose", "RPGprayer" ],
-    "ksp_version": "1.3",
+    "ksp_version": "1.4",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/16801-*"
     },

--- a/NetKAN/AviationLights.netkan
+++ b/NetKAN/AviationLights.netkan
@@ -1,11 +1,11 @@
 {
-    "$kref": "#/ckan/github/MOARdV/AviationLights",
     "spec_version": "v1.4",
-    "identifier": "AviationLights",
-    "name": "Aviation Lights",
-    "license": "CC-BY-NC-SA-4.0",
-    "author": [ "MOARdV", "BigNose", "RPGprayer" ],
-    "ksp_version": "1.4",
+    "identifier":   "AviationLights",
+    "name":         "Aviation Lights",
+    "author":       [ "MOARdV", "BigNose", "RPGprayer" ],
+    "$kref":        "#/ckan/github/MOARdV/AviationLights",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/16801-*"
     },


### PR DESCRIPTION
I'm honestly a little unsure as to how this affects versions previous to v4.0.0 of the mod, which should still be marked as 1.3 compatible only.