### PR TITLE
Use AnimatedDecouplers' version file

### DIFF
--- a/NetKAN/AnimatedDecouplers.netkan
+++ b/NetKAN/AnimatedDecouplers.netkan
@@ -5,7 +5,7 @@
     "name"            : "Animated Decouplers",
     "abstract"        : "Extensions of KSP's decouplers that play animations.",
     "license"         : "CC-BY-SA-4.0",
-    "ksp_version" 	  : "1.3.0",
+    "$vref"           : "#/ckan/ksp-avc",
     "resources"       : {
         "repository" : "https://github.com/Starwaster/AnimatedDecouplers"
     },


### PR DESCRIPTION
This mod has a .version file, but its netkan currently hard codes a KSP version, which is now out of date.
Now it has a `$vref` instead.
Fixes #6730.