### PR TITLE
Create CraftManager.netkan

### DIFF
--- a/NetKAN/CraftManager.netkan
+++ b/NetKAN/CraftManager.netkan
@@ -5,8 +5,7 @@
     "license"      : "CC-BY-4.0",
     "abstract"     : "Craft Manager is a replacement for the stock craft list in the editors that adds a bunch features the stock list lacks and opens much faster.\nSearch, Sort and Organize your craft, view and load craft from any save, move/copy them between saves, transfer them between editors, load your subassemblies in the same interface.\nCraft can be tagged with custom tags which you can manually assign. Tags can also be given a rule so they also auto associate with craft.",
     "ksp_version"  : "1.4",
-    "version"      : "1.1.1",
     "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/174596-13x14x-craft-manager%C2%A0-search-sort-tag-share-your-craft/"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/174596-*"
     }
 }

--- a/NetKAN/CraftManager.netkan
+++ b/NetKAN/CraftManager.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version" : 1.4,
+    "spec_version" : v1.4,
     "identifier"   : "CraftManager",
     "$kref"        : "#/ckan/github/Sujimichi/CraftManager",
     "license"      : "CC-BY-4.0",

--- a/NetKAN/CraftManager.netkan
+++ b/NetKAN/CraftManager.netkan
@@ -1,0 +1,12 @@
+{
+    "spec_version" : 1.4,
+    "identifier"   : "CraftManager",
+    "$kref"        : "#/ckan/github/Sujimichi/CraftManager",
+    "license"      : "CC-BY-4.0",
+    "abstract"     : "Craft Manager is a replacement for the stock craft list in the editors that adds a bunch features the stock list lacks and opens much faster.\nSearch, Sort and Organize your craft, view and load craft from any save, move/copy them between saves, transfer them between editors, load your subassemblies in the same interface.\nCraft can be tagged with custom tags which you can manually assign. Tags can also be given a rule so they also auto associate with craft.",
+    "ksp_version"  : "1.4",
+    "version"      : "1.1.1",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/174596-13x14x-craft-manager%C2%A0-search-sort-tag-share-your-craft/"
+    }
+}

--- a/NetKAN/CraftManager.netkan
+++ b/NetKAN/CraftManager.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version" : v1.4,
+    "spec_version" : "v1.4",
     "identifier"   : "CraftManager",
     "$kref"        : "#/ckan/github/Sujimichi/CraftManager",
     "license"      : "CC-BY-4.0",

--- a/NetKAN/CraftManager.netkan
+++ b/NetKAN/CraftManager.netkan
@@ -5,6 +5,13 @@
     "license"      : "CC-BY-4.0",
     "abstract"     : "Craft Manager is a replacement for the stock craft list in the editors that adds a bunch features the stock list lacks and opens much faster.\nSearch, Sort and Organize your craft, view and load craft from any save, move/copy them between saves, transfer them between editors, load your subassemblies in the same interface.\nCraft can be tagged with custom tags which you can manually assign. Tags can also be given a rule so they also auto associate with craft.",
     "ksp_version"  : "1.4",
+    "x_netkan_override": [ {
+        "version":  "<1.1.0",
+        "delete":   [ "ksp_version" ],
+        "override": {
+            "ksp_version": "1.3"
+        }
+    } ],
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/174596-*"
     }


### PR DESCRIPTION
I have reached out to the developer and gained permission. However, he asked that I try to also register a older release of the mod, which is compatible with ksp 1.3.
Should I add something to this file, or create CraftManagerLegacy.netkan? The developer does not use KSP-AVC, though I have advised them to.