### PR TITLE
Use CTT's version file

### DIFF
--- a/NetKAN/CommunityTechTree.netkan
+++ b/NetKAN/CommunityTechTree.netkan
@@ -2,6 +2,7 @@
     "spec_version"   : "v1.4",
     "identifier"     : "CommunityTechTree",
     "$kref"          : "#/ckan/spacedock/534",
+    "$vref"          : "#/ckan/ksp-avc",
     "license"        : "CC-BY-NC-4.0",
     "x_netkan_epoch" : "1",
     "depends" : [


### PR DESCRIPTION
This mod has a version file promising compatibility up to KSP 1.4.9, but we're only using SpaceDock's compatible version of 1.4.2.
This pull request tells Netkan to look at the version file.

Should help with the validation error in #6618.