### PR TITLE
[#7368] Fix for kdex vref

### DIFF
--- a/NetKAN/KDEX.netkan
+++ b/NetKAN/KDEX.netkan
@@ -2,7 +2,7 @@
 	"spec_version"    : "v1.4",
 	"identifier"      : "KDEX",
 	"$kref"           : "#/ckan/github/mwerle/kdex",
-	"$vref"           : "#/ckan/ksp-avc",
+	"$vref"           : "#/ckan/ksp-avc/masTerTorch/kdex.version",
 	"name"            : "Kerbal Dust Experiment",
 	"abstract"        : "The Kerbal Dust Experiment by masTerTorch is a replica of LADEEs LDEX instrument.",
 	"description"     : "Inspired by the NASA mission LADEE. The objective of LADEE was to investigate the mysteries of the lunar atmosphere and the question of levitated lunar dust. It carried a scientific instrument called the Lunar Dust Experiment (LDEX). This instrument was an impact ionization dust detector. In this way it was possible to measure the density of dust particles.",


### PR DESCRIPTION
Specify path to "kdex.version" instead of leaving it up to ckan to find it automagically.

Fixes #7368 