### PR TITLE
Remove redundant hard coded game version from LaserDist

### DIFF
--- a/NetKAN/LaserDist.netkan
+++ b/NetKAN/LaserDist.netkan
@@ -7,7 +7,6 @@
     "author"       : "Steven Mading",
     "abstract"     : "Gives exact laser distances for use with kOS and other scripted autopilot systems.",
     "license"      : "GPL-3.0",
-    "ksp_version"  : "1.1.2",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/141697-laserdist-a-distance-measuring-laser-part-for-kos/"
     },


### PR DESCRIPTION
This module has a `$vref` and a `ksp_version` property. The latter has caused all of its versions to be stamped with a min version of 1.1.2 even though the forum thread just says 1.7.3.

Now the `$vref` shall reign supreme.