### PR TITLE
Add vref to PreciseEditor

### DIFF
--- a/NetKAN/PreciseEditor.netkan
+++ b/NetKAN/PreciseEditor.netkan
@@ -5,9 +5,9 @@
     "abstract"       : "Editor mod to set a part's position and angle values with great precision. Also show CoM, CoL and CoT coordinates.",
     "author"         : "jfrouleau",
     "$kref"          : "#/ckan/github/jfrouleau/PreciseEditor",
+    "$vref"          : "#/ckan/ksp-avc",
     "license"        : "GPL-3.0",
     "release_status" : "stable",
-    "ksp_version"    : "1.6.0",
     "resources"      : {
         "homepage"   : "https://github.com/jfrouleau/PreciseEditor",
         "repository" : "https://github.com/jfrouleau/PreciseEditor"


### PR DESCRIPTION
PreciseEditor now has a .version file. this pull request uses it.
Closes #6946.