### PR TITLE
Set game version range for MakingHistoryEngineTweaks

### DIFF
--- a/NetKAN/MakingHistoryEngineTweaks.netkan
+++ b/NetKAN/MakingHistoryEngineTweaks.netkan
@@ -2,6 +2,8 @@
     "spec_version": "v1.4",
     "identifier":   "MakingHistoryEngineTweaks",
     "$kref":        "#/ckan/github/TykoTek/EngineTweaks_for_MakingHistory",
+    "ksp_version_min": "1.4",
+    "ksp_version_max": "1.5",
     "license":      "MIT",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/174303-*"


### PR DESCRIPTION
@TykoTek says this mod is no longer necessary as of KSP 1.6.

Fixes #6938.