### PR TITLE
Add netkan files for new TestFlight configs.

### DIFF
--- a/NetKAN/TestFlightConfig-KerbalAtomics.netkan
+++ b/NetKAN/TestFlightConfig-KerbalAtomics.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier": "TestFlightConfig-KerbalAtomics",
     "name": "TestFlight Config for Kerbal Atomics",
-    "abstract": "This config pack adds TestFlight support for Kerbal Atomics parts.",
+    "abstract": "This config pack adds TestFlight support for Kerbal Atomics parts. It does not affect stock parts; install a stock TestFlight config if desired.",
     "$kref": "#/ckan/github/Starstrider42/TestFlight-Configs",
     "release_status": "testing",
     "license": "MIT",

--- a/NetKAN/TestFlightConfig-KerbalAtomics.netkan
+++ b/NetKAN/TestFlightConfig-KerbalAtomics.netkan
@@ -1,0 +1,30 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "TestFlightConfig-KerbalAtomics",
+    "name": "TestFlight Config for Kerbal Atomics",
+    "abstract": "This config pack adds TestFlight support for Kerbal Atomics parts.",
+    "$kref": "#/ckan/github/Starstrider42/TestFlight-Configs",
+    "release_status": "testing",
+    "resources": {
+        "bugtracker": "https://github.com/Starstrider42/TestFlight-Configs/issues"
+    },
+    "provides": [
+        "TestFlightConfig"
+    ],
+    "depends": [
+        { "name": "TestFlightConfigLibrary" },
+        { "name": "ModuleManager" },
+        {
+            "name": "KerbalAtomics",
+            "min_version": "1:1.0"
+        }
+    ],
+    "install": [
+        {
+            "file": "GameData/TestFlight/Config",
+            "install_to": "GameData/TestFlight",
+            "filter_regexp": "(?<!KA_.+\\.cfg)$"
+        }
+    ],
+    "x_maintained_by": "Starstrider42"
+}

--- a/NetKAN/TestFlightConfig-KerbalAtomics.netkan
+++ b/NetKAN/TestFlightConfig-KerbalAtomics.netkan
@@ -5,6 +5,7 @@
     "abstract": "This config pack adds TestFlight support for Kerbal Atomics parts.",
     "$kref": "#/ckan/github/Starstrider42/TestFlight-Configs",
     "release_status": "testing",
+    "license": "MIT",
     "resources": {
         "bugtracker": "https://github.com/Starstrider42/TestFlight-Configs/issues"
     },

--- a/NetKAN/TestFlightConfig-NFPropulsion.netkan
+++ b/NetKAN/TestFlightConfig-NFPropulsion.netkan
@@ -1,0 +1,30 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "TestFlightConfig-NFPropulsion",
+    "name": "TestFlight Config for Near Future Propulsion",
+    "abstract": "This config pack adds TestFlight support for Near Future Propulsion parts.",
+    "$kref": "#/ckan/github/Starstrider42/TestFlight-Configs",
+    "release_status": "testing",
+    "resources": {
+        "bugtracker": "https://github.com/Starstrider42/TestFlight-Configs/issues"
+    },
+    "provides": [
+        "TestFlightConfig"
+    ],
+    "depends": [
+        { "name": "TestFlightConfigLibrary" },
+        { "name": "ModuleManager" },
+        {
+            "name": "NearFuturePropulsion",
+            "min_version": "1.0"
+        }
+    ],
+    "install": [
+        {
+            "file": "GameData/TestFlight/Config",
+            "install_to": "GameData/TestFlight",
+            "filter_regexp": "(?<!NFP_.+\\.cfg)$"
+        }
+    ],
+    "x_maintained_by": "Starstrider42"
+}

--- a/NetKAN/TestFlightConfig-NFPropulsion.netkan
+++ b/NetKAN/TestFlightConfig-NFPropulsion.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier": "TestFlightConfig-NFPropulsion",
     "name": "TestFlight Config for Near Future Propulsion",
