### PR TITLE
Specify version file for MissionController

### DIFF
--- a/NetKAN/MissionController2.netkan
+++ b/NetKAN/MissionController2.netkan
@@ -2,7 +2,7 @@
     "spec_version"  : "v1.4",
     "identifier"    : "MissionController2",
     "$kref"         : "#/ckan/github/malkuth1974/MissionController2",
-    "$vref"         : "#/ckan/ksp-avc",
+    "$vref"         : "#/ckan/ksp-avc/MissionController.*\.version",
     "license"       : "GPL-3.0",
     "name": "Mission Controller 2",
     "abstract": "Mission Controller 2 Adds New Economy Adjustments and Contracts to Kerbal Space Program.",

--- a/NetKAN/MissionController2.netkan
+++ b/NetKAN/MissionController2.netkan
@@ -2,7 +2,7 @@
     "spec_version"  : "v1.4",
     "identifier"    : "MissionController2",
     "$kref"         : "#/ckan/github/malkuth1974/MissionController2",
-    "$vref"         : "#/ckan/ksp-avc/MissionController.*\.version",
+    "$vref"         : "#/ckan/ksp-avc/MissionController.*\\.version",
     "license"       : "GPL-3.0",
     "name": "Mission Controller 2",
     "abstract": "Mission Controller 2 Adds New Economy Adjustments and Contracts to Kerbal Space Program.",


### PR DESCRIPTION
MissionController has accidentally shipped KSP-AVC's version file in addition to its own, which is making Netkan error out on it. This pull request adds a regex to select the right one.