### PR TITLE
Rename ABFW -> AFBW

### DIFF
--- a/NetKAN/AdvancedFlyByWire-Linux.netkan
+++ b/NetKAN/AdvancedFlyByWire-Linux.netkan
@@ -1,33 +1,30 @@
 {
-  "spec_version": 1,
-  "identifier": "AdvancedFlyByWire-Linux",
-  "release_status": "stable",
-  "$kref" : "#/ckan/spacedock/1870",
-  "$vref" : "#/ckan/ksp-avc",
-  "resources": {
-    "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/175359-14-afbw-joystick-controller-mod/",
-    "repository": "https://github.com/linuxgurugamer/ksp-advanced-flybywire"
-  },
-  "install": [
-    {
-      "file": "GameData/ksp-advanced-flybywire",
-      "install_to": "GameData"
-    }
-  ],
-  "depends": [
-        { "name" : "ToolbarController" },
-	{ "name" : "ClickThroughBlocker" }
-  ],
-  "conflicts": [
-    {
-    "name": "AdvancedFlyByWireRevived"
-    }
-  ],
-  "recommends": [
-    {
-      "name": "KSP-AVC"
-    }
- ],
-  "x_netkan_license_ok": true,
-  "provides": ["AdvancedFlyByWireRevived"]
+    "spec_version": 1,
+    "identifier":   "AdvancedFlyByWire-Linux",
+    "name":         "Advanced Fly-By-Wire (Linux)",
+    "$kref":        "#/ckan/spacedock/1870",
+    "$vref":        "#/ckan/ksp-avc",
+    "release_status": "stable",
+    "resources": {
+        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/175359-*",
+        "repository": "https://github.com/linuxgurugamer/ksp-advanced-flybywire"
+    },
+    "install": [ {
+        "file":       "GameData/ksp-advanced-flybywire",
+        "install_to": "GameData"
+    } ],
+    "provides": [
+        "AdvancedFlyByWireRevived"
+    ],
+    "conflicts": [
+        { "name": "AdvancedFlyByWireRevived" }
+    ],
+    "depends": [
+        { "name" : "ToolbarController"   },
+        { "name" : "ClickThroughBlocker" }
+    ],
+    "recommends": [
+        { "name": "KSP-AVC" }
+    ],
+    "x_netkan_license_ok": true
 }

--- a/NetKAN/AdvancedFlyByWire-OSX.netkan
+++ b/NetKAN/AdvancedFlyByWire-OSX.netkan
@@ -1,33 +1,30 @@
 {
-  "spec_version": 1,
-  "identifier": "AdvancedFlyByWire-OSX",
-  "release_status": "stable",
-  "$kref" : "#/ckan/spacedock/1878",
-  "$vref" : "#/ckan/ksp-avc",
-  "resources": {
-    "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/175359-14-afbw-joystick-controller-mod/",
-    "repository": "https://github.com/linuxgurugamer/ksp-advanced-flybywire"
-  },
-  "install": [
-    {
-      "file": "GameData/ksp-advanced-flybywire",
-      "install_to": "GameData"
-    }
-  ],
-  "depends": [
-        { "name" : "ToolbarController" },
-  { "name" : "ClickThroughBlocker" }
-  ],
-  "conflicts": [
-    {
-    "name": "AdvancedFlyByWireRevived"
-    }
-  ],
-  "recommends": [
-    {
-      "name": "KSP-AVC"
-    }
- ],
-  "x_netkan_license_ok": true,
-  "provides": ["AdvancedFlyByWireRevived"]
+    "spec_version": 1,
+    "identifier":   "AdvancedFlyByWire-OSX",
+    "name":         "Advanced Fly-By-Wire (OSX)",
+    "$kref":        "#/ckan/spacedock/1878",
+    "$vref":        "#/ckan/ksp-avc",
+    "release_status": "stable",
+    "resources": {
+        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/175359-*",
+        "repository": "https://github.com/linuxgurugamer/ksp-advanced-flybywire"
+    },
+    "install": [ {
+        "file":       "GameData/ksp-advanced-flybywire",
+        "install_to": "GameData"
+    } ],
+    "provides": [
+        "AdvancedFlyByWireRevived"
+    ],
+    "conflicts": [
+        { "name": "AdvancedFlyByWireRevived" }
+    ],
+    "depends": [
+         { "name": "ToolbarController"   },
+         { "name": "ClickThroughBlocker" }
+    ],
+    "recommends": [
+        { "name": "KSP-AVC" }
+    ],
+    "x_netkan_license_ok": true
 }

--- a/NetKAN/AdvancedFlyByWire.netkan
+++ b/NetKAN/AdvancedFlyByWire.netkan
@@ -1,49 +1,42 @@
 {
     "spec_version": 1,
-    "$kref"    : "#/ckan/spacedock/1869",
-    "$vref"    : "#/ckan/ksp-avc",
-    "name"     : "Advanced Fly-By-Wire (Windows, x64)",
-    "abstract" : "Joystick & controller mod with multiple presets and in-flight controls binding!",
-    "identifier": "AdvancedFlyByWire",
-    "release_status" : "stable",
-    "resources" : {
-        "homepage"   : "https://forum.kerbalspaceprogram.com/index.php?/topic/175359-14-afbw-joystick-controller-mod/",
-        "repository" : "https://github.com/linuxgurugamer/ksp-advanced-flybywire"
+    "identifier":   "AdvancedFlyByWire",
+    "name":         "Advanced Fly-By-Wire (Windows)",
+    "$kref":        "#/ckan/spacedock/1869",
+    "$vref":        "#/ckan/ksp-avc",
+    "release_status": "stable",
+    "resources": {
+        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/175359-*",
+        "repository": "https://github.com/linuxgurugamer/ksp-advanced-flybywire"
     },
-    "install" : [
-        {
-            "file"       : "SDL2.dll",
-            "install_to" : "GameRoot"
-        },
-        {
-            "file"       : "SDL_LICENSE",
-            "install_to" : "GameRoot"
-        },
-	{
-            "file": "XINPUTDOTNET_LICENSE",
-            "install_to": "GameRoot"
-        },
-        {
-            "file"       : "XInputInterface.dll",
-            "install_to" : "GameRoot"
-        },
-        {
-            "file"       : "GameData/ksp-advanced-flybywire",
-            "install_to" : "GameData"
-        }
+    "install": [ {
+        "file":       "SDL2.dll",
+        "install_to": "GameRoot"
+    }, {
+        "file":       "SDL_LICENSE",
+        "install_to": "GameRoot"
+    }, {
+        "file":       "XINPUTDOTNET_LICENSE",
+        "install_to": "GameRoot"
+    }, {
+        "file":       "XInputInterface.dll",
+        "install_to": "GameRoot"
+    }, {
+        "file":       "GameData/ksp-advanced-flybywire",
+        "install_to": "GameData"
+    } ],
+    "provides": [
+        "AdvancedFlyByWireRevived"
+    ],
+    "conflicts": [
+        { "name": "AdvancedFlyByWireRevived" }
     ],
     "depends": [
-        { "name" : "ToolbarController" },
-	{ "name" : "ClickThroughBlocker" }
+        { "name": "ToolbarController"   },
+        { "name": "ClickThroughBlocker" }
     ],
-    "recommends" : [
-        { "name" : "KSP-AVC" }
+    "recommends": [
+        { "name": "KSP-AVC" }
     ],
-    "provides": ["AdvancedFlyByWireRevived"],
-    "conflicts": [
-      {
-        "name": "AdvancedFlyByWireRevived"
-      }
-    ],
-    "x_netkan_license_ok" : true
+    "x_netkan_license_ok": true
 }


### PR DESCRIPTION
There are three Advanced Fly-By-Wire mods, one each for Windows, Mac, and Linux. Their metadata currently isn't very consistent:

| Identifier | Name | Abstract |
| --- | --- | --- |
| AdvancedFlyByWire | Advanced Fly-By-Wire (Windows, x64) | Joystick & controller mod with multiple presets and in-flight controls binding! |
| AdvancedFlyByWire-OSX | ABFW Revived (OSX version) | AFBW is an input overhaul mod. It dramatically enhances the stock input system with a bunch of fixes and many new features. |
| AdvancedFlyByWire-Linux | AFBW Revived (Linux version) | AFBW is an input overhaul mod. It dramatically enhances the stock input system with a bunch of fixes and many new features. |

If you sort by name in CKAN, these all appear in different parts of the list, and ABFW is a misspelling.

## Changes

| Identifier | Name | Abstract |
| --- | --- | --- |
| AdvancedFlyByWire | Advanced Fly-By-Wire (Windows) | AFBW is an input overhaul mod. It dramatically enhances the stock input system with a bunch of fixes and many new features. |
| AdvancedFlyByWire-OSX | Advanced Fly-By-Wire (OSX) | AFBW is an input overhaul mod. It dramatically enhances the stock input system with a bunch of fixes and many new features. |
| AdvancedFlyByWire-Linux | Advanced Fly-By-Wire (Linux) | AFBW is an input overhaul mod. It dramatically enhances the stock input system with a bunch of fixes and many new features. |

Now they sort together.

Fixes linuxgurugamer/ksp-advanced-flybywire#16.