### PR TITLE
Override ReCoupler compatible versions

### DIFF
--- a/NetKAN/ReCoupler.netkan
+++ b/NetKAN/ReCoupler.netkan
@@ -1,9 +1,16 @@
 {
-    "x_via": "Automated SpaceDock CKAN submission",
-    "license": "MIT",
-    "identifier": "ReCoupler",
-    "$kref": "#/ckan/spacedock/1250",
     "spec_version": "v1.4",
-     "x_netkan_epoch": 1
-
+    "identifier":   "ReCoupler",
+    "$kref":        "#/ckan/spacedock/1250",
+    "license":      "MIT",
+    "x_via":        "Automated SpaceDock CKAN submission",
+    "x_netkan_epoch": 1,
+    "x_netkan_override": [ {
+        "version": "1:1.3.1",
+        delete:    [ "ksp_version" ],
+        "override": {
+            "ksp_version_min": "1.3",
+            "ksp_version_max": "1.4"
+        }
+    } ]
 }

--- a/NetKAN/ReCoupler.netkan
+++ b/NetKAN/ReCoupler.netkan
@@ -7,7 +7,7 @@
     "x_netkan_epoch": 1,
     "x_netkan_override": [ {
         "version": "1:1.3.1",
-        delete:    [ "ksp_version" ],
+        "delete":  [ "ksp_version" ],
         "override": {
             "ksp_version_min": "1.3",
             "ksp_version_max": "1.4"


### PR DESCRIPTION
KSP-CKAN/CKAN-meta#1350 is attempting to update this mod to be compatible with all of KSP 1.3 and 1.4, as per [its forum thread](https://forum.kerbalspaceprogram.com/index.php?/topic/157131-*). However, it's hosted on SpaceDock and has no version file, so that change would be overwritten by the NetKAN bot on its next pass.

Instead, this pull request puts these changes in an override in the netkan file.

Closes KSP-CKAN/CKAN-meta#1350.