### PR TITLE
Force v for FullAutoStrut

### DIFF
--- a/NetKAN/FullAutoStrut.netkan
+++ b/NetKAN/FullAutoStrut.netkan
@@ -1,7 +1,8 @@
 {
-    "$kref": "#/ckan/spacedock/1479",
-    "identifier": "FullAutoStrut",
-    "license": "MIT",
-    "x_via": "Automated SpaceDock CKAN submission",
-    "spec_version": "v1.4"
+    "spec_version": "v1.4",
+    "identifier":   "FullAutoStrut",
+    "$kref":        "#/ckan/spacedock/1479",
+    "license":      "MIT",
+    "x_via":        "Automated SpaceDock CKAN submission",
+    "x_netkan_force_v": true
 }


### PR DESCRIPTION
This mod has some versions with a 'v' and some without, and it's causing confusion.

![image](https://user-images.githubusercontent.com/1559108/42137000-62a1d0f6-7d54-11e8-9888-29c24965b8b3.png)

![image](https://user-images.githubusercontent.com/1559108/42137001-64fab1c4-7d54-11e8-864e-d587bf0dcc05.png)

This pull request adds the `x_netkan_force_v` property to try to work around this. I haven't used this property before, so I'm not sure it will work, and will be checking the validation output to find out.