### PR TITLE
Move extras to right location

### DIFF
--- a/NetKAN/CryoEngines-LFO.netkan
+++ b/NetKAN/CryoEngines-LFO.netkan
@@ -11,6 +11,6 @@
         { "name" : "CryoEngines" }
     ],
     "install": [
-        { "find" : "CryoEnginesLFO", "install_to" : "GameData/CryoEngines/Extras" }
+        { "find" : "CryoEnginesLFO", "install_to" : "GameData" }
     ]
 }

--- a/NetKAN/KerbalAtomics-NFECompatibility.netkan
+++ b/NetKAN/KerbalAtomics-NFECompatibility.netkan
@@ -11,6 +11,6 @@
         { "name" : "NearFutureElectrical" }
     ],
     "install" : [
-        { "find" : "NearFutureElectricaNTRs", "install_to" : "GameData/KerbalAtomics/Extras" }
+        { "find" : "NearFutureElectricaNTRs", "install_to" : "GameData" }
     ]
 }

--- a/NetKAN/NearFutureElectrical-DecayingRTGs.netkan
+++ b/NetKAN/NearFutureElectrical-DecayingRTGs.netkan
@@ -10,6 +10,6 @@
         { "name" : "NearFutureElectrical" }
     ],
     "install" : [
-        { "find" : "DecayingRTGs", "install_to" : "GameData/NearFutureElectrical/Extras" }
+        { "find" : "DecayingRTGs", "install_to" : "GameData" }
     ]
 }

--- a/NetKAN/NearFuturePropulsion-LowThrustEP.netkan
+++ b/NetKAN/NearFuturePropulsion-LowThrustEP.netkan
@@ -14,8 +14,6 @@
         { "name" : "NearFuturePropulsion" }
     ],
     "install" : [
-        { "find" : "NFPropulsionTweakPatch.cfg", "install_to" : "GameData/NearFuturePropulsion/Extras",   "find_matches_files": true }
+        { "find" : "NFPropulsionTweakPatch.cfg", "install_to" : "GameData",   "find_matches_files": true }
     ]
 }
-
-

--- a/NetKAN/NearFuturePropulsionExtras.frozen
+++ b/NetKAN/NearFuturePropulsionExtras.frozen
@@ -15,6 +15,6 @@
         { "name" : "NearFuturePropulsion" }
     ],
     "install" : [
-        { "find" : "Extras", "install_to" : "GameData/NearFuturePropulsion" }
+        { "find" : "Extras", "install_to" : "GameData" }
     ]
 }


### PR DESCRIPTION
I discovered that all the Extras support packages for my mods install to an incorrect location, creating ModuleManager targeting conflicts. They are intended to go in the GameData root. I've changed this for the ones I could track down in this PR.