### PR TITLE
De-stage Kopernicus

### DIFF
--- a/NetKAN/Kopernicus.netkan
+++ b/NetKAN/Kopernicus.netkan
@@ -4,7 +4,6 @@
     "name"          : "Kopernicus Planetary System Modifier",
     "abstract"      : "Allows users to replace the planetary system used by the game.",
     "$kref"         : "#/ckan/github/Kopernicus/Kopernicus",
-    "x_netkan_staging": true,
     "$vref"         : "#/ckan/ksp-avc/GameData/Kopernicus/Plugins/Kopernicus.version",
     "x_netkan_epoch": "2",
     "release_status": "development",


### PR DESCRIPTION
Kopernicus had netkan staging enabled in #4794. The rationale was:

> Might want to add any mod with manually set ksp_version to the staging queue so new versions don't get generated for the wrong KSP versions.

Kopernicus has a version file and a $vref as of #5535, so that reasoning no longer applies. This pull request disables staging for that reason.