### PR TITLE
Get newer DynamicBatteryStorage

### DIFF
--- a/NetKAN/DynamicBatteryStorage.netkan
+++ b/NetKAN/DynamicBatteryStorage.netkan
@@ -1,17 +1,20 @@
 {
-    "spec_version": "v1.4",
-    "comment": "Dynamic Battery Storage does not have its own release. Sourced from the KerbalAtomics archive.",
-    "identifier": "DynamicBatteryStorage",
-    "$kref": "#/ckan/spacedock/710",
+    "spec_version":   "v1.4",
+    "identifier":     "DynamicBatteryStorage",
+    "name":           "Dynamic Battery Storage",
+    "abstract":       "A plugin that works around the problems of stock electricity consumption/generation at high time warp.",
+    "comment":        "Dynamic Battery Storage does not have its own release. Sourced from the NearFutureElectrical archive.",
+    "$kref":          "#/ckan/spacedock/558",
+    "$vref":          "#/ckan/ksp-avc/DynamicBatteryStorage.version",
     "x_netkan_epoch": 1,
-    "$vref": "#/ckan/ksp-avc",
-    "name": "Dynamic Battery Storage",
-    "abstract": "A plugin that works around the problems of stock electricity consumption/generation at high time warp.",
-    "license": "CC-BY-NC-SA-4.0",
+    "license":        "CC-BY-NC-SA-4.0",
     "resources": {
-      "repository": "https://github.com/ChrisAdderley/DynamicBatteryStorage"
+        "repository": "https://github.com/ChrisAdderley/DynamicBatteryStorage"
     },
     "install" : [
-        { "file" : "GameData/DynamicBatteryStorage", "install_to" : "GameData" }
+        {
+            "file":        "GameData/DynamicBatteryStorage",
+            "install_to" : "GameData"
+        }
     ]
 }

--- a/NetKAN/DynamicBatteryStorage.netkan
+++ b/NetKAN/DynamicBatteryStorage.netkan
@@ -5,8 +5,8 @@
     "abstract":       "A plugin that works around the problems of stock electricity consumption/generation at high time warp.",
     "comment":        "Dynamic Battery Storage does not have its own release. Sourced from the NearFutureElectrical archive.",
     "$kref":          "#/ckan/spacedock/558",
-    "$vref":          "#/ckan/ksp-avc/GameData/DynamicBatteryStorage/Versioning/DynamicBatteryStorage.version",
-    "x_netkan_epoch": 1,
+    "$vref":          "#/ckan/ksp-avc/DynamicBatteryStorage.version",
+    "x_netkan_epoch": 2,
     "license":        "CC-BY-NC-SA-4.0",
     "resources": {
         "repository": "https://github.com/ChrisAdderley/DynamicBatteryStorage"

--- a/NetKAN/DynamicBatteryStorage.netkan
+++ b/NetKAN/DynamicBatteryStorage.netkan
@@ -5,7 +5,7 @@
     "abstract":       "A plugin that works around the problems of stock electricity consumption/generation at high time warp.",
     "comment":        "Dynamic Battery Storage does not have its own release. Sourced from the NearFutureElectrical archive.",
     "$kref":          "#/ckan/spacedock/558",
-    "$vref":          "#/ckan/ksp-avc/DynamicBatteryStorage.version",
+    "$vref":          "#/ckan/ksp-avc/GameData/DynamicBatteryStorage/Versioning/DynamicBatteryStorage.version",
     "x_netkan_epoch": 1,
     "license":        "CC-BY-NC-SA-4.0",
     "resources": {


### PR DESCRIPTION
DynamicBatteryStorage is one of those mods that exists only as a bundled dependency in multiple other mods. Currently it's sourced from KerbalAtomics' download, which hasn't been updated to 1.4. Now it's switched to NearFutureElectrical, which is updated to 1.4. It also will hopefully pull from the right KSP-AVC file now.

Fixes KSP-CKAN/CKAN#2404.