### PR TITLE
Add install stanzas for KerbinSide

### DIFF
--- a/NetKAN/KerbinSide.netkan
+++ b/NetKAN/KerbinSide.netkan
@@ -1,13 +1,13 @@
 {
     "spec_version": "v1.16",
-    "$kref": "#/ckan/spacedock/1347",
-    "license": "restricted",
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160099-122-kerbin-side-continued/"
-    },
-    "identifier": "KerbinSide",
-    "$vref": "#/ckan/ksp-avc",
+    "identifier":   "KerbinSide",
+    "$kref":        "#/ckan/spacedock/1347",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "restricted",
     "x_netkan_epoch" : "3",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160099-*"
+    },
     "install": [
         {
             "find"       : "MainBases",
@@ -15,6 +15,14 @@
         },
         {
             "find"       : "GroundControl",
+            "install_to" : "GameData/KerbinSide"
+        },
+        {
+            "find"       : "Centers",
+            "install_to" : "GameData/KerbinSide"
+        },
+        {
+            "find"       : "FreeAssets",
             "install_to" : "GameData/KerbinSide"
         },
         {


### PR DESCRIPTION
## Problem

KerbinSide has several folders split between KerbinSide and KerbinSideCore, and a few that aren't installed by anything.

https://spacedock.info/mod/1347

| Folder | Module |
| --- | --- |
| Centers | *Missing* |
| CoreAssets | KerbinSideCore |
| Flags | KerbinSideCore |
| FreeAssets | *Missing* |
| GroundControl | KerbinSide |
| MainBases | KerbinSide |

## Changes

Now the Centers and FreeAssets folders are included in KerbinSide.

Fixes #6888.