### PR TITLE
Fix BetterScienceLabsContinued install path

### DIFF
--- a/NetKAN/BetterScienceLabsContinued.netkan
+++ b/NetKAN/BetterScienceLabsContinued.netkan
@@ -16,7 +16,7 @@
     ],
     "install": [
         {
-            "find"       : "Better Science Labs Continued",
+            "find"       : "BetterScienceLabsContinued",
             "install_to" : "GameData"
         }
     ]


### PR DESCRIPTION
Current error:

> Could not find Better Science Labs Continued entry in zipfile to install

The spaces have been removed from the path in the ZIP.