### PR TITLE
Fix ThorTech's path again

### DIFF
--- a/NetKAN/ThorTech.netkan
+++ b/NetKAN/ThorTech.netkan
@@ -11,6 +11,6 @@
     ],
     "install": [ {
         "find":       "ThorTech",
-        "install_to": "GameData/DeepSky/ThorTech"
+        "install_to": "GameData/DeepSky"
     } ]
 }


### PR DESCRIPTION
#6559 updated this mod's install path, but I thought it had to include the full path. Apparently it only needs the parent directory. That makes sense given that we usually install to GameData.

This is on SpaceDock so it won't pass tests till KSP-CKAN/CKAN#2453 gets resolved.

Fixes https://forum.kerbalspaceprogram.com/index.php?/topic/168326-131-143-thor-tech-v0962-~-may-10-2018/&do=findComment&comment=3385780