### PR TITLE
Make Porkjet overhaul compatible with all future versions

### DIFF
--- a/NetKAN/PartOverhauls.netkan
+++ b/NetKAN/PartOverhauls.netkan
@@ -1,6 +1,6 @@
 {
     "spec_version"   : 1,
-    "name"           : "Part Overhauls",
+    "name"           : "Porkjet's Part Overhauls",
     "abstract"       : "Porkjet's in-progress part overhauls",
     "identifier"     : "PartOverhauls",
     "download"       : "https://archive.org/download/PartOverhauls/PartOverhauls.zip",
@@ -9,7 +9,6 @@
     "author"         : "Porkjet",
     "release_status" : "development",
     "ksp_version_min": "1.1.0",
-    "ksp_version_max": "1.3.9",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/index.php?/topic/147582-update-12-pre-release-is-here/"
     },


### PR DESCRIPTION
This pull request makes two changes to `PartOverhauls.netkan`.

1. Add "Porkjet's" to the start of the `name` property because players generally identify this mod with that user name (the `identifier` is unchanged)
2. Remove the `ksp_version_max` property, previously set to 1.3.9. This mod contains only parts, not plugins,  and the [original announcement](https://forum.kerbalspaceprogram.com/index.php?/topic/147582-update-12-pre-release-is-here/) doesn't specify version limitations, so there's no reason to think these will become incompatible. This will make the part overhauls show up for KSP 1.4 again.