### PR TITLE
Remove install stanzas for DSSHU config files

### DIFF
--- a/NetKAN/DeepSpaceSurfaceHabitatUnitPack.netkan
+++ b/NetKAN/DeepSpaceSurfaceHabitatUnitPack.netkan
@@ -19,22 +19,6 @@
         {
             "find":       "GameData/DSSHU",
             "install_to": "GameData"
-        }, {
-            "find":       "DSSHU-ConnectedLivingSpace.cfg",
-            "install_to": "GameData/DSSHU",
-            "find_matches_files": true
-        }, {
-            "find":       "DSSHU-KerbalInventorySystem.cfg",
-            "install_to": "GameData/DSSHU",
-            "find_matches_files": true
-        }, {
-            "find":       "DSSHU-Tweakscale.cfg",
-            "install_to": "GameData/DSSHU",
-            "find_matches_files": true
-        }, {
-            "find":       "DSSHU-USILifeSupport.cfg",
-            "install_to": "GameData/DSSHU",
-            "find_matches_files": true
-        } 
+        }
     ]
 }


### PR DESCRIPTION
The config files moved to a subfolder of `GameData/DSSHU` in the latest release, and as a result they were also picked up by the standard `"find":       "GameData/DSSHU"`, thus they were installed twice in the end.

