### PR TITLE
Update compatible versions for GravityTurn

### DIFF
--- a/NetKAN/GravityTurnContinued.netkan
+++ b/NetKAN/GravityTurnContinued.netkan
@@ -5,7 +5,8 @@
     "name": "GravityTurn Continued",
     "author": [ "AndyMt", "Overengineer1" ],
     "abstract": "Automated highly efficient launches",
-    "ksp_version": "1.4",
+    "ksp_version_min": "1.3",
+    "ksp_version_max": "1.6",
     "license": "GPL-3.0",
     "x_netkan_epoch": 2,
     "resources": {


### PR DESCRIPTION
This mod has a hard coded game version of 1.4, but it should be 1.3-1.6.

Replaces KSP-CKAN/CKAN-meta#1394 which tried to do this in CKAN-meta and got overwritten by the bot.