### PR TITLE
Stop staging KSPInterstellarExtended

### DIFF
--- a/NetKAN/KSPInterstellarExtended.netkan
+++ b/NetKAN/KSPInterstellarExtended.netkan
@@ -3,7 +3,6 @@
     "identifier"        : "KSPInterstellarExtended",
     "$kref"             : "#/ckan/spacedock/172",
     "$vref"             : "#/ckan/ksp-avc",
-    "x_netkan_staging"  : true,
     "resources": {
         "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/172026-*",
         "repository": "https://github.com/sswelm/KSP-Interstellar-Extended"


### PR DESCRIPTION
- New releases of this mod are coming out at a rapid rate
- The metadata being generated is fine and doesn't need manual review (we haven't had any issues reported that could have been caught that way)
- The author submits netkan PRs from time to time, so we can work with him directly if there are any problems
- The staging mechanism doesn't currently work very well with pull requests; if we need to make an edit (as we did in the first staged PR), it won't be reflected on the bot's branch, so we get the *entire* history of staged releases in each PR, which can't be merged normally without messing things up.

For these reasons, the `x_netkan_staging` property is now turned off for KSPInterstellarExtended.