### PR TITLE
Portrait Stats explicit install directive

### DIFF
--- a/NetKAN/PortraitStats.netkan
+++ b/NetKAN/PortraitStats.netkan
@@ -4,6 +4,12 @@
     "$kref":        "#/ckan/spacedock/133",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "MIT",
+    "install": [
+        {
+            "file": "GameData/PortraitStats",
+            "install_to": "GameData"
+        }
+    ],
     "x_netkan_override": [
         {
             "version": ">=15.0",


### PR DESCRIPTION
Portrait Stats bundles CommunityTraitIcons for manual installs. If I understand correctly, should not include the bundled dependency when doing CKAN install so it can be obtained and updated separately.

Will this fix the existing ckans in CKAN-meta automatically or should I PR corresponding changes there as well?