### PR TITLE
Force v for SpecialMissionProjects versions

### DIFF
--- a/NetKAN/SpecialMissionProjects.netkan
+++ b/NetKAN/SpecialMissionProjects.netkan
@@ -9,7 +9,7 @@
   "$kref": "#/ckan/spacedock/1238",
   "x_via": "Automated Linuxgurugamer CKAN script",
   "identifier": "SpecialMissionProjects",
-  "abstract": "This mod is made up with tweaked parts to be more useful such as adding more fuel in tanks, more powerful batterys, self refueling parts that are faster and use alot less resources than the stock parts, new types of fuel. In SMP you get new ships with each update that use SMP parts.",
+  "abstract": "This mod is made up with tweaked parts to be more useful such as adding more fuel in tanks, more powerful batteries, self refueling parts that are faster and use alot less resources than the stock parts, new types of fuel. In SMP you get new ships with each update that use SMP parts.",
   "license": "unrestricted",
   "x_netkan_version_edit": "^V?(?<version>.+)$"
 }

--- a/NetKAN/SpecialMissionProjects.netkan
+++ b/NetKAN/SpecialMissionProjects.netkan
@@ -9,5 +9,7 @@
   "$kref": "#/ckan/spacedock/1238",
   "x_via": "Automated Linuxgurugamer CKAN script",
   "identifier": "SpecialMissionProjects",
-  "license": "unrestricted"
+  "abstract": This mod is made up with tweaked parts to be more useful such as adding more fuel in tanks, more powerful batterys, self refueling parts that are faster and use alot less resources than the stock parts, new types of fuel. In SMP you get new ships with each update that use SMP parts.
+  "license": "unrestricted",
+  "x_netkan_force_v": true
 }

--- a/NetKAN/SpecialMissionProjects.netkan
+++ b/NetKAN/SpecialMissionProjects.netkan
@@ -11,5 +11,5 @@
   "identifier": "SpecialMissionProjects",
   "abstract": "This mod is made up with tweaked parts to be more useful such as adding more fuel in tanks, more powerful batterys, self refueling parts that are faster and use alot less resources than the stock parts, new types of fuel. In SMP you get new ships with each update that use SMP parts.",
   "license": "unrestricted",
-  "x_netkan_force_v": true
+  "x_netkan_version_edit": "^V?(?<version>.+)$"
 }

--- a/NetKAN/SpecialMissionProjects.netkan
+++ b/NetKAN/SpecialMissionProjects.netkan
@@ -9,7 +9,7 @@
   "$kref": "#/ckan/spacedock/1238",
   "x_via": "Automated Linuxgurugamer CKAN script",
   "identifier": "SpecialMissionProjects",
-  "abstract": This mod is made up with tweaked parts to be more useful such as adding more fuel in tanks, more powerful batterys, self refueling parts that are faster and use alot less resources than the stock parts, new types of fuel. In SMP you get new ships with each update that use SMP parts.
+  "abstract": "This mod is made up with tweaked parts to be more useful such as adding more fuel in tanks, more powerful batterys, self refueling parts that are faster and use alot less resources than the stock parts, new types of fuel. In SMP you get new ships with each update that use SMP parts.",
   "license": "unrestricted",
   "x_netkan_force_v": true
 }


### PR DESCRIPTION
The mod versions are out of order due to irregular usage of the 'v' in the version strings.
![grafik](https://user-images.githubusercontent.com/28812678/56698454-465b0600-66f2-11e9-862e-98e10d435804.png)
The abstract is now set manually because the generation from spacedock did some weird stuff in previous versions. The new one is copied from the first section of the spacedock description.

I'll open another PR in ckan-meta to fix the .ckan files.