### PR TITLE
Don't filter MiniAVC out of LTP

### DIFF
--- a/NetKAN/LoadingTipsPlus.netkan
+++ b/NetKAN/LoadingTipsPlus.netkan
@@ -6,7 +6,6 @@
     "$vref":        "#/ckan/ksp-avc",
     "install":      [{
         "find":          "LoadingTipsPlus",
-        "install_to":    "GameData",
-        "filter_regexp": "MiniAVC.*"
+        "install_to":    "GameData"
     }]
 }


### PR DESCRIPTION
We're not supposed to de-bundle MiniAVC, see #1455. I didn't know that while indexing this mod, and I filtered it. This pull request removes that filter.