### PR TITLE
DMagic Orbital Science recommendation changed from US1 to US2

### DIFF
--- a/NetKAN/DMagicOrbitalScience.netkan
+++ b/NetKAN/DMagicOrbitalScience.netkan
@@ -20,7 +20,7 @@
         { "name": "CapCom"                 },
         { "name": "ContractRewardModifier" },
         { "name": "OuterPlanetsMod"        },
-        { "name": "UniversalStorage"       },
+        { "name": "UniversalStorage2"       },
         { "name": "ScienceAlert"           },
         { "name": "SCANsat"                },
         { "name": "CommunityTechTree"      }

--- a/NetKAN/SCANsat.netkan
+++ b/NetKAN/SCANsat.netkan
@@ -16,7 +16,8 @@
         { "name": "RasterPropMonitor" }
     ],
     "conflicts": [
-        { "name": "ContractConfigurator-ScanSatLite" }
+        { "name": "ContractConfigurator-ScanSatLite" },
+	{ "name": "Overdrive" }
     ],
     "resources": {
         "repository": "https://github.com/S-C-A-N/SCANsat"

--- a/NetKAN/SCANsat.netkan
+++ b/NetKAN/SCANsat.netkan
@@ -16,8 +16,7 @@
         { "name": "RasterPropMonitor" }
     ],
     "conflicts": [
-        { "name": "ContractConfigurator-ScanSatLite" },
-        { "name": "Overdrive" }
+        { "name": "ContractConfigurator-ScanSatLite" }
     ],
     "resources": {
         "repository": "https://github.com/S-C-A-N/SCANsat"

--- a/NetKAN/SCANsat.netkan
+++ b/NetKAN/SCANsat.netkan
@@ -17,7 +17,7 @@
     ],
     "conflicts": [
         { "name": "ContractConfigurator-ScanSatLite" },
-	{ "name": "Overdrive" }
+        { "name": "Overdrive" }
     ],
     "resources": {
         "repository": "https://github.com/S-C-A-N/SCANsat"


### PR DESCRIPTION
Some weird SCANsat netkan change seems to have tagged along with this update for some reason, I'm not sure how to get rid of it. It seems to be white space changes and a block for OverDrive, the UI replacement mod. I seem to remember that mod causing issues with SCANsat at some point, but I'm not sure if that is still the case.