### PR TITLE
KSPI-E: update homepage, dependencies, and install

### DIFF
--- a/NetKAN/KSPInterstellarExtended.netkan
+++ b/NetKAN/KSPInterstellarExtended.netkan
@@ -5,35 +5,41 @@
     "$vref"             : "#/ckan/ksp-avc",
     "x_netkan_staging"  : true,
     "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/155255-12213-kspi-extended",
+        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/172026-*",
         "repository": "https://github.com/sswelm/KSP-Interstellar-Extended"
     },
-    "license"            : "GPL-3.0",
-    "install" : [
+    "license"           : "GPL-3.0",
+    "install": [
         {
             "find"      : "GameData/WarpPlugin",
             "install_to": "GameData"
+        }, {
+            "find"      : "InterstellarHybridRocketry",
+            "install_to": "GameData"
         }
     ],
-    "depends" : [
-        { "name"        : "CommunityResourcePack", "min_version" : "0.7.1" },
-        { "name"        : "CommunityTechTree", "min_version" : "1:3.2.0" },
-        { "name"        : "InterstellarFuelSwitch-Core", "min_version" : "2.9.5" },
-        { "name"        : "TweakScale", "min_version" : "2.3.3"},
-        { "name"        : "ModuleManager", "min_version" : "2.8.1" }
-        
+    "depends": [
+        { "name"        : "CommunityResourcePack",       "min_version" : "0.7.1"   },
+        { "name"        : "CommunityTechTree",           "min_version" : "1:3.2.0" },
+        { "name"        : "InterstellarFuelSwitch-Core", "min_version" : "2.9.5"   },
+        { "name"        : "TweakScale",                  "min_version" : "2.3.3"   },
+        { "name"        : "ModuleManager",               "min_version" : "2.8.1"   }
     ],
     "recommends": [
-        { "name"        : "PatchManager", "min_version" : "0.0.10" },
-        { "name"        : "UniversalStorage", "min_version" : "1.2.2" },
-        { "name"        : "InterstellarFuelSwitch", "min_version" : "2.9.5"},
-        { "name"        : "FilterExtensions", "min_version" : "3.0.0"},
-        { "name"        : "HideEmptyTechNodes", "min_version" : "0.8.0" },
+        { "name"        : "PatchManager",           "min_version" : "0.0.10" },
+        { "name"        : "UniversalStorage",       "min_version" : "1.2.2"  },
+        { "name"        : "InterstellarFuelSwitch", "min_version" : "2.9.5"  },
+        { "name"        : "FilterExtensions",       "min_version" : "3.0.0"  },
+        { "name"        : "HideEmptyTechNodes",     "min_version" : "0.8.0"  },
         { "name"        : "KerbalJointReinforcement" },
-        { "name"        : "UniversalStorage" },
-        { "name"        : "PersistentRotation" }, 
-        { "name"        : "PhotonSailor" },
-        { "name"        : "TexturesUnlimited"},
-        { "name"        : "HeatControl"}
+        { "name"        : "UniversalStorage"         },
+        { "name"        : "PersistentRotation"       }, 
+        { "name"        : "PhotonSailor"             },
+        { "name"        : "TexturesUnlimited"        },
+        { "name"        : "HeatControl"              },
+        { "name"        : "ToolbarController"        }
+    ],
+    "suggests": [
+        { "name"        : "FilterExtensions"  }
     ]
 }

--- a/NetKAN/PersistentRotation.netkan
+++ b/NetKAN/PersistentRotation.netkan
@@ -1,15 +1,24 @@
 {
-    "$kref": "#/ckan/spacedock/447",
     "spec_version": "v1.4",
-    "identifier": "PersistentRotation",
-    "license": "GPL-3.0",
+    "$kref":        "#/ckan/spacedock/447",
+    "identifier":   "PersistentRotation",
+    "license":      "GPL-3.0",
     "suggests": [
         { "name": "Toolbar" }
     ],
     "install": [
-        { "file": "PersistentRotation/GameData/PersistentRotation", "install_to": "GameData" }
+        {
+            "file":       "PersistentRotation/GameData/PersistentRotation",
+            "install_to": "GameData"
+        }
     ],
-	"x_netkan_override": [
+    "x_netkan_override": [
+        {
+            "version": "1.8.5",
+            "override": {
+                "ksp_version": "1.4"
+            }
+        }.
         {
             "version": "1.8.1",
             "override": {

--- a/NetKAN/PersistentRotation.netkan
+++ b/NetKAN/PersistentRotation.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
-    "$kref":        "#/ckan/spacedock/447",
     "identifier":   "PersistentRotation",
+    "$kref":        "#/ckan/spacedock/447",
     "license":      "GPL-3.0",
     "suggests": [
         { "name": "Toolbar" }
@@ -18,7 +18,7 @@
             "override": {
                 "ksp_version": "1.4"
             }
-        }.
+        },
         {
             "version": "1.8.1",
             "override": {


### PR DESCRIPTION
The bot staged an update for KSPI-E :+1:, and a few issues surfaced.

Closes KSP-CKAN/CKAN-meta#1357.

### Homepage

The homepage link is broken, probably from an earlier iteration of the forum.

Now it's updated to point to the current support thread.

### InterstellarHybridRocketry

The ZIP has a folder by this name, but it's not handled in the netkan either as a dependency or an install stanza. It seems to consist of an engine, tank, and IRSU for a hybrid solid/liquid motor based on aluminüm. As far as I can tell this is not a standalone mod but an integral part of KSPI-E packaged outside the usual WarpPlugin folder.

Now a new install stanza handles this folder.

### ToolbarController, FilterExtensions

These mods have folders in the ZIP but aren't listed as dependencies.

Now ToolbarController is recommended and FilterExtensions is suggested, since the forum thread explicitly says it's optional.

### PersistentRotation

This mod is in the ZIP but not installed in testing, because it's currently considered only compatible with KSP 1.4.0, because the author picked "1.4" on SpaceDock. However, the forum thread says "1.4" rather than "1.4.0", so we can infer that the author intended to support all of KSP 1.4.

Now an override makes the current version of this mod compatible with all of KSP 1.4.

### KerbalJointReinforcement

This mod is included in the ZIP, but it's an unofficial update for KSP 1.4. The official version of the mod only supports KSP 1.3, and no one has stepped up to fully adopt the mod.

Nothing is changed about this in this pull request. CKAN probably ought not get into the business of indexing unofficial unsupported updates of high profile mods.