### PR TITLE
Obey UniversalStorage2's version file

### DIFF
--- a/NetKAN/UniversalStorage2.netkan
+++ b/NetKAN/UniversalStorage2.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "UniversalStorage2",
     "$kref":        "#/ckan/spacedock/1933",
+    "$vref":        "#/ckan/ksp-avc",
     "license":      "restricted",
     "depends": [
         { "name": "ModuleManager"         },


### PR DESCRIPTION
Apparently this mod has a version file now, but its netkan is only set up to use the version from SpaceDock. Now it has a vref.

Fixes #7004.