### PR TITLE
Add conflict with SigmaDimensions to SSRSS-Rescale

### DIFF
--- a/NetKAN/SSRSS-Cont.netkan
+++ b/NetKAN/SSRSS-Cont.netkan
@@ -16,7 +16,7 @@
         { "name": "ModuleManager" },
         { "name": "Kopernicus" },
         { "name": "RealSolarSystem" },
-        { "name": "SigmaDimensions" }
+        { "name": "SSRSS-Rescale" }
     ],
     "recommends":
     [

--- a/NetKAN/SSRSS-Rescale.netkan
+++ b/NetKAN/SSRSS-Rescale.netkan
@@ -1,19 +1,20 @@
 {
     "spec_version": "v1.4",
-    "identifier": "SSRSS-Rescale",
-    "$kref": "#/ckan/github/Sigma88/Sigma-Dimensions",
-    "$vref": "#/ckan/ksp-avc",
-    "name": "Stock Size Real Solar System - Rescale",
-    "abstract": "Rescales the system to stock size.",
-    "license": "restricted",
-    "depends":
-    [
+    "identifier":   "SSRSS-Rescale",
+    "name":         "Stock Size Real Solar System - Rescale",
+    "abstract":     "Rescales the system to stock size.",
+    "$kref":        "#/ckan/github/Sigma88/Sigma-Dimensions",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "restricted",
+    "depends": [
         { "name": "SSRSS-Cont" }
     ],
-    "install":
-    [
+    "conflicts": [
+        { "name": "SigmaDimensions" }
+    ],
+    "install": [
         {
-            "find": "Dimensions",
+            "find":       "Dimensions",
             "install_to": "GameData/Sigma"
         }
     ]


### PR DESCRIPTION
## Problem

SigmaDimensions and SSRSS-Rescale seem to be the same mod. They have identical `$kref`s and `install` stanzas. Unsurprisingly this causes problems if you try to install both.

The reason for this is not clear but it does seem to be deliberate; see #5435:

> Added SSRSS-Rescale as a 'fake' SigmaDimensions

## Changes

Now SSRSS-Rescale is marked as conflicting with SigmaDimensions.

Fixes #7235.