### PR TITLE
TextureReplacerReplaced should provide TextureReplacer

### DIFF
--- a/NetKAN/TextureReplacerReplaced.netkan
+++ b/NetKAN/TextureReplacerReplaced.netkan
@@ -1,39 +1,39 @@
 {
-	"spec_version": "v1.4",
-	"name": "TextureReplacerReplaced",
-	"$kref": "#/ckan/github/HaArLiNsH/TextureReplacerReplaced",
-	"identifier": "TextureReplacerReplaced",
-	"release_status": "testing",
-	"$vref": "#/ckan/ksp-avc",
-	"author": ["shaw", "RangeMachine", "HaArLiNsH"],
-	"abstract": "Kerbal and suits personalisation, texture replacement and reflections.",
-	"license": "MIT",
-	"comment": "Plugin is MIT, but some parts CC-BY-NC-SA, and we always specify most restrictive in metadata.",
-	"resources": 	{
-							"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/161898-*",
-							"repository": "https://github.com/HaArLiNsH/TextureReplacerReplaced"
-						},
-	"conflicts": [ { "name": "TextureReplacer" } ],
-	"install"  : [
-						{
-							"find"       : "000_TRR_Config",
-							"install_to" : "GameData"
-						},
-						{
-							"find"       : "TextureReplacerReplaced",
-							"install_to" : "GameData"
-						}
-					],
-	"depends" : 	[
-							{ "name" : "ModuleManager"	}
-						],	
-	"recommends" : [
-								{ "name" : "WindowShine" }								
-							],
-	"suggests" : 	[							
-							{ "name" : "DiverseKerbalHeads" },
-							{ "name" : "TRRGuide" },
-							{ "name" : "TRR-MyTextureMod" },
-							{ "name" : "UKS" }
-						]
+    "spec_version": "v1.4",
+    "identifier":   "TextureReplacerReplaced",
+    "name":         "Texture Replacer Replaced",
+    "abstract":     "Kerbal and suits personalisation, texture replacement and reflections",
+    "$kref":        "#/ckan/github/HaArLiNsH/TextureReplacerReplaced",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "MIT",
+    "comment":      "Plugin is MIT, but some parts CC-BY-NC-SA, and we always specify most restrictive in metadata.",
+    "author":       [ "shaw", "RangeMachine", "HaArLiNsH" ],
+    "release_status": "testing",
+    "resources": {
+        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/161898-*",
+        "repository": "https://github.com/HaArLiNsH/TextureReplacerReplaced"
+    },
+    "provides": [ "TextureReplacer" ],
+	"conflicts": [
+        { "name": "TextureReplacer" }
+    ],
+	"install"  : [ {
+        "find"       : "000_TRR_Config",
+        "install_to" : "GameData"
+    }, {
+        "find"       : "TextureReplacerReplaced",
+        "install_to" : "GameData"
+    } ],
+    "depends" : [
+        { "name" : "ModuleManager"	}
+    ],
+    "recommends" : [
+        { "name" : "WindowShine" }
+    ],
+    "suggests" : [
+        { "name" : "DiverseKerbalHeads" },
+        { "name" : "TRRGuide"           },
+        { "name" : "TRR-MyTextureMod"   },
+        { "name" : "UKS"                }
+    ]
 }


### PR DESCRIPTION
## Problem

If you try to install Astronomer's Visual Pack in CmdLine or GUI with KSP 1.3 through 1.7 marked as compatible, it'll prompt you to choose a TextureReplacer equivalent multiple times:

```
$ _build/ckan install AstronomersVisualPack
Too many mods provide Scatterer-sunflare. Please pick from the following:

1) GPO (Gameslinx Planet Overhaul)
2) GPP (Galileo's Planet Pack)
3) Scatterer-sunflare (scatterer - sunflare)
Enter a number between 1 and 3 (To cancel press "c" or "n".):
3
Too many mods provide Scatterer-config. Please pick from the following:

1) GPO (Gameslinx Planet Overhaul)
2) SSRSS-Cont (SSRSS Continued)
3) Scatterer-config (scatterer - default config)
Enter a number between 1 and 3 (To cancel press "c" or "n".):
3
Too many mods provide AVP-Textures. Please pick from the following:

1) AVP-2kTextures (Astronomer's Visual Pack-2k Textures)
2) AVP-4kTextures (Astronomer's Visual Pack-4k Textures)
3) AVP-8kTextures (Astronomer's Visual Pack-8k Textures)
Enter a number between 1 and 3 (To cancel press "c" or "n".):
1
Too many mods provide TextureReplacer. Please pick from the following:

1) TextureReplacer (TextureReplacer)
2) TextureReplacerReplaced (TextureReplacerReplaced)
Enter a number between 1 and 2 (To cancel press "c" or "n".):
2
Too many mods provide TextureReplacer. Please pick from the following:

1) TextureReplacer (TextureReplacer)
2) TextureReplacerReplaced (TextureReplacerReplaced)
Enter a number between 1 and 2 (To cancel press "c" or "n".):
2

Unhandled Exception: System.ArgumentException: Already contains module:TextureReplacerReplaced
   at CKAN.RelationshipResolver.Add(CkanModule module, SelectionReason reason)
   at CKAN.RelationshipResolver.AddModulesToInstall(IEnumerable`1 modules)
   at CKAN.RelationshipResolver..ctor(IEnumerable`1 modulesToInstall, IEnumerable`1 modulesToRemove, RelationshipResolverOptions options, IRegistryQuerier registry, KspVersionCriteria kspversion)
   at CKAN.RelationshipResolver..ctor(IEnumerable`1 modulesToInstall, IEnumerable`1 modulesToRemove, RelationshipResolverOptions options, IRegistryQuerier registry, KspVersionCriteria kspversion)
   at CKAN.ModuleInstaller.InstallList(List`1 modules, RelationshipResolverOptions options, IDownloader downloader)
   at CKAN.CmdLine.Install.RunCommand(KSP ksp, Object raw_options)
   at CKAN.CmdLine.Install.RunCommand(KSP ksp, Object raw_options)
   at CKAN.CmdLine.Install.RunCommand(KSP ksp, Object raw_options)
   at CKAN.CmdLine.Install.RunCommand(KSP ksp, Object raw_options)
   at CKAN.CmdLine.Install.RunCommand(KSP ksp, Object raw_options)
   at CKAN.CmdLine.Install.RunCommand(KSP ksp, Object raw_options)
   at CKAN.CmdLine.MainClass.RunSimpleAction(Options cmdline, CommonOptions options, String[] args, IUser user, KSPManager manager)
   at CKAN.CmdLine.MainClass.Execute(KSPManager manager, CommonOptions opts, String[] args)
   at CKAN.CmdLine.MainClass.Main(String[] args)
```

## Cause

Originally, TRR provided TR, and all was good in the world. 0.5.1 and 0.5.2 were stamped with this metadata.

Then later, KSP-CKAN/NetKAN#6049 changed the netkan so TRR provided TRR instead of TR. This caused problems, and later KSP-CKAN/NetKAN#6068 removed the provides completely. 0.5.3 and 0.5.4 were stamped with this metadata.

So the end result is this in CKAN-meta:

| Version | Notes |
| --- | --- |
| 0.5.1 | Provides TextureReplacer |
| 0.5.2 | Provides TextureReplacer |
| 0.5.3 | Provides nothing |
| 0.5.4 | Provides nothing |

For CmdLine and GUI, when they're asked to install TextureReplacer as a dependency, they notice that TRR provides it because of those older versions, but when they add it to the change set, they add the latest compatible version instead, which doesn't provide TR. So they ask again which TR-equivalent to install, and so on until something goes more wrong.

(ConsoleUI installs 0.5.2 as it should, but then allows you to upgrade TRR, which produces an inconsistent state.)

## Changes

Now TRR provides TR as it originally did and should have all along.

Fixes part of KSP-CKAN/CKAN#2738.