### PR TITLE
Fix KerbalAlarmClock hole for KSP 1.5

### DIFF
--- a/NetKAN/KerbalAlarmClock.netkan
+++ b/NetKAN/KerbalAlarmClock.netkan
@@ -31,6 +31,13 @@
             "override": {
                 "ksp_version_min" : "1.1.3"
             }
+        },
+        {
+            "version": [ ">=v3.9.0.0","<v3.10.0.0" ],
+            "after": "avc",
+            "override": {
+                "ksp_version_max" : "1.5.99"
+            }
         }
     ]
 }


### PR DESCRIPTION
There's a hole in the compatible KSP versions for the KerbalAlarmClock; KSP 1.5.0-1.5.99 is missing. This fills in that gap.

I don't think a hole like this is changeable upstream, so I wrote it as an override here.