### PR TITLE
KopernicusExpansionContinued-Common

### DIFF
--- a/NetKAN/KopernicusExpansionContinued-CometTail.netkan
+++ b/NetKAN/KopernicusExpansionContinued-CometTail.netkan
@@ -7,9 +7,12 @@
     "license":      "GPL-3.0",
     "install": [ {
         "find":       "KopernicusExpansion",
-        "install_to": "GameData"
+        "install_to": "GameData",
+        "filter":     [ "KEX-Common.dll" ]
+
     } ],
     "depends":  [
-        { "name" : "Kopernicus" }
+        { "name": "Kopernicus"                          },
+        { "name": "KopernicusExpansionContinued-Common" }
     ]
 }

--- a/NetKAN/KopernicusExpansionContinued-Common.netkan
+++ b/NetKAN/KopernicusExpansionContinued-Common.netkan
@@ -1,0 +1,16 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "KopernicusExpansionContinued-Common",
+    "name":         "Kopernicus Expansion Continued - Common",
+    "author":       [ "MrHappyFace", "StollD" ],
+    "$kref":        "#/ckan/github/StollD/KopernicusExpansion-Continued/asset_match/CometTail",
+    "license":      "GPL-3.0",
+    "install": [ {
+        "find":       "KEX-Common.dll",
+        "find_matches_files": true,
+        "install_to": "GameData/KopernicusExpansion/Plugins"
+    } ],
+    "depends":  [
+        { "name" : "Kopernicus" }
+    ]
+}

--- a/NetKAN/KopernicusExpansionContinued-Common.netkan
+++ b/NetKAN/KopernicusExpansionContinued-Common.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.16",
     "identifier":   "KopernicusExpansionContinued-Common",
     "name":         "Kopernicus Expansion Continued - Common",
     "author":       [ "MrHappyFace", "StollD" ],

--- a/NetKAN/KopernicusExpansionContinued-EVAFootprints.netkan
+++ b/NetKAN/KopernicusExpansionContinued-EVAFootprints.netkan
@@ -7,9 +7,12 @@
     "license":      "GPL-3.0",
     "install": [ {
         "find":       "KopernicusExpansion",
-        "install_to": "GameData"
+        "install_to": "GameData",
+        "filter":     [ "KEX-Common.dll" ]
+
     } ],
     "depends":  [
-        { "name" : "Kopernicus" }
+        { "name": "Kopernicus"                          },
+        { "name": "KopernicusExpansionContinued-Common" }
     ]
 }

--- a/NetKAN/KopernicusExpansionContinued-EmissiveFX.netkan
+++ b/NetKAN/KopernicusExpansionContinued-EmissiveFX.netkan
@@ -7,9 +7,12 @@
     "license":      "GPL-3.0",
     "install": [ {
         "find":       "KopernicusExpansion",
-        "install_to": "GameData"
+        "install_to": "GameData",
+        "filter":     [ "KEX-Common.dll" ]
+
     } ],
     "depends":  [
-        { "name" : "Kopernicus" }
+        { "name": "Kopernicus"                          },
+        { "name": "KopernicusExpansionContinued-Common" }
     ]
 }

--- a/NetKAN/KopernicusExpansionContinued-ProceduralGasGiants.netkan
+++ b/NetKAN/KopernicusExpansionContinued-ProceduralGasGiants.netkan
@@ -7,9 +7,12 @@
     "license":      "GPL-3.0",
     "install": [ {
         "find":       "KopernicusExpansion",
-        "install_to": "GameData"
+        "install_to": "GameData",
+        "filter":     [ "KEX-Common.dll" ]
+
     } ],
     "depends":  [
-        { "name" : "Kopernicus" }
+        { "name": "Kopernicus"                          },
+        { "name": "KopernicusExpansionContinued-Common" }
     ]
 }


### PR DESCRIPTION
## Problem

KopernicusExpansionContinued is ten separate downloads for various features, indexed in #7247. Four of them install `KEX-Common.dll`, so if you try to install them together, you get a conflict for that file:

```
File : GameData/KopernicusExpansion/Plugins/KEX-Common.dll
Installing Mod : KopernicusExpansionContinued-EmissiveFX release-1.7.1-5
Owning Mod: KopernicusExpansionContinued-CometTail
CKAN Version : v1.26.4
```

## Changes

Now `KopernicusExpansionContinued-Common` is added to install just that one file, and the other modules depend on this new module and skip installing the file themselves.

Fixes #7378.