### PR TITLE
Add dependencies and recommendations to SuperfluousNodes

### DIFF
--- a/NetKAN/SuperfluousNodes.netkan
+++ b/NetKAN/SuperfluousNodes.netkan
@@ -4,7 +4,13 @@
     "$kref":        "#/ckan/spacedock/2064",
     "license":      "MIT",
     "depends": [
-        { "name": "ModuleManager" }
+        { "name": "ModuleManager" },
+        { "name": "B9PartSwitch"  }
+    ],
+    "recommends": [
+        { "name": "KIS"          },
+        { "name": "KAS"          },
+        { "name": "Konstruction" }
     ],
     "install": [ {
         "find_regexp": "SuperfluousNodes.*",


### PR DESCRIPTION
This forum thread says:

![image](https://user-images.githubusercontent.com/1559108/59472077-c832fa00-8e2c-11e9-8198-d0e660dc3162.png)

https://forum.kerbalspaceprogram.com/index.php?/topic/181663-17-superfluous-nodes-06-plethora-of-extra-nodes-for-stock-parts/

Now those are reflected in the netkan.