### PR TITLE
Clean up duplicate science info module

### DIFF
--- a/NetKAN/ExtendedInfoSciExp.frozen
+++ b/NetKAN/ExtendedInfoSciExp.frozen
@@ -1,4 +1,5 @@
 {
+  "comment": "THIS IS A DUPLICATE OF ScienceSituationInfo. DO NOT UNFREEZE.",
   "license": "CC-BY-SA",
   "identifier": "ExtendedInfoSciExp",
   "x_via": "Automated Linuxgurugamer CKAN script",

--- a/NetKAN/ScienceSituationInfo.netkan
+++ b/NetKAN/ScienceSituationInfo.netkan
@@ -1,18 +1,14 @@
 {
     "spec_version": "v1.4",
-    "identifier": "ScienceSituationInfo",
-    "abstract": "Extended information about Scientific Experiments in VAB/SPH",
-    "license": "CC-BY-NC",
-    "$kref": "#/ckan/spacedock/1008",
-    "ksp_version"	:	"1.3.1",
-    "version": "1.3.1.1",
+    "identifier":   "ScienceSituationInfo",
+    "abstract":     "Extended information about Scientific Experiments in VAB/SPH",
+    "$kref":        "#/ckan/spacedock/1008",
+    "x_netkan_epoch": 1,
+    "license":      "CC-BY-SA",
     "install": [
         {
-            "file"       : "OLDD",
-            "install_to" : "GameData",
-            "filter"     : "Thumbs.db"
+            "file":       "OLDD",
+            "install_to": "GameData"
         }
     ]
 }
-
-


### PR DESCRIPTION
## Problems

- https://spacedock.info/mod/1008 is indexed twice, as ScienceSituationInfo and ExtendedInfoSciExp
- ScienceSituationInfo has the wrong license
- ScienceSituationInfo lists version 1.3.1.2 as 1.3.1.1
- ScienceSituationInfo is missing several versions that are indexed under ExtendedInfoSciExp

## Causes

Timeline of events:

1. ScienceSituationInfo indexed 2015-10-23, #2445 (#2333)
2. ScienceSituationInfo frozen 2016-02-18, #3107 (#3106)
3. ExtendedInfoSciExp indexed 2016-10-26, #4826
4. ExtendedInfoSciExp epoched 2016-12-31, #5101
5. ScienceSituationInfo unfrozen 2017-02-26, #5290
6. ScienceSituationInfo re-frozen 2017-02-26, #5291
7. ScienceSituationInfo unfrozen 2018-02-15, #6247

## Changes

- ExtendedInfoSciExp frozen with comment about it being a duplicate
- ScienceSituationInfo no longer hard codes version or ksp_version
- ScienceSituationInfo license update to match SD
- ScienceSituationInfo has epoch added for backwards compatibility with versions indexed under ExtendedInfoSciExp (planning to move these)
- ScienceSituationInfo install stanza filter removed because there's no Thumbs.db in the ZIP

Part of the fix to #6716.