### PR TITLE
add unBlur

### DIFF
--- a/NetKAN/unBlur.netkan
+++ b/NetKAN/unBlur.netkan
@@ -1,0 +1,24 @@
+{
+    "spec_version" : "v1.16",
+    "identifier"   : "unBlur",
+    "name"         : "unBlur",
+    "abstract"     : "Allows fixing blurry UI textures without renaming or modifying actual texture files in the installation.",
+    "author"       : "cake-pie",
+    "license"      : "MIT",
+    "$kref"        : "#/ckan/github/cake-pie/unBlur",
+    "ksp_version_min" : "1.3.0",
+    "ksp_version_max" : "1.7.9",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?showtopic=184268"
+    },
+    "install": [
+        {
+            "find_regexp": "unBlur.*\\.dll$",
+            "find_matches_files": true,
+            "install_to": "GameData"
+        }
+    ],
+    "supports": [
+        { "name": "ModuleManager", "min_version" : "2.3.2" }
+    ]
+}


### PR DESCRIPTION
Lets end users fix blurry UI textures in other mods via config, without having to modify or rename installed texture files.