### PR TITLE
Use Harmony bundled with AirlockPlus

### DIFF
--- a/NetKAN/AirlockPlus.netkan
+++ b/NetKAN/AirlockPlus.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version" : "v1.2",
+    "spec_version" : "v1.16",
     "identifier"   : "AirlockPlus",
     "name"         : "AirlockPlus",
     "abstract"     : "Allows the use of any airlock on a vessel in conjunction with any crew part on the vessel, without requiring manual crew transfer.",
@@ -10,6 +10,28 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?showtopic=160268"
     },
+    "install": [
+        {
+            "file": "GameData/AirlockPlus",
+            "install_to": "GameData"
+        },
+        {
+            "find_regexp": "0Harmony.*\\.dll$",
+            "find_matches_files": true,
+            "install_to": "GameData/AirlockPlus"
+        }
+    ],
+    "x_netkan_override": [{
+        "version": "<=v0.0.10",
+        "override": {
+            "install": [
+                {
+                    "file": "GameData/AirlockPlus",
+                    "install_to": "GameData"
+                }
+            ]
+        }
+    }],
     "depends": [
         { "name": "ModuleManager" }
     ],


### PR DESCRIPTION
Since #7131 and #7200 are clearly going nowhere fast due to continued inertia, this is intended to provide some kind of workable interim arrangement so as to stop holding up my releases.

For now I will be bundling Harmony for manual installs in a manner similar to what I laid out in https://github.com/KSP-CKAN/NetKAN/issues/7131#issuecomment-484625693 which follows the generally established convention for bundling Module Manager.

In this compromise approach, CKAN can take that bundled dll and put it in the mod folder instead of GameData to prevent collision between multiple mods that bundle Harmony in this way. This is effectively the same as the "suggestion" in #7131 that all mods that require Harmony to include their "own" copy of it.

For reasons already discussed in #7131 this is not my preferred approach; I cannot guarantee that this won't run into problems down the line. #7200 is still the more robust and recommended solution.

Syntax check requested before merge.  
For sample refer to [prerelease version](https://github.com/cake-pie/AirlockPlus/releases/tag/v0.0.10.9).