### PR TITLE
Added dependancy on CommunityTechTree to Photon Sailor

### DIFF
--- a/NetKAN/PhotonSailor.netkan
+++ b/NetKAN/PhotonSailor.netkan
@@ -14,7 +14,8 @@
         "install_to": "GameData"
     } ],
     "depends": [
-        { "name": "ModuleManager" }
+        { "name": "ModuleManager" },
+        { "name": "CommunityTechTree", "min_version" : "1:3.3.2" }
     ],
     "recommends": [
         { "name": "PersistentRotation"      },


### PR DESCRIPTION
In order to play with the new KSC laser, you need to have acces to several CTT technodes.