### PR TITLE
Have NavballDockAlignIndCE provide and conflict with NavballDockingIndicator

### DIFF
--- a/NetKAN/NavballDockAlignIndCE.netkan
+++ b/NetKAN/NavballDockAlignIndCE.netkan
@@ -1,14 +1,18 @@
 {
-  "spec_version": "v1.4",
-  "install": [
-    {
-      "install_to": "GameData",
-      "find": "NavBallDockingAlignmentIndicatorCE"
-    }
-  ],
-  "$vref": "#/ckan/ksp-avc",
-  "$kref": "#/ckan/spacedock/1098",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "identifier": "NavballDockAlignIndCE",
-  "license": "GPL-3.0"
+    "spec_version": "v1.4",
+    "identifier":   "NavballDockAlignIndCE",
+    "$kref":        "#/ckan/spacedock/1098",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "GPL-3.0"
+    "install": [
+        {
+            "find":       "NavBallDockingAlignmentIndicatorCE",
+            "install_to": "GameData"
+        }
+    ],
+    "conflicts": [
+        { "name": "NavballDockingIndicator"}
+    ],
+    "provides": [ "NavballDockingIndicator" ],
+    "x_via": "Automated Linuxgurugamer CKAN script"
 }

--- a/NetKAN/NavballDockAlignIndCE.netkan
+++ b/NetKAN/NavballDockAlignIndCE.netkan
@@ -3,7 +3,7 @@
     "identifier":   "NavballDockAlignIndCE",
     "$kref":        "#/ckan/spacedock/1098",
     "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0"
+    "license":      "GPL-3.0",
     "install": [
         {
             "find":       "NavBallDockingAlignmentIndicatorCE",
@@ -14,5 +14,5 @@
         { "name": "NavballDockingIndicator"}
     ],
     "provides": [ "NavballDockingIndicator" ],
-    "x_via": "Automated Linuxgurugamer CKAN script"
+    "x_via":    "Automated Linuxgurugamer CKAN script"
 }


### PR DESCRIPTION
At least one active mod suggests NavballDockingIndicator, which was last indexed for KSP 1.0.5.

A newer fork, CommunityNavballDockingIndicator, was available for KSP 1.1. This mod both provides and conflicts with NavballDockingIndicator, so it is considered as an option for relationships involving NavballDockingIndicator.

NavballDockAlignIndCE is the current up to date fork. It previously did not provide or conflict with NavballDockingIndicator. Now it does.