### PR TITLE
Fix versioning for AstronomersVisualPack

### DIFF
--- a/NetKAN/AstronomersVisualPack.netkan
+++ b/NetKAN/AstronomersVisualPack.netkan
@@ -1,27 +1,29 @@
 {
     "spec_version" : 1,
-	"abstract"     : "Revival of the total visual overhaul for Kerbal Space Program by Astronomer.",
     "identifier"   : "AstronomersVisualPack",
-    "$kref"        : "#/ckan/github/themaster402/AstronomersVisualPack/asset_match/AVP.v.*.zip",
-    "$vref" : "#/ckan/ksp-avc",
-    "license"      : "LGPL-3.0",
 	"name"         : "Astronomer's Visual Pack",
+	"abstract"     : "Revival of the total visual overhaul for Kerbal Space Program by Astronomer.",
+    "$kref"        : "#/ckan/github/themaster402/AstronomersVisualPack/asset_match/AVP.v.*.zip",
+    "$vref"        : "#/ckan/ksp-avc",
+    "x_netkan_trust_version_file" : true,
+    "x_netkan_epoch" : 1,
+    "license"      : "LGPL-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160878-ksp-130-astronomers-visual-pack-updated-and-repackaged-314-duality/"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160878-*"
 	},
     "depends" : [
         { "name": "ModuleManager" },
         { "name": "AVP-Textures" },
         { "name": "Kopernicus" },
         { "name": "Scatterer" },
-	    { "name": "LoadingScreenManager" },
-		{ "name": "EnvironmentalVisualEnhancements" }
-	],
-	"recommends" : [
-		{ "name": "DistantObject" },
-		{ "name": "PlanetShine" },
-		{ "name": "Chatterer" },
-		{ "name": "TextureReplacer"}
+        { "name": "LoadingScreenManager" },
+        { "name": "EnvironmentalVisualEnhancements" }
+    ],
+    "recommends" : [
+        { "name": "DistantObject" },
+        { "name": "PlanetShine" },
+        { "name": "Chatterer" },
+        { "name": "TextureReplacer"}
     ],
     "provides" : [
         "EnvironmentalVisualEnhancements-Config"


### PR DESCRIPTION
Astronomer's Visual Pack follows a non-sequential versioning scheme in its GitHub release versions (51 < 52 < 53 < 6 < 61 < 62 < 63 < 7, etc.), but has a proper Major.Minor.Patch structure in its version file. Since Netkan prefers GitHub release versions by default, this means that v3.63 is currently considered the highest version, even though v3.7 is newer.

This pull request sets `"x_netkan_trust_version_file"` to `true` to make future versions work correctly, and increments the epoch to force the current version to be higher than v3.63.

Fixes #6480.