### PR TITLE
Epoch ChakaMonkey to make room for fixes

### DIFF
--- a/NetKAN/ChakaMonkeyExplorationSystems.netkan
+++ b/NetKAN/ChakaMonkeyExplorationSystems.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "ChakaMonkeyExplorationSystems",
     "$kref":        "#/ckan/spacedock/599",
+    "x_netkan_epoch": 3,
     "license":      "restricted",
     "depends": [
         { "name": "AnimatedDecouplers" },
@@ -11,14 +12,11 @@
         { "name": "MK12PodIVAReplacementbyASET" },
         { "name": "RasterPropMonitor-Core", "min_version" : "0.21.2" }
     ],
-    "install": [
-        {
-            "find": "CMES",
-            "install_to": "GameData"
-        },
-        {
-            "find": "VAB",
-            "install_to": "Ships"
-        }
-    ]
+    "install": [ {
+        "find": "CMES",
+        "install_to": "GameData"
+    }, {
+        "find": "VAB",
+        "install_to": "Ships"
+    } ]
 }


### PR DESCRIPTION
With apologies to our Aussie teammates, "That's not a chaotically versioned mod; ***this*** is a chaotically versioned mod":

![image](https://user-images.githubusercontent.com/1559108/60772016-6f7b1800-a0df-11e9-8ff9-05905f1d0353.png)

Properly epoching this would make a good college admissions or job interview question. Try it yourself before checking out my answer:

<details><summary>My plan for epoching ChakaMonkey</summary>

- 3:Chaka_Monkey_161_B
- 3:1.4.3.a
- 2:Chaka_143
- 1:Chaka_Monkey_Evolution_1.3.1_X
- 1:1.3_X
- 1:1.3_Collectors_Edition
- Chaka_Monkey_Exploration_Systems_1.2.2.X
- Chaka_Monkey_Exploration_Systems_1.2.2
- Chaka_Monkey_Exploration_Systems_1.1.3
- 1.1_BETA

</details>

ckan compat add 1.4 1.5