### PR TITLE
SDHI-ServiceModuleSystem compatibility and staging

### DIFF
--- a/NetKAN/SDHI-ServiceModuleSystem.netkan
+++ b/NetKAN/SDHI-ServiceModuleSystem.netkan
@@ -5,7 +5,9 @@
     "name"         : "Sum Dum Heavy Industries - Service Module System",
     "abstract"     : "Service Module and accessories designed specifically for use with the stock Mk1-2 Command Pod, vaguely resembling NASA's Orion MPCV. May or may not have a convincing stockalike appearance.",
     "license"      : "CC-BY-SA-4.0",
-    "ksp_version"  : "1.5",
+    "ksp_version"  : "1.6",
+    "x_netkan_staging": true,
+    "x_netkan_force_v": true,
     "resources"    : {
         "homepage"   : "http://forum.kerbalspaceprogram.com/index.php?/topic/48073-121-sdhi-service-module-system-v321-20-november-2016/",
         "repository" : "https://github.com/sumghai/SDHI_ServiceModuleSystem"
@@ -31,6 +33,5 @@
         { "name" : "ShipManifest"                       },
         { "name" : "ConnectedLivingSpace"               },
         { "name" : "PEBKACIndustriesLaunchEscapeSystem" }
-    ],
-    "x_netkan_force_v" : true
+    ]
 }


### PR DESCRIPTION
SDHI-ServiceModuleSystem's game compatibility is hard coded in its .netkan, and currently out of date. It's now updated from 1.5 to 1.6.

Similar to #6992, the Netkan bot's staging feature is now enabled for this mod so we can check compatibility before a new version goes live.

Fixes #6993.