### PR TITLE
Point KittopiaTech to Legacy repo

### DIFF
--- a/NetKAN/KittopiaTech.netkan
+++ b/NetKAN/KittopiaTech.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version"  : "v1.4",
     "identifier"    : "KittopiaTech",
-    "$kref"         : "#/ckan/github/Kopernicus/KittopiaTech",
+    "$kref"         : "#/ckan/github/Kopernicus/KittopiaTech-Legacy",
     "name"          : "KittopiaTech",
     "abstract"      : "A Kopernicus visual editor for ingame planet editing and exporting.",
     "release_status": "development",


### PR DESCRIPTION
This mod has been erroring out for quite a while, because the author deleted all the releases.
The forum thread explains that they're moved to a new repo, so this pull request makes that change.