### PR TITLE
Update KerbalKonstructs.netkan

### DIFF
--- a/NetKAN/KerbalKonstructs.netkan
+++ b/NetKAN/KerbalKonstructs.netkan
@@ -19,5 +19,8 @@
             "find"       : "KerbalKonstructs",
             "install_to" : "GameData"
         }
-    ]
+    ],
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151818-*"
+    }
 }

--- a/NetKAN/KerbalKonstructs.netkan
+++ b/NetKAN/KerbalKonstructs.netkan
@@ -2,7 +2,7 @@
     "spec_version" : "v1.4",
     "identifier"   : "KerbalKonstructs",
     "author"       : [ "AlphaAsh", "ozraven", "Ger_space" ],
-    "$kref"        : "#/ckan/spacedock/1052",
+    "$kref"        : "#/ckan/github/GER-Space/Kerbal-Konstructs",
     "$vref"        : "#/ckan/ksp-avc",
     "license"      : "restricted",
     "comment"      : "Plugin is MIT, but Static Assets, Artwork & Models are ARR",

--- a/NetKAN/KerbalKonstructs.netkan
+++ b/NetKAN/KerbalKonstructs.netkan
@@ -1,6 +1,7 @@
 {
     "spec_version" : "v1.4",
     "identifier"   : "KerbalKonstructs",
+    "abstract"     : "New buildings and launch sites",
     "author"       : [ "AlphaAsh", "ozraven", "Ger_space" ],
     "$kref"        : "#/ckan/github/GER-Space/Kerbal-Konstructs",
     "$vref"        : "#/ckan/ksp-avc",

--- a/NetKAN/KerbalKonstructs.netkan
+++ b/NetKAN/KerbalKonstructs.netkan
@@ -7,7 +7,6 @@
     "$vref"        : "#/ckan/ksp-avc",
     "license"      : "restricted",
     "comment"      : "Plugin is MIT, but Static Assets, Artwork & Models are ARR",
-    "x_netkan_license_ok" : true,
     "depends"      : [
         { "name"   : "ModuleManager" }
     ],


### PR DESCRIPTION
The SpaceDock release 10 days behind the GitHub one, and counting. The GitHub release appears to be released and is perhaps a better $kref for this particular mod. This has been observed in the past, with version 1.3.9.6 of the mod releasing 9 days later on SpaceDock than on GitHub, as one example. CKAN would improve as a service were this switch to be made.