### PR TITLE
Epoch AJEExtendedConfigs

### DIFF
--- a/NetKAN/AJEExtendedConfigs.netkan
+++ b/NetKAN/AJEExtendedConfigs.netkan
@@ -12,5 +12,6 @@
         { "name": "ModuleManager"     },
         { "name": "AdvancedJetEngine" }
     ],
-    "x_netkan_epoch": 2
+    "x_netkan_epoch":   2,
+    "x_netkan_force_v": true
 }

--- a/NetKAN/AJEExtendedConfigs.netkan
+++ b/NetKAN/AJEExtendedConfigs.netkan
@@ -11,5 +11,6 @@
     "depends": [
         { "name": "ModuleManager"     },
         { "name": "AdvancedJetEngine" }
-    ]
+    ],
+    "x_netkan_epoch": 2
 }


### PR DESCRIPTION
Another interesting versioning system...
![versions](https://user-images.githubusercontent.com/28812678/62423361-2effc180-b6c0-11e9-82d5-5357af6501f8.png)

My plan is to epoch all new versions (including the latest) twice,
and this weird `202` version once. Should get it sorted.
Also put a `x_netkan_force_v` in, so future capital `V` get converted to lower ones.