### PR TITLE
Use IFS's version file

### DIFF
--- a/NetKAN/InterstellarFuelSwitch-Core.netkan
+++ b/NetKAN/InterstellarFuelSwitch-Core.netkan
@@ -1,6 +1,7 @@
 {
     "spec_version" : "v1.4",
     "$kref"        : "#/ckan/spacedock/175",
+    "$vref"        : "#/ckan/ksp-avc/InterstellarFuelSwitch.version",
     "identifier"   : "InterstellarFuelSwitch-Core",
     "name"         : "Interstellar Fuel Switch Core",
     "abstract"     : "Core plugin for Interstellar Fuel Switch",


### PR DESCRIPTION
This mod ships a valid version file, but it's not used. Currently it only specifies compatibility with the same version as indicated on SpaceDock, but that might change in the future. This pull request updates the netkan to check the version file.