### PR TITLE
Fix Moar Filter Extension Configs

### DIFF
--- a/NetKAN/MoarFEConfigs.netkan
+++ b/NetKAN/MoarFEConfigs.netkan
@@ -1,11 +1,11 @@
 {
-  "license": "unknown",
+  "license": "CC0",
   "identifier": "MoarFEConfigs",
   "x_via": "Automated Linuxgurugamer CKAN script",
   "$kref": "#/ckan/spacedock/2071",
   "install": [
     {
-      "find": "Moar Filter Exension Configs",
+      "find": "MoarFilterExensionConfigs",
       "install_to": "GameData"
     }
   ],


### PR DESCRIPTION
This module's folder path changed, and the license on SD says "Creative Commons Zero v1.0 Universal" but is "unknown" in the netkan.