### PR TITLE
Mark French translation as French translation

### DIFF
--- a/NetKAN/KSPFrenchTranslation.netkan
+++ b/NetKAN/KSPFrenchTranslation.netkan
@@ -4,6 +4,9 @@
     "identifier": "KSPFrenchTranslation",
     "license": "MIT",
     "spec_version": "v1.10",
+    "localizations": [
+        "fr-fr"
+    ],
     "depends": [
         { "name": "ModuleManager" }
     ],


### PR DESCRIPTION
This mod is a French translation, but the config file labels it with the "en-us" locale. Maybe this was because French was not in the game's language list at the time, so it had to be faked?

Now it's hard coded in the netkan.