### PR TITLE
Epoch xScience due to vV

### DIFF
--- a/NetKAN/xScience.netkan
+++ b/NetKAN/xScience.netkan
@@ -1,28 +1,25 @@
 {
     "spec_version": "v1.26",
-    "identifier": "xScience",
-    "$kref": "#/ckan/spacedock/234",
-    "license": "CC-BY-NC-SA-4.0",
-    "author": ["Z-Key Aerospace", "Brodrick"],
-    "abstract": "The Science Report and Checklist for KSP.  [x] Science! keeps track of the science experiments you have completed and recovered to Kerbal Space Center. It also tracks science you have gathered which is held on vehicles and kerbals.  No matter what game scene you are in, what you current vehicle is, [x] Science! always reports on all science held anywhere.",
+    "identifier":   "xScience",
+    "abstract":     "The Science Report and Checklist for KSP.  [x] Science! keeps track of the science experiments you have completed and recovered to Kerbal Space Center. It also tracks science you have gathered which is held on vehicles and kerbals.  No matter what game scene you are in, what you current vehicle is, [x] Science! always reports on all science held anywhere.",
+    "author":       [ "Z-Key Aerospace", "Brodrick" ],
+    "license":      "CC-BY-NC-SA-4.0",
+    "$kref":        "#/ckan/spacedock/234",
+    "x_netkan_force_v": true,
+    "x_netkan_epoch":   1,
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/107661-ksp-105-x-science",
+        "homepage":   "http://forum.kerbalspaceprogram.com/index.php?/topic/107661-ksp-105-x-science",
         "repository": "https://github.com/thewebbooth/KSP-X-Science"
     },
-    "install": [
-        {
-            "file": "GameData/[x] Science!",
-            "install_to": "GameData"
+    "install": [ {
+        "file":       "GameData/[x] Science!",
+        "install_to": "GameData"
+    } ],
+    "x_netkan_override": [ {
+        "version": "4.14",
+        "override": {
+            "download": "https://themoose.co.uk/ksp/x-science-v4.14.zip"
         }
-    ],
-    "x_netkan_override": [
-        {
-            "version": "4.14",
-            "override": {
-                "download": "https://themoose.co.uk/ksp/x-science-v4.14.zip"
-            }
-        }
-    ],
-    "x_netkan_force_v": true,
+    } ],
     "replaced_by": { "name": "xScienceContinued" }
 }


### PR DESCRIPTION
See KSP-CKAN/CKAN#2823; this module was generating 'vV' in its versions on CKAN thanks to `x_netkan_force_v`. Now that flag will replace 'V' with 'v' instead, but that means that newer versions will be counted as older because they lack the 'V'.

![image](https://user-images.githubusercontent.com/1559108/60450794-2841e280-9c1a-11e9-9973-f3b3e3a8f4e8.png)

An epoch is added to address this.