### PR TITLE
SapceDock catch-up 11

### DIFF
--- a/NetKAN/Atoren.netkan
+++ b/NetKAN/Atoren.netkan
@@ -1,0 +1,9 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "Atoren",
+    "$kref":        "#/ckan/spacedock/2101",
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus"    }
+    ]
+}

--- a/NetKAN/Atoren.netkan
+++ b/NetKAN/Atoren.netkan
@@ -6,5 +6,11 @@
     "depends": [
         { "name": "ModuleManager" },
         { "name": "Kopernicus"    }
-    ]
+    ],
+    "x_netkan_override": [ {
+        "version": "1.3.1_to_1.6.1",
+        "override": {
+            "version": "1.0"
+        }
+    } ]
 }

--- a/NetKAN/Atoren.netkan
+++ b/NetKAN/Atoren.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "Atoren",
     "$kref":        "#/ckan/spacedock/2101",
+    "license":      "GPL-3.0",
     "depends": [
         { "name": "ModuleManager" },
         { "name": "Kopernicus"    }

--- a/NetKAN/ThalassaSystem.netkan
+++ b/NetKAN/ThalassaSystem.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "ThalassaSystem",
     "$kref":        "#/ckan/spacedock/2097",
+    "license":      "MIT",
     "install": [ {
         "find":       "Thalassa",
         "install_to": "GameData",

--- a/NetKAN/ThalassaSystem.netkan
+++ b/NetKAN/ThalassaSystem.netkan
@@ -1,0 +1,14 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "ThalassaSystem",
+    "$kref":        "#/ckan/spacedock/2097",
+    "install": [ {
+        "find":       "Thalassa",
+        "install_to": "GameData",
+        "filter":     [ ".DS_Store" ]
+    } ],
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus"    }
+    ]
+}

--- a/NetKAN/TopiaiSystem.netkan
+++ b/NetKAN/TopiaiSystem.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "TopiaiSystem",
     "$kref":        "#/ckan/spacedock/2103",
+    "license":      "MIT",
     "install": [ {
         "find":       "Topiai",
         "install_to": "GameData",

--- a/NetKAN/TopiaiSystem.netkan
+++ b/NetKAN/TopiaiSystem.netkan
@@ -1,0 +1,14 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "TopiaiSystem",
+    "$kref":        "#/ckan/spacedock/2103",
+    "install": [ {
+        "find":       "Topiai",
+        "install_to": "GameData",
+        "filter":     [ ".DS_Store" ]
+    } ],
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus"    }
+    ]
+}


### PR DESCRIPTION
KSP-SpaceDock/SpaceDock#188 is not fixed.
These are the mods added since #7029 (and #7044).