### PR TITLE
Force v for DistantObject

### DIFF
--- a/NetKAN/DistantObject.netkan
+++ b/NetKAN/DistantObject.netkan
@@ -1,22 +1,21 @@
 {
     "spec_version": 1,
-    "identifier": "DistantObject",
-    "$kref": "#/ckan/github/MOARdV/DistantObject",
-	"$vref": "#/ckan/ksp-avc",
-    "name": "Distant Object Enhancement",
-    "abstract": "Visual enhancement mod that makes objects realistically visible over large distances.",
-    "license": "CC-BY-4.0",
+    "identifier":   "DistantObject",
+    "name":         "Distant Object Enhancement",
+    "abstract":     "Visual enhancement mod that makes objects realistically visible over large distances",
+    "$kref":        "#/ckan/github/MOARdV/DistantObject",
+    "$vref":        "#/ckan/ksp-avc",
+    "x_netkan_force_v": true,
+    "license":      "CC-BY-4.0",
     "resources" : {
-        "homepage"     : "https://forum.kerbalspaceprogram.com/index.php?/topic/89214-*"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/89214-*"
     },
-    "depends": [
-        {
-            "name": "DistantObject-config"
-        }
-    ],
-    "install": [{
-        "file": "GameData/DistantObject",
+    "depends": [ {
+    	"name": "DistantObject-config"
+    } ],
+    "install": [ {
+        "file":       "GameData/DistantObject",
         "install_to": "GameData",
-        "filter": "PlanetColors.cfg"
-    }]
+        "filter":     "PlanetColors.cfg"
+    } ]
 }


### PR DESCRIPTION
## Problem

DistantObject dropped the 'v' version number prefix in the latest release.

https://github.com/KSP-CKAN/CKAN-meta/tree/master/DistantObject
https://github.com/MOARdV/DistantObject/releases

![image](https://user-images.githubusercontent.com/1559108/50408520-ec344d80-07b0-11e9-8b4d-95fd4fd84b51.png)

## Changes

Now `x_netkan_force_v` is set to `true` to add the 'v'.

Fixes KSP-CKAN/CKAN#2623.