### PR TITLE
Fix spec_versions

### DIFF
--- a/NetKAN/PartOverhaulsSETI.netkan
+++ b/NetKAN/PartOverhaulsSETI.netkan
@@ -1,6 +1,6 @@
 {
-  "spec_version": 1,
-  "identifier": "PartOverhaulsSETI",
-  "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Y3mo/SETI-NetKAN/master/PartOverhaulsSETI.netkan",
-  "x_netkan_license_ok": true
+    "spec_version": "v1.4",
+    "identifier": "PartOverhaulsSETI",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Y3mo/SETI-NetKAN/master/PartOverhaulsSETI.netkan",
+    "x_netkan_license_ok": true
 }

--- a/NetKAN/SETI-BalanceMod.netkan
+++ b/NetKAN/SETI-BalanceMod.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "SETI-BalanceMod",
     "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Y3mo/SETI-NetKAN/master/SETI-BalanceMod.netkan",
     "x_netkan_license_ok": true

--- a/NetKAN/SETI-CareerChallenge.netkan
+++ b/NetKAN/SETI-CareerChallenge.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-CareerChallenge",
     "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Y3mo/SETI-NetKAN/master/SETI-CareerChallenge.netkan",
     "x_netkan_license_ok": true

--- a/NetKAN/SETI-CustomBarnKit.netkan
+++ b/NetKAN/SETI-CustomBarnKit.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-CustomBarnKit",
     "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Y3mo/SETI-NetKAN/master/SETI-CustomBarnKit.netkan",
     "x_netkan_license_ok": true

--- a/NetKAN/SETI-ProbeControlEnabler.netkan
+++ b/NetKAN/SETI-ProbeControlEnabler.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-ProbeControlEnabler",
     "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Y3mo/SETI-NetKAN/master/SETI-ProbeControlEnabler.netkan",
     "x_netkan_license_ok": true

--- a/NetKAN/SETI-RebalanceMaterialsGoo.netkan
+++ b/NetKAN/SETI-RebalanceMaterialsGoo.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-RebalanceMaterialsGoo",
     "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Y3mo/SETI-NetKAN/master/SETI-RebalanceMaterialsGoo.netkan",
     "x_netkan_license_ok": true

--- a/NetKAN/SETI-RemoteTech.netkan
+++ b/NetKAN/SETI-RemoteTech.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "SETI-RemoteTech",
     "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Y3mo/SETI-NetKAN/master/SETI-RemoteTech.netkan",
     "x_netkan_license_ok": true

--- a/NetKAN/UnmannedBeforeManned.netkan
+++ b/NetKAN/UnmannedBeforeManned.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.2",
+    "spec_version": "v1.4",
     "identifier": "UnmannedBeforeManned",
     "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Y3mo/SETI-NetKAN/master/UnmannedBeforeManned.netkan",
     "x_netkan_license_ok": true

--- a/NetKAN/UnmannedBeforeMannedChallenge.netkan
+++ b/NetKAN/UnmannedBeforeMannedChallenge.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier": "UnmannedBeforeMannedChallenge",
     "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Y3mo/SETI-NetKAN/master/UnmannedBeforeMannedChallenge.netkan",
     "x_netkan_license_ok": true


### PR DESCRIPTION
## Problem

With KSP-CKAN/CKAN#2915's newly strict validation of metanetkans, several mods have new errors:

> New inflation error for SETI-RemoteTech: spec_version v1.4+ required for install with 'find'
> New inflation error for SETI-CareerChallenge: spec_version v1.4+ required for install with 'find'
> New inflation error for SETI-RebalanceMaterialsGoo: spec_version v1.4+ required for install with 'find'
> New inflation error for PartOverhaulsSETI: spec_version v1.4+ required for install with 'find'
> New inflation error for Ringworld: spec_version v1.18+ required for license 'Unlicense'
> New inflation error for UnmannedBeforeMannedChallenge: spec_version v1.4+ required for install with 'find'
> New inflation error for UnmannedBeforeManned: spec_version v1.4+ required for install with 'find'
> New inflation error for SETI-ProbeControlEnabler: spec_version v1.4+ required for install with 'find'
> New inflation error for SETI-BalanceMod: spec_version v1.4+ required for install with 'find'
> New inflation error for SETI-CustomBarnKit: spec_version v1.4+ required for install with 'find'

## Changes

Ringworld is fixed in https://github.com/HebaruSan/Ringworld/commit/78044a53955c16fb942ec23aebf19cb1251b32e4#diff-66a547d927b7d277ed7760cfe574b4d1.

The rest are added to Y3mo/SETI-NetKAN#2. Since I don't expect a response from the author, this PR fixes them in the core NetKAN entries as well.