### PR TITLE
Remove GameData from Kerbalism RO config install stanza

### DIFF
--- a/NetKAN/Kerbalism-Config-RO.netkan
+++ b/NetKAN/Kerbalism-Config-RO.netkan
@@ -19,7 +19,7 @@
         { "name": "RP-0" }
     ],
     "install": [ {
-        "find":       "GameData/KerbalismConfig",
+        "find":       "KerbalismConfig",
         "install_to": "GameData"
     } ]
 }


### PR DESCRIPTION
The 0.1 version of this mod contained `GameData/KerbalismConfig`.
The 0.1.1 version just contains `KerbalismConfig` in the root of the ZIP.

http://status.ksp-ckan.space/

| NetKAN | Last Checked | Last Inflated | Last Indexed | Last Error ▾ |
| --- | --- | --- | --- | --- |
| Kerbalism-Config-RO | an hour ago | an hour ago | N/A | Could not find GameData/KerbalismConfig entry in zipfile to install |