### PR TITLE
Fix Kerbalism install stanzas

### DIFF
--- a/NetKAN/Kerbalism-Config-Default.netkan
+++ b/NetKAN/Kerbalism-Config-Default.netkan
@@ -14,7 +14,7 @@
 		"name": "Kerbalism-Config"
 	}],
 	"install": [{
-			"file": "KerbalismConfig",
+			"find": "KerbalismConfig",
 			"install_to": "GameData"
 		}
 	]

--- a/NetKAN/Kerbalism.netkan
+++ b/NetKAN/Kerbalism.netkan
@@ -70,7 +70,7 @@
 		"name": "UKS"
 	}],
 	"install": [{
-		"file": "Kerbalism",
+		"find": "Kerbalism",
 		"install_to": "GameData"
 	}]
 }


### PR DESCRIPTION
`file` requires the specified path to start at the root.

`find` looks in subfolders.

This release of Kerbalism put the relevant folders inside `GameData`, but the netkan used `file`. This was not known at the time of #7228 because the new release was not available yet. Now it's fixed.