### PR TITLE
Couple of fixes for Tundra Exploration

### DIFF
--- a/NetKAN/TundraExploration.netkan
+++ b/NetKAN/TundraExploration.netkan
@@ -20,6 +20,12 @@
             "find"       : "TundraExploration",
             "install_to" : "GameData",
             "filter"     : "Thumbs.db"
+        },
+        {
+            "find": "Ships/VAB",
+            "install_to": "Ships",
+            "optional": true,
+            "description": "Tundra Exploration example craft"
         }
     ]
 }

--- a/NetKAN/TundraExploration.netkan
+++ b/NetKAN/TundraExploration.netkan
@@ -8,7 +8,8 @@
         { "name": "NearFutureSolar-Core" },
         { "name": "B9PartSwitch" },
         { "name": "TundraTechnologies" },
-        { "name": "ModuleManager" }
+        { "name": "ModuleManager" },
+        { "name": "SpaceXLegs" }
     ],
     "recommends" : [
         { "name" : "RasterPropMonitor-Core" },


### PR DESCRIPTION
* It depends on Kerbal Reusability Expansion, so include that dependency
* Allow installation of example craft

This was done in talks with the author, @damonvv