### PR TITLE
Override Firespitter 7.13's max KSP version to 1.7

### DIFF
--- a/NetKAN/Firespitter.netkan
+++ b/NetKAN/Firespitter.netkan
@@ -7,6 +7,12 @@
     "license"      : "restricted",
     "$vref"        : "#/ckan/ksp-avc",
     "x_netkan_force_v" : true,
+    "x_netkan_override": [ {
+        "version":  "v7.13.0",
+        "override": {
+            "ksp_version_max": "1.7"
+        }
+    } ],
     "resources" : {
         "homepage" : "http://snjo.github.io/",
         "repository"  : "https://github.com/snjo/Firespitter"

--- a/NetKAN/FirespitterCore.netkan
+++ b/NetKAN/FirespitterCore.netkan
@@ -1,13 +1,19 @@
 {
     "spec_version"    : "v1.16",
     "identifier"      : "FirespitterCore",
-    "$kref"           : "#/ckan/github/snjo/Firespitter",
-    "license"         : "restricted",
     "name"            : "Firespitter Core",
     "abstract"        : "Core Firespitter.dll. Install `Firespitter` for the whole shebang",
+    "$kref"           : "#/ckan/github/snjo/Firespitter",
+    "license"         : "restricted",
     "author"          : "Roverdude",
     "$vref"           : "#/ckan/ksp-avc",
     "x_netkan_force_v" : true,
+    "x_netkan_override": [ {
+        "version":  "v7.13.0",
+        "override": {
+            "ksp_version_max": "1.7"
+        }
+    } ],
     "resources" : {
         "homepage" : "http://snjo.github.io/",
         "repository"  : "https://github.com/snjo/Firespitter"

--- a/NetKAN/FirespitterResourcesConfig.netkan
+++ b/NetKAN/FirespitterResourcesConfig.netkan
@@ -1,12 +1,18 @@
 {
     "spec_version"    : "v1.4",
     "identifier"      : "FirespitterResourcesConfig",
+    "name"            : "Firespitter Resources config",
+    "abstract"        : "Resource definition required by some mods",
     "$kref"           : "#/ckan/github/snjo/Firespitter",
     "license"         : "restricted",
     "x_netkan_force_v" : true,
-   "name" : "Firespitter Resources config",
-   "abstract" : "Resource definition required by some mods",
     "$vref"         :   "#/ckan/ksp-avc",
+    "x_netkan_override": [ {
+        "version":  "v7.13.0",
+        "override": {
+            "ksp_version_max": "1.7"
+        }
+    } ],
     "resources" : {
         "homepage" : "http://snjo.github.io/",
         "repository"  : "https://github.com/snjo/Firespitter"


### PR DESCRIPTION
@sarbian reports on Discord that Firespitter 7.13 is not built for KSP 1.8 (which includes a Unity upgrade and therefore mostly breaks compatibility across the board), but this commit marked the max KSP version as 1.8.9 back in August:

https://github.com/snjo/Firespitter/commit/d6ec90eb76f09a03a1858db85f745a1ad789018f

If we can confirm this, these overrides will set it back to 1.7.