### PR TITLE
Allow KJRNext to drop in for KJRorig/cont for ChakaMonkeyExplorationSystems

### DIFF
--- a/NetKAN/ChakaMonkeyExplorationSystems.netkan
+++ b/NetKAN/ChakaMonkeyExplorationSystems.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.26",
     "identifier":   "ChakaMonkeyExplorationSystems",
     "$kref":        "#/ckan/spacedock/599",
     "x_netkan_epoch": 3,

--- a/NetKAN/ChakaMonkeyExplorationSystems.netkan
+++ b/NetKAN/ChakaMonkeyExplorationSystems.netkan
@@ -6,7 +6,10 @@
     "license":      "restricted",
     "depends": [
         { "name": "AnimatedDecouplers" },
-        { "name": "KerbalJointReinforcement" },
+        { "any_of": [ 
+            { "name": "KerbalJointReinforcement" },
+            { "name": "KerbalJointReinforcementNext" }
+        ]},
         { "name": "ProceduralFairings" },
         { "name": "ASETProps" },
         { "name": "MK12PodIVAReplacementbyASET" },


### PR DESCRIPTION
ChakaMonkeyExplorationSystems depends on KJR (original/Continued).

A user in the forum reported, that this keeps him from installing it together with InfernalRoboticsNext, which depends on KJRNext:
https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1264-orion/&do=findComment&comment=3687555

A `"any_of": ["KerbalJointReinforcement", "KerbalJointReinforcementNext"]` relationship should solve this.

Rudolf Meier (the author of KJRNext) wrote, that CMES _should_ work with KJRNext, but he didn't test it.
Neither did I find anything about using it with KJRNext in CMES' forum thread.
And there's no answer by YANFRET yet.

@HebaruSan, can we still change the metadata? Or should we wait for a comment by YANFRET?

ckan compat add 1.7