### PR TITLE
Add DiRT

### DIFF
--- a/NetKAN/DiRT.netkan
+++ b/NetKAN/DiRT.netkan
@@ -1,0 +1,11 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "DiRT",
+    "$kref":        "#/ckan/github/cydonian-monk/KSP-DiRT",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "MIT",
+    "conflicts": [
+        { "name": "TextureReplacer"         },
+        { "name": "TextureReplacerReplaced" }
+    ]
+}

--- a/NetKAN/DiRT.netkan
+++ b/NetKAN/DiRT.netkan
@@ -4,6 +4,9 @@
     "$kref":        "#/ckan/github/cydonian-monk/KSP-DiRT",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "MIT",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/172055-*"
+    },
     "conflicts": [
         { "name": "TextureReplacer"         },
         { "name": "TextureReplacerReplaced" }


### PR DESCRIPTION
Drop-in Replacement Textures is a simplified texture replacement mod.

It's a dependency for #6425. A new release just came out with fixes to the .version file that makes it possible to list on CKAN.