### PR TITLE
Stop trusting Kerbalism's version file

### DIFF
--- a/NetKAN/Kerbalism.netkan
+++ b/NetKAN/Kerbalism.netkan
@@ -3,7 +3,6 @@
     "identifier": "Kerbalism",
     "$kref": "#/ckan/spacedock/1774",
     "$vref": "#/ckan/ksp-avc/Kerbalism/Kerbalism.version",
-    "x_netkan_trust_version_file": true,
     "license": "Unlicense",
     "author": [ "ShotgunNinja", "N70" ],
     "resources": {


### PR DESCRIPTION
In #6575 we switched Kerbalism from SpaceDock to GItHub, but this mod's GitHub versions are inconsistent in whether they are prefixed with a 'v', so we used `x_netkan_trust_version_file` to make a smooth transition without epochs. Later it was switched back to GitHub.

Now the .version file in the latest release is wrong but the version on SpaceDock is right (see steamp0rt/Kerbalism#306), so `x_netkan_trust_version_file` is removed.