### PR TITLE
Add DeepFreeze dependency on BackgroundResources

### DIFF
--- a/NetKAN/DeepFreeze.netkan
+++ b/NetKAN/DeepFreeze.netkan
@@ -8,6 +8,7 @@
     "depends" : [
         { "name" : "ModuleManager", "min_version" : "2.3.5" },
         { "name" : "REPOSoftTech-Agencies" },
+        { "name" : "CommunityResourcePack" },
         { "name" : "BackgroundResources" }
     ],
     "recommends" : [

--- a/NetKAN/DeepFreeze.netkan
+++ b/NetKAN/DeepFreeze.netkan
@@ -1,13 +1,14 @@
 {
-    "identifier": "DeepFreeze",
-    "x_via": "Author JPLRepo",
     "spec_version": "v1.4",
-    "$kref": "#/ckan/spacedock/142",
-    "$vref": "#/ckan/ksp-avc",
-    "license": "CC-BY-NC-SA-4.0",
+    "identifier":   "DeepFreeze",
+    "$kref":        "#/ckan/spacedock/142",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "CC-BY-NC-SA-4.0",
+    "x_via":        "Author JPLRepo",
     "depends" : [
         { "name" : "ModuleManager", "min_version" : "2.3.5" },
-        { "name" : "REPOSoftTech-Agencies" }
+        { "name" : "REPOSoftTech-Agencies" },
+        { "name" : "BackgroundResources" }
     ],
     "recommends" : [
         { "name" : "Toolbar" },
@@ -19,17 +20,13 @@
     ],
     "suggests": [
         { "name" : "USI-LS" },
-        { "name" : "TACLS" },
+        { "name" : "TACLS"  },
         { "name" : "Snacks" }
     ],
     "install": [
         { 
-            "find": "REPOSoftTech", 
-            "install_to": "GameData", 
-            "filter": [ 
-                "Agencies",
-                "RSTKSPUtils"
-            ]
+            "find":       "REPOSoftTech/DeepFreeze", 
+            "install_to": "GameData/REPOSoftTech"
         }
     ]
 }


### PR DESCRIPTION
DeepFreeze bundles BackgroundResources in its latest version, which has triggered a conflict with that module. Now we handle this via a proper dependency.

Fixes #7276.

ckan compat add 1.6