### PR TITLE
Install stanza for KerbalChangelog

### DIFF
--- a/NetKAN/KerbalChangelog.netkan
+++ b/NetKAN/KerbalChangelog.netkan
@@ -1,9 +1,13 @@
 {
-    "spec_version" : 1,
+    "spec_version" : "v1.16",
     "identifier"   : "KerbalChangelog",
     "$kref"        : "#/ckan/github/BenjaminCronin/KerbalChangelog",
     "license"      : "MIT",
     "$vref"        : "#/ckan/ksp-avc",
+    "install": [ {
+        "find_regexp": "KerbalChangeLog.*",
+        "install_to":  "GameData"
+    } ],
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/179207-*"
     }


### PR DESCRIPTION
Previous releases contained a folder matching the identifier.
The latest one has KerbalChangeLog1.1.4 instead.