### PR TITLE
Switch Kerbalism to GitHub

### DIFF
--- a/NetKAN/Kerbalism.netkan
+++ b/NetKAN/Kerbalism.netkan
@@ -1,12 +1,12 @@
 {
     "spec_version": "v1.18",
     "identifier": "Kerbalism",
-    "$kref": "#/ckan/spacedock/1774",
+    "$kref": "#/ckan/github/steamp0rt/Kerbalism",
     "$vref": "#/ckan/ksp-avc/GameData/Kerbalism/Kerbalism.version",
     "license": "Unlicense",
     "author": [ "ShotgunNinja", "N70" ],
     "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/172400-141-kerbalism-v13/",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/172400-*",
         "repository": "https://gitlab.com/N70/Kerbalism"
     },
     "depends": [

--- a/NetKAN/Kerbalism.netkan
+++ b/NetKAN/Kerbalism.netkan
@@ -3,6 +3,7 @@
     "identifier": "Kerbalism",
     "$kref": "#/ckan/github/steamp0rt/Kerbalism",
     "$vref": "#/ckan/ksp-avc/GameData/Kerbalism/Kerbalism.version",
+    "x_netkan_trust_version_file": true,
     "license": "Unlicense",
     "author": [ "ShotgunNinja", "N70" ],
     "resources": {


### PR DESCRIPTION
This mod is suffering from bot reversion syndrome; the author replaced the download after the bot cached it, so now the checksums are wrong and [our fixes](https://github.com/KSP-CKAN/CKAN-meta/commit/e5aafca7dcb173abc89a2a9e13e63ed1822dc71c) are [reverted every 3 hours](https://github.com/KSP-CKAN/CKAN-meta/commit/58b549be2e64c73e994880fbfd1c4b501d11df9c#diff-cf1d668dd5b46acd533e4d55ca704640).

As of KSP-CKAN/CKAN#2337, GitHub is immune to this problem. This mod's releases are hosted there as well, so now we'll use GitHub for it instead.