### PR TITLE
Use version file for DecouplerShroud

### DIFF
--- a/NetKAN/DecouplerShroud.netkan
+++ b/NetKAN/DecouplerShroud.netkan
@@ -3,6 +3,7 @@
     "identifier":   "DecouplerShroud",
     "$kref":        "#/ckan/spacedock/1692",
     "license":      "MIT",
+    "$vref": "#/ckan/ksp-avc",
     "x_via":        "Automated SpaceDock CKAN submission",
     "depends": [
         { "name": "ModuleManager" }


### PR DESCRIPTION
I've added a version file to my mod. The "$vref" line will get the ksp version from that file, correct? And does this affect the current release, or just new ones?