### PR TITLE
Restore epoch of KerbalAtomics

### DIFF
--- a/NetKAN/KerbalAtomics.netkan
+++ b/NetKAN/KerbalAtomics.netkan
@@ -1,5 +1,6 @@
 {
-    "spec_version": "v1.4",
+    "spec_version"  : "v1.4",
     "identifier"    : "KerbalAtomics",
-    "$kref"         : "#/ckan/netkan/https://github.com/ChrisAdderley/KerbalAtomics/raw/master/CKAN/KerbalAtomics.netkan"
+    "$kref"         : "#/ckan/netkan/https://github.com/ChrisAdderley/KerbalAtomics/raw/master/CKAN/KerbalAtomics.netkan",
+    "x_netkan_epoch": 1
 }


### PR DESCRIPTION
#7105 dropped this mod's epoch, so recent versions have been indexed as older than previous versions:

![image](https://user-images.githubusercontent.com/1559108/57576457-a91d0300-744f-11e9-8f80-7737535761a0.png)

Now the epoch is restored.