### PR TITLE
Epoch AirParkContinued

### DIFF
--- a/NetKAN/AirParkContinued.netkan
+++ b/NetKAN/AirParkContinued.netkan
@@ -1,13 +1,12 @@
 {
-  "license": "GPL-2.0",
-  "identifier": "AirParkContinued",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "$kref": "#/ckan/spacedock/936",
-  "install": [
-    {
-      "find": "AirPark",
-      "install_to": "GameData"
-    }
-  ],
-  "spec_version": "v1.4"
+  "spec_version": "v1.4",
+  "identifier":   "AirParkContinued",
+  "$kref":        "#/ckan/spacedock/936",
+  "license":      "GPL-2.0",
+  "x_netkan_epoch": 1,
+  "install": [ {
+    "find":       "AirPark",
+    "install_to": "GameData"
+  } ],
+  "x_via": "Automated Linuxgurugamer CKAN script"
 }


### PR DESCRIPTION
This module had an out of order release for KSP 1.3.1 (which is still somewhat popular among RSS players), and we need to add an epoch to make room to fix it:

![image](https://user-images.githubusercontent.com/1559108/60616592-5a417900-9dc1-11e9-9e31-2597dfd0daed.png)
