### PR TITLE
Add replaced_by to OSE Workshop branches

### DIFF
--- a/NetKAN/OSEWorkShopCont.netkan
+++ b/NetKAN/OSEWorkShopCont.netkan
@@ -1,5 +1,5 @@
 {
-  "spec_version": "v1.4",
+  "spec_version": "v1.26",
   "install": [
     {
       "install_to": "GameData",

--- a/NetKAN/OSEWorkShopCont.netkan
+++ b/NetKAN/OSEWorkShopCont.netkan
@@ -16,5 +16,6 @@
   "$kref": "#/ckan/spacedock/1448",
   "x_via": "Automated Linuxgurugamer CKAN script",
   "identifier": "OSEWorkShopCont",
-  "license": "CC-BY-NC-SA-4.0"
+  "license": "CC-BY-NC-SA-4.0",
+  "replaced_by": "OSEWorkShopReworked"
 }

--- a/NetKAN/OSEWorkShopCont.netkan
+++ b/NetKAN/OSEWorkShopCont.netkan
@@ -17,5 +17,5 @@
   "x_via": "Automated Linuxgurugamer CKAN script",
   "identifier": "OSEWorkShopCont",
   "license": "CC-BY-NC-SA-4.0",
-  "replaced_by": "OSEWorkShopReworked"
+  "replaced_by": { "name": "OSEWorkShopReworked" }
 }


### PR DESCRIPTION
OSEWorkShopCont goes up to version 1.2.5 on KSP 1.4.2.
OSEWorkShopReworked is a new fork with versions up to 1.2.9 on KSP 1.6.1.

This pull request marks the former as `replaced_by` the latter.
Part of #7027.

ckan compat add 1.4 1.5 1.6