### PR TITLE
Fix B9-PWings-Modified versions and mark replaced

### DIFF
--- a/NetKAN/B9-PWings-Modified.netkan
+++ b/NetKAN/B9-PWings-Modified.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.26",
     "identifier": "B9-PWings-Modified",
     "$kref": "#/ckan/github/01010101lzy/B9-PWings-Fork",
     "$vref": "#/ckan/ksp-avc",

--- a/NetKAN/B9-PWings-Modified.netkan
+++ b/NetKAN/B9-PWings-Modified.netkan
@@ -21,5 +21,12 @@
             "file": "GameData/B9_Aerospace_ProceduralWings",
             "install_to": "GameData"
         }
-    ]
+    ],
+    "replaced_by": { "name": "B9-PWings-Fork" },
+    "x_netkan_override": [ {
+        "version": "0.3.2H",
+        "override": {
+            "ksp_version_max": "1.1.2"
+        }
+    } ]
 }


### PR DESCRIPTION
B9-PWings-Modified says to use B9-PWings-Fork

https://forum.kerbalspaceprogram.com/index.php?/topic/126997-pluginsee-active-fork-b9-procedural-parts-modified/

Now CKAN will say the same thing thanks to the `replaced_by` property.

In addition, its game version range is incorrect. Its version file only has a min of 1.1.0, but  the max formerly went up to 1.1.2. I believe this was sourced from the remote version file, which I think was shared with B9-PWings-Fork. Later when that mod released new versions, the remote version file would have been updated and the max version was removed:

https://github.com/KSP-CKAN/CKAN-meta/commit/e5278aebe665ac82e880f944322a3650a912c513#diff-4d6fd65d832feab68871bca806c2bae1

Now it's back via an override.

Fixes #7329.