### PR TITLE
Bump AVP epoch

### DIFF
--- a/NetKAN/AstronomersVisualPack.netkan
+++ b/NetKAN/AstronomersVisualPack.netkan
@@ -6,7 +6,7 @@
     "$kref"        : "#/ckan/github/themaster402/AstronomersVisualPack/asset_match/AVP.v.*.zip",
     "$vref"        : "#/ckan/ksp-avc",
     "x_netkan_trust_version_file" : true,
-    "x_netkan_epoch" : 1,
+    "x_netkan_epoch" : 2,
     "license"      : "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160878-*"


### PR DESCRIPTION
This module had an out of order release, which was epoched in KSP-CKAN/CKAN-meta#1477:

![screenshot](https://user-images.githubusercontent.com/1559108/60399351-c5d1df00-9b52-11e9-88f4-aa8537442b22.png)

However, that simply pushed it to the front of the line, avove other newer versions:

![image](https://user-images.githubusercontent.com/1559108/60617424-3aab5000-9dc3-11e9-9bd7-e395d072a11c.png)


**Two** epochs were needed. Now we have them.