### PR TITLE
Make RemoteTechRedevAntennas support 1.3 and 1.4

### DIFF
--- a/NetKAN/RemoteTechRedevAntennas.netkan
+++ b/NetKAN/RemoteTechRedevAntennas.netkan
@@ -23,7 +23,7 @@
     ],
     "x_netkan_override": [ {
         "version": "0.1",
-        "delete":  [ "version" ],
+        "delete":  [ "ksp_version" ],
         "override": {
             "ksp_version_min": "1.3",
             "ksp_version_max": "1.4"

--- a/NetKAN/RemoteTechRedevAntennas.netkan
+++ b/NetKAN/RemoteTechRedevAntennas.netkan
@@ -20,5 +20,13 @@
     ],
     "conflicts": [
         { "name": "RemoteTech" }
-    ]
+    ],
+    "x_netkan_override": [ {
+        "version": "0.1",
+        "delete":  [ "version" ],
+        "override": {
+            "ksp_version_min": "1.3",
+            "ksp_version_max": "1.4"
+        }
+    } ]
 }


### PR DESCRIPTION
[@KSP-TaxiService says](https://github.com/KSP-CKAN/NetKAN/pull/6660#issuecomment-410899718) that this mod supports KSP 1.3 and up. This pull request adds an override to do that (if I got the syntax right).