### PR TITLE
Add force_v to FlagPack

### DIFF
--- a/NetKAN/FlagPack.netkan
+++ b/NetKAN/FlagPack.netkan
@@ -7,9 +7,11 @@
     "resources": {
         "homepage": "https://github.com/willwill2will54/Flag-Pack/"
     },
-    "install":[
+    "install": [
         {
             "find": "FlagPack",
             "install_to": "GameData"
-        }]
+        }
+    ],
+    "x_netkan_force_v": true
 }


### PR DESCRIPTION
This mod's earliest versions are v1.0 and v1.1, but the latest is just 1.1.1 without the 'v'.
Setting force_v to head off problems.