### PR TITLE
Use version files for DMagic's mods

### DIFF
--- a/NetKAN/CapCom.netkan
+++ b/NetKAN/CapCom.netkan
@@ -1,19 +1,20 @@
 {
     "spec_version": "v1.2",
-    "identifier": "CapCom",
-    "$kref": "#/ckan/spacedock/131",
-    "license": "MIT",
+    "identifier":   "CapCom",
+    "$kref":        "#/ckan/spacedock/131",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "MIT",
     "depends": [
         { "name": "ProgressParser" },
         { "name": "ContractParser" }
     ],
     "suggests": [
         { "name": "ContractRewardModifier" },
-        { "name": "ContractsWindowPlus" }
+        { "name": "ContractsWindowPlus"    }
     ],
     "install": [
         {
-            "file": "GameData/DMagicUtilities/CapCom",
+            "file":       "GameData/DMagicUtilities/CapCom",
             "install_to": "GameData/DMagicUtilities"
         }
     ]

--- a/NetKAN/ContractsWindowPlus.netkan
+++ b/NetKAN/ContractsWindowPlus.netkan
@@ -1,19 +1,20 @@
 {
     "spec_version": "v1.2",
-    "identifier": "ContractsWindowPlus",
-    "$kref": "#/ckan/spacedock/130",
-    "license": "MIT",
+    "identifier":   "ContractsWindowPlus",
+    "$kref":        "#/ckan/spacedock/130",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "MIT",
     "depends": [
         { "name": "ProgressParser" },
         { "name": "ContractParser" }
     ],
     "suggests": [
-        { "name": "CapCom" },
+        { "name": "CapCom"                 },
         { "name": "ContractRewardModifier" }
     ],
     "install": [
         {
-            "file": "GameData/DMagicUtilities/ContractsWindow",
+            "file":       "GameData/DMagicUtilities/ContractsWindow",
             "install_to": "GameData/DMagicUtilities"
         }
     ]

--- a/NetKAN/DMagicOrbitalScience.netkan
+++ b/NetKAN/DMagicOrbitalScience.netkan
@@ -1,8 +1,9 @@
 {
     "spec_version": 1,
-    "identifier": "DMagicOrbitalScience",
-    "$kref": "#/ckan/spacedock/128",
-    "license": "BSD-3-clause",
+    "identifier":   "DMagicOrbitalScience",
+    "$kref":        "#/ckan/spacedock/128",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "BSD-3-clause",
     "install": [
         {
             "file": "GameData/DMagicOrbitalScience",
@@ -16,15 +17,15 @@
         { "name": "ContractsWindowPlus" }
     ],
     "suggests": [
-        { "name": "CapCom" },
+        { "name": "CapCom"                 },
         { "name": "ContractRewardModifier" },
-        { "name": "OuterPlanetsMod" },
-        { "name": "UniversalStorage" },
-        { "name": "ScienceAlert" },
-        { "name": "SCANsat" },
-        { "name": "CommunityTechTree" }
+        { "name": "OuterPlanetsMod"        },
+        { "name": "UniversalStorage"       },
+        { "name": "ScienceAlert"           },
+        { "name": "SCANsat"                },
+        { "name": "CommunityTechTree"      }
     ],
-	"conflicts": [
+    "conflicts": [
         { "name": "ForScience" }
     ],
     "x_netkan_override": [

--- a/NetKAN/PortraitStats.netkan
+++ b/NetKAN/PortraitStats.netkan
@@ -1,8 +1,9 @@
 {
     "spec_version": 1,
-    "identifier": "PortraitStats",
-    "$kref": "#/ckan/spacedock/133",
-    "license": "MIT",
+    "identifier":   "PortraitStats",
+    "$kref":        "#/ckan/spacedock/133",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "MIT",
     "x_netkan_override": [
         {
             "version": ">=15.0",


### PR DESCRIPTION
#6503 pointed out several mods with official support for all of 1.4.x that are only indexed for one game version. They have version files that specify 1.4.0-1.4.8, but they're not being used currently.

This pull request updates these mods to get the compatible versions from their version files.

Fixes #6503.