### PR TITLE
Epoch AviationLights

### DIFF
--- a/NetKAN/AviationLights.netkan
+++ b/NetKAN/AviationLights.netkan
@@ -5,6 +5,7 @@
     "author":       [ "MOARdV", "BigNose", "RPGprayer" ],
     "$kref":        "#/ckan/github/MOARdV/AviationLights",
     "$vref":        "#/ckan/ksp-avc",
+    "x_netkan_epoch": 1,
     "license":      "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/173305-*"


### PR DESCRIPTION
This mod had an out of order release a while back by omitting its 'v' prefix.

![image](https://user-images.githubusercontent.com/1559108/60621995-bced4180-9dce-11e9-92fd-c15b9968303e.png)

Now it has an epoch to make room for the needed fixes.