### PR TITLE
Remove KJR provides from KJRNext

### DIFF
--- a/NetKAN/KerbalJointReinforcementNext.netkan
+++ b/NetKAN/KerbalJointReinforcementNext.netkan
@@ -8,9 +8,6 @@
     "$vref"          : "#/ckan/ksp-avc",
     "license"        : "GPL-3.0",
     "release_status" : "stable",
-    "provides"       : [
-        "KerbalJointReinforcement"
-    ],
     "conflicts"      : [
         { "name": "KerbalJointReinforcement" }
     ],


### PR DESCRIPTION
## Problems

#7101 indexed KerbalJointReinforcementNext with a `provides` property containing `KerbalJointReinforcement`, because this module is a successor module and might be preferred by some users who, say, install a craft module recommending KJR. This has caused two problems so far:

- In #7203 a RealismOverhaul team member reported that KJRNext providing KJR causes issues for them:
  > Also I would like to point out KJR NEXT should NOT be able to provide for KJR. RO/RSS does not support next at all. It has known issues with the RO/RSS suite of mods, in fact both RO and KJR Continued conflicts with next yet ckan seems to be allowing people to install it with these mods.
- In #7210 we discovered that it's very difficult, if even possible, for IRNext to conflict with old KJR and KJRContinued without also conflicting with KJRNext. Since KJRNext provides KJR, any `conflicts` relationship with KJR implicitly includes KJRNext as well, and the `min_version` and `max_version` properties of such a conflict relationship are only applied to KJR, not KJRNext.

## Changes

Now KJRNext no longer provides KJR. This should help the RO folks with whatever conflicts they were having, and also allow us to have IRNext conflict with KJR and KJRContinued while recommending KJRNext.

(Note that older versions will be updated in a separate pull request in CKAN-meta.)