### PR TITLE
Have DiazosLandingHeight provide LandingHeight

### DIFF
--- a/NetKAN/DiazosLandingHeight.netkan
+++ b/NetKAN/DiazosLandingHeight.netkan
@@ -1,19 +1,20 @@
 {
-    "spec_version"      : "v1.4",
-    "$kref"             : "#/ckan/spacedock/1844",
-    "$vref"             : "#/ckan/ksp-avc",
-    "name"              : "Diazo's Landing Height Display",
-    "identifier"        : "DiazosLandingHeight",
-    "author"            : "Diazo,linuxgurugamer",
-    "abstract" : "Display true height to ground from the bottom of your vessel on in-game altimeter when in surface mode. Display altitude above sea level (KSP Default) when in orbit mode.",
-    "license" : "GPL-3.0",
+    "spec_version"   : "v1.4",
+    "$kref"          : "#/ckan/spacedock/1844",
+    "$vref"          : "#/ckan/ksp-avc",
+    "name"           : "Diazo's Landing Height Display",
+    "identifier"     : "DiazosLandingHeight",
+    "author"         : [ "Diazo", "linuxgurugamer" ],
+    "abstract"       : "Display true height to ground from the bottom of your vessel on in-game altimeter when in surface mode. Display altitude above sea level (KSP Default) when in orbit mode.",
+    "license"        : "GPL-3.0",
     "release_status" : "stable",
     "resources" : {
-        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/174510-14-diazos-landing-height/"
+        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/174510-*"
     },
     "conflicts": [
 	 { "name" : "LandingHeight" }
     ],
+    "provides": [ "LandingHeight" ],
     "install" : [
         {
             "find"       : "LandingHeight",


### PR DESCRIPTION
At least one active mod suggests LandingHeight, which was last updated for KSP 1.3.
DiazosLandingHeight is a fork that is supported through KSP 1.6.1.

Now DiazosLandingHeight provides LandingHeight.
The author field is also converted to a list.