### PR TITLE
Update PreciseEditor.netkan

### DIFF
--- a/NetKAN/PreciseEditor.netkan
+++ b/NetKAN/PreciseEditor.netkan
@@ -7,7 +7,7 @@
     "$kref"          : "#/ckan/github/jfrouleau/PreciseEditor",
     "license"        : "GPL-3.0",
     "release_status" : "testing",
-    "ksp_version"    : "1.4.5",
+    "ksp_version"    : "1.5.1",
     "resources"      : {
         "homepage"   : "https://github.com/jfrouleau/PreciseEditor",
         "repository" : "https://github.com/jfrouleau/PreciseEditor"


### PR DESCRIPTION
PreciseEditor recently updated for KSP 1.5.1. It's hosted on GitHub and doesn't have a .version file, so the compatible game version is maintained in the netkan. This PR updates it from 1.4.5 to 1.5.1.

Closes #6799.