### PR TITLE
Require specific Scatterer for RSSVE

### DIFF
--- a/NetKAN/RSSVE-HR.netkan
+++ b/NetKAN/RSSVE-HR.netkan
@@ -10,15 +10,23 @@
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/153511-rssve",
         "repository": "https://github.com/PhineasFreak/RSSVE"
     },
-    "provides": [ "RSSVE-Textures" ],
+    "provides": [
+        "EnvironmentalVisualEnhancements-Config",
+        "RSSVE-Textures",
+        "Scatterer-config",
+        "Scatterer-sunflare"
+    ],
     "conflicts": [
-        { "name": "RSSVE-Textures" }
+        { "name": "EnvironmentalVisualEnhancements-Config" },
+        { "name": "RSSVE-Textures" },
+        { "name": "Scatterer-config" },
+        { "name": "Scatterer-sunflare" }
     ],
     "depends": [
         { "name": "ModuleManager" },
         { "name": "EnvironmentalVisualEnhancements" },
         { "name": "RealSolarSystem" },
-        { "name": "Scatterer"}
+        { "name": "Scatterer", "version": "2:v0.0320b" }
     ],
     "recommends": [
         { "name": "DistantObjectEnhancement" },

--- a/NetKAN/RSSVE-LR.netkan
+++ b/NetKAN/RSSVE-LR.netkan
@@ -10,15 +10,23 @@
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/153511-rssve",
         "repository": "https://github.com/PhineasFreak/RSSVE"
     },
-    "provides": [ "RSSVE-Textures" ],
+    "provides": [
+        "EnvironmentalVisualEnhancements-Config",
+        "RSSVE-Textures",
+        "Scatterer-config",
+        "Scatterer-sunflare"
+    ],
     "conflicts": [
-        { "name": "RSSVE-Textures" }
+        { "name": "EnvironmentalVisualEnhancements-Config" },
+        { "name": "RSSVE-Textures" },
+        { "name": "Scatterer-config" },
+        { "name": "Scatterer-sunflare" }
     ],
     "depends": [
         { "name": "ModuleManager" },
         { "name": "EnvironmentalVisualEnhancements" },
         { "name": "RealSolarSystem" },
-        { "name": "Scatterer"}
+        { "name": "Scatterer", "version": "2:v0.0320b" }
     ],
     "recommends": [
         { "name": "DistantObjectEnhancement" },


### PR DESCRIPTION
## Problem

https://github.com/KSP-CKAN/NetKAN/pull/5321#issuecomment-439599861:

> I have been getting false "bug reports" about Scatterer not working. **[RSSVE requires specific mod versions that are documented in the RSSVE wiki](https://github.com/PhineasFreak/RSSVE/wiki/Installation)** and not all mod versions will work with it.

When installing this, I also got prompted for several `provides` relationships that look like they should be satisfied by RSSVE.

## Changes

- Scatterer 2:v0.0320b is now required as per the referenced wiki page
- New provides/conflicts based on inspecting the configs:
  - EnvironmentalVisualEnhancements-Config
  - Scatterer-config
  - Scatterer-sunflare

All changes are made to both RSSVE-HR and RSSVE-LR.

@PhineasFreak, I'd like to check the bug reports you received to confirm that they're fixed now. Can you please point us towards them? I thought they might be on the RSSVE forum thread, but it's locked. Thanks!