### PR TITLE
Update KerbalRenamer game version

### DIFF
--- a/NetKAN/KerbalRenamer.netkan
+++ b/NetKAN/KerbalRenamer.netkan
@@ -6,10 +6,10 @@
     "abstract"     : "Renames, re-stats, even gender-bends Kerbals procedurally.",
     "author"       : [ "regex", "KSP-RO Group"],
     "license"      : "BSD-2-clause",
-    "ksp_version"  : "1.2.2",
+    "ksp_version"  : "1.4.3",
     "install": [
         {
-            "find": "GameData/KerbalRenamer",
+            "find":       "GameData/KerbalRenamer",
             "install_to": "GameData"
         }
     ]


### PR DESCRIPTION
This mod is released for specific game versions, but it doesn't have a version file, so the compatible version is stored in its netkan entry. The latest release is for KSP 1.4.3, and this pull request updates the netkan for that.

Fixes KSP-CKAN/CKAN#2446.