### PR TITLE
Add DebugStuff

### DIFF
--- a/NetKAN/DebugStuff.netkan
+++ b/NetKAN/DebugStuff.netkan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "DebugStuff",
+    "name":         "Debug Stuff",
+    "abstract":     "Display the transform & colliders of a part in wireframe and display the part hierarchy",
+    "author":       "Sarbian",
+    "license":      "MIT",
+    "$kref":        "#/ckan/jenkins/https://ksp.sarbian.com/jenkins/job/DebugStuff",
+    "x_netkan_jenkins":      { "use_filename_version": true },
+    "x_netkan_version_edit": "^DebugStuff-(?<version>\\d+\\.\\d+\\.\\d+\\.\\d+)\\.zip$",
+    "resources": {
+        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/135726-*",
+        "repository": "https://github.com/sarbian/DebugStuff"
+    }
+}

--- a/NetKAN/DebugStuff.netkan
+++ b/NetKAN/DebugStuff.netkan
@@ -8,6 +8,7 @@
     "$kref":        "#/ckan/jenkins/https://ksp.sarbian.com/jenkins/job/DebugStuff",
     "x_netkan_jenkins":      { "use_filename_version": true },
     "x_netkan_version_edit": "^DebugStuff-(?<version>\\d+\\.\\d+\\.\\d+\\.\\d+)\\.zip$",
+    "ksp_version_min": "1.0",
     "resources": {
         "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/135726-*",
         "repository": "https://github.com/sarbian/DebugStuff"


### PR DESCRIPTION
This mod can show collider wireframes. It's hosted on Sarbian's Jenkins.

Sarbian's OK:  https://forum.kerbalspaceprogram.com/index.php?/topic/135726-1x-debugstuff-2018-03-13-see-the-hidden-secrets-of-the-game-objects/&do=findComment&comment=3531852