### PR TITLE
Fix bad min version syntax

### DIFF
--- a/NetKAN/IR-Model-Rework-Core.netkan
+++ b/NetKAN/IR-Model-Rework-Core.netkan
@@ -11,7 +11,7 @@
     "version": "v02",
     "ksp_version": "1.1.2",
     "depends": [
-        { "name": "InfernalRobotics", "version_min": "0.19.4" }
+        { "name": "InfernalRobotics", "min_version": "0.19.4" }
     ],
     "recommends": [
         { "name": "IR-Model-Rework-Expansion" },

--- a/NetKAN/IR-Model-Rework-Expansion.netkan
+++ b/NetKAN/IR-Model-Rework-Expansion.netkan
@@ -11,7 +11,7 @@
     "version": "v02",
     "ksp_version": "1.1.2",
     "depends": [
-        { "name": "InfernalRobotics", "version_min": "0.19.4" },
+        { "name": "InfernalRobotics", "min_version": "0.19.4" },
         { "name": "IR-Model-Rework-Core" }
     ],
     "recommends": [

--- a/NetKAN/IR-Model-Rework-Utility.netkan
+++ b/NetKAN/IR-Model-Rework-Utility.netkan
@@ -11,7 +11,7 @@
     "version": "v02",
     "ksp_version": "1.1.2",
     "depends": [
-        { "name": "InfernalRobotics", "version_min": "0.19.4" },
+        { "name": "InfernalRobotics", "min_version": "0.19.4" },
         { "name": "IR-Model-Rework-Core" },
         { "name": "TweakableEverything" },
         { "name": "ToadicusTools" }

--- a/NetKAN/SentarExpansion.netkan
+++ b/NetKAN/SentarExpansion.netkan
@@ -4,7 +4,7 @@
     "$kref"         : "#/ckan/spacedock/238",
     "license"       : "GPL-3.0",
     "depends": [
-        { "name": "Kopernicus", "version_min": "1:beta-03-3" },
+        { "name": "Kopernicus", "min_version": "1:beta-03-3" },
         { "name" : "ModuleManager" }
     ],
     "x_netkan_epoch": 1


### PR DESCRIPTION
## Problem

Some modules have `version_min` properties in relationships. The correct property is `min_version`:

https://github.com/KSP-CKAN/CKAN/blob/6b4cd143996f029b94162ec89a2e0cb86f9a7c3f/Core/Types/CkanModule.cs#L37-L42

Noticed during #7056.

This pull request fixes it.