### PR TITLE
Update Spectra.netkan

### DIFF
--- a/NetKAN/Spectra.netkan
+++ b/NetKAN/Spectra.netkan
@@ -1,69 +1,56 @@
 {
 	"spec_version": "v1.4",
-	"name": "Spectra",
-	"abstract": "You are the closest to adventure, when you are the farthest from home.",
-	"identifier": "Spectra",
-	"license": "MIT",
+	"identifier":   "Spectra",
+	"name":         "Spectra",
+	"abstract":     "A well optimized and yet breathtakingly beautiful revamp of all celestial bodies in KSP",
+	"$kref":        "#/ckan/spacedock/1505",
+	"license":      "MIT",
 	"release_status": "stable",
-	"$kref": "#/ckan/spacedock/1505",
 	"resources": {
-		"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/159443-130131"
+		"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/159443-*"
 	},
 	"provides": [
 		"PlanetShine-Config"
 	],
-	"conflicts": [{
-		"name": "PlanetShine-Config"
-	}],
-	"depends": [{
-			"name": "KSPRC-Textures"
-		},
-		{
-			"name": "ModuleManager"
-		},
-		{
-			"name": "EnvironmentalVisualEnhancements"
-		},
-		{
-			"name": "Scatterer"
-		},
-		{
-			"name": "TextureReplacerReplaced"
-		},
-		{
-			"name": "Kopernicus"
-		}
+	"conflicts": [
+		{ "name": "PlanetShine-Config" }
 	],
-	"install": [{
-			"file": "Step 2 - Spectra/GameData/TextureReplacerReplaced",
+	"depends": [
+		{ "name": "ModuleManager"                   },
+		{ "name": "EnvironmentalVisualEnhancements" },
+		{ "name": "Scatterer"                       },
+		{ "name": "TextureReplacer"                 },
+		{ "name": "Kopernicus"                      }
+	],
+	"install": [
+		{
+			"file":       "Step 2 - Spectra/GameData/TextureReplacer",
 			"install_to": "GameData",
-			"filter": "logoFullRed_alt.dds"
-		}, {
-			"file": "Step 2 - Spectra/GameData/Spectra",
+			"filter":     "logoFullRed_alt.dds"
+		},
+		{
+			"file":       "Step 2 - Spectra/GameData/Spectra",
 			"install_to": "GameData"
 		},
 		{
-			"file": "Step 4 - Extras/PlanetShine/Config",
-			"install_to": "GameData/PlanetShine"
+			"file":       "Step 2 - Spectra/GameData/KSRPC",
+			"install_to": "GameData"
 		},
 		{
-			"file": "Step 4 - Extras/PlanetShine/Icons",
+			"file":       "Step 4 - Extras/PlanetShine/Config",
 			"install_to": "GameData/PlanetShine"
 		}
 	],
-	"recommends": [{
-			"name": "DistantObject"
-		},
-		{
-			"name": "RealPlume-StockConfigs"
-		},
-		{
-			"name": "WindowShineTR"
-		}
+	"recommends": [
+		{ "name": "DistantObject"          },
+		{ "name": "RealPlume-StockConfigs" },
+		{ "name": "ReStock"                },
+		{ "name": "PlanetShine"            },
+		{ "name": "SpaceplaneCorrections"  }
 	],
 	"x_netkan_override": [{
 		"version": "v1.1.3",
-		"delete": ["ksp_version"],
+		"delete":  [ "ksp_version" ],
 		"override": {
 			"ksp_version_min": "1.3",
 			"ksp_version_max": "1.3.99"

--- a/NetKAN/Spectra.netkan
+++ b/NetKAN/Spectra.netkan
@@ -33,7 +33,7 @@
 			"install_to": "GameData"
 		},
 		{
-			"file":       "Step 2 - Spectra/GameData/KSRPC",
+			"file":       "Step 2 - Spectra/GameData/KSPRC",
 			"install_to": "GameData"
 		},
 		{

--- a/NetKAN/Spectra.netkan
+++ b/NetKAN/Spectra.netkan
@@ -37,7 +37,7 @@
 			"install_to": "GameData"
 		},
 		{
-			"file":       "Step 4 - Extras/PlanetShine/Config",
+			"file":       "Step 3 - Extras/PlanetShine/Config",
 			"install_to": "GameData/PlanetShine"
 		}
 	],


### PR DESCRIPTION
This mod has an indexing error currently due to the changing of some folders:

```
Module contains no files matching: file="Step 2 - Spectra/GameData/TextureReplacerReplaced", file="Step 2 - Spectra/GameData/Spectra", file="Step 4 - Extras/PlanetShine/Config", file="Step 4 - Extras/PlanetShine/Icons"
```

In addition, some dependencies are out of date.

ckan compat add 1.4