### PR TITLE
Use RealHeat's .version file

### DIFF
--- a/NetKAN/RealHeat.netkan
+++ b/NetKAN/RealHeat.netkan
@@ -2,7 +2,7 @@
     "spec_version" : "v1.4",
     "identifier"   : "RealHeat",
     "$kref"        : "#/ckan/github/KSP-RO/RealHeat",
-    "$vref"        : "ksp-avc",
+    "$vref"        : "#/ckan/ksp-avc",
     "name"         : "RealHeat",
     "abstract"     : "Improves the realism of KSP's thermodynamics.",
     "license"      : "CC-BY-SA",

--- a/NetKAN/RealHeat.netkan
+++ b/NetKAN/RealHeat.netkan
@@ -2,7 +2,7 @@
     "spec_version" : "v1.4",
     "identifier"   : "RealHeat",
     "$kref"        : "#/ckan/github/KSP-RO/RealHeat",
-    "$vref":       : "ksp-avc",
+    "$vref"        : "ksp-avc",
     "name"         : "RealHeat",
     "abstract"     : "Improves the realism of KSP's thermodynamics.",
     "license"      : "CC-BY-SA",

--- a/NetKAN/RealHeat.netkan
+++ b/NetKAN/RealHeat.netkan
@@ -2,6 +2,7 @@
     "spec_version" : "v1.4",
     "identifier"   : "RealHeat",
     "$kref"        : "#/ckan/github/KSP-RO/RealHeat",
+    "$vref":       : "ksp-avc",
     "name"         : "RealHeat",
     "abstract"     : "Improves the realism of KSP's thermodynamics.",
     "license"      : "CC-BY-SA",
@@ -9,13 +10,12 @@
         "homepage"   : "https://forum.kerbalspaceprogram.com/index.php?/topic/115066-113-realheat-minimalist-v43-july-3/",
         "repository" : "https://github.com/KSP-RO/RealHeat"
     },
-    "ksp_version"  : "1.4.3",
-     "depends"        : [
+    "depends"        : [
         { "name": "ModularFlightIntegrator" }
     ],
     "install"        : [
         {
-            "find": "RealHeat",
+            "find":       "RealHeat",
             "install_to": "GameData"
         }
     ],


### PR DESCRIPTION
RealHeat's latest release has a version file, so this pull request removes the hard coding of `ksp_version` in favor of a `$vref`.

@rsparkyc, tagging you in case GitHub doesn't send you a notification automatically.

Fixes #6692.