### PR TITLE
Add AirlockPlus-Localization

### DIFF
--- a/NetKAN/AirlockPlus-Localization.netkan
+++ b/NetKAN/AirlockPlus-Localization.netkan
@@ -1,10 +1,10 @@
 {
-    "spec_version" : "v1.2",
+    "spec_version" : "v1.4",
     "identifier"   : "AirlockPlus-Localization",
     "name"         : "AirlockPlus Localization",
     "abstract"     : "Localizations for AirlockPlus",
     "author"       : "cake-pie",
-    "license"      : "restricted",
+    "license"      : "CC-BY-SA-4.0",
     "$kref"        : "#/ckan/github/cake-pie/AirlockPlus/asset_match/localization",
     "$vref"        : "#/ckan/ksp-avc",
     "resources": {

--- a/NetKAN/AirlockPlus-Localization.netkan
+++ b/NetKAN/AirlockPlus-Localization.netkan
@@ -1,0 +1,20 @@
+{
+    "spec_version" : "v1.2",
+    "identifier"   : "AirlockPlus-Localization",
+    "name"         : "AirlockPlus Localization",
+    "abstract"     : "Localizations for AirlockPlus",
+    "author"       : "cake-pie",
+    "license"      : "restricted",
+    "$kref"        : "#/ckan/github/cake-pie/AirlockPlus/asset_match/localization",
+    "$vref"        : "#/ckan/ksp-avc",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?showtopic=160268"
+    },
+    "install": [ {
+        "find":       "AirlockPlus",
+        "install_to": "GameData"
+    } ],
+    "depends": [
+        { "name": "AirlockPlus" }
+    ]
+}


### PR DESCRIPTION
Re-doing #7201 because it was merged without permission from author on opt-out list.

AirlockPlus ships its localization assets in a separate ZIP. This pull request indexes it.

Came up in discussion of KSP-CKAN/CKAN#2760. Note that this pull request will **not** set the `localizations` property because it's not part of the spec/schema yet.