### PR TITLE
Fix MainSailor module names

### DIFF
--- a/NetKAN/MainSailorTextures-Fairings.netkan
+++ b/NetKAN/MainSailorTextures-Fairings.netkan
@@ -3,7 +3,7 @@
     "identifier": "MainSailorTextures-Fairings",
     "ksp_version": "any",
     "$kref": "#/ckan/spacedock/487",
-    "name": "Procedural Parts - MainSailor's Procedural Textures - Gamma Textures",
+    "name": "Procedural Parts - MainSailor's Procedural Textures - Fairings Textures",
     "license": "CC-BY-NC-SA-4.0",
     "abstract": "Procedural Parts complementary textures by MainSailor for fairings",
     "depends": [

--- a/NetKAN/MainSailorTextures-Theta.netkan
+++ b/NetKAN/MainSailorTextures-Theta.netkan
@@ -3,7 +3,7 @@
     "identifier": "MainSailorTextures-Theta",
     "ksp_version": "any",
     "$kref": "#/ckan/spacedock/487",
-    "name": "Procedural Parts - MainSailor's Procedural Textures - Gamma Textures",
+    "name": "Procedural Parts - MainSailor's Procedural Textures - Theta Textures",
     "license": "CC-BY-NC-SA-4.0",
     "abstract": "Procedural Parts textures by MainSailor - a look at What-if?",
     "depends": [


### PR DESCRIPTION
## Problem

This ain't right:

![image](https://user-images.githubusercontent.com/1559108/52825771-bb231b80-3083-11e9-8e0d-8fdb11108c60.png)

One of those is MainSailorTextures-Fairings, and another is MainSailorTextures-Theta.

## Changes

Now they're named that way instead of looking like duplicates of Gamma.