### PR TITLE
Use KerbalFlightIndicators's version file

### DIFF
--- a/NetKAN/KerbalFlightIndicators.netkan
+++ b/NetKAN/KerbalFlightIndicators.netkan
@@ -2,10 +2,10 @@
     "spec_version" : 1,
     "identifier"   : "KerbalFlightIndicators",
     "$kref"        : "#/ckan/github/PapaJoesSoup/KerbalFlightIndicators",
+    "$vref"        : "#/ckan/ksp-avc",
     "name"         : "Kerbal Flight Indicators",
     "abstract"     : "Displays indicators for the flight vector and other things. Works like a HUD. In external view, too!",
     "license"      : "CC-BY-NC-SA-3.0",
-    "ksp_version"  : "1.3",
     "resources" : {
         "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/172904-141-kerbal-flight-indicators-release-16-2018-03-23/"
     },


### PR DESCRIPTION
This mod previously had a game version hard coded in the netkan, but its latest release includes a version file. This pull request updates the netkan to use the version file.

Closes KSP-CKAN/CKAN-meta#1352.