### PR TITLE
Remove hard coded game versions for ModularFlightIntegrator

### DIFF
--- a/NetKAN/ModularFlightIntegrator.netkan
+++ b/NetKAN/ModularFlightIntegrator.netkan
@@ -11,8 +11,6 @@
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/106369-122-modularflightintegrator-124-131-march-23th/",
         "repository": "https://github.com/sarbian/ModularFlightIntegrator"
     },
-    "ksp_version_min": "1.4.0",
-    "ksp_version_max": "1.4.90",
     "install": [
         {
             "find": "ModularFlightIntegrator",


### PR DESCRIPTION
This mod has a vref and a version file specifying 1.5.0 as the minimum.
The hard coded values in the netkan brought that down to 1.4.0, which is bad.
Now the vref stands alone.