### PR TITLE
Fix mk4 version file and deps

### DIFF
--- a/NetKAN/MarkIVSpaceplaneSystem.netkan
+++ b/NetKAN/MarkIVSpaceplaneSystem.netkan
@@ -2,15 +2,13 @@
     "spec_version"   : "v1.4",
     "identifier"     : "MarkIVSpaceplaneSystem",
     "$kref"          : "#/ckan/spacedock/809",
-    "$vref"          : "#/ckan/ksp-avc/MarkIV.version",
+    "$vref"          : "#/ckan/ksp-avc/MarkIVSystem.version",
     "release_status" : "stable",
     "license"        : "CC-BY-NC-SA-4.0",
     "depends": [
-        { "name" : "B9PartSwitch" },
-        { "name" : "CommunityResourcePack" },
-        { "name" : "DeployableEngines" },
-        { "name" : "FirespitterCore" },
         { "name" : "ModuleManager" },
+        { "name" : "B9PartSwitch" },
+        { "name" : "DeployableEngines" },
         { "name" : "NearFutureProps" }
     ],
     "suggests": [


### PR DESCRIPTION
MarkIVSpaceplaneSystem's .version file got renamed, and some of its dependencies haven't been included in the download for quite a while.