### PR TITLE
Fix Nertea vrefs

### DIFF
--- a/NetKAN/CryoEngines.netkan
+++ b/NetKAN/CryoEngines.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier": "CryoEngines",
     "$kref": "#/ckan/spacedock/709",
-    "$vref": "#/ckan/ksp-avc",
+    "$vref": "#/ckan/ksp-avc/CryoEngines.version",
     "x_netkan_epoch": 1,
     "name": "Cryogenic Engines",
     "license": "CC-BY-NC-SA-4.0",

--- a/NetKAN/HeatControl.netkan
+++ b/NetKAN/HeatControl.netkan
@@ -2,7 +2,7 @@
     "spec_version"   : "v1.4",
     "identifier"     : "HeatControl",
     "$kref"          : "#/ckan/spacedock/537",
-    "$vref"          : "#/ckan/ksp-avc",
+    "$vref"          : "#/ckan/ksp-avc/HeatControl.version",
     "release_status" : "stable",
     "license"        : "restricted",
     "depends" : [

--- a/NetKAN/KerbalAtomics.netkan
+++ b/NetKAN/KerbalAtomics.netkan
@@ -2,9 +2,9 @@
     "spec_version": "v1.4",
     "identifier": "KerbalAtomics",
     "$kref": "#/ckan/spacedock/710",
-    "$vref": "#/ckan/ksp-avc",
+    "$vref": "#/ckan/ksp-avc/KerbalAtomics.version",
     "x_netkan_epoch": 1,
-    "name": "Kerbal Atomics",    
+    "name": "Kerbal Atomics",
     "license": "CC-BY-NC-SA-4.0",
     "depends": [
         { "name" : "B9PartSwitch" },

--- a/NetKAN/MarkIVSpaceplaneSystem.netkan
+++ b/NetKAN/MarkIVSpaceplaneSystem.netkan
@@ -2,7 +2,7 @@
     "spec_version"   : "v1.4",
     "identifier"     : "MarkIVSpaceplaneSystem",
     "$kref"          : "#/ckan/spacedock/809",
-    "$vref"          : "#/ckan/ksp-avc",
+    "$vref"          : "#/ckan/ksp-avc/MarkIV.version",
     "release_status" : "stable",
     "license"        : "CC-BY-NC-SA-4.0",
     "install": [


### PR DESCRIPTION
Nertea has added a bunch of extra .version files to the latest versions of his mods:

http://status.ksp-ckan.org

| Mod | Error |
| --- | --- |
| MarkIVSpaceplaneSystem | Too many .version files located: GameData/MarkIVSystem/Versioning/MarkIV.version, GameData/MarkIVSystem/Versioning/KSP-AVC.version |
| KerbalAtomics | Too many .version files located: GameData/KerbalAtomics/Versioning/KSP-AVC.version, GameData/KerbalAtomics/Versioning/KerbalAtomics.version |
| HeatControl | Too many .version files located: GameData/HeatControl/Versioning/KSP-AVC.version, GameData/HeatControl/Versioning/HeatControl.version |
| CryoEngines | Too many .version files located: GameData/CryoEngines/Versioning/KSP-AVC.version, GameData/CryoEngines/Versioning/CryoEngines.version |

Now these netkans know which .version file to use.