### PR TITLE
Add Custom Asteroids OPM config.

### DIFF
--- a/NetKAN/CustomAsteroids-Pops-OPM-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-OPM-Outer.netkan
@@ -1,0 +1,5 @@
+{
+    "spec_version": "v1.2",
+    "identifier": "CustomAsteroids-Pops-OPM-Outer",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Starstrider42/Custom-Asteroids-Extras/master/CustomAsteroids-Pops-OPM-Outer.netkan"
+}

--- a/NetKAN/CustomAsteroids-Pops-OPM-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-OPM-Outer.netkan
@@ -14,13 +14,13 @@
     "ksp_version_min": "1.4.0",
     "depends": [
         {
+            "name": "OuterPlanetsMod"
+        },
+        {
             "name": "CustomAsteroids",
             "min_version": "v1.6.0",
             "max_version": "v1.99.99",
             "comment": "Requires localization support."
-        },
-        {
-            "name": "OuterPlanetsMod"
         }
     ],
     "provides": [ "CustomAsteroids-Pops" ],

--- a/NetKAN/CustomAsteroids-Pops-OPM-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-OPM-Outer.netkan
@@ -1,5 +1,35 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "CustomAsteroids-Pops-OPM-Outer",
-    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Starstrider42/Custom-Asteroids-Extras/master/CustomAsteroids-Pops-OPM-Outer.netkan"
+    "name": "Custom Asteroids (unofficial OPM config)",
+    "abstract": "Adds Kentaurs and trans-Neidonian objects",
+    "$kref": "#/ckan/github/Starstrider42/Custom-Asteroids-Extras",
+    "x_netkan_github": {
+        "use_source_archive": true
+    },
+    "license": "MIT",
+    "resources": {
+        "bugtracker": "https://github.com/Starstrider42/Custom-Asteroids-Extras/issues"
+    },
+    "ksp_version_min": "1.4.0",
+    "depends": [
+        {
+            "name": "CustomAsteroids",
+            "min_version": "v1.6.0",
+            "max_version": "v1.99.99",
+            "comment": "Requires localization support."
+        },
+        {
+            "name": "OuterPlanetsMod"
+        }
+    ],
+    "provides": [ "CustomAsteroids-Pops" ],
+    "install": [
+        {
+            "find": "config",
+            "install_to": "GameData/CustomAsteroids",
+            "filter_regexp": "(?<!Trans-Neidon\\.cfg)$"
+        }
+    ],
+    "x_maintained_by": "Starstrider42"
 }


### PR DESCRIPTION
This PR registers a new Custom Asteroids config with CKAN. The proper NetKAN file can be found at https://github.com/Starstrider42/Custom-Asteroids-Extras/blob/master/CustomAsteroids-Pops-OPM-Outer.netkan.