### PR TITLE
MechJeb2 compatibility and staging

### DIFF
--- a/NetKAN/MechJeb2.netkan
+++ b/NetKAN/MechJeb2.netkan
@@ -14,7 +14,8 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154834-*",
         "repository": "https://github.com/MuMech/MechJeb2"
     },
-    "ksp_version": "1.5",
+    "ksp_version": "1.6",
+    "x_netkan_staging": true,
     "install": [
         {
             "find": "MechJeb2",
@@ -34,7 +35,7 @@
                 "ksp_version" : "1.2"
             }
         },
-		{
+        {
             "version": "2.5.8.0",
             "override": {
                 "ksp_version" : "1.1"


### PR DESCRIPTION
MechJeb's game version is hard coded in the netkan, which has caused the latest version to be out of date. Now it's updated from 1.5 to 1.6.

#4794 made the point that staging might be a good way to avoid this, since it would allow us to check the game versions before they go live. So now staging is enabled.