### PR TITLE
Support original game versions for BBT 1.6.1

### DIFF
--- a/NetKAN/BetterBurnTime.netkan
+++ b/NetKAN/BetterBurnTime.netkan
@@ -1,6 +1,14 @@
 {
-    "identifier": "BetterBurnTime",
-    "$kref": "#/ckan/spacedock/21",
     "spec_version": "v1.4",
-    "license": "CC-BY-NC-ND-4.0"
+    "identifier":   "BetterBurnTime",
+    "$kref":        "#/ckan/spacedock/21",
+    "license":      "CC-BY-NC-ND-4.0",
+    "x_netkan_override": [ {
+        "version":  "1.6.1",
+        "delete":   [ "ksp_version" ],
+        "override": {
+            "ksp_version_min": "1.3.1",
+            "ksp_version_max": "1.4"
+        }
+    } ]
 }


### PR DESCRIPTION
BetterBurnTime 1.6.1 originally supported KSP 1.3.1, and as more game versions were released, that same version of BBT remained compatible, so its version on SpaceDock was simply updated, currently at 1.4.4. This meant that while you could have installed it on several previous game versions, it no longer appears as compatible.

This pull request overrides BBT 1.6.1 to support 1.3.1 through all of 1.4.

Fixes #6629.