### PR TITLE
Get RealisticHeatMgmt from GitHub

### DIFF
--- a/NetKAN/RealisticHeatMgmt.netkan
+++ b/NetKAN/RealisticHeatMgmt.netkan
@@ -1,18 +1,16 @@
 {
-  "spec_version": "v1.4",
-  "install": [
-    {
-      "install_to": "GameData",
-      "find": "Realistic Heat Managment"
-    }
-  ],
-  "depends": [
-    {
-      "name": "ModuleManager"
-    }
-  ],
-  "$kref": "#/ckan/spacedock/1420",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "identifier": "RealisticHeatMgmt",
-  "license": "MIT"
+    "spec_version": "v1.4",
+    "install": [
+        {
+            "find":       "Realistic Heat Managment",
+            "install_to": "GameData"
+        }
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
+    "$kref":      "#/ckan/github/BottleRocketeer/RealisticHeatManagment",
+    "x_via":      "Automated Linuxgurugamer CKAN script",
+    "identifier": "RealisticHeatMgmt",
+    "license":    "MIT"
 }


### PR DESCRIPTION
This was removed from SpaceDock, but is still on GitHub. We could freeze it, but if we let the bot index it on GitHub then the version already in CKAN would still work.