### PR TITLE
Updating TweakScale to cope with more than one folder on the package.

### DIFF
--- a/NetKAN/TweakScale.netkan
+++ b/NetKAN/TweakScale.netkan
@@ -13,12 +13,12 @@
         "pellinor",
         "LisiasT"
     ],
-    "install" : {
+    "install" : [
         {
             "file" : "GameData/TweakScale",
             "install_to" : "GameData"
         }
-    },
+    ],
     "resources": {
         "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/179030-*",
         "repository": "https://github.com/net-lisias-ksp/TweakScale"

--- a/NetKAN/TweakScale.netkan
+++ b/NetKAN/TweakScale.netkan
@@ -13,6 +13,12 @@
         "pellinor",
         "LisiasT"
     ],
+    "install" : {
+        {
+            "file" : "GameData/TweakScale",
+            "install_to" : "GameData"
+        }
+    },
     "resources": {
         "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/179030-*",
         "repository": "https://github.com/net-lisias-ksp/TweakScale"


### PR DESCRIPTION
See https://forum.kerbalspaceprogram.com/index.php?/topic/179030-14-tweakscale-under-lisias-management-2431-2019-0725/&do=findComment&comment=3642572 and subsequent; the default install stanza was finding `Extras/TweakScale` instead.