### PR TITLE
Force 'v' for Spectra

### DIFF
--- a/NetKAN/Spectra.netkan
+++ b/NetKAN/Spectra.netkan
@@ -55,5 +55,6 @@
 			"ksp_version_min": "1.3",
 			"ksp_version_max": "1.3.99"
 		}
-	}]
+	}],
+	"x_netkan_force_v": true
 }


### PR DESCRIPTION
![Spectra](https://user-images.githubusercontent.com/28812678/63305170-26290580-c2e6-11e9-94ac-2b094bf77e20.png)

Latest version is missing a `v`.

ckan compat add 1.6