### PR TITLE
Update NMSG.netkan

### DIFF
--- a/NetKAN/NMSG.netkan
+++ b/NetKAN/NMSG.netkan
@@ -6,7 +6,7 @@
         { "name": "ModuleManager", "min_version": "2.6.0" }
     ],
     "recommends": [
-        { "name": "xScience" },
+        { "name": "xScienceContinued" },
         { "name": "ContractConfigurator" }
     ],
     "license": "MIT",
@@ -25,6 +25,14 @@
         "override" : {
         "ksp_version_min" : "1.2.2",
         "ksp_version_max" : "1.3.99"
+        }
+    },
+    {
+        "version" : "3.0",
+        "delete" : [ "ksp_version" ],
+        "override" : {
+        "ksp_version_min" : "1.2.2",
+        "ksp_version_max" : "1.7"
         }
     }
     ],


### PR DESCRIPTION
This mod is currently listed in CKAN as having a max version of 1.4.1. It actually works fine on 1.7.1 as well, so I propose overriding the max version to make it available and easy to install for anyone using an up-to-date game.

At the same time, I propose recommending xScienceContinued instead of xScience. The original mod is no longer maintained and has been continued for newer KSP versions by @Flupster. (Thanks @Flupster!)

If there's a better way to do it, or if I should fork the mod and maintain it myself, I'm open to that as well.