### PR TITLE
Fix installation of RSSVE

### DIFF
--- a/NetKAN/RSSVE-HR.netkan
+++ b/NetKAN/RSSVE-HR.netkan
@@ -12,21 +12,19 @@
     },
     "provides": [
         "EnvironmentalVisualEnhancements-Config",
-        "RSSVE-Textures",
-        "Scatterer-config",
-        "Scatterer-sunflare"
+        "RSSVE-Textures"
     ],
     "conflicts": [
         { "name": "EnvironmentalVisualEnhancements-Config" },
-        { "name": "RSSVE-Textures" },
-        { "name": "Scatterer-config" },
-        { "name": "Scatterer-sunflare" }
+        { "name": "RSSVE-Textures" }
     ],
     "depends": [
         { "name": "ModuleManager" },
         { "name": "EnvironmentalVisualEnhancements" },
         { "name": "RealSolarSystem" },
-        { "name": "Scatterer", "version": "2:v0.0320b" }
+        { "name": "Scatterer", "version": "2:v0.0320b" },
+        { "name": "Scatterer-config", "version": "2:v0.0320b" },
+        { "name": "Scatterer-sunflare", "version": "2:v0.0320b" }
     ],
     "recommends": [
         { "name": "DistantObjectEnhancement" },

--- a/NetKAN/RSSVE-LR.netkan
+++ b/NetKAN/RSSVE-LR.netkan
@@ -12,21 +12,19 @@
     },
     "provides": [
         "EnvironmentalVisualEnhancements-Config",
-        "RSSVE-Textures",
-        "Scatterer-config",
-        "Scatterer-sunflare"
+        "RSSVE-Textures"
     ],
     "conflicts": [
         { "name": "EnvironmentalVisualEnhancements-Config" },
-        { "name": "RSSVE-Textures" },
-        { "name": "Scatterer-config" },
-        { "name": "Scatterer-sunflare" }
+        { "name": "RSSVE-Textures" }
     ],
     "depends": [
         { "name": "ModuleManager" },
         { "name": "EnvironmentalVisualEnhancements" },
         { "name": "RealSolarSystem" },
-        { "name": "Scatterer", "version": "2:v0.0320b" }
+        { "name": "Scatterer", "version": "2:v0.0320b" },
+        { "name": "Scatterer-config", "version": "2:v0.0320b" },
+        { "name": "Scatterer-sunflare", "version": "2:v0.0320b" }
     ],
     "recommends": [
         { "name": "DistantObjectEnhancement" },


### PR DESCRIPTION
Currently, scatterer configs for stock are not installed and RSSVE depends on them. This makes installation of RSSVE broken.