### PR TITLE
Override latest EVE compatibility up to 1.7

### DIFF
--- a/NetKAN/EnvironmentalVisualEnhancements.netkan
+++ b/NetKAN/EnvironmentalVisualEnhancements.netkan
@@ -25,7 +25,7 @@
     ],
     "x_netkan_override": [ {
         "version": "2:EVE-1.4.2-2",
-        "override: {
+        "override": {
             "ksp_version_max": "1.7"
         }
     } ]

--- a/NetKAN/EnvironmentalVisualEnhancements.netkan
+++ b/NetKAN/EnvironmentalVisualEnhancements.netkan
@@ -6,6 +6,7 @@
     "abstract"     : "City Lights for Kerbin and Clouds for Any planet you wish",
     "license"      : "MIT",
     "$vref"        : "#/ckan/ksp-avc",
+    "x_netkan_epoch": "2",
     "resources": {
         "homepage"   : "http://forum.kerbalspaceprogram.com/index.php?/topic/149733-EVE",
         "repository" : "https://github.com/WazWaz/EnvironmentalVisualEnhancements"
@@ -22,5 +23,10 @@
     "conflicts": [
         { "name" : "EnvironmentalVisualEnhancements-LR" }
     ],
-    "x_netkan_epoch": "2"
+    "x_netkan_override": [ {
+        "version": "2:EVE-1.4.2-2",
+        "override: {
+            "ksp_version_max": "1.7"
+        }
+    } ]
 }


### PR DESCRIPTION
themaster402/AstronomersVisualPack#2 noted that AVP doesn't show as compatible unless you have KSP 1.4 marked as compatible. This is because it depends on EVE, which hasn't been updated since 1.4.

Users on EVE's forum thread reported that it works fine on KSP 1.6 and 1.7. I submitted WazWaz/EnvironmentalVisualEnhancements#18 to update the version file to reflect this, and that change was accepted. This may be interpreted as agreement that EVE's current release is supported up to KSP 1.7. This pull request adds an override to make that change in CKAN's metadata.