### PR TITLE
Update M3X netkan

### DIFF
--- a/NetKAN/Mk3Expansion.netkan
+++ b/NetKAN/Mk3Expansion.netkan
@@ -6,15 +6,20 @@
     "depends": [
         { "name": "ModuleManager" },
         { "name": "CommunityResourcePack" },
-        { "name": "InterstellarFuelSwitch-Core" }
-],
-    "suggests": [
-    { "name": "FerramAerospaceResearch" }
+        { "name": "B9PartSwitch" }
     ],
     "install" : [
         {
             "find"       : "GameData/Mk3Expansion",
             "install_to" : "GameData"
-        }
+        },
+        {
+            "find"        : "VAB",
+            "install_to"  : "Ships"
+        },
+        {
+            "find"        : "SPH",
+            "install_to"  : "Ships"
+}
     ]
 }


### PR DESCRIPTION
Updates M3X dependency from IFS to B9PS and adds M3X example craft.