### PR TITLE
Switch SDHI-SharedAssets to main SDHI repo

### DIFF
--- a/NetKAN/SDHI-SharedAssets.netkan
+++ b/NetKAN/SDHI-SharedAssets.netkan
@@ -14,7 +14,7 @@
     },
     "install" : [
         {
-            "file"       : "Agencies",
+            "find"       : "Agencies",
             "install_to" : "GameData/SDHI"
         }
     ]

--- a/NetKAN/SDHI-SharedAssets.netkan
+++ b/NetKAN/SDHI-SharedAssets.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version"   : "v1.4",
     "identifier"     : "SDHI-SharedAssets",
-    "$kref"          : "#/ckan/github/sumghai/SDHI_SharedAssets",
+    "$kref"          : "#/ckan/github/sumghai/SDHI_ServiceModuleSystem",
     "name"           : "Sum Dum Heavy Industries - Shared Assets",
     "abstract"       : "Agency folders shared by multiple SDHI-branded add-ons for Kerbal Space Program",
     "license"        : "CC-BY-SA-4.0",


### PR DESCRIPTION
The sumghai/SDHI_SharedAssets repository contained releases of Agencies files used by SDHI_ServiceModuleSystem and SDHI_StrobeOMatic. This repo has been deleted, and its CKAN module is erroring out currently.

The files are still in both of those modules. Now we extract them from SDHI_ServiceModuleSystem.