-    "abstract": "This config pack adds TestFlight support for Near Future Propulsion parts.",
+    "abstract": "This config pack adds TestFlight support for Near Future Propulsion parts. It does not affect stock parts; install a stock TestFlight config if desired.",
     "$kref": "#/ckan/github/Starstrider42/TestFlight-Configs",
     "release_status": "testing",
     "license": "MIT",

--- a/NetKAN/TestFlightConfig-NFPropulsion.netkan
+++ b/NetKAN/TestFlightConfig-NFPropulsion.netkan
@@ -5,6 +5,7 @@
     "abstract": "This config pack adds TestFlight support for Near Future Propulsion parts.",
     "$kref": "#/ckan/github/Starstrider42/TestFlight-Configs",
     "release_status": "testing",
+    "license": "MIT",
     "resources": {
         "bugtracker": "https://github.com/Starstrider42/TestFlight-Configs/issues"
     },

--- a/NetKAN/TestFlightConfig-NFSpacecraft.netkan
+++ b/NetKAN/TestFlightConfig-NFSpacecraft.netkan
@@ -1,0 +1,30 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "TestFlightConfig-NFSpacecraft",
+    "name": "TestFlight Config for Near Future Spacecraft",
+    "abstract": "This config pack adds TestFlight support for Near Future Spacecraft parts.",
+    "$kref": "#/ckan/github/Starstrider42/TestFlight-Configs",
+    "release_status": "testing",
+    "resources": {
+        "bugtracker": "https://github.com/Starstrider42/TestFlight-Configs/issues"
+    },
+    "provides": [
+        "TestFlightConfig"
+    ],
+    "depends": [
+        { "name": "TestFlightConfigLibrary" },
+        { "name": "ModuleManager" },
+        {
+            "name": "NearFutureSpacecraft",
+            "min_version": "1.2"
+        }
+    ],
+    "install": [
+        {
+            "file": "GameData/TestFlight/Config",
+            "install_to": "GameData/TestFlight",
+            "filter_regexp": "(?<!NFS_.+\\.cfg)$"
+        }
+    ],
+    "x_maintained_by": "Starstrider42"
+}

--- a/NetKAN/TestFlightConfig-NFSpacecraft.netkan
+++ b/NetKAN/TestFlightConfig-NFSpacecraft.netkan
@@ -5,6 +5,7 @@
     "abstract": "This config pack adds TestFlight support for Near Future Spacecraft parts.",
     "$kref": "#/ckan/github/Starstrider42/TestFlight-Configs",
     "release_status": "testing",
+    "license": "MIT",
     "resources": {
         "bugtracker": "https://github.com/Starstrider42/TestFlight-Configs/issues"
     },

--- a/NetKAN/TestFlightConfig-NFSpacecraft.netkan
+++ b/NetKAN/TestFlightConfig-NFSpacecraft.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier": "TestFlightConfig-NFSpacecraft",
     "name": "TestFlight Config for Near Future Spacecraft",
-    "abstract": "This config pack adds TestFlight support for Near Future Spacecraft parts.",
+    "abstract": "This config pack adds TestFlight support for Near Future Spacecraft parts. It does not affect stock parts; install a stock TestFlight config if desired.",
     "$kref": "#/ckan/github/Starstrider42/TestFlight-Configs",
     "release_status": "testing",
     "license": "MIT",

--- a/NetKAN/TestFlightConfig-Stock-S42.netkan
+++ b/NetKAN/TestFlightConfig-Stock-S42.netkan
@@ -1,0 +1,33 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "TestFlightConfig-Stock-S42",
+    "name": "TestFlight Config for Stock (alternative config)",
+    "abstract": "This config pack adds TestFlight support for Stock parts.",
+    "$kref": "#/ckan/github/Starstrider42/TestFlight-Configs",
+    "release_status": "testing",
+    "resources": {
+        "bugtracker": "https://github.com/Starstrider42/TestFlight-Configs/issues"
+    },
+    "provides": [
+        "TestFlightConfig"
+    ],
+    "ksp_version_min": "1.4",
+    "ksp_version_max": "1.7",
+    "comment": "ksp_version_max because each release adds TF-eligible parts",
+    "depends": [
+        { "name": "TestFlightConfigLibrary" },
+        { "name": "ModuleManager" }
+    ],
+    "conflicts": [
+        { "name": "TestFlightConfigStock", "comment": "Modifies same parts" },
+        { "name": "RealismOverhaul", "comment": "Removes stock parts" }
+    ],
+    "install": [
+        {
+            "file": "GameData/TestFlight/Config",
+            "install_to": "GameData/TestFlight",
+            "filter_regexp": "(?<!Stock_.+\\.cfg)$"
+        }
+    ],
+    "x_maintained_by": "Starstrider42"
+}

--- a/NetKAN/TestFlightConfig-Stock-S42.netkan
+++ b/NetKAN/TestFlightConfig-Stock-S42.netkan
@@ -5,6 +5,7 @@
     "abstract": "This config pack adds TestFlight support for Stock parts.",
     "$kref": "#/ckan/github/Starstrider42/TestFlight-Configs",
     "release_status": "testing",
+    "license": "MIT",
     "resources": {
         "bugtracker": "https://github.com/Starstrider42/TestFlight-Configs/issues"
     },

--- a/NetKAN/TestFlightConfigLibrary.netkan
+++ b/NetKAN/TestFlightConfigLibrary.netkan
@@ -1,0 +1,32 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "TestFlightConfigLibrary",
+    "name": "TestFlight Generic Config Library",
+    "abstract": "ModuleManager scripts for simplifying and standardizing TestFlight configs. Do *not* provide TestFlight support by themselves.",
+    "$kref": "#/ckan/github/Starstrider42/TestFlight-Configs",
+    "release_status": "testing",
+    "resources": {
+        "bugtracker": "https://github.com/Starstrider42/TestFlight-Configs/issues"
+    },
+    "depends": [
+        { "name": "ModuleManager" },
+        {
+            "name": "TestFlight",
+            "min_version": "1.8.0"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "RealismOverhaul",
+            "comment": "RO uses similar scripts; they will likely interfere with each other."
+        }
+    ],
+    "install": [
+        {
+            "file": "GameData/TestFlight/Config",
+            "install_to": "GameData/TestFlight",
+            "filter_regexp": "(?<!Generic_.+\\.cfg)$"
+        }
+    ],
+    "x_maintained_by": "Starstrider42"
+}

--- a/NetKAN/TestFlightConfigLibrary.netkan
+++ b/NetKAN/TestFlightConfigLibrary.netkan
@@ -5,6 +5,7 @@
     "abstract": "ModuleManager scripts for simplifying and standardizing TestFlight configs. Do *not* provide TestFlight support by themselves.",
     "$kref": "#/ckan/github/Starstrider42/TestFlight-Configs",
     "release_status": "testing",
+    "license": "MIT",
     "resources": {
         "bugtracker": "https://github.com/Starstrider42/TestFlight-Configs/issues"
     },

--- a/NetKAN/TestFlightConfigStock.netkan
+++ b/NetKAN/TestFlightConfigStock.netkan
@@ -27,7 +27,8 @@
         "TestFlightConfig"
     ],
     "conflicts": [
-        { "name": "TestFlightConfig" }
+        { "name": "TestFlightConfig-Stock-S42", "comment": "Modifies same parts" },
+        { "name": "RealismOverhaul", "comment": "Removes stock parts" }
     ],
     "x_netkan_override": [
         {


### PR DESCRIPTION
This PR adds `.netkan` files for the major TestFlight config packs in Starstrider42/TestFlight-Configs. 

Local testing shows that while the dependency metadata allows/forbids the correct combinations of mods, the conflict between `TestFlightConfig-Stock-S42` and the original `TestFlightConfigStock` is not handled consistently -- the latter sometimes displays on the relationship tab as "not indexed" (despite being blocked correctly), and CKAN won't let you switch between the two config packs without uninstalling TestFlight first. 😲 I'm not sure if that's a bug in CKAN's dependency resolution or in the `.ckan` files.