### PR TITLE
Update NewTantares game versions

### DIFF
--- a/NetKAN/NewTantares.netkan
+++ b/NetKAN/NewTantares.netkan
@@ -5,8 +5,8 @@
     "identifier"   : "NewTantares",
     "$kref"        : "#/ckan/github/Tantares/Tantares",
     "license"      : "CC-BY-NC-SA-4.0",
-    "ksp_version_min" : "1.4.0",
-    "ksp_version_max" : "1.4.2",
+    "ksp_version_min" : "1.4",
+    "ksp_version_max" : "1.5",
     "abstract"     : "Stockalike Soyuz, LK and more!",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/73686-Tantares"

--- a/NetKAN/NewTantaresLV.netkan
+++ b/NetKAN/NewTantaresLV.netkan
@@ -5,8 +5,7 @@
     "identifier"   : "NewTantaresLV",
     "$kref"        : "#/ckan/github/Tantares/TantaresLV",
     "license"      : "CC-BY-NC-SA-4.0",
-    "ksp_version_min"  : "1.4.0",
-    "ksp_version_max"  : "1.4.1",
+    "ksp_version"  : "1.5",
     "abstract"     : "Stockalike N1, Soyuz and more!",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/73686-Tantares"


### PR DESCRIPTION
Tantares and TantaresLV are hosted on GitHub and don't have version files, so their version compatibility is tracked in their netkan files. The latest releases are compatible with 1.4-1.5 and 1.5 respectively, according to their forum threads. This pull request makes that update.

Fixes #6802.