### PR TITLE
Allow any game version for EVE-HR

### DIFF
--- a/NetKAN/EnvironmentalVisualEnhancements-HR.netkan
+++ b/NetKAN/EnvironmentalVisualEnhancements-HR.netkan
@@ -5,8 +5,6 @@
     "name"         : "Environmental Visual Enhancements - Stock Planet Config files",
     "abstract"     : "Default configuration for EVE",
     "license"      : "MIT",
-    "ksp_version_min"  : "1.2.0",
-    "ksp_version_max"  : "1.3.9",
     "resources": {
         "homepage"   : "http://forum.kerbalspaceprogram.com/index.php?/topic/149733-EVE",
         "repository" : "https://github.com/WazWaz/EnvironmentalVisualEnhancements"


### PR DESCRIPTION
As per #6445, `EnvironmentalVisualEnhancements-HR` should not be version-specific. Currently it has a max game version of 1.3.9.

This pull request removes version limits from this module.

Fixes #6445.