### PR TITLE
Epoch BonVoyage

### DIFF
--- a/NetKAN/BonVoyage.netkan
+++ b/NetKAN/BonVoyage.netkan
@@ -3,6 +3,6 @@
     "identifier": "BonVoyage",
     "spec_version": "v1.4",
     "license": "GPL-3.0",
-    "x_netkan_epoch": 1
+    "x_netkan_epoch": 1,
     "x_via": "Automated SpaceDock CKAN submission"
 }

--- a/NetKAN/BonVoyage.netkan
+++ b/NetKAN/BonVoyage.netkan
@@ -3,5 +3,6 @@
     "identifier": "BonVoyage",
     "spec_version": "v1.4",
     "license": "GPL-3.0",
+    "x_netkan_epoch": 1
     "x_via": "Automated SpaceDock CKAN submission"
 }


### PR DESCRIPTION
Typo in latest version:
`0.5.0_-_Come_all_you_young_sailormen_listen_to_me`, most likely should be
`0.15.0_-_Come_all_you_young_sailormen_listen_to_me`

![BonVoyage](https://user-images.githubusercontent.com/28812678/63307791-f41ca100-c2ef-11e9-84e7-c26139a820bb.png)