### PR TITLE
Remove DecalStickers' vref

### DIFF
--- a/NetKAN/DecalStickers.netkan
+++ b/NetKAN/DecalStickers.netkan
@@ -1,25 +1,15 @@
 {
-  "spec_version": "v1.4",
-  "install": [
-    {
-      "install_to": "GameData",
-      "find": "blackheart"
-    }
-  ],
-  "depends": [
-    {
-      "name": "FirespitterResourcesConfig"
-    },
-    {
-      "name": "ModuleManager"
-    },
-    {
-      "name": "FirespitterCore"
-    }
-  ],
-  "$vref": "#/ckan/ksp-avc",
-  "$kref": "#/ckan/spacedock/1108",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "identifier": "DecalStickers",
-  "license": "unknown"
+    "spec_version": "v1.4",
+    "identifier":   "DecalStickers",
+    "$kref":        "#/ckan/spacedock/1108",
+    "license":      "GPL-1.0",
+    "install": [ {
+        "find":       "blackheart",
+        "install_to": "GameData"
+    } ],
+    "depends": [
+        { "name": "FirespitterResourcesConfig" },
+        { "name": "ModuleManager"              },
+        { "name": "FirespitterCore"            }
+    ]
 }


### PR DESCRIPTION
This mod currently has an error on the status page.

> Unexpected character encountered while parsing value: <. Path '', line 0, position 0.

This is in reference to its version file. However, this mod does not have its own version file; rather, netkan is finding the version file of an embedded copy of Firespitter. (And the file contents are a 75 KB HTML document instead of a version file, hence the error.)