### PR TITLE
Ships folder moved in ImpossibleInnovations, add vref, fix homepage

### DIFF
--- a/NetKAN/ImpossibleInnovations.netkan
+++ b/NetKAN/ImpossibleInnovations.netkan
@@ -2,23 +2,20 @@
     "spec_version" : 1,
     "identifier"   : "ImpossibleInnovations",
     "$kref"        : "#/ckan/spacedock/340",
+    "$vref"        : "#/ckan/ksp-avc",
     "license"      : "CC-BY-NC-SA-4.0",
     "resources" : {
-        "homepage"  : "http://forum.kerbalspaceprogram.com/index.php?/topic/77933-104-impossible-innovations",
-        "repository": "https://github.com/JandCandO/ImpossibleInnovations"
+        "homepage"  : "https://forum.kerbalspaceprogram.com/index.php?/topic/175694-*",
+        "repository": "https://github.com/net-lisias-ksp/ImpossibleInnovations"
     },
     "depends": [
-        {"name" : "TweakScale"},
-        {"name" : "ModuleManager"}
+        { "name" : "TweakScale"    },
+        { "name" : "ModuleManager" }
     ],
     "install": [
         {
-            "file": "GameData/ImpossibleInnovations",
+            "file":       "GameData/ImpossibleInnovations",
             "install_to": "GameData"
-        },
-        {
-            "file": "Ships",
-            "install_to": "Ships"
         }
     ],
     "x_netkan_override" : [

--- a/NetKAN/ImpossibleInnovations.netkan
+++ b/NetKAN/ImpossibleInnovations.netkan
@@ -17,10 +17,14 @@
             "file":       "GameData/ImpossibleInnovations",
             "install_to": "GameData",
             "filter":     [ "Ships" ]
-        },	
-        {	
-            "find":       "Ships",	
-            "install_to": "Ships"	
+        },
+        {
+            "find":       "Ships/VAB",
+            "install_to": "Ships"
+        },
+        {
+            "find":       "Ships/SPH",
+            "install_to": "Ships"
         }
     ],
     "x_netkan_override" : [

--- a/NetKAN/ImpossibleInnovations.netkan
+++ b/NetKAN/ImpossibleInnovations.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version" : 1,
+    "spec_version" : "v1.16",
     "identifier"   : "ImpossibleInnovations",
     "$kref"        : "#/ckan/spacedock/340",
     "$vref"        : "#/ckan/ksp-avc",

--- a/NetKAN/ImpossibleInnovations.netkan
+++ b/NetKAN/ImpossibleInnovations.netkan
@@ -15,7 +15,12 @@
     "install": [
         {
             "file":       "GameData/ImpossibleInnovations",
-            "install_to": "GameData"
+            "install_to": "GameData",
+            "filter":     [ "Ships" ]
+        },	
+        {	
+            "find":       "Ships",	
+            "install_to": "Ships"	
         }
     ],
     "x_netkan_override" : [


### PR DESCRIPTION
This mod currently says

```
Module contains no files matching: file="GameData/ImpossibleInnovations", file="Ships"
```

It has changed ownership and the format is slightly modified.