### PR TITLE
Add Harmony dependency for future AirlockPlus versions

### DIFF
--- a/NetKAN/AirlockPlus.netkan
+++ b/NetKAN/AirlockPlus.netkan
@@ -11,8 +11,17 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?showtopic=160268"
     },
     "depends": [
+        { "name": "Harmony-DOTNET" },
         { "name": "ModuleManager" }
     ],
+    "x_netkan_override": [{
+        "version": "<=v0.0.10",
+        "override": {
+            "depends": [
+                { "name": "ModuleManager" }
+            ]
+        }
+    }],
     "recommends": [
         { "name": "CommunityTraitIcons" }
     ],

--- a/NetKAN/Harmony-DOTNET.netkan
+++ b/NetKAN/Harmony-DOTNET.netkan
@@ -1,0 +1,20 @@
+{
+    "spec_version" : "v1.16",
+    "identifier"   : "Harmony-DOTNET",
+    "name"         : "Harmony",
+    "abstract"     : "A library for patching, replacing and decorating .NET and Mono methods during runtime.",
+    "author"       : "Andreas Pardeike",
+    "license"      : "MIT",
+    "$kref"        : "#/ckan/github/pardeike/Harmony/asset_match/[Rr]elease.zip",
+    "ksp_version" : "any",
+    "resources": {
+        "repository": "https://github.com/pardeike/Harmony"
+    },
+    "install": [
+        {
+            "find": "net35/0Harmony.dll",
+            "find_matches_files": true,
+            "install_to": "GameData"
+        }
+    ]
+}


### PR DESCRIPTION
Resolves #7131 -- will wait no further, moving ahead with staging necessary changes for next release.

~Testing `AirlockPlus.netkan` locally with `netkan.exe` generated `AirlockPlus-v0.0.10.ckan` for the existing version but it contained the new `Harmony-DONTNET` line, shouldn't `x_netkan_override` have removed that, or am I missing something?~ Fixed. Thanks @DasSkelett!
