### PR TITLE
Normalize install_to paths

### DIFF
--- a/NetKAN/BlacklegIndustriesMMTantaresTACLS.netkan
+++ b/NetKAN/BlacklegIndustriesMMTantaresTACLS.netkan
@@ -13,7 +13,7 @@
     "install": [
         {
             "file" : "blackind/MMPatches/Tantares_TACLifeSupport.cfg",
-            "install_to" : "GameData/blackind/MMPatches/"
+            "install_to" : "GameData/blackind/MMPatches"
         }
     ],
     "depends": [

--- a/NetKAN/CommunityPartsTitlesExtrasNoCCKDup.netkan
+++ b/NetKAN/CommunityPartsTitlesExtrasNoCCKDup.netkan
@@ -21,7 +21,7 @@
     "install" : [
         {
             "file"       : "GameData/002_CommunityPartsTitles/Extras/category_hide_cck.cfg",
-            "install_to" : "GameData/002_CommunityPartsTitles/Extras/",
+            "install_to" : "GameData/002_CommunityPartsTitles/Extras",
             "comment"    : "Install category_hide_cck.cfg into Extras/ folder. So it is kind of Extra for Extra."
         }
     ]

--- a/NetKAN/OinkersSkybox.netkan
+++ b/NetKAN/OinkersSkybox.netkan
@@ -12,11 +12,11 @@
     "install": [
         {
             "find":"Default",
-            "install_to": "GameData/TextureReplacer/"
+            "install_to": "GameData/TextureReplacer"
         },
         {
             "find":"EnvMap",
-            "install_to": "GameData/TextureReplacer/"
+            "install_to": "GameData/TextureReplacer"
         }
     ]
 }

--- a/NetKAN/VersatileToolboxSystem-TACLSPack.netkan
+++ b/NetKAN/VersatileToolboxSystem-TACLSPack.netkan
@@ -10,57 +10,57 @@
     "install": [
         {
             "find"       : "Parts/vts_nazari/vtsfood.cfg",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         },
         {
             "find"       : "Parts/vts_nazari/vtsfood.mu",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         },
         {
             "find"       : "Parts/vts_nazari/vtslifesupport.cfg",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         },
         {
             "find"       : "Parts/vts_nazari/vtslifesupport.mu",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         },
         {
             "find"       : "Parts/vts_nazari/vtsoxygen.cfg",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         },
         {
             "find"       : "Parts/vts_nazari/vtsoxygen.mu",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         },
         {
             "find"       : "Parts/vts_nazari/vtstankLabeloxygen.png",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         },
         {
             "find"       : "Parts/vts_nazari/vtstankLabelsupport.png",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         },
         {
             "find"       : "Parts/vts_nazari/vtstankLabelwater.png",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         },
         {
             "find"       : "Parts/vts_nazari/vtswater.cfg",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         },
         {
             "find"       : "Parts/vts_nazari/vtswater.mu",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         }
     ]

--- a/NetKAN/VersatileToolboxSystem-USIPack.netkan
+++ b/NetKAN/VersatileToolboxSystem-USIPack.netkan
@@ -10,52 +10,52 @@
     "install": [
         {
             "find"       : "Parts/vts_nazari/vtsfertilizer.cfg",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         },
         {
             "find"       : "Parts/vts_nazari/vtsfertilizer.mu",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         },
         {
             "find"       : "Parts/vts_nazari/vtskarbonite.cfg",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         },
         {
             "find"       : "Parts/vts_nazari/vtskarbonite.mu",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         },
         {
             "find"       : "Parts/vts_nazari/vtsmulch.cfg",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         },
         {
             "find"       : "Parts/vts_nazari/vtsmulch.mu",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         },
         {
             "find"       : "Parts/vts_nazari/vtssupplies.cfg",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         },
         {
             "find"       : "Parts/vts_nazari/vtssupplies.mu",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         },
         {
             "find"       : "Parts/vts_nazari/vtstankKarbonite.png",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         },
         {
             "find"       : "Parts/vts_nazari/vtstankLabelKarbonite.png",
-            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari/",
+            "install_to" : "GameData/MP_Nazari/Parts/vts_nazari",
             "find_matches_files": true
         }
     ]


### PR DESCRIPTION
See KSP-CKAN/CKAN#2880, `install_to` paths that are not normalized can trigger a problem with repeating notifications of changed metadata in GUI.

This PR fixes several such values. There should still be a separate code fix to avoid this problem in the future, and probably another PR in CKAN-meta to fix any .ckan files that aren't addressed by this PR.