### PR TITLE
Add ProbesBeforeCrew

### DIFF
--- a/NetKAN/ProbesBeforeCrew.netkan
+++ b/NetKAN/ProbesBeforeCrew.netkan
@@ -1,0 +1,46 @@
+{
+  "spec_version": "v1.4",
+  "install": [
+    {
+      "install_to": "GameData",
+      "find": "ProbesBeforeCrew"
+    }
+  ],
+  "depends": [
+    {
+      "name": "ModuleManager"
+    },
+    {
+      "name": "CommunityTechTree"
+    }
+  ],
+  "supports": [
+    {
+      "name": "DMagicOrbitalScience"
+    },
+    {
+      "name": "UniversalStorage2"
+    },
+    {
+      "name": "kOS"
+    },
+    {
+      "name": "TACLS"
+    },
+    {
+      "name": "SCANsat"
+    },
+    {
+      "name": "StationPartsExpansionRedux"
+    },
+    {
+      "name": "MissingHistory"
+    },
+    {
+      "name": "RemoteTech"
+    }
+  ],
+  "$kref": "#/ckan/spacedock/2043",
+  "identifier": "ProbesBeforeCrew",
+  "license": "MIT"
+}


### PR DESCRIPTION
Mod author Requested on IRC

> <_Zee> hello friends
<_Zee> I've created a mod and a few of my users have asked me to add it to the CKAN. I don't use CKAN but I want to support the request. I did my best to follow the wiki instructions, but all it really instructed me to do was tick the "add to CKAN' box on Spacedock, which I did a week ago. I've tried searching for my mod on the CKAN, but its either not th
<_Zee> ere or I'm using it wrong. Help would be appreciated!
<_Zee> The mod name is Probes Before Crew