### PR TITLE
Add Kopernicus-Backport

### DIFF
--- a/NetKAN/Kopernicus-Backport.netkan
+++ b/NetKAN/Kopernicus-Backport.netkan
@@ -1,0 +1,42 @@
+{
+    "spec_version"  : "v1.4",
+    "identifier"    : "Kopernicus",
+    "name"          : "Kopernicus Planetary System Modifier",
+    "abstract"      : "Allows users to replace the planetary system used by the game.",
+    "$kref"         : "#/ckan/github/Kopernicus/Kopernicus-Backport",
+    "$vref"         : "#/ckan/ksp-avc/GameData/Kopernicus/Plugins/Kopernicus.version",
+    "x_netkan_version_edit": {
+        "find":    "^backport-(?<version>[-0-9.]+)$",
+        "replace": "release-${version}",
+        "strict":  true
+    },
+    "x_netkan_epoch": "2",
+    "release_status": "development",
+    "license"       : "LGPL-3.0",
+    "author": [
+        "BryceSchroeder",
+        "Teknoman117",
+        "Thomas P.",
+        "NathanKell",
+        "KillAshley",
+        "Gravitasi",
+        "KCreator",
+        "Sigma88"
+    ],
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/181547-*"
+    },
+    "depends": [
+        { "name": "ModuleManager", "min_version": "2.8.0" },
+        { "name": "ModularFlightIntegrator", "min_version": "1.2.4.0" }
+    ],
+    "suggests": [
+        { "name": "KittopiaTech" }
+    ],
+    "install": [
+        {
+            "find"      : "Kopernicus",
+            "install_to": "GameData"
+        }
+    ]
+}


### PR DESCRIPTION
See https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1260-baikonur/&do=findComment&comment=3609503

Kopernicus releases additional versions for older game versions on a separate repo.

https://github.com/Kopernicus/Kopernicus-Backport/releases

Currently they're all missing from CKAN, so anyone using Kopernicus on an older version will have an out of date copy of the mod. This pull request adds a netkan that checks the backport repo and indexes its releases under the Kopernicus identifier. A `x_netkan_version_edit` property is used to replace "backport" in the version string with "release", to prevent this from causing problems with the version sort.