### PR TITLE
New FAR fork

### DIFF
--- a/NetKAN/FerramAerospaceResearch.netkan
+++ b/NetKAN/FerramAerospaceResearch.netkan
@@ -1,18 +1,18 @@
 {
     "spec_version": 1,
     "identifier": "FerramAerospaceResearch",
-    "$kref": "#/ckan/github/dkavolis/Ferram-Aerospace-Research",
+    "$kref": "#/ckan/github/ferram4/Ferram-Aerospace-Research",
     "$vref": "#/ckan/ksp-avc",
     "x_netkan_epoch": "3",
     "x_netkan_staging": true,
     "x_netkan_version_edit": "^[vV]?(?<version>\\d+(?:\\.\\d+){0,3}[A-Za-z]?)(?:_[A-Za-z0-9_]+)?$",
     "name": "Ferram Aerospace Research",
     "abstract": "FAR replaces KSP's stock part-centered aerodynamics model with one based on real-life physics.",
-    "author": "ferram4,dkavolis",
-    "license": "GPL-3.0",
+    "author": "ferram4",
+    "license": "restricted",
     "resources" : {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/179445-*",
-        "repository": "https://github.com/dkavolis/Ferram-Aerospace-Research"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/19321-1",
+        "repository": "https://github.com/ferram4/Ferram-Aerospace-Research"
     },
     "provides"  : [ "AerodynamicModel", "FAR" ],
     "conflicts" : [ { "name" : "AerodynamicModel" } ],

--- a/NetKAN/FerramAerospaceResearch.netkan
+++ b/NetKAN/FerramAerospaceResearch.netkan
@@ -1,18 +1,18 @@
 {
     "spec_version": 1,
     "identifier": "FerramAerospaceResearch",
-    "$kref": "#/ckan/github/ferram4/Ferram-Aerospace-Research",
+    "$kref": "#/ckan/github/dkavolis/Ferram-Aerospace-Research",
     "$vref": "#/ckan/ksp-avc",
     "x_netkan_epoch": "3",
     "x_netkan_staging": true,
     "x_netkan_version_edit": "^[vV]?(?<version>\\d+(?:\\.\\d+){0,3}[A-Za-z]?)(?:_[A-Za-z0-9_]+)?$",
     "name": "Ferram Aerospace Research",
     "abstract": "FAR replaces KSP's stock part-centered aerodynamics model with one based on real-life physics.",
-    "author": "ferram4",
-    "license": "restricted",
+    "author": "ferram4,dkavolis",
+    "license": "GPL-3.0",
     "resources" : {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/19321-1",
-        "repository": "https://github.com/ferram4/Ferram-Aerospace-Research"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/179445-*",
+        "repository": "https://github.com/dkavolis/Ferram-Aerospace-Research"
     },
     "provides"  : [ "AerodynamicModel", "FAR" ],
     "conflicts" : [ { "name" : "AerodynamicModel" } ],

--- a/NetKAN/FerramAerospaceResearchContinued.netkan
+++ b/NetKAN/FerramAerospaceResearchContinued.netkan
@@ -8,7 +8,7 @@
     "x_netkan_version_edit": "^[vV]?(?<version>\\d+(?:\\.\\d+){0,3}[A-Za-z]?)(?:_[A-Za-z0-9_]+)?$",
     "name": "Ferram Aerospace Research",
     "abstract": "FAR replaces KSP's stock part-centered aerodynamics model with one based on real-life physics.",
-    "author": "ferram4,dkavolis",
+    "author": [ "ferram4", "dkavolis" ],
     "license": "GPL-3.0",
     "resources" : {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/179445-*",

--- a/NetKAN/FerramAerospaceResearchContinued.netkan
+++ b/NetKAN/FerramAerospaceResearchContinued.netkan
@@ -1,0 +1,46 @@
+{
+    "spec_version": 1,
+    "identifier": "FerramAerospaceResearchContinued",
+    "$kref": "#/ckan/github/dkavolis/Ferram-Aerospace-Research",
+    "$vref": "#/ckan/ksp-avc",
+    "x_netkan_epoch": "3",
+    "x_netkan_staging": true,
+    "x_netkan_version_edit": "^[vV]?(?<version>\\d+(?:\\.\\d+){0,3}[A-Za-z]?)(?:_[A-Za-z0-9_]+)?$",
+    "name": "Ferram Aerospace Research",
+    "abstract": "FAR replaces KSP's stock part-centered aerodynamics model with one based on real-life physics.",
+    "author": "ferram4,dkavolis",
+    "license": "GPL-3.0",
+    "resources" : {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/179445-*",
+        "repository": "https://github.com/dkavolis/Ferram-Aerospace-Research"
+    },
+    "provides"  : [ "AerodynamicModel", "FAR" ],
+    "conflicts" : [ { "name" : "AerodynamicModel" } ],
+    "depends" : [
+        { "name" : "ModuleManager" },
+        { "name" : "ModularFlightIntegrator" }
+    ],
+    "install" : [
+        {
+            "file"       : "GameData/FerramAerospaceResearch",
+            "install_to" : "GameData",
+            "filter"     : "config.xml"
+        },
+        {
+            "file"        : "Ships",
+            "install_to"  : "Ships",
+            "optional"    : true,
+            "description" : "FAR example craft"
+        }
+    ],
+    "x_netkan_override": [
+        {
+            "version": "3:0.15.9",
+            "delete": [ "ksp_version" ],
+            "override": {
+                "ksp_version_min": "1.3.0",
+                "ksp_version_max": "1.3.99"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Replaced the restricted assets with different ones so there are no licensing issues. Would like to get this on CKAN so everyone can use one version and not many different recompiles. 

If I was providing backports, how would that work with CKAN? Would I need to create multiple releases one for each KSP version?

Edit: build fails because ModularFlightIntegrator is not found for KSP 1.5 but a version from KSP 1.4.5 works.