### PR TITLE
Remove hard coding of ACA version

### DIFF
--- a/NetKAN/AircraftCarrierAccessories.netkan
+++ b/NetKAN/AircraftCarrierAccessories.netkan
@@ -1,10 +1,11 @@
 {
-    "license": "MIT",
-    "identifier": "AircraftCarrierAccessories",
     "spec_version": "v1.4",
-    "$kref": "#/ckan/spacedock/1068",
+    "identifier":   "AircraftCarrierAccessories",
+    "$kref":        "#/ckan/spacedock/1068",
     "x_netkan_epoch": 1,
-    "version": "1.2.4",
-    "install": [ { "find" : "KFC",
-                   "install_to" : "GameData"} ]
+    "license":      "MIT",
+    "install": [ {
+        "find"       : "KFC",
+        "install_to" : "GameData"
+    } ]
 }


### PR DESCRIPTION
This mod had its `version` property hard coded in #5194, which has completely messed it up. The author has released **eleven** versions since then, from 1.2.5 through 1.5.1, but instead of being indexed normally, they've all been re-indexed under the 1.2.4 version:

https://github.com/KSP-CKAN/CKAN-meta/commits/master/AircraftCarrierAccessories/AircraftCarrierAccessories-1-1.2.4.ckan

:cry: 

Now the hard coding is removed.