### PR TITLE
Add missing Near Future dependencies

### DIFF
--- a/NetKAN/NearFutureConstruction.netkan
+++ b/NetKAN/NearFutureConstruction.netkan
@@ -7,6 +7,7 @@
     "license"             : "CC-BY-NC-SA-4.0",
     "$vref"               : "#/ckan/ksp-avc",
     "depends" : [
+        { "name" : "ModuleManager" },
         { "name" : "B9PartSwitch" },
         { "name" : "CommunityResourcePack" }
     ],

--- a/NetKAN/NearFutureSolar.netkan
+++ b/NetKAN/NearFutureSolar.netkan
@@ -7,6 +7,7 @@
     "license"             : "CC-BY-NC-SA-4.0",
     "$vref"               : "#/ckan/ksp-avc",
     "depends": [
+        { "name" : "ModuleManager" },
         { "name" : "NearFutureSolar-Core" }
     ],
     "suggests": [


### PR DESCRIPTION
NearFutureSolar and NearFutureConstruction both bundle ModuleManager and list it as required on their forum pages, but it's not a dependency in CKAN. This pull request adds it.

Fixes #7091.