### PR TITLE
Override versions for DiscordRP

### DIFF
--- a/NetKAN/DiscordRP.netkan
+++ b/NetKAN/DiscordRP.netkan
@@ -6,5 +6,13 @@
     "license": "MIT",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/168196-14-discordrp-rich-presence-integration/"
-    }
+    },
+    "x_netkan_override": [ [
+        "version": "1.0.3",
+        "delete": [ "ksp_version" ],
+        "override": {
+            "ksp_version_min": "1.2",
+            "ksp_version_max": "1.4"
+        }
+    } ]
 }

--- a/NetKAN/DiscordRP.netkan
+++ b/NetKAN/DiscordRP.netkan
@@ -7,7 +7,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/168196-14-discordrp-rich-presence-integration/"
     },
-    "x_netkan_override": [ [
+    "x_netkan_override": [ {
         "version": "1.0.3",
         "delete": [ "ksp_version" ],
         "override": {


### PR DESCRIPTION
## Motivation

[DiscordRP says this on Curse](https://kerbal.curseforge.com/projects/discordrp/files/2532403):

![image](https://user-images.githubusercontent.com/1559108/44006065-311c9072-9e6d-11e8-9586-31d0d7e05a88.png)

However, currently it's filed as 1.4.0 only, and occasionally 1.3 only (see #6622).

## Changes

Now this mod's compatible game version is overridden to reflect its compatibility with KSP 1.2 through 1.4. This will more accurately reflect the versions on Curse. It also fixes #6622, since Netkan will now discard the value that seems to be fluctuating back and forth.