### PR TITLE
Added Kerbalism Science-Only configuration pack

### DIFF
--- a/NetKAN/Kerbalism-Config-ScienceOnly.netkan
+++ b/NetKAN/Kerbalism-Config-ScienceOnly.netkan
@@ -1,0 +1,21 @@
+{
+	"spec_version": "v1.18",
+	"$kref": "#/ckan/github/Kerbalism/KerbalismScienceOnly",
+	"$vref": "#/ckan/ksp-avc",
+	"license": "Unlicense",
+	"identifier": "Kerbalism-Config-ScienceOnly",
+	"name": "Kerbalism - Science-Only Config",
+	"abstract": "Science-Only configuration for Kerbalism. Disables life support, radiation and all other features",
+	"author": ["Kerbalism Contributors"],
+	"provides": ["Kerbalism-Config"],
+	"depends": [{
+		"name": "Kerbalism"
+	}],
+	"conflicts": [{
+		"name": "Kerbalism-Config"
+	}],
+	"install": [{
+		"find": "KerbalismScienceOnly",
+		"install_to": "GameData"
+	}]
+}

--- a/NetKAN/Kerbalism-Config-ScienceOnly.netkan
+++ b/NetKAN/Kerbalism-Config-ScienceOnly.netkan
@@ -1,21 +1,22 @@
 {
-	"spec_version": "v1.18",
-	"$kref": "#/ckan/github/Kerbalism/KerbalismScienceOnly",
-	"$vref": "#/ckan/ksp-avc",
-	"license": "Unlicense",
-	"identifier": "Kerbalism-Config-ScienceOnly",
-	"name": "Kerbalism - Science-Only Config",
-	"abstract": "Science-Only configuration for Kerbalism. Disables life support, radiation and all other features",
-	"author": ["Kerbalism Contributors"],
-	"provides": ["Kerbalism-Config"],
-	"depends": [{
-		"name": "Kerbalism"
-	}],
-	"conflicts": [{
-		"name": "Kerbalism-Config"
-	}],
-	"install": [{
-		"find": "KerbalismScienceOnly",
-		"install_to": "GameData"
-	}]
+    "spec_version": "v1.18",
+    "$kref": "#/ckan/github/Kerbalism/KerbalismScienceOnly",
+    "$vref": "#/ckan/ksp-avc",
+    "license": "Unlicense",
+    "identifier": "Kerbalism-Config-ScienceOnly",
+    "name": "Kerbalism - Science-Only Config",
+    "abstract": "Science-Only configuration for Kerbalism. Disables life support, radiation and all other features",
+    "author": ["Kerbalism Contributors"],
+    "provides": ["Kerbalism-Config"],
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "Kerbalism" }
+    ],
+    "conflicts": [{
+        "name": "Kerbalism-Config"
+    }],
+    "install": [{
+        "find": "KerbalismScienceOnly",
+        "install_to": "GameData"
+    }]
 }


### PR DESCRIPTION
A configuration pack that disables everything Kerbalism - everything but the science feature.

This has been requested quite a few times on the forum.