### PR TITLE
force_v for StationScienceContinued to avoid override

### DIFF
--- a/NetKAN/StationScienceContinued.netkan
+++ b/NetKAN/StationScienceContinued.netkan
@@ -1,34 +1,30 @@
 {
     "spec_version": "v1.4",
-    "identifier": "StationScienceContinued",
+    "identifier":   "StationScienceContinued",
+    "name":         "Station Science Continued",
+    "abstract":     "Station Science mod adds several large parts designed to be integrated into a permanent space station.",
+    "description":  "This mod adds several large parts designed to be integrated into a permanent space station: the Science Lab, the Zoology Bay, the Cyclotron, and the Spectrometron. These heavy parts provide facilities for performing experiments. Experiments are held in small, light pods that you can dock with your space station, execute, and bring back to the surface for Science points. The Spectrometron uses the Cyclotron to analyze Surface Samples that you've brought into orbit, and allows you to transmit the data home for full value. In addition, there are tanks for storing Kibbal for the Zoology Bay.",
+    "author":       "tomf",
+    "$kref":        "#/ckan/github/tomforwood/StationScience",
+    "$vref":        "#/ckan/ksp-avc",
+    "x_netkan_force_v": true,
     "release_status": "stable",
-    "$vref": "#/ckan/ksp-avc",
-    "license": "restricted",
+    "license":      "restricted",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-122-station-science-contunued-v210/",
+        "homepage":  "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-*",
         "x_preview": "http://i.imgur.com/63DTlDLl.png"
     },
-    "name": "Station Science Continued",
-    "abstract": "Station Science mod adds several large parts designed to be integrated into a permanent space station.",
-    
-    "description": "This mod adds several large parts designed to be integrated into a permanent space station: the Science Lab, the Zoology Bay, the Cyclotron, and the Spectrometron. These heavy parts provide facilities for performing experiments. Experiments are held in small, light pods that you can dock with your space station, execute, and bring back to the surface for Science points. The Spectrometron uses the Cyclotron to analyze Surface Samples that you've brought into orbit, and allows you to transmit the data home for full value. In addition, there are tanks for storing Kibbal for the Zoology Bay.",
- "conflicts" : [
-        { "name" : "StationScience" }
+    "conflicts": [
+        { "name": "StationScience" }
     ],
-    "install" : [
-        {
-            "find"       : "StationScience",
-            "install_to" : "GameData"
+    "install": [ {
+        "find":       "StationScience",
+        "install_to": "GameData"
+    } ],
+    "x_netkan_override": [ {
+        "version": [ ">=2.1.0", "<=v2.2.1" ],
+        "override": {
+            "ksp_version_max": "1.2.2"
         }
-    ],
-    "author": "tomf",
-    "$kref"        : "#/ckan/github/tomforwood/StationScience",
-    "x_netkan_override": [
-        {
-            "version": [ ">=2.1.0", "<=v2.2.1" ],
-            "override": {
-                "ksp_version_max": "1.2.2"
-            }
-        }
-    ]
+    } ]
 }


### PR DESCRIPTION
## Problem

This mod's versions had a 'v' prefix, which was dropped in the latest release:

![image](https://user-images.githubusercontent.com/1559108/59876337-f488d200-9368-11e9-8ff9-492b2a6573c4.png)

Since all versions without a 'v' prefix are considered less than all versions with a 'v' prefix, this caused this override to improperly fire:

https://github.com/KSP-CKAN/NetKAN/blob/43bebe54e30dca1129eea99c100eeda9191d59d9/NetKAN/StationScienceContinued.netkan#L26-L33

Which caused `ksp_version_max` to be set to 1.2.2, while `ksp_version_min` was 1.6.0. When the max is less than the min, the module is compatible with nothing.

Now all of this mod's versions will start with 'v', fixing the above.

Fixes #7262.