### PR TITLE
Reactivate KSPIE's version file

### DIFF
--- a/NetKAN/KSPInterstellarExtended.netkan
+++ b/NetKAN/KSPInterstellarExtended.netkan
@@ -2,9 +2,8 @@
     "spec_version"      : "v1.4",
     "identifier"        : "KSPInterstellarExtended",
     "$kref"             : "#/ckan/spacedock/172",
-    "comment"           : "$vref           : #/ckan/ksp-avc",
+    "$vref"             : "#/ckan/ksp-avc",
     "x_netkan_staging"  : true,
-    "comment"           : "return vref when .version file is valid",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/155255-12213-kspi-extended",
         "repository": "https://github.com/sswelm/KSP-Interstellar-Extended"


### PR DESCRIPTION
This mod's $vref is commented out with a note indicating this was done because the version file was invalid. The version file in the current download looks OK to me, so this pull request is a test of whether it's time to uncomment this $vref.