### PR TITLE
Remove DiscordRP override

### DIFF
--- a/NetKAN/DiscordRP.netkan
+++ b/NetKAN/DiscordRP.netkan
@@ -1,18 +1,10 @@
 {
     "spec_version": 1,
-    "identifier": "DiscordRP",
-    "abstract": "DiscordRP introduces Rich Presence integration for KSP.",
-    "$kref": "#/ckan/curse/283006",
-    "license": "MIT",
+    "identifier":   "DiscordRP",
+    "abstract":     "DiscordRP introduces Rich Presence integration for KSP",
+    "$kref":        "#/ckan/curse/283006",
+    "license":      "MIT",
     "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/168196-14-discordrp-rich-presence-integration/"
-    },
-    "x_netkan_override": [ {
-        "version": "1.0.3",
-        "delete": [ "ksp_version" ],
-        "override": {
-            "ksp_version_min": "1.2",
-            "ksp_version_max": "1.4"
-        }
-    } ]
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/168196-*"
+    }
 }


### PR DESCRIPTION
DiscordRP was having a problem with inconsistent versioning, see #6622. In #6674, we set an override to try to stabilize it. More recently, KSP-CKAN/CKAN#2616 should have created a better solution that made the overrides unnecessary. Now the overrides are removed.