### PR TITLE
Add CustomPreLaunchChecks, a KerbalKonstructs dependency

### DIFF
--- a/NetKAN/CustomPreLaunchChecks.netkan
+++ b/NetKAN/CustomPreLaunchChecks.netkan
@@ -1,0 +1,8 @@
+{
+	"spec_version": "v1.4",
+	"identifier":   "CustomPreLaunchChecks",
+	"abstract":     "A C# API so you can write your own prelaunch Checks, that run when you press the launch button in the VAB or SPH",
+	"$kref":        "#/ckan/github/GER-Space/CustomPreLauchChecks",
+	"$vref":        "#/ckan/ksp-avc",
+	"license":      "MIT"
+}

--- a/NetKAN/CustomPreLaunchChecks.netkan
+++ b/NetKAN/CustomPreLaunchChecks.netkan
@@ -1,8 +1,11 @@
 {
-	"spec_version": "v1.4",
-	"identifier":   "CustomPreLaunchChecks",
-	"abstract":     "A C# API so you can write your own prelaunch Checks, that run when you press the launch button in the VAB or SPH",
-	"$kref":        "#/ckan/github/GER-Space/CustomPreLauchChecks",
-	"$vref":        "#/ckan/ksp-avc",
-	"license":      "MIT"
+    "spec_version": "v1.4",
+    "identifier":   "CustomPreLaunchChecks",
+    "abstract":     "A C# API so you can write your own prelaunch Checks, that run when you press the launch button in the VAB or SPH",
+    "$kref":        "#/ckan/github/GER-Space/CustomPreLauchChecks",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "MIT",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/187525-*"
+    }
 }

--- a/NetKAN/KerbalKonstructs.netkan
+++ b/NetKAN/KerbalKonstructs.netkan
@@ -8,7 +8,8 @@
     "license"      : "restricted",
     "comment"      : "Plugin is MIT, but Static Assets, Artwork & Models are ARR",
     "depends"      : [
-        { "name"   : "ModuleManager" }
+        { "name"   : "ModuleManager"         },
+        { "name"   : "CustomPreLaunchChecks" }
     ],
     "suggests": [
         { "name"   : "KKtoSD" }


### PR DESCRIPTION
Three versions ago, KerbalKonstructs added a new bundled mod in its download. This PR indexes it and adds it as a dependency. We will need an additional PR in CKAN-meta for two older KK versions.