### PR TITLE
Switch Chaka to platform neutral version of AnimatedDecouplers

### DIFF
--- a/NetKAN/ChakaMonkeyExplorationSystems.netkan
+++ b/NetKAN/ChakaMonkeyExplorationSystems.netkan
@@ -1,10 +1,10 @@
 {
-    "license": "restricted",
-    "identifier": "ChakaMonkeyExplorationSystems",
-    "$kref": "#/ckan/spacedock/599",
     "spec_version": "v1.4",
+    "identifier":   "ChakaMonkeyExplorationSystems",
+    "$kref":        "#/ckan/spacedock/599",
+    "license":      "restricted",
     "depends": [
-        { "name": "AnimatedDecouplers-x86" },
+        { "name": "AnimatedDecouplers" },
         { "name": "KerbalJointReinforcement" },
         { "name": "ProceduralFairings" },
         { "name": "ASETProps" },


### PR DESCRIPTION
This mod is out for KSP 1.4.3, but one of its dependencies only goes up to KSP 1.1:

![image](https://user-images.githubusercontent.com/1559108/50258589-47082680-03f8-11e9-92b7-4b2e3bc3428a.png)

This is because AnimatedDecouplers-x86 is now just AnimatedDecouplers. This pull request makes that change.