### PR TITLE
Fix Kopernicus homepage

### DIFF
--- a/NetKAN/Kopernicus.netkan
+++ b/NetKAN/Kopernicus.netkan
@@ -1,11 +1,12 @@
 {
     "spec_version"  : "v1.4",
     "identifier"    : "Kopernicus",
-    "$kref"         : "#/ckan/github/Kopernicus/Kopernicus",
-    "$vref"         : "#/ckan/ksp-avc/GameData/Kopernicus/Plugins/Kopernicus.version",
-    "x_netkan_epoch": "2",
     "name"          : "Kopernicus Planetary System Modifier",
     "abstract"      : "Allows users to replace the planetary system used by the game.",
+    "$kref"         : "#/ckan/github/Kopernicus/Kopernicus",
+    "x_netkan_staging": true,
+    "$vref"         : "#/ckan/ksp-avc/GameData/Kopernicus/Plugins/Kopernicus.version",
+    "x_netkan_epoch": "2",
     "release_status": "development",
     "license"       : "LGPL-3.0",
     "author": [
@@ -19,9 +20,8 @@
         "Sigma88"
     ],
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/140580-Kopernicus"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/181547-*"
     },
-    "x_netkan_staging": true,
     "depends": [
         { "name": "ModuleManager", "min_version": "2.8.0" },
         { "name": "ModularFlightIntegrator", "min_version": "1.2.4.0" }


### PR DESCRIPTION
Kopernicus has a broken link as `resources.homepage`.

I don't know exactly how or why that happened. Maybe another forum migration? Maybe the incident where a moderator's account was compromised and abused to delete threads?

Whatever the cause, it's fixed now.

Fixes #6978.