### PR TITLE
Remove AirlockPlus-Localization suggestion of AirlockPlus

### DIFF
--- a/NetKAN/AirlockPlus.netkan
+++ b/NetKAN/AirlockPlus.netkan
@@ -16,9 +16,6 @@
     "recommends": [
         { "name": "CommunityTraitIcons" }
     ],
-    "suggests": [
-        { "name": "AirlockPlus-Localization" }
-    ],
     "supports": [
         { "name": "ConnectedLivingSpace" }
     ]


### PR DESCRIPTION
The suggestion has been forgotten to be removed in https://github.com/KSP-CKAN/NetKAN/commit/8456e9ae2dd7ac4c15bf09cfa48255da782c0726.

@cake-pie, can you give a go?