### PR TITLE
Update Nuke-TinyPartsRefueled.netkan

### DIFF
--- a/NetKAN/Nuke-TinyPartsRefueled.netkan
+++ b/NetKAN/Nuke-TinyPartsRefueled.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "Nuke-TinyPartsRefueled",
     "author":        [ "Nuke", "zer0Kerbal" ],
-    "$kref":        "#/ckan/spacedock/2174",
+    "$kref":        "#/ckan/spacedock/2175",
     "license":      "CC-BY-NC-SA-4.0",
     "install": [ {
         "find":       "GameData/Nuke",


### PR DESCRIPTION
This module was uploaded, then deleted from SpaceDock and re-uploaded at a new URL. There's no indication of why that happened on the forum thread or the SpaceDock page.