### PR TITLE
Unfreeze Landertron

### DIFF
--- a/NetKAN/Landertron.netkan
+++ b/NetKAN/Landertron.netkan
@@ -1,9 +1,10 @@
 {
-    "comment"      : "Mod author has temporarily opted out of CKAN installation for this mod",
     "spec_version" : 1,
     "identifier"   : "Landertron",
     "name"         : "Landertrons",
     "$kref"        : "#/ckan/github/Kerbas-ad-astra/XTLandertron",
+    "$vref"        : "#/ckan/ksp-avc",
+    "license"      : "CC-BY-SA-4.0",
     "recommends": [
         { "name": "HGR" }
     ],
@@ -11,9 +12,7 @@
         { "name": "KAS" },
         { "name": "KIS" }
     ],
-    "license"      : "CC-BY-4.0",
-    "ksp_version"  : "1.2",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149826-12-landertrons-automatic-landing-retro-rockets-v015-02016-oct-13-0340-utc/"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/149826-*"
     }
 }


### PR DESCRIPTION
This mod was almost indexed in #4863, then frozen instead in #4871, then the mod author gave the all-clear in a comment on #5180, but it wasn't actually indexed at that time.

Now it's unfrozen and has a $vref.

Fixes #6864.