### PR TITLE
Set Unlicense for applicable mods

### DIFF
--- a/NetKAN/ContractConfigurator-SCANsat.netkan
+++ b/NetKAN/ContractConfigurator-SCANsat.netkan
@@ -22,7 +22,7 @@
     ],
     "install": [
         {
-            "find":       "CC_Contracts",
+            "find":       "ContractPacks",
             "install_to": "GameData"
         }
     ],

--- a/NetKAN/ContractConfigurator-SCANsat.netkan
+++ b/NetKAN/ContractConfigurator-SCANsat.netkan
@@ -1,12 +1,13 @@
 {
     "spec_version": "v1.4",
-    "identifier": "ContractConfigurator-SCANsat",
-    "abstract": "A Mission pack creating SCANsat contracts",
-    "name": "SCANsat mission pack",
-    "license": "public-domain",
-    "x_netkan_license_ok": true,
+    "identifier":   "ContractConfigurator-SCANsat",
+    "name":         "SCANsat mission pack",
+    "abstract":     "A Mission pack creating SCANsat contracts",
+    "author":       "SimonTheSourcerer",
+    "$kref":        "#/ckan/github/SimonTheSourcerer/CCSCANsatMissionPack",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "WTFPL",
     "x_maintained_by": "hakan42, who loves to fly missions with contracts in them",
-    "ksp_version_max" : "1.0.5",
     "depends": [
         {
             "name": "ContractConfigurator"
@@ -21,14 +22,11 @@
     ],
     "install": [
         {
-            "find": "CC_Contracts",
+            "find":       "CC_Contracts",
             "install_to": "GameData"
         }
     ],
     "resources": {
         "repository": "https://github.com/SimonTheSourcerer/CCSCANsatMissionPack"
     },
-    "author": "SimonTheSourcerer",
-    "version": "1.0.2",
-    "download": "https://github.com/SimonTheSourcerer/CCSCANsatMissionPack/releases/download/1.0.2/CCSCANsatMissionPack.zip"
 }

--- a/NetKAN/ContractConfigurator-SCANsat.netkan
+++ b/NetKAN/ContractConfigurator-SCANsat.netkan
@@ -28,5 +28,5 @@
     ],
     "resources": {
         "repository": "https://github.com/SimonTheSourcerer/CCSCANsatMissionPack"
-    },
+    }
 }

--- a/NetKAN/ControlLock.netkan
+++ b/NetKAN/ControlLock.netkan
@@ -1,21 +1,23 @@
 {
-    "spec_version" : 1,
-    "$kref" : "#/ckan/github/SirDiazo/ControlLock",
-    "name" : "Control Lock",
-    "identifier" : "ControlLock",
-    "author" : "Diazo",
-    "abstract" : "Lock KSP so that when entering text in a text field, you do not pass commands to your vessel.",
-    "license" : "public-domain",
-    "release_status" : "stable",
-    "ksp_version" : "1.1",
-    "resources" : {
-        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/97829-11apr2416-control-lock-input-text-into-text-fields-without-issuing-commands-to-your-vessel/"
+    "spec_version": "v1.18",
+    "identifier":   "ControlLock",
+    "name":         "Control Lock",
+    "abstract":     "Lock KSP so that when entering text in a text field, you do not pass commands to your vessel.",
+    "author":       "Diazo",
+    "$kref":        "#/ckan/github/SirDiazo/ControlLock",
+    "license":      "Unlicense",
+    "release_status": "stable",
+    "ksp_version":  "1.1",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/97829-*"
     },
-    "recommends" : [ { "name" : "Toolbar" } ],
-    "install" : [
+    "recommends": [
+        { "name": "Toolbar" }
+    ],
+    "install": [
         {
-            "file" : "GameData/001ControlLock",
-            "install_to" : "GameData"
+            "file":       "GameData/001ControlLock",
+            "install_to": "GameData"
         }
     ]
 }

--- a/NetKAN/CoolRockets.netkan
+++ b/NetKAN/CoolRockets.netkan
@@ -5,6 +5,7 @@
     "abstract":     "Cryo and Launch Particle Effects",
     "author":       [ "sarbian", "dtobi" ],
     "$kref":        "#/ckan/jenkins/https://ksp.sarbian.com/jenkins/job/ColdRockets",
+    "version":      "0.08",
     "ksp_version":  "1.1",
     "x_netkan_staging": true,
     "x_netkan_staging_reason": "Game version hard-coded in netkan, please confirm it matches the forum thread",

--- a/NetKAN/CoolRockets.netkan
+++ b/NetKAN/CoolRockets.netkan
@@ -1,20 +1,23 @@
 {
     "spec_version": 1,
-    "identifier": "CoolRockets",
-    "name": "CoolRockets",
-    "abstract": "Cryo and Launch Particle Effects",
-    "author": [ "sarbian", "dtobi" ],
-    "license": "public-domain",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/61925-11x-coolrockets-cryo-and-launch-particle-fx/"
-    },
+    "identifier":   "CoolRockets",
+    "name":         "CoolRockets",
+    "abstract":     "Cryo and Launch Particle Effects",
+    "author":       [ "sarbian", "dtobi" ],
+    "$kref":        "#/ckan/jenkins/https://ksp.sarbian.com/jenkins/job/ColdRockets",
+    "ksp_version":  "1.1",
+    "x_netkan_staging": true,
+    "x_netkan_staging_reason": "Game version hard-coded in netkan, please confirm it matches the forum thread",
+    "license":      "public-domain",
     "release_status": "development",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/61925-*"
+    },
     "depends": [
-        { "name": "SmokeScreen", "min_version": "2.5.2" },
-        { "name": "ModuleManager" }
-    ],
-    "version": "0.08",
-    "ksp_version_min": "1.0.0",
-    "ksp_version_max": "1.0.4",
-    "download": "https://ksp.sarbian.com/jenkins/job/ColdRockets/4/artifact/CoolRockets.zip"
+        { "name": "ModuleManager" },
+        {
+            "name":        "SmokeScreen",
+            "min_version": "2.5.2"
+        }
+    ]
 }

--- a/NetKAN/EasyVesselSwitch.netkan
+++ b/NetKAN/EasyVesselSwitch.netkan
@@ -1,6 +1,6 @@
 {
-    "spec_version"    : 1,
+    "spec_version"    : "v1.18",
     "identifier"      : "EasyVesselSwitch",
     "$kref"           : "#/ckan/netkan/https://raw.githubusercontent.com/ihsoft/EasyVesselSwitch/master/EasyVesselSwitch.netkan",
-    "license"         : "public-domain"
+    "license"         : "Unlicense"
 }

--- a/NetKAN/ExceptionDetector.netkan
+++ b/NetKAN/ExceptionDetector.netkan
@@ -1,18 +1,19 @@
 {
-	"spec_version": 1,
-	"identifier": "ExceptionDetector",
-	"$kref": "#/ckan/spacedock/600",
-	"license": "public-domain",
+	"spec_version": "v1.18",
+	"identifier":   "ExceptionDetector",
+	"$kref":        "#/ckan/spacedock/600",
+	"license":      "Unlicense",
 	"release_status": "stable",
 	"resources": {
-		"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/98658-exceptiondetector-11-ksp-any-version/",
+		"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/98658-*",
 		"repository": "https://github.com/godarklight/ExceptionDetector"
 	},
-	"install": [{
-		"file": "GameData/ExceptionDetector",
+	"install": [ {
+		"file":       "GameData/ExceptionDetector",
 		"install_to": "GameData"
-	}],
-	"x_netkan_override": [{
+	} ],
+	"x_netkan_override": [
+		{
 			"version": "3",
 			"delete" : [ "ksp_version" ],
 			"override": {

--- a/NetKAN/KScale2.netkan
+++ b/NetKAN/KScale2.netkan
@@ -1,10 +1,12 @@
 {
-    "license"      : "public-domain",
-    "identifier"   : "KScale2",
     "spec_version" : "v1.4",
+    "identifier"   : "KScale2",
     "$kref"        : "#/ckan/spacedock/349",
     "$vref"        : "#/ckan/ksp-avc",
-    "resources"    : { "homepage" : "http://www.kingtiger.co.uk/kingtiger/wordpress/KScale2" },
+    "license"      : "public-domain",
+    "resources"    : {
+        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/112905-*"
+    },
     "depends" : [
         { "name": "SigmaDimensions" }
     ],
@@ -13,7 +15,7 @@
     ],
     "install": [
         {
-            "find": "KScale2",
+            "find":       "KScale2",
             "install_to": "GameData"
         }
     ]

--- a/NetKAN/LayeredAnimations.netkan
+++ b/NetKAN/LayeredAnimations.netkan
@@ -1,10 +1,10 @@
 {
-    "spec_version": 1,
-    "identifier": "LayeredAnimations",
-    "$kref": "#/ckan/github/Starwaster/LayeredAnimations",
-    "name": "Layered Animations",
-    "abstract": "Adds layers to KSP's ModuleAnimateGeneric",
-    "license": "public-domain",
+    "spec_version": "v1.18",
+    "identifier":   "LayeredAnimations",
+    "name":         "Layered Animations",
+    "abstract":     "Adds layers to KSP's ModuleAnimateGeneric",
+    "$kref":        "#/ckan/github/Starwaster/LayeredAnimations",
+    "license":      "Unlicense",
     "ksp_version_min": "0.90",
     "ksp_version_max": "1.0.4",
     "install": [

--- a/NetKAN/NavBallsToYou.netkan
+++ b/NetKAN/NavBallsToYou.netkan
@@ -1,6 +1,6 @@
 {
-    "identifier": "NavBallsToYou",
-    "spec_version": "v1.4",
-    "$kref": "#/ckan/spacedock/458",
-    "license": "public-domain"
+    "spec_version": "v1.18",
+    "identifier":   "NavBallsToYou",
+    "$kref":        "#/ckan/spacedock/458",
+    "license":      "Unlicense"
 }

--- a/NetKAN/ReflectionPlugin.netkan
+++ b/NetKAN/ReflectionPlugin.netkan
@@ -1,13 +1,13 @@
 {
-    "spec_version" : "v1.4",
+    "spec_version" : "v1.18",
     "identifier"   : "ReflectionPlugin",
     "$kref"        : "#/ckan/github/raidernick/Reflection-Plugin-Continued",
     "name"         : "Reflection Plugin Continued",
     "abstract"     : "Make stuff shiny, plugin for modders",
-	"author"       : [ "Razchek", "Starwaster", "RaiderNick" ],
-    "license"      : "public-domain",
+    "author"       : [ "Razchek", "Starwaster", "RaiderNick" ],
+    "license"      : "Unlicense",
     "$vref"        : "#/ckan/ksp-avc",
-	"x_netkan_epoch"   : 1,
+    "x_netkan_epoch"   : 1,
     "resources": {
         "homepage": "https://github.com/raidernick/Reflection-Plugin-Continued"
     },

--- a/NetKAN/StockNoContracts.netkan
+++ b/NetKAN/StockNoContracts.netkan
@@ -1,9 +1,9 @@
 {
-    "spec_version": 1,
-    "$kref": "#/ckan/spacedock/111",
-    "$vref" : "#/ckan/ksp-avc",
-    "identifier": "StockNoContracts",
-    "license": "public-domain",
+    "spec_version": "v1.18",
+    "identifier":   "StockNoContracts",
+    "$kref":        "#/ckan/spacedock/111",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "Unlicense",
     "depends": [
         { "name": "ModuleManager", "min_version": "2.6.0" }
     ]

--- a/NetKAN/StockPlugins.netkan
+++ b/NetKAN/StockPlugins.netkan
@@ -1,9 +1,9 @@
 {
-    "spec_version" : 1,
-    "identifier" : "StockPlugins",
-    "$kref" : "#/ckan/spacedock/112",
-    "$vref" : "#/ckan/ksp-avc",
-    "license": "public-domain",
+    "spec_version": "v1.18",
+    "identifier":   "StockPlugins",
+    "$kref":        "#/ckan/spacedock/112",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "Unlicense",
     "depends": [
         { "name": "ModuleManager", "min_version": "2.6.0" }
     ],

--- a/NetKAN/StockRT.netkan
+++ b/NetKAN/StockRT.netkan
@@ -1,9 +1,9 @@
 {
-    "spec_version": 1,
-    "identifier": "StockRT",
-    "$kref": "#/ckan/spacedock/113",
-    "$vref" : "#/ckan/ksp-avc",
-    "license": "public-domain",
+    "spec_version": "v1.18",
+    "identifier":   "StockRT",
+    "$kref":        "#/ckan/spacedock/113",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "Unlicense",
     "depends": [
         { "name": "ModuleManager", "min_version": "2.6.0" },
         { "name": "RemoteTech", "min_version": "v1.6.0" }

--- a/NetKAN/StockSCANsat.netkan
+++ b/NetKAN/StockSCANsat.netkan
@@ -1,9 +1,9 @@
 {
-    "spec_version": 1,
-    "identifier": "StockSCANsat",
-    "$kref": "#/ckan/spacedock/114",
-    "$vref" : "#/ckan/ksp-avc",
-    "license": "public-domain",
+    "spec_version": "v1.18",
+    "identifier":   "StockSCANsat",
+    "$kref":        "#/ckan/spacedock/114",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "Unlicense",
     "depends": [
         { "name": "ModuleManager", "min_version": "2.6.0" },
         { "name": "SCANsat", "min_version": "v16.0"}


### PR DESCRIPTION
As noted in #4131, several mods are released under the Unlicense and should be marked that way. Now they are (and their `spec_version` is updated to `v1.18`).

In some cases, the Unlicense in fact was not used, so those are skipped or updated to their actual license. A few mods are switched from a `download` property to a `$kref`, have their `homepage` updated, etc.

Note that the Unlicense is just a specific version of public domain (it's one of the built-in choices on GitHub). Technically a mod released into the public domain and a mod using the Unlicense have the same terms and conditions. Since CKAN supports both `public-domain` and `Unlicense` as license values, I have opted to set any mod that specifically mentions "unlicense" as `Unlicense` and leave those simply stating "public domain" as `public-domain`.

This is a partial fix for #4131. Some of the affected mods have no netkans and will need a separate PR in CKAN-meta.

ckan compat add 1.0