### PR TITLE
Fix KWRocketryRebalanced install stanza

### DIFF
--- a/NetKAN/KWRocketryRebalanced.netkan
+++ b/NetKAN/KWRocketryRebalanced.netkan
@@ -25,7 +25,7 @@
     ],
     "install" : [
         {
-            "find"       : "KWRocketryRebalanced/GameData/KWRocketry",
+            "find"       : "GameData/KWRocketry",
             "install_to" : "GameData"
         }
     ]


### PR DESCRIPTION
No longer has an extra parent directory for GameData, currently erroring out with "Could not find KWRocketryRebalanced/GameData/KWRocketry entry in zipfile to install"