### PR TITLE
Latest CustomAsteroids configs need recent CA version.

### DIFF
--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -9,9 +9,9 @@
     "depends": [
         {
             "name": "CustomAsteroids",
-            "min_version": "v1.3.0",
+            "min_version": "v1.6.0",
             "max_version": "v1.99.99",
-            "comment": "Requires beta distribution and asteroid types."
+            "comment": "Requires localization support."
         }
     ],
     "provides": [ "CustomAsteroids-Pops" ],
@@ -43,7 +43,15 @@
     ],
     "x_netkan_override" : [
         {
-            "version" : [ ">= v1.3.0", "< v2.0.0" ],
+            "version" : [ ">= v1.6.0", "< v2.0.0" ],
+            "override" : {
+                "comment": "Match to Custom Asteroids v1.6.0, see NetKAN#3841.",
+                "ksp_version_min": "1.4.0"
+            },
+            "delete" : [ "ksp_version" ]
+        },
+        {
+            "version" : [ ">= v1.3.0", "< v1.6.0" ],
             "override" : {
                 "comment": "Match to Custom Asteroids v1.3.0, see NetKAN#3841.",
                 "ksp_version_min": "1.1.0"

--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -45,7 +45,7 @@
         {
             "version" : [ ">= v1.6.0", "< v2.0.0" ],
             "override" : {
-                "comment": "Match to Custom Asteroids v1.6.0, see NetKAN#3841.",
+                "comment": "Match to Custom Asteroids v1.6.0, see NetKAN#6963.",
                 "ksp_version_min": "1.4.0"
             },
             "delete" : [ "ksp_version" ]

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -9,9 +9,9 @@
     "depends": [
         {
             "name": "CustomAsteroids",
-            "min_version": "v1.3.0",
+            "min_version": "v1.6.0",
             "max_version": "v1.99.99",
-            "comment": "Requires asteroid types."
+            "comment": "Requires localization support."
         }
     ],
     "provides": [ "CustomAsteroids-Pops" ],
@@ -45,7 +45,15 @@
     ],
     "x_netkan_override" : [
         {
-            "version" : [ ">= v1.3.0", "< v2.0.0" ],
+            "version" : [ ">= v1.6.0", "< v2.0.0" ],
+            "override" : {
+                "comment": "Match to Custom Asteroids v1.6.0, see NetKAN#3841.",
+                "ksp_version_min": "1.4.0"
+            },
+            "delete" : [ "ksp_version" ]
+        },
+        {
+            "version" : [ ">= v1.3.0", "< v1.6.0" ],
             "override" : {
                 "comment": "Match to Custom Asteroids v1.3.0, see NetKAN#3841.",
                 "ksp_version_min": "1.1.0"

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -47,7 +47,7 @@
         {
             "version" : [ ">= v1.6.0", "< v2.0.0" ],
             "override" : {
-                "comment": "Match to Custom Asteroids v1.6.0, see NetKAN#3841.",
+                "comment": "Match to Custom Asteroids v1.6.0, see NetKAN#6963.",
                 "ksp_version_min": "1.4.0"
             },
             "delete" : [ "ksp_version" ]

--- a/NetKAN/CustomAsteroids-Pops-Stock-Stockalike.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Stockalike.netkan
@@ -9,9 +9,9 @@
     "depends": [
         {
             "name": "CustomAsteroids",
-            "min_version": "v1.3.0",
+            "min_version": "v1.6.0",
             "max_version": "v1.99.99",
-            "comment": "Requires intercept blocks and conditional spawning."
+            "comment": "Requires localization support."
         }
     ],
     "provides": [ "CustomAsteroids-Pops" ],
@@ -36,7 +36,15 @@
     ],
     "x_netkan_override" : [
         {
-            "version" : [ ">= v1.0.0", "< v2.0.0" ],
+            "version" : [ ">= v1.6.0", "< v2.0.0" ],
+            "override" : {
+                "comment": "Match to Custom Asteroids v1.6.0, see NetKAN#3841.",
+                "ksp_version_min": "1.4.0"
+            },
+            "delete" : [ "ksp_version" ]
+        },
+        {
+            "version" : [ ">= v1.0.0", "< v1.6.0" ],
             "override" : {
                 "comment": "Match to Custom Asteroids v1.3.0, see NetKAN#3841.",
                 "ksp_version_min": "1.1.0"

--- a/NetKAN/CustomAsteroids-Pops-Stock-Stockalike.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Stockalike.netkan
@@ -38,7 +38,7 @@
         {
             "version" : [ ">= v1.6.0", "< v2.0.0" ],
             "override" : {
-                "comment": "Match to Custom Asteroids v1.6.0, see NetKAN#3841.",
+                "comment": "Match to Custom Asteroids v1.6.0, see NetKAN#6963.",
                 "ksp_version_min": "1.4.0"
             },
             "delete" : [ "ksp_version" ]


### PR DESCRIPTION
This PR updates versions 1.6+ of stock Custom Asteroids configs to depend on Custom Asteroids 1.6 or later. Previous versions of the configs may also be used with CA 1.6, but new configs may not work with older versions of Custom Asteroids.