### PR TITLE
Self-host KA netkans, add two new packages

### DIFF
--- a/NetKAN/KerbalAtomics-NFECompatibility.netkan
+++ b/NetKAN/KerbalAtomics-NFECompatibility.netkan
@@ -1,16 +1,5 @@
 {
     "spec_version": "v1.4",
-    "identifier": "KerbalAtomics-NFECompatibility",
-    "$kref": "#/ckan/spacedock/710",
-    "name": "Kerbal Atomics - NFE Compatibility Patch",
-    "author": "Nertea",
-    "abstract" : "Optional, experimental patch that makes Kerbal Atomics nuclear engines utilize the Near Future Electrical reactor plugin.",
-    "license": "CC-BY-NC-SA-4.0",
-    "depends": [
-        { "name" : "KerbalAtomics" },
-        { "name" : "NearFutureElectrical" }
-    ],
-    "install" : [
-        { "find" : "NearFutureElectricaNTRs", "install_to" : "GameData" }
-    ]
+    "identifier"    : "KerbalAtomics-NFECompatibility",
+    "$kref"         : "#/ckan/netkan/https://github.com/ChrisAdderley/KerbalAtomics/raw/master/CKAN/KerbalAtomics-NFECompatibility.netkan"
 }

--- a/NetKAN/KerbalAtomics-NTRModSupport.netkan
+++ b/NetKAN/KerbalAtomics-NTRModSupport.netkan
@@ -1,0 +1,5 @@
+{
+    "spec_version": "v1.4",
+    "identifier"    : "KerbalAtomics-NTRModSupport",
+    "$kref"         : "#/ckan/netkan/https://github.com/ChrisAdderley/KerbalAtomics/raw/master/CKAN/KerbalAtomics-NTRModSupport.netkan"
+}

--- a/NetKAN/KerbalAtomics-NTRsUseLF.netkan
+++ b/NetKAN/KerbalAtomics-NTRsUseLF.netkan
@@ -1,0 +1,5 @@
+{
+    "spec_version": "v1.4",
+    "identifier"    : "KerbalAtomics-NTRsUseLF",
+    "$kref"         : "#/ckan/netkan/https://github.com/ChrisAdderley/KerbalAtomics/raw/master/CKAN/KerbalAtomics-NTRsUseLF.netkan"
+}

--- a/NetKAN/KerbalAtomics.netkan
+++ b/NetKAN/KerbalAtomics.netkan
@@ -2,5 +2,4 @@
     "spec_version": "v1.4",
     "identifier"    : "KerbalAtomics",
     "$kref"         : "#/ckan/netkan/https://github.com/ChrisAdderley/KerbalAtomics/raw/master/CKAN/KerbalAtomics.netkan"
-
 }

--- a/NetKAN/KerbalAtomics.netkan
+++ b/NetKAN/KerbalAtomics.netkan
@@ -1,30 +1,6 @@
 {
     "spec_version": "v1.4",
-    "identifier": "KerbalAtomics",
-    "$kref": "#/ckan/spacedock/710",
-    "$vref": "#/ckan/ksp-avc/KerbalAtomics.version",
-    "x_netkan_epoch": 1,
-    "name": "Kerbal Atomics",
-    "license": "CC-BY-NC-SA-4.0",
-    "depends": [
-        { "name" : "B9PartSwitch" },
-        { "name" : "CommunityResourcePack" },
-        { "name" : "CryoTanks" },
-        { "name" : "DeployableEngines" },
-        { "name" : "ModuleManager" }
-    ],
-    "recommends" : [
-        { "name" : "CommunityTechTree" }
-    ],
-    "suggests" : [
-        { "name" : "CryoEngines" },
-        { "name" : "NearFutureConstruction" },
-        { "name" : "NearFutureElectrical" },
-        { "name" : "NearFuturePropulsion" },
-        { "name" : "NearFutureSolar" },
-        { "name" : "NearFutureSpacecraft" }
-    ],
-    "install" : [
-        { "find" : "KerbalAtomics", "install_to" : "GameData" }
-    ]
+    "identifier"    : "KerbalAtomics",
+    "$kref"         : "#/ckan/netkan/https://github.com/ChrisAdderley/KerbalAtomics/raw/master/CKAN/KerbalAtomics.netkan"
+
 }


### PR DESCRIPTION
Adds two previously non-CKAN enabled mods, and self-hosts all netkan metadata. 