### PR TITLE
Create KerbalChangelog.netkan

### DIFF
--- a/NetKAN/KerbalChangelog.netkan
+++ b/NetKAN/KerbalChangelog.netkan
@@ -3,8 +3,8 @@
     "identifier"   : "KerbalChangelog",
     "$kref"        : "#/ckan/github/BenjaminCronin/KerbalChangelog",
     "license"      : "MIT",
-	"$vref" : "#/ckan/ksp-avc"
+    "$vref"        : "#/ckan/ksp-avc",
     "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/179207-14x-15x-kerbal-changelog-v111-102718/"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/179207-*"
     }
 }

--- a/NetKAN/KerbalChangelog.netkan
+++ b/NetKAN/KerbalChangelog.netkan
@@ -1,0 +1,10 @@
+{
+    "spec_version" : 1,
+    "identifier"   : "KerbalChangelog",
+    "$kref"        : "#/ckan/github/BenjaminCronin/KerbalChangelog",
+    "license"      : "MIT",
+    "ksp_version"  : "1.5.9",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/179207-14x-15x-kerbal-changelog-v111-102718/"
+    }
+}

--- a/NetKAN/KerbalChangelog.netkan
+++ b/NetKAN/KerbalChangelog.netkan
@@ -3,7 +3,7 @@
     "identifier"   : "KerbalChangelog",
     "$kref"        : "#/ckan/github/BenjaminCronin/KerbalChangelog",
     "license"      : "MIT",
-    "ksp_version"  : "1.5.9",
+	"$vref" : "#/ckan/ksp-avc"
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/179207-14x-15x-kerbal-changelog-v111-102718/"
     }


### PR DESCRIPTION
If possible I'd like this mod to be available for KSP v.1.4.x AND 1.5.x. I take it that `ksp_version` is the max KSP version that the mod is available for, is this the case?