### PR TITLE
Switch KerbalKonstructs to SpaceDock

### DIFF
--- a/NetKAN/KerbalKonstructs.netkan
+++ b/NetKAN/KerbalKonstructs.netkan
@@ -3,7 +3,7 @@
     "identifier"   : "KerbalKonstructs",
     "abstract"     : "New buildings and launch sites",
     "author"       : [ "AlphaAsh", "ozraven", "Ger_space" ],
-    "$kref"        : "#/ckan/github/GER-Space/Kerbal-Konstructs",
+    "$kref"        : "#/ckan/spacedock/1052",
     "$vref"        : "#/ckan/ksp-avc",
     "license"      : "restricted",
     "comment"      : "Plugin is MIT, but Static Assets, Artwork & Models are ARR",


### PR DESCRIPTION
The author forgot to attach the download to the latest GitHub release. Switch this one to SpaceDock where that's impossible.