### PR TITLE
Fix TestFlight installation

### DIFF
--- a/NetKAN/TestFlight.netkan
+++ b/NetKAN/TestFlight.netkan
@@ -1,35 +1,36 @@
 {
-    "spec_version" : "v1.2",
-    "name" : "TestFlight",
-    "abstract" : "Flight Testing of your space hardware in KSP!  Fly your parts to gain flight data and make them more reliable and less likely to fail.  THIS IS THE PLUGIN ONLY.  You will need a TestFlight Config pack in order for any parts to actually be controlled by TestFlight.",
-    "identifier" : "TestFlight",
-    "$vref" : "#/ckan/ksp-avc",
-    "$kref" : "#/ckan/github/KSP-RO/TestFlight/asset_match/TestFlightCore*",
-    "license" : "CC-BY-NC-SA-4.0",
-    "release_status" : "stable",
-    "resources" : {
-        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/99043-122-testflight-v180-01-may-2017-bring-flight-testing-to-ksp/",
-        "repository" : "https://github.com/KSP-RO/TestFlight",
-        "bugtracker" : "https://github.com/KSP-RO/TestFlight/issues"
+    "spec_version": "v1.2",
+    "identifier":   "TestFlight",
+    "name":         "TestFlight",
+    "abstract":     "Flight Testing of your space hardware in KSP!  Fly your parts to gain flight data and make them more reliable and less likely to fail.  THIS IS THE PLUGIN ONLY.  You will need a TestFlight Config pack in order for any parts to actually be controlled by TestFlight.",
+    "$kref":        "#/ckan/github/KSP-RO/TestFlight/asset_match/TestFlightCore*",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "CC-BY-NC-SA-4.0",
+    "release_status": "stable",
+    "resources": {
+        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/99043-*",
+        "repository": "https://github.com/KSP-RO/TestFlight",
+        "bugtracker": "https://github.com/KSP-RO/TestFlight/issues"
     },
     "install" : [
         {
-            "file"       : "GameData/TestFlight",
-            "install_to" : "GameData"
+            "file":       "GameData/TestFlight",
+            "install_to": "GameData",
+            "filter":     [ "Config" ]
         }
     ],
-    "depends" : [
+    "depends": [
         { "name" : "ModuleManager", "min_version" : "2.6.1" },
         { "name" : "TestFlightConfig" }
 
     ],
-    "x_netkan_override" : [
+    "x_netkan_override": [
         {
-            "version" : "1.3.1.1",
-            "delete" : [ "ksp_version" ],
-            "override" : {
-                "ksp_version_min" : "1.0.2",
-                "ksp_version_max" : "1.0.4"
+            "version": "1.3.1.1",
+            "delete":  [ "ksp_version" ],
+            "override": {
+                "ksp_version_min": "1.0.2",
+                "ksp_version_max": "1.0.4"
             }
         }
     ]

--- a/NetKAN/TestFlightConfigStock.netkan
+++ b/NetKAN/TestFlightConfigStock.netkan
@@ -1,40 +1,41 @@
 {
-    "spec_version" : "v1.2",
-    "name" : "TestFlight Config Stock",
-    "abstract" : "Config pack for the TestFlight plugin.  This config pack adds TestFlight support for Stock parts.",
-    "identifier" : "TestFlightConfigStock",
-    "$vref" : "#/ckan/ksp-avc",
-    "$kref" : "#/ckan/github/KSP-RO/TestFlight/asset_match/TestFlightConfigStock*",
-    "license" : "CC-BY-NC-SA-4.0",
-    "release_status" : "stable",
-    "resources" : {
-        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/99043-122-testflight-v180-01-may-2017-bring-flight-testing-to-ksp/",
-        "repository" : "https://github.com/KSP-RO/TestFlight",
-        "bugtracker" : "https://github.com/KSP-RO/TestFlight/issues"
+    "spec_version": "v1.2",
+    "identifier":   "TestFlightConfigStock",
+    "name":         "TestFlight Config Stock",
+    "abstract":     "Config pack for the TestFlight plugin.  This config pack adds TestFlight support for Stock parts.",
+    "$kref":        "#/ckan/github/KSP-RO/TestFlight/asset_match/TestFlightConfigStock*",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "CC-BY-NC-SA-4.0",
+    "release_status": "stable",
+    "resources": {
+        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/99043-*",
+        "repository": "https://github.com/KSP-RO/TestFlight",
+        "bugtracker": "https://github.com/KSP-RO/TestFlight/issues"
     },
-    "install" : [
+    "install": [
         {
-            "file"       : "GameData/TestFlight",
-            "install_to" : "GameData"
+            "file":       "GameData/TestFlight",
+            "install_to": "GameData",
+            "filter":     [ "ignore.txt" ]
         }
     ],
-    "depends" : [
-        { "name" : "ModuleManager", "min_version" : "2.6.1" },
-        { "name" : "TestFlight", "min_version" : "1.3.1" }
+    "depends": [
+        { "name": "ModuleManager", "min_version": "2.6.1" },
+        { "name": "TestFlight",    "min_version": "1.3.1" }
     ],
-    "provides" : [
+    "provides": [
         "TestFlightConfig"
     ],
-    "conflicts" : [
-        { "name" : "TestFlightConfig" }
+    "conflicts": [
+        { "name": "TestFlightConfig" }
     ],
-    "x_netkan_override" : [
+    "x_netkan_override": [
         {
-            "version" : "1.3.1.1",
-            "delete" : [ "ksp_version" ],
-            "override" : {
-                "ksp_version_min" : "1.0.2",
-                "ksp_version_max" : "1.0.4"
+            "version": "1.3.1.1",
+            "delete":  [ "ksp_version" ],
+            "override": {
+                "ksp_version_min": "1.0.2",
+                "ksp_version_max": "1.0.4"
             }
         }
     ]


### PR DESCRIPTION
## Problem

These modules both try to install a zero-byte `Config\ignore.txt` file that shouldn't be there, see KSP-RO/TestFlight#191.

![image](https://user-images.githubusercontent.com/1559108/60851491-e3521900-a1e2-11e9-965d-303adc37af56.png)

![image](https://user-images.githubusercontent.com/1559108/60851497-e816cd00-a1e2-11e9-95d4-6a673cadf5e9.png)

This prevents them from installing, since they depend on each other:

```
About to install...

 * TestFlight 1.10.0.0 (cached)
 * TestFlight Config Stock 1.10.0.0 (cached)

Module "TestFlight" successfully installed

Oh no! We tried to overwrite a file owned by another mod!
Please try a `ckan update` and try again.

If this problem re-occurs, then it maybe a packaging bug.
Please report it at:

https://github.com/KSP-CKAN/NetKAN/issues/new

Please including the following information in your report:

File           : GameData/TestFlight/Config/ignore.txt
Installing Mod : TestFlightConfigStock 1.10.0.0
Owning Mod     : TestFlight
CKAN Version   : v1.26.2

Your GameData has been returned to its original state.

Error during installation!
An unknown error occurred, please try again!
```

## Changes

Now the `ignore.txt` file is filtered out of Config, and the whole `Config` folder is filtered out of Core.

Fixes KSP-CKAN/NetKAN#7307.