### PR TITLE
Bump ComfortableLanding epoch

### DIFF
--- a/NetKAN/ComfortableLanding.netkan
+++ b/NetKAN/ComfortableLanding.netkan
@@ -1,19 +1,15 @@
 {
   "spec_version": "v1.4",
-  "install": [
-    {
-      "install_to": "GameData",
-      "find": "ComfortableLanding"
-    }
-  ],
+  "identifier":   "ComfortableLanding",
+  "$kref":        "#/ckan/spacedock/1528",
+  "x_netkan_epoch": 2,
+  "license":      "GPL-3.0",
+  "install": [ {
+    "find":       "ComfortableLanding",
+    "install_to": "GameData"
+  } ],
   "depends": [
-    {
-      "name": "ModuleManager"
-    }
+    { "name": "ModuleManager" }
   ],
-  "x_netkan_epoch": 1,
-  "$kref": "#/ckan/spacedock/1528",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "identifier": "ComfortableLanding",
-  "license": "GPL-3.0"
+  "x_via": "Automated Linuxgurugamer CKAN script"
 }


### PR DESCRIPTION
This mod was unnecessarily epoched in #6588, and then later released a version in need of an epoch:

![image](https://user-images.githubusercontent.com/1559108/60627180-d1d0d180-9ddc-11e9-8c6b-d2cc94dd501a.png)

Now the epoch is bumped again to make room for fixing this.