### PR TITLE
Migrate mods with alternate downloads off of Curse

### DIFF
--- a/NetKAN/ExperimentTracker.netkan
+++ b/NetKAN/ExperimentTracker.netkan
@@ -1,17 +1,26 @@
 {
     "spec_version" : 1,
     "identifier"   : "ExperimentTracker",
-    "$kref"        : "#/ckan/curse/250310",
+    "$kref"        : "#/ckan/github/derrrey/ExperimentTracker",
+    "$vref"        : "#/ckan/ksp-avc",
     "license"      : "Apache-2.0",
     "abstract"     : "This mod lists all science experiments and helps to deploy them fast and easy.",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/146984-113-experimenttracker/"
     },
     "x_netkan_force_v": true,
-	  "install": [ 
+    "install": [ 
         {
             "file"       : "ExperimentTracker",
             "install_to" : "GameData"
+        }
+    ],
+    "x_netkan_override": [
+        {
+            "version": "v1.3.1",
+            "override": {
+                "ksp_version": "1.2"
+            }
         }
     ]
 }

--- a/NetKAN/OPTSpacePlaneMain.netkan
+++ b/NetKAN/OPTSpacePlaneMain.netkan
@@ -34,7 +34,6 @@
     "x_netkan_override": [
         {
             "version": "v2.0.1",
-            "delete": [ "ksp_version" ],
             "override": {
                 "ksp_version": "1.3"
             }

--- a/NetKAN/OPTSpacePlaneMain.netkan
+++ b/NetKAN/OPTSpacePlaneMain.netkan
@@ -1,7 +1,8 @@
 {
     "spec_version" : "v1.9",
     "identifier"   : "OPTSpacePlaneMain",
-    "$kref"        : "#/ckan/curse/225018",
+    "$kref"        : "#/ckan/spacedock/1028",
+    "$vref"        : "#/ckan/ksp-avc",
     "license"      : "CC-BY-NC-SA-4.0",
     "abstract"     : "Over 50 stock-a-like, large space plane oriented parts",
     "resources"    : {

--- a/NetKAN/OPTSpacePlaneMain.netkan
+++ b/NetKAN/OPTSpacePlaneMain.netkan
@@ -30,5 +30,14 @@
             "find"       : "OPT",
             "install_to" : "GameData"
         }
+    ],
+    "x_netkan_override": [
+        {
+            "version": "v2.0.1",
+            "delete": [ "ksp_version" ],
+            "override": {
+                "ksp_version": "1.3"
+            }
+        }
     ]
 }

--- a/NetKAN/StoreMyReports.netkan
+++ b/NetKAN/StoreMyReports.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version" : "v1.20",
     "identifier" : "StoreMyReports",
-    "$kref" : "#/ckan/curse/273255",
+    "$kref" : "#/ckan/github/CYBUTEK/StoreMyReports",
     "$vref" : "#/ckan/ksp-avc",
     "abstract"     : "Fix the inability for Kerbals to find glove-boxes within their vessel or pockets on their EVA suits.",
     "resources" : {

--- a/NetKAN/StoreMyReports.netkan
+++ b/NetKAN/StoreMyReports.netkan
@@ -9,6 +9,5 @@
         "homepage" : "http://forum.kerbalspaceprogram.com/index.php?/topic/163826-13-store-my-reports",
         "bugtracker" : "https://github.com/CYBUTEK/StoreMyReports/issues",
         "repository" : "https://github.com/CYBUTEK/StoreMyReports"
-    },
-    "x_netkan_license_ok" : true
+    }
 }

--- a/NetKAN/StoreMyReports.netkan
+++ b/NetKAN/StoreMyReports.netkan
@@ -3,6 +3,7 @@
     "identifier" : "StoreMyReports",
     "$kref" : "#/ckan/github/CYBUTEK/StoreMyReports",
     "$vref" : "#/ckan/ksp-avc",
+    "license": "GPL-3.0",
     "abstract"     : "Fix the inability for Kerbals to find glove-boxes within their vessel or pockets on their EVA suits.",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/index.php?/topic/163826-13-store-my-reports",

--- a/NetKAN/WaterSounds.netkan
+++ b/NetKAN/WaterSounds.netkan
@@ -1,6 +1,7 @@
 {
     "identifier": "WaterSounds",
-    "$kref": "#/ckan/curse/230690",
+    "$kref": "#/ckan/spacedock/786",
+    "$vref": "#/ckan/ksp-avc",
     "spec_version": "v1.4",
     "license": "GPL-2.0",
     "abstract": "Adds the sound of water gently lapping at the sides of your craft when splashed down.",


### PR DESCRIPTION
We found out in #6481 that Curse can't auto update anymore, because the API has been asked to shut down.

There are 12 mods with a `"$kref"` on Curse, 4 of which are also hosted elsewhere. This pull request migrates those 4 to their alternate hosts.