### PR TITLE
Update manually maintained mods

### DIFF
--- a/NetKAN/CTTStockRebalance.netkan
+++ b/NetKAN/CTTStockRebalance.netkan
@@ -1,17 +1,18 @@
 {
-    "x_via": "Automated SpaceDock CKAN submission",
-    "$kref": "#/ckan/spacedock/1361",
-    "license": "GPL-3.0",
     "spec_version": "v1.4",
-    "identifier": "CTTStockRebalance",
+    "identifier":   "CTTStockRebalance",
+    "$kref":        "#/ckan/spacedock/2008",
+    "x_netkan_epoch": "1",
+    "license":      "GPL-3.0",
     "depends": [
         { "name": "CommunityTechTree" },
-        { "name": "ModuleManager" }
+        { "name": "ModuleManager"     }
     ],
     "install": [
         {
-            "find":"GameData/CTTStockRebalance",
+            "find":       "GameData/CTTStockRebalance",
             "install_to": "GameData"
         }
-    ]
+    ],
+    "x_via": "Automated SpaceDock CKAN submission"
 }

--- a/NetKAN/Kethane.netkan
+++ b/NetKAN/Kethane.netkan
@@ -2,14 +2,14 @@
     "spec_version": 1,
     "identifier":   "Kethane",
     "name":         "Kethane Mining",
-    "abstract":     "Adds a new resource that you can mine and convert into fuels.",
+    "abstract":     "Adds a new resource that you can mine and convert into fuels",
     "author":       "taniwha",
+    "$kref":        "#/ckan/http/http://taniwha.org/~bill/Kethane-0.10.0.zip",
+    "version":      "0.10.0",
+    "ksp_version":  "1.5",
     "license":      "restricted",
     "resources": {
         "homepage":   "http://forum.kerbalspaceprogram.com/index.php?/topic/119480-*",
         "repository": "https://github.com/taniwha-qf/Kethane"
-    },
-    "version":     "0.9.10",
-    "ksp_version": "1.3.1",
-    "download": "http://taniwha.org/~bill/Kethane-0.9.10.zip"
+    }
 }

--- a/NetKAN/SDHI-ServiceModuleSystem.netkan
+++ b/NetKAN/SDHI-ServiceModuleSystem.netkan
@@ -5,33 +5,31 @@
     "name"         : "Sum Dum Heavy Industries - Service Module System",
     "abstract"     : "Service Module and accessories designed specifically for use with the stock Mk1-2 Command Pod, vaguely resembling NASA's Orion MPCV. May or may not have a convincing stockalike appearance.",
     "license"      : "CC-BY-SA-4.0",
-    "ksp_version"  : "1.3.0",
+    "ksp_version"  : "1.5",
     "resources"    : {
         "homepage"   : "http://forum.kerbalspaceprogram.com/index.php?/topic/48073-121-sdhi-service-module-system-v321-20-november-2016/",
         "repository" : "https://github.com/sumghai/SDHI_ServiceModuleSystem"
     },
     "install": [
       {
-        "file": "GameData/SDHI",
+        "file":       "GameData/SDHI",
         "install_to": "GameData",
-        "filter" : [
-               "Agencies"
-        ]
+        "filter":     [ "Agencies" ]
       }
     ],
     "depends"      : [
         { "name" : "AnimatedDecouplers" },
-        { "name" : "ModuleManager" },
-        { "name" : "RealChute" },
-        { "name" : "SDHI-SharedAssets" }
+        { "name" : "ModuleManager"      },
+        { "name" : "RealChute"          },
+        { "name" : "SDHI-SharedAssets"  }
     ],
     "suggests"     : [
-        { "name" : "DeadlyReentry" },
-        { "name" : "FerramAerospaceResearch" },
-        { "name" : "TACLS" },
-        { "name" : "USI-LS" },
-        { "name" : "ShipManifest" },
-        { "name" : "ConnectedLivingSpace" },
+        { "name" : "DeadlyReentry"                      },
+        { "name" : "FerramAerospaceResearch"            },
+        { "name" : "TACLS"                              },
+        { "name" : "USI-LS"                             },
+        { "name" : "ShipManifest"                       },
+        { "name" : "ConnectedLivingSpace"               },
         { "name" : "PEBKACIndustriesLaunchEscapeSystem" }
     ],
     "x_netkan_force_v" : true


### PR DESCRIPTION
These mods have out of date metadata.

- CTTStockRebalance was re-uploaded by someone else and marked as compatible with KSP 1.5.1
- Kethane is hosted on taniwha.org and requires manual maintenance of everything
- SDHI-ServiceModuleSystem is on GitHub but has no version file, so it was listed as compatible with the wrong game version

Now they're fixed.