### PR TITLE
Have GravityTurnContinued provide GravityTurn

### DIFF
--- a/NetKAN/GravityTurnContinued.netkan
+++ b/NetKAN/GravityTurnContinued.netkan
@@ -16,6 +16,7 @@
     "conflicts": [
         { "name": "GravityTurn" }
     ],
+    "provides": [ "GravityTurn" ],
     "install": [
         {
             "find": "GravityTurn",


### PR DESCRIPTION
At least one active mod suggests GravityTurn, which was last indexed for KSP 1.0.5.
GravityTurnContinued is more up to date. This pull request marks it as providing GravityTurn so it can be pulled in for such relationships.