### PR TITLE
Source Nertea dependencies from independent repositories

### DIFF
--- a/NetKAN/CryoTanks.netkan
+++ b/NetKAN/CryoTanks.netkan
@@ -5,7 +5,6 @@
     "name":         "Cryogenic Tanks",
     "$kref":        "#/ckan/github/ChrisAdderley/CryoTanks",
     "$vref":        "#/ckan/ksp-avc/CryoTanks.version",
-    "x_netkan_trust_version_file": true,
     "license":      "CC-BY-NC-SA-4.0",
     "depends": [
         { "name": "ModuleManager"         },

--- a/NetKAN/CryoTanks.netkan
+++ b/NetKAN/CryoTanks.netkan
@@ -1,26 +1,25 @@
 {
     "spec_version": "v1.4",
-    "comment": "CryoTanks does not have its own release. Sourced from the KerbalAtomics archive.",
-    "identifier": "CryoTanks",
-    "$kref": "#/ckan/spacedock/710",
-    "$vref": "#/ckan/ksp-avc/CryoTanks.version",
+    "identifier":   "CryoTanks",
+    "abstract":     "A set of fuel tanks containing liquid hydrogen, with active cryocooling",
+    "name":         "Cryogenic Tanks",
+    "$kref":        "#/ckan/github/ChrisAdderley/CryoTanks",
+    "$vref":        "#/ckan/ksp-avc/CryoTanks.version",
     "x_netkan_trust_version_file": true,
-    "name": "Cryogenic Tanks",
-    "abstract": "A set of fuel tanks containing liquid hydrogen, with active cryocooling.",
-    "license": "CC-BY-NC-SA-4.0",
-    "resources": {
-      "repository": "https://github.com/ChrisAdderley/CryoTanks"
-    },
+    "license":      "CC-BY-NC-SA-4.0",
     "depends": [
-        { "name" : "CommunityResourcePack" },
-        { "name" : "ModuleManager" },
-        { "name" : "DynamicBatteryStorage" }
+        { "name": "ModuleManager"         },
+        { "name": "CommunityResourcePack" },
+        { "name": "DynamicBatteryStorage" }
     ],
-    "supports" : [
-        { "name" : "KerbalAtomics" },
-        { "name" : "CryoEngines" }
+    "supports": [
+        { "name": "KerbalAtomics" },
+        { "name": "CryoEngines"   }
     ],
-    "install" : [
-        { "file" : "GameData/CryoTanks", "install_to" : "GameData" }
+    "install": [
+        {
+            "file":       "GameData/CryoTanks",
+            "install_to": "GameData"
+        }
     ]
 }

--- a/NetKAN/DeployableEngines.netkan
+++ b/NetKAN/DeployableEngines.netkan
@@ -1,17 +1,19 @@
 {
     "spec_version": "v1.4",
-    "comment": "DeployableEngines does not have its own release. Sourced from the KerbalAtomics archive.",
-    "identifier": "DeployableEngines",
-    "$kref": "#/ckan/spacedock/710",
-    "$vref": "#/ckan/ksp-avc/GameData/KerbalAtomics/Versioning/KerbalAtomics.version",
-    "name": "Deployable Engines Plugin",
-    "abstract": "A plugin to manage extending/retracting engine nozzles.",
-    "license": "CC-BY-NC-SA-4.0",
-    "supports" : [
-        { "name" : "KerbalAtomics" },
-        { "name" : "CryoEngines" }
+    "identifier":   "DeployableEngines",
+    "abstract":     "A plugin to manage extending/retracting engine nozzles",
+    "name":         "Deployable Engines Plugin",
+    "$kref":        "#/ckan/github/ChrisAdderley/DeployableEngines",
+    "$vref":        "#/ckan/ksp-avc/DeployableEngines.version",
+    "license":      "CC-BY-NC-SA-4.0",
+    "supports": [
+        { "name": "KerbalAtomics" },
+        { "name": "CryoEngines"   }
     ],
-    "install" : [
-        { "find" : "DeployableEngines", "install_to" : "GameData" }
+    "install": [
+        {
+            "find":       "DeployableEngines",
+            "install_to": "GameData"
+        }
     ]
 }

--- a/NetKAN/DynamicBatteryStorage.netkan
+++ b/NetKAN/DynamicBatteryStorage.netkan
@@ -2,20 +2,16 @@
     "spec_version":   "v1.4",
     "identifier":     "DynamicBatteryStorage",
     "name":           "Dynamic Battery Storage",
-    "abstract":       "A plugin that works around the problems of stock electricity consumption/generation at high time warp.",
-    "comment":        "Dynamic Battery Storage does not have its own release. Sourced from the NearFutureElectrical archive.",
-    "$kref":          "#/ckan/spacedock/558",
+    "abstract":       "A plugin that works around the problems of stock electricity consumption/generation at high time warp",
+    "$kref":          "#/ckan/github/ChrisAdderley/DynamicBatteryStorage",
     "$vref":          "#/ckan/ksp-avc/DynamicBatteryStorage.version",
     "x_netkan_epoch": 2,
     "x_netkan_trust_version_file": true,
     "license":        "CC-BY-NC-SA-4.0",
-    "resources": {
-        "repository": "https://github.com/ChrisAdderley/DynamicBatteryStorage"
-    },
-    "install" : [
+    "install": [
         {
-            "file":        "GameData/DynamicBatteryStorage",
-            "install_to" : "GameData"
+            "file":       "GameData/DynamicBatteryStorage",
+            "install_to": "GameData"
         }
     ]
 }

--- a/NetKAN/NearFutureProps.netkan
+++ b/NetKAN/NearFutureProps.netkan
@@ -2,7 +2,7 @@
     "spec_version":   "v1.4",
     "identifier":     "NearFutureProps",
     "name":           "Near Future IVA Props",
-    "abstract":       "Props used to build IVA spaces in various mods by Nertea.",
+    "abstract":       "Props used to build IVA spaces in various mods by Nertea",
     "$kref":          "#/ckan/github/ChrisAdderley/NearFutureProps",
     "$vref":          "#/ckan/ksp-avc",
     "x_netkan_epoch": "1",
@@ -18,16 +18,6 @@
         {
             "find":       "NearFutureProps",
             "install_to": "GameData"
-        }
-    ],
-    "x_netkan_override": [
-        {
-            "version" : "0.4.2",
-            "delete" : [ "ksp_version" ],
-            "override" : {
-                "ksp_version_min" : "1.0.2",
-                "ksp_version_max" : "1.0.4"
-            }
         }
     ]
 }


### PR DESCRIPTION
## Motivation

Up until recently, some of Nertea's mods only existed as bundled pieces of other mods, and their netkans had to choose one download as the source. This created a sort of artificial dependency situation, where (for example) KerbalAtomics might not be installable until NearFutureElectrical updated, or vice versa, even though they're technically independent, because they depend on bundled mods that we source from one or the other.

See KSP-CKAN/CKAN#2404 for an example.

## Changes

Nertea asked on a Discord about opportunities to improve how his mods work with CKAN, and I mentioned this. He has graciously decided to provide standalone releases for these dependencies.

Now the bundled dependencies are sourced from their own independent repositories.

| Mod | Change |
| --- | --- |
| CryoTanks | Change kref from KerbalAtomics SD to CryoTanks GH |
| DeployableEngines | Change kref from KerbalAtomics SD to DeployableEngines GH |
| DynamicBatteryStorage | Change kref from NearFutureElectrical SD to DynamicBatteryStorage GH |
| NearFutureProps | Remove old override that could mess up a future version |

This will mean that if the dependencies are released first, KerbalAtomics and NearFutureElectrical will be installable immediately upon release.

(As of the initial submission of this PR, some of the repos may not yet have any releases. This is all still being finalized, so we will rebuild this PR as needed.)