### PR TITLE
Update RealHeat game version

### DIFF
--- a/NetKAN/RealHeat.netkan
+++ b/NetKAN/RealHeat.netkan
@@ -9,7 +9,7 @@
         "homepage"   : "https://forum.kerbalspaceprogram.com/index.php?/topic/115066-113-realheat-minimalist-v43-july-3/",
         "repository" : "https://github.com/KSP-RO/RealHeat"
     },
-    "ksp_version"  : "1.3.1",
+    "ksp_version"  : "1.4.3",
      "depends"        : [
         { "name": "ModularFlightIntegrator" }
     ],


### PR DESCRIPTION
This mod lives on GitHub and has no .version file, so the CKAN team has the pleasure of maintaining its version compatibility manually.

https://github.com/KSP-RO/RealHeat/releases

Fixes #6572.