### PR TITLE
ProjectManager 1.8 demarcation

### DIFF
--- a/NetKAN/ProjectManager.netkan
+++ b/NetKAN/ProjectManager.netkan
@@ -1,27 +1,23 @@
 {
-  "spec_version": "v1.4",
-  "install": [
-    {
-      "install_to": "GameData",
-      "find": "ProjectManager"
-    }
-  ],
-  "$kref": "#/ckan/github/Tantares/ProjectManager",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "identifier": "ProjectManager",
-  "license": "CC-BY-NC-SA-4.0",
-  "x_netkan_override": [
-    {
-      "version": "<v2.3",
-      "override": {
-        "ksp_version_max": "1.7"
-      }
+    "spec_version":    "v1.4",
+    "identifier":      "ProjectManager",
+    "$kref":           "#/ckan/github/Tantares/ProjectManager",
+    "ksp_version_min": "1.8",
+    "x_netkan_staging": true,
+    "x_netkan_staging_reason": "Game version hard-coded in netkan. Please confirm it still matches the forum thread.",
+    "license":         "CC-BY-NC-SA-4.0",
+    "resoures": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/184785-*"
     },
-    {
-      "version": ">=v2.3",
-      "override": {
-        "ksp_version_min": "1.8"
-      }
-    }
-  ]
+    "install": [ {
+        "find":       "ProjectManager",
+        "install_to": "GameData"
+    } ],
+    "x_netkan_override": [ {
+        "version": "<v2.3",
+        "override": {
+            "ksp_version_max": "1.7"
+        }
+    } ],
+    "x_via": "Automated Linuxgurugamer CKAN script"
 }

--- a/NetKAN/ProjectManager.netkan
+++ b/NetKAN/ProjectManager.netkan
@@ -9,5 +9,19 @@
   "$kref": "#/ckan/github/Tantares/ProjectManager",
   "x_via": "Automated Linuxgurugamer CKAN script",
   "identifier": "ProjectManager",
-  "license": "CC-BY-NC-SA-4.0"
+  "license": "CC-BY-NC-SA-4.0",
+  "x_netkan_override": [
+    {
+      "version": "<v2.3",
+      "override": {
+        "ksp_version_max": "1.7"
+      }
+    },
+    {
+      "version": ">=v2.3",
+      "override": {
+        "ksp_version_min": "1.8"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
ProjectManager v2.3 is a recompile for 1.8 and does not work with previous ksp versions. This can be expected to be the case for all following versions of the mod.