### PR TITLE
Updating netKAN to cope with the new Redist scheme.

### DIFF
--- a/NetKAN/TweakScale.netkan
+++ b/NetKAN/TweakScale.netkan
@@ -15,6 +15,10 @@
     ],
     "install" : [
         {
+            "file" : "GameData/999_Scale_Redist.dll",
+            "install_to" : "GameData"
+        },
+        {
             "file" : "GameData/TweakScale",
             "install_to" : "GameData"
         }


### PR DESCRIPTION
New scheme for Redist.dll distribution is needed to avoid spamming the KSP.log with AddOn Binder errors.