### PR TITLE
Version override for DMagicScienceAnimate

### DIFF
--- a/NetKAN/DMagicScienceAnimate.netkan
+++ b/NetKAN/DMagicScienceAnimate.netkan
@@ -9,6 +9,9 @@
         "file":       "GameData/DMagicScienceAnimate",
         "install_to": "GameData"
     } ],
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/65734-*"
+    },
     "x_netkan_override": [ {
         "version": "v0.20",
         "override": {

--- a/NetKAN/DMagicScienceAnimate.netkan
+++ b/NetKAN/DMagicScienceAnimate.netkan
@@ -5,11 +5,14 @@
     "name"         : "DMModuleScienceAnimateGeneric",
     "abstract"     : "A replacement for ModuleScienceExperiment and ModuleAnimateGeneric",
     "license"      : "BSD-2-clause",
-    "ksp_version"   : "1.3",
-    "install": [
-        {
-                "file": "GameData/DMagicScienceAnimate",
-            "install_to": "GameData"
+    "install": [ {
+        "file":       "GameData/DMagicScienceAnimate",
+        "install_to": "GameData"
+    } ],
+    "x_netkan_override": [ {
+        "version": "v0.20",
+        "override": {
+            "ksp_version": "1.4"
         }
-    ]
+    } ]
 }


### PR DESCRIPTION
This mod has its version hard coded in the netkan because it's hosted on GitHub and there's no version file, and the version is now out of date.

This pull request changes it to a version-specific override so future versions won't have old game versions applied.