### PR TITLE
Use AVC kref for ExtraPlanetaryLaunchpads

### DIFF
--- a/NetKAN/ExtraPlanetaryLaunchpads.netkan
+++ b/NetKAN/ExtraPlanetaryLaunchpads.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version"   : 1,
     "name"           : "Extraplanetary Launchpads",
-    "$kref"          : "#/ckan/http/http://taniwha.org/~bill/Extraplanetary_Launchpads_v6.2.1.zip",
+    "$kref"          : "#/ckan/ksp-avc/http://taniwha.org/~bill/EL.version",
     "$vref"          : "#/ckan/ksp-avc/ExtraplanetaryLaunchpads/Plugins/EL.version",
     "abstract"       : "Adds the ability to build crafts in flight mode to your game.",
     "identifier"     : "ExtraPlanetaryLaunchpads",


### PR DESCRIPTION
ExtraPlanetaryLaunchpads previously required manual netkan updates for each release, but it has [an online .version file](http://taniwha.org/~bill/EL.version). As of KSP-CKAN/CKAN#2517, we can use that file to find the latest release. A new version of this mod dropped today, and the online .version file was updated.

This pull request updates ExtraPlanetaryLaunchpads to use its online .version file to find new releases.