### PR TITLE
SpaceDock catch-up 5

### DIFF
--- a/NetKAN/AATI-Flags.netkan
+++ b/NetKAN/AATI-Flags.netkan
@@ -1,0 +1,10 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "AATI-Flags",
+    "$kref":        "#/ckan/spacedock/2006",
+    "license":      "GPL-3.0",
+    "install": [ {
+        "find":       "aati-flags",
+        "install_to": "GameData"
+    } ]
+}

--- a/NetKAN/AdvancedTextures.netkan
+++ b/NetKAN/AdvancedTextures.netkan
@@ -1,0 +1,7 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "AdvancedTextures",
+    "$kref":        "#/ckan/github/GER-Space/AdvancedTextures",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "MIT"
+}

--- a/NetKAN/AdvancedTextures.netkan
+++ b/NetKAN/AdvancedTextures.netkan
@@ -1,7 +1,11 @@
 {
     "spec_version": "v1.4",
     "identifier":   "AdvancedTextures",
+    "abstract":     "For modders who want to use KSP internal textures, which are not distributable, in their mods",
     "$kref":        "#/ckan/github/GER-Space/AdvancedTextures",
     "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT"
+    "license":      "MIT",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/179920-*"
+    }
 }

--- a/NetKAN/DeclasseVoodooCar.netkan
+++ b/NetKAN/DeclasseVoodooCar.netkan
@@ -1,0 +1,11 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "DeclasseVoodooCar",
+    "$kref":        "#/ckan/spacedock/2001",
+    "license":      "CC-BY-NC-ND",
+    "install": [ {
+        "find":       "GR_Declasse_Voodoo",
+        "install_to": "GameData",
+        "filter":     [ ".DS_Store" ]
+    } ]
+}

--- a/NetKAN/MilkyWay-Skybox.netkan
+++ b/NetKAN/MilkyWay-Skybox.netkan
@@ -1,0 +1,13 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "MilkyWay-Skybox",
+    "$kref":        "#/ckan/spacedock/2004",
+    "license":      "CC-BY-NC-ND-4.0",
+    "depends": [
+        { "name": "TextureReplacer" }
+    ],
+    "install": [ {
+        "find":       "Default",
+        "install_to": "GameData/TextureReplacer"
+    } ]
+}

--- a/NetKAN/PureElectricEngines.netkan
+++ b/NetKAN/PureElectricEngines.netkan
@@ -1,0 +1,10 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "PureElectricEngines",
+    "$kref":        "#/ckan/spacedock/1998",
+    "license":      "MIT",
+    "install": [ {
+        "find":       "JDSA",
+        "install_to": "GameData"
+    } ]
+}

--- a/NetKAN/SpaceXLandingPad.netkan
+++ b/NetKAN/SpaceXLandingPad.netkan
@@ -1,0 +1,14 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "SpaceXLandingPad",
+    "$kref":        "#/ckan/spacedock/1670",
+    "license":      "MIT",
+    "depends": [
+        { "name": "ModuleManager"    },
+        { "name": "KerbalKonstructs" }
+    ],
+    "install": [ {
+        "find":       "Omega's_Spacex_Style_Landingpads",
+        "install_to": "GameData"
+    } ]
+}

--- a/NetKAN/StockalikeUtilityVehicles.netkan
+++ b/NetKAN/StockalikeUtilityVehicles.netkan
@@ -1,0 +1,13 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "StockalikeUtilityVehicles",
+    "$kref":        "#/ckan/spacedock/2005",
+    "license":      "CC-BY-NC-ND-4.0",
+    "depends": [
+        { "name": "AdvancedTextures" }
+    ],
+    "install": [ {
+        "find":       "OSUV",
+        "install_to": "GameData"
+    } ]
+}

--- a/NetKAN/WoodSpaceProgram.netkan
+++ b/NetKAN/WoodSpaceProgram.netkan
@@ -1,0 +1,13 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "WoodSpaceProgram",
+    "$kref":        "#/ckan/spacedock/2002",
+    "license":      "MIT",
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
+    "install": [ {
+        "find":       "Wood Space Program",
+        "install_to": "GameData"
+    } ]
+}


### PR DESCRIPTION
More mods have been added to SpaceDock with CKAN flair. They have to be handled manually due to KSP-SpaceDock/SpaceDock#188.

Previous was #6827.

Fixes #6846.