### PR TITLE
Update MFT to 5.12.3

### DIFF
--- a/NetKAN/ModularFuelTanks.netkan
+++ b/NetKAN/ModularFuelTanks.netkan
@@ -8,7 +8,7 @@
     "author"         : ["taniwha", "NathanKell", "Swamp Ig", "ChestBurster", "ialdabaoth"],
     "description"    : "Modular Fuel Tanks allows any supported tank to be filled with exactly how much or how little fuel you want, of whatever type you want (though different tanks may allow or disallow certain fuels; jet fuel tanks won't take oxidizer for instance).",
     "resources" : {
-        "homepage"     : "http://forum.kerbalspaceprogram.com/index.php?/topic/58235-11-modular-fuel-tanks-v570/",
+        "homepage"     : "http://forum.kerbalspaceprogram.com/index.php?/topic/58235-*",
         "repository"   : "https://github.com/NathanKell/ModularFuelSystem"
     },
     "depends": [
@@ -26,7 +26,8 @@
         { "name" : "SDHI-ServiceModuleSystem" },
         { "name" : "SpaceShuttleEngines"      }
     ],
-    "version"        : "5.12.1",
-    "ksp_version_min" : "1.4",
-    "download"       : "http://taniwha.org/~bill/ModularFuelTanks_v5.11.0.zip"
+    "version"        : "5.12.3",
+    "ksp_version_min" : "1.6",
+    "ksp_version_max" : "1.7",
+    "download"       : "http://taniwha.org/~bill/ModularFuelTanks_v5.12.3.zip"
 }


### PR DESCRIPTION
This module has to be updated manually.

Note that #7086 created bad data that needs to be cleaned up; the version was changed without updating the download URL, so CKAN was telling users that 5.11.0 was 5.12.1. The version constraint as of that PR is probably wrong as well (seems to depend on changes in 1.6, and a later version is only supported up to 1.7, so an open ended interval starting with 1.4 doesn't make sense at either end). Another pull request in CKAN-meta will fix that next...