### PR TITLE
Use original repo and version info for CommunityDeltaVMaps

### DIFF
--- a/NetKAN/CommunityDeltaVMaps.netkan
+++ b/NetKAN/CommunityDeltaVMaps.netkan
@@ -1,8 +1,14 @@
 {
     "spec_version": "v1.16",
     "identifier":   "CommunityDeltaVMaps",
-    "$kref":        "#/ckan/spacedock/1914",
+    "name":         "Community Delta-V Maps",
+    "abstract":     "KSPedia addition of map displaying delta-V requirements to reach bodies in the stock Kerbol system.",
+    "$kref":        "#/ckan/github/Kowgan/ksp_cheat_sheets",
     "license":      "CC-BY-NC-SA-4.0",
+    "ksp_version_min": "1.3",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/87463-*",
+    },
     "install": [ {
         "find_regexp":        "Delta-V Map.*\\.ksp",
         "install_to":         "GameData/CommunityDeltaVMaps",

--- a/NetKAN/CommunityDeltaVMaps.netkan
+++ b/NetKAN/CommunityDeltaVMaps.netkan
@@ -7,7 +7,7 @@
     "license":      "CC-BY-NC-SA-4.0",
     "ksp_version_min": "1.3",
     "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/87463-*",
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/87463-*"
     },
     "install": [ {
         "find_regexp":        "Delta-V Map.*\\.ksp",


### PR DESCRIPTION
In #6686 we indexed CommunityDeltaVMaps, but this was a third party re-upload to SpaceDock. Another third party attempted the same with a new re-upload in #7390, possibly just to update the compatibility? It wasn't explained.

Now the original repo is used, and the compatibility is updated to match the forum thread's info of 1.3+. This way the authorship will be accurate, new versions will be detected, and the compatible game versions will be correct.

https://forum.kerbalspaceprogram.com/index.php?/topic/87463-13-community-delta-v-map-26
