### PR TITLE
Populate known staging reasons

### DIFF
--- a/NetKAN/ContractConfigurator-HistoricMissions.netkan
+++ b/NetKAN/ContractConfigurator-HistoricMissions.netkan
@@ -1,14 +1,14 @@
 {
     "spec_version": "v1.4",
-    "license": "CC-BY-NC-SA-4.0",
-    "$kref": "#/ckan/spacedock/450",
     "identifier": "ContractConfigurator-HistoricMissions",
     "abstract": "This pack currently adds over 600... yes you read correctly... over 600 contracts to the base game following the historic progression of both NASA and its Russian counterparts, each mission has been made into a contract for the game. This version is for non RSS/RO KSP",
+    "$kref": "#/ckan/spacedock/450",
+    "license": "CC-BY-NC-SA-4.0",
+    "x_netkan_staging": true,
+    "x_netkan_staging_reason": "This mod has historically messed up our install instructions as the contents are reorganised",
     "depends": [
         { "name": "ContractConfigurator", "min_version": "1.15.1" }
     ],
-    "x_netkan_staging": true,
-    "comment": "This mod has historically messed up our install instructions as the contents are reorganised",
     "install": [
         {
             "find"       : "RegularVersion/ContractPacks/HistoricMissions",

--- a/NetKAN/ContractConfigurator-HistoricMissionsRSS.netkan
+++ b/NetKAN/ContractConfigurator-HistoricMissionsRSS.netkan
@@ -1,16 +1,16 @@
 {
     "spec_version": "v1.4",
-    "license": "CC-BY-NC-SA-4.0",
-    "$kref": "#/ckan/spacedock/450",
     "identifier": "ContractConfigurator-HistoricMissionsRSS",
     "name": "Contract Pack: Historic Missions for RSS",
     "abstract": "This pack currently adds over 600... yes you read correctly... over 600 contracts to the base game following the historic progression of both NASA and its Russian counterparts, each mission has been made into a contract for the game. This version is for RSS/RO KSP",
+    "$kref": "#/ckan/spacedock/450",
+    "license": "CC-BY-NC-SA-4.0",
+    "x_netkan_staging": true,
+    "x_netkan_staging_reason": "This mod has historically messed up our install instructions as the contents are reorganised",
     "depends": [
         { "name": "ContractConfigurator", "min_version": "1.15.1" },
         { "name": "RealSolarSystem" }
     ],
-    "x_netkan_staging": true,
-    "comment": "This mod has historically messed up our install instructions as the contents are reorganised",
     "install": [
         {
             "find"       : "RSSVersion/ContractPacks/HistoricMissions",

--- a/NetKAN/FerramAerospaceResearch.netkan
+++ b/NetKAN/FerramAerospaceResearch.netkan
@@ -1,14 +1,15 @@
 {
     "spec_version": 1,
     "identifier": "FerramAerospaceResearch",
+    "name": "Ferram Aerospace Research",
+    "abstract": "FAR replaces KSP's stock part-centered aerodynamics model with one based on real-life physics.",
+    "author": "ferram4",
     "$kref": "#/ckan/github/ferram4/Ferram-Aerospace-Research",
     "$vref": "#/ckan/ksp-avc",
     "x_netkan_epoch": "3",
     "x_netkan_staging": true,
+    "x_netkan_staging_reason": "This mod is very popular and has had problems with CKAN installation in the past. Please inspect carefully.",
     "x_netkan_version_edit": "^[vV]?(?<version>\\d+(?:\\.\\d+){0,3}[A-Za-z]?)(?:_[A-Za-z0-9_]+)?$",
-    "name": "Ferram Aerospace Research",
-    "abstract": "FAR replaces KSP's stock part-centered aerodynamics model with one based on real-life physics.",
-    "author": "ferram4",
     "license": "restricted",
     "resources" : {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/19321-1",

--- a/NetKAN/MechJeb2.netkan
+++ b/NetKAN/MechJeb2.netkan
@@ -16,13 +16,14 @@
     },
     "ksp_version": "1.6",
     "x_netkan_staging": true,
+    "x_netkan_staging_reason": "Game versions hard coded in NetKAN. Please check that it matches the forum thread.",
     "install": [
         {
             "find": "MechJeb2",
             "install_to": "GameData"
         }
     ],
-    "x_netkan_override": [    
+    "x_netkan_override": [
         {
             "version": "2.7.0.0",
             "override": {

--- a/NetKAN/MilitaryVehicleChassis.netkan
+++ b/NetKAN/MilitaryVehicleChassis.netkan
@@ -1,10 +1,10 @@
 {
-    "$kref": "#/ckan/spacedock/686",
     "spec_version": "v1.2",
     "identifier": "MilitaryVehicleChassis",
+    "$kref": "#/ckan/spacedock/686",
     "license": "MIT",
     "x_netkan_staging": true,
-    "comment": "Mod author decided to take out the mod directory from the zipfile. Hopefully it will come back",
+    "x_netkan_staging_reason": "Mod author decided to take out the mod directory from the zipfile. Hopefully it will come back.",
     "install": [
         {
             "file": "A310",

--- a/NetKAN/PlanetWiki-OPM.netkan
+++ b/NetKAN/PlanetWiki-OPM.netkan
@@ -1,13 +1,11 @@
 {
+    "spec_version": 1,
     "identifier": "PlanetWiki-OPM",
     "$kref": "#/ckan/spacedock/881",
     "license": "CC-BY-NC-SA-4.0",
-    "spec_version": 1,
     "depends": [
         { "name": "OuterPlanetsMod" }
     ],
-    "x_netkan_staging": true,
-    "comment": "Staging turned on to check overridden KSP version",
     "install": [
         {
             "file": "GameData/planetwiki_opm.ksp",

--- a/NetKAN/RoverFuelTanks.netkan
+++ b/NetKAN/RoverFuelTanks.netkan
@@ -1,15 +1,14 @@
 {
     "spec_version": "v1.4",
-    "x_via": "Automated SpaceDock CKAN submission",
-    "license": "MIT",
     "identifier": "RoverFuelTanks",
     "$kref": "#/ckan/spacedock/1166",
+    "license": "MIT",
     "install": [
         {
-            "find":"Parts",
+            "find": "Parts",
             "install_to": "GameData/RoverFuelTanks",
             "comment": "something odd about that zip file"
         }
     ],
-    "x_netkan_staging": true
+    "x_via": "Automated SpaceDock CKAN submission"
 }

--- a/NetKAN/RoverWheelSounds.netkan
+++ b/NetKAN/RoverWheelSounds.netkan
@@ -1,14 +1,14 @@
 {
     "spec_version": 1,
-    "comment": "Staging enabled due to manual KSP version information.",
     "identifier": "RoverWheelSounds",
-    "$kref": "#/ckan/github/pizzaoverhead/WheelSounds",
     "name": "Rover Wheel Sounds",
+    "$kref": "#/ckan/github/pizzaoverhead/WheelSounds",
     "license": "GPL-2.0",
+    "ksp_version_min": "1.2",
+    "ksp_version_max": "1.5",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/50431-RoverWheelSounds"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/50431-*"
     },
-    "ksp_version": "1.2.0",
     "depends": [
         { "name": "ModuleManager", "min_version": "2.5.1" }
     ],
@@ -19,5 +19,6 @@
         }
     ],
     "x_netkan_version_edit": "^[vV]?(?<version>.+)$",
-    "x_netkan_staging": true
+    "x_netkan_staging": true,
+    "x_netkan_staging_reason": "Game versions hard coded in NetKAN due to syntax error in version file. Please check that it matches the forum thread."
 }

--- a/NetKAN/SDHI-ServiceModuleSystem.netkan
+++ b/NetKAN/SDHI-ServiceModuleSystem.netkan
@@ -1,15 +1,16 @@
 {
     "spec_version" : "v1.4",
     "identifier"   : "SDHI-ServiceModuleSystem",
-    "$kref"        : "#/ckan/github/sumghai/SDHI_ServiceModuleSystem",
     "name"         : "Sum Dum Heavy Industries - Service Module System",
     "abstract"     : "Service Module and accessories designed specifically for use with the stock Mk1-2 Command Pod, vaguely resembling NASA's Orion MPCV. May or may not have a convincing stockalike appearance.",
+    "$kref"        : "#/ckan/github/sumghai/SDHI_ServiceModuleSystem",
     "license"      : "CC-BY-SA-4.0",
     "ksp_version"  : "1.6",
     "x_netkan_staging": true,
+    "x_netkan_staging_reason": "Game versions hard coded in NetKAN. Please check that it matches the forum thread.",
     "x_netkan_force_v": true,
     "resources"    : {
-        "homepage"   : "http://forum.kerbalspaceprogram.com/index.php?/topic/48073-121-sdhi-service-module-system-v321-20-november-2016/",
+        "homepage"   : "https://forum.kerbalspaceprogram.com/index.php?/topic/48073-*",
         "repository" : "https://github.com/sumghai/SDHI_ServiceModuleSystem"
     },
     "install": [

--- a/NetKAN/SovietConversion.netkan
+++ b/NetKAN/SovietConversion.netkan
@@ -1,10 +1,13 @@
 {
-    "license": "CC-BY-NC-SA-4.0",
+    "spec_version": "v1.4",
     "identifier": "SovietConversion",
     "$kref": "#/ckan/spacedock/858",
-    "spec_version": "v1.4",
-    "conflicts" : [ 
-        { "name" : "RemoteTech" } 
+    "license": "CC-BY-NC-SA-4.0",
+    "x_netkan_epoch": "1",
+    "x_netkan_staging": true,
+    "x_netkan_staging_reason": "Check Contares max version",
+    "conflicts" : [
+        { "name" : "RemoteTech" }
     ],
     "depends": [
         { "name": "NewTantares" },
@@ -14,8 +17,6 @@
         { "name": "ModuleManager" },
         { "name": "AdditionalProgressionContracts" }
     ],
-    "x_netkan_staging": true,
-    "comment": "Check Contares max version",
     "recommends": [
         { "name": "AsteroidDay" },
         { "name": "Taerobee" },
@@ -33,6 +34,5 @@
             "find": "SovietConversion",
             "install_to": "GameData"
         }
-    ],
-    "x_netkan_epoch": "1"
+    ]
 }

--- a/NetKAN/SovietConversion.netkan
+++ b/NetKAN/SovietConversion.netkan
@@ -13,7 +13,7 @@
         { "name": "NewTantares" },
         { "name": "NewTantaresLV" },
         { "name": "ABLaunchers" },
-        { "name": "Contares", "max_version" : "1.7.4" },
+        { "name": "Contares" },
         { "name": "ModuleManager" },
         { "name": "AdditionalProgressionContracts" }
     ],

--- a/NetKAN/StockVisualEnhancements.netkan
+++ b/NetKAN/StockVisualEnhancements.netkan
@@ -1,14 +1,15 @@
 {
     "spec_version"   : "v1.4",
-    "$kref"          : "#/ckan/github/Galileo88/StockVisualEnhancements/asset_match/SVE.v.*.zip",
-    "$vref"          : "#/ckan/ksp-avc",
     "identifier"     : "StockVisualEnhancements",
     "name"           : "Stock Visual Enhancements",
     "abstract"       : "A visual enhancement pack using EVE and Scatterer for the stock planets.",
+    "$kref"          : "#/ckan/github/Galileo88/StockVisualEnhancements/asset_match/SVE.v.*.zip",
+    "$vref"          : "#/ckan/ksp-avc",
     "license"        : "CC-BY-NC-SA",
     "release_status" : "stable",
     "x_netkan_epoch" : "3",
     "x_netkan_staging": true,
+    "x_netkan_staging_reason": "Tricky dependencies, make sure the SVE-Textures providers are indexed",
     "resources" : {
         "homepage"     : "https://forum.kerbalspaceprogram.com/index.php?/topic/143288-*"
     },


### PR DESCRIPTION
As of KSP-CKAN/NetKAN-bot#88 we now have the option to set a property `x_netkan_staging_reason` in a netkan to tell metadata maintainers why a module has staging enabled. This property is used as the body of a staged pull request when present.

In several cases, the `comment` property had this information; these are now updated to use `x_netkan_staging_reason` instead.

In other cases the reason for staging could be figured out by checking the pull requests where it was enabled. These now have `x_netkan_staging_reason` added.

RoverWheelSounds now has its game versions updated to match its forum thread.

PlanetWiki-OPM had its reason for staging removed in #4988, so it is now no longer staged.

ckan compat add 1.1