### PR TITLE
Use game version from SpaceDock for SASAG

### DIFF
--- a/NetKAN/SASAG.netkan
+++ b/NetKAN/SASAG.netkan
@@ -1,12 +1,11 @@
 {
     "spec_version": "v1.4",
-    "identifier": "SASAG",
-    "license": "public-domain",
-    "$kref": "#/ckan/spacedock/1380",
-    "ksp_version": "1.2.2",
+    "identifier":   "SASAG",
+    "$kref":        "#/ckan/spacedock/1380",
+    "license":      "public-domain",
     "install": [
         {
-            "find": "XyphosAerospace",
+            "find":       "XyphosAerospace",
             "install_to": "GameData"
         }
     ]


### PR DESCRIPTION
This mod is hard coded to KSP 1.2.2, but that's not correct for any version of it.
This pull request removes that, so the version listed on SpaceDock can be used instead.