### PR TITLE
Add TelemachusReborn

### DIFF
--- a/NetKAN/TelemachusReborn.netkan
+++ b/NetKAN/TelemachusReborn.netkan
@@ -21,7 +21,7 @@
     ],
     "recommends" : [
         {
-            "name": "RasterPropMonitor",
+            "name": "RasterPropMonitor"
         }
     ],
     "install" : [

--- a/NetKAN/TelemachusReborn.netkan
+++ b/NetKAN/TelemachusReborn.netkan
@@ -1,0 +1,42 @@
+{
+    "spec_version"   : 1,
+    "identifier"     : "TelemachusReborn",
+    "$kref"          : "#/ckan/github/TeleIO/Telemachus-1",
+    "$vref"          : "#/ckan/ksp-avc",
+    "name"           : "Telemachus Reborn",
+    "abstract"       : "Telemachus is a universal Web Telemetry Mod for Kerbal Space Program. It allows you to access any aspects of game from browser.",
+    "author"         : "DanGSun",
+    "license"        : "MIT",
+    "release_status" : "stable",
+    "x_netkan_version_edit": "^[vV]?(?<version>[\\d\\.]+)(?:-.+)*",
+    "resources"      : {
+        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/144482-*",
+        "spacedock" : "https://spacedock.info/mod/2012/Telemachus%20Reborn"
+    },
+    "provides" : [ "Telemachus" ],
+    "conflicts" : [
+         { "name" : "Telemachus" },
+         { "name" : "TelemachusContinued" },
+         { "name" : "Telemachus-2" }
+    ],
+    "recommends" : [
+        {
+            "name": "RasterPropMonitor",
+        }
+    ],
+    "install" : [
+        {
+            "file"   : "GameData/Telemachus",
+            "install_to" : "GameData"
+        }
+    ],
+    "x_netkan_override": [
+        {
+            "version": "1.7.0",
+            "override": {
+                "ksp_version_min" : "1.6.0",
+                "ksp_version_max" : "1.7"
+            }
+        }
+    ]
+}

--- a/NetKAN/TelemachusReborn.netkan
+++ b/NetKAN/TelemachusReborn.netkan
@@ -10,7 +10,7 @@
     "release_status" : "stable",
     "x_netkan_version_edit": "^[vV]?(?<version>[\\d\\.]+)(?:-.+)*",
     "resources"      : {
-        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/144482-*",
+        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/179887-*",
         "spacedock" : "https://spacedock.info/mod/2012/Telemachus%20Reborn"
     },
     "provides" : [ "Telemachus" ],


### PR DESCRIPTION
See https://github.com/TeleIO/Telemachus-1/issues/15

Telemachus Reborn is a maintained fork of Telemachus - a mod to access telemetry data from your web browser.

@DanGSun is going to include an AVC .version file in the future.
For the current release, a `x_netkan_override` is used to set the KSP version compatibility.

I had to do some trickery with the `x_netkan_version_edit` regex, because the latest release contains the release name in the Git(Hub) tag:
https://github.com/KSP-CKAN/NetKAN/blob/b72748d63fc7656e5c3ed346be3fe911a4f6a43d/NetKAN/TelemachusReborn.netkan#L11
@HebaruSan, any suggestions to improve the that, or is it okay like this?