### PR TITLE
Vref for RemoteTechRedevAntennas

### DIFF
--- a/NetKAN/RemoteTechRedevAntennas.netkan
+++ b/NetKAN/RemoteTechRedevAntennas.netkan
@@ -2,6 +2,7 @@
     "spec_version" : 1,
     "identifier"   : "RemoteTechRedevAntennas",
     "$kref"        : "#/ckan/spacedock/1929",
+    "$vref"        : "#/ckan/ksp-avc",
     "license"      : "GPL-3.0",
     "abstract"     : "Standalone and optional antenna package of RemoteTech Redev for Kerbal Space Program's stock CommNet",
     "name"         : "RemoteTech Redev Antennas",


### PR DESCRIPTION
This mod has a version file, updating the netkan to use it.

Fixes #6783.

@techman83, purging D8C909AA-netkan-RemoteTechRedevAntennas.zip might help prevent future bot problems here, since this download appears to have been modified in-place on SpaceDock.