### PR TITLE
Prune redundant author lists

### DIFF
--- a/NetKAN/BurnTogetherContinued.netkan
+++ b/NetKAN/BurnTogetherContinued.netkan
@@ -5,7 +5,6 @@
     "$vref": "#/ckan/ksp-avc",
     "name": "BurnTogether Continued",
     "abstract": "Set spacecraft or rovers to follow your craft, matching velocity and thrust to weight ratio.",
-    "author": [ "BahamutoD", "Papa_Joe" ],
     "license": "CC-BY-SA-2.0",
     "ksp_version": "1.3.0",
     "resources" : {

--- a/NetKAN/DestructionEffects.netkan
+++ b/NetKAN/DestructionEffects.netkan
@@ -1,14 +1,13 @@
 {
     "spec_version": 1,
     "identifier": "DestructionEffects",
-    "$kref": "#/ckan/github/jrodrigv/DestructionEffects",
     "name": "Destruction Effects",
     "abstract": "This mod adds flames and smoke to certain parts' joint break event.",
-    "author": [ "BahamutoD", "jrodrigv" ],
+    "$kref": "#/ckan/github/jrodrigv/DestructionEffects",
+    "$vref": "#/ckan/ksp-avc",
     "license": "CC0",
-    "$vref"        : "#/ckan/ksp-avc",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/99088-10xdestruction-effects-flames-and-smoke-on-joint-breaks"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/99088-*"
     },
     "x_netkan_epoch": 2
 }

--- a/NetKAN/DistantObject-default.netkan
+++ b/NetKAN/DistantObject-default.netkan
@@ -3,7 +3,6 @@
     "identifier":   "DistantObject-default",
     "name":         "Distant Object Enhancement Continued default config",
     "abstract":     "Default planets colors",
-    "author":       ["duckytopia", "MOARdv", "TheDarkBadger"],
     "$kref":        "#/ckan/github/TheDarkBadger/DistantObject",
     "$vref":        "#/ckan/ksp-avc",
     "x_netkan_force_v": true,

--- a/NetKAN/DistantObject.netkan
+++ b/NetKAN/DistantObject.netkan
@@ -3,7 +3,6 @@
     "identifier":   "DistantObject",
     "name":         "Distant Object Enhancement Continued",
     "abstract":     "Visual enhancement mod that makes objects realistically visible over large distances",
-    "author":       ["duckytopia", "MOARdv", "TheDarkBadger"],
     "$kref":        "#/ckan/github/TheDarkBadger/DistantObject",
     "$vref":        "#/ckan/ksp-avc",
     "x_netkan_force_v": true,

--- a/NetKAN/FerramAerospaceResearchContinued.netkan
+++ b/NetKAN/FerramAerospaceResearchContinued.netkan
@@ -1,13 +1,12 @@
 {
     "spec_version": 1,
     "identifier": "FerramAerospaceResearchContinued",
+    "name": "Ferram Aerospace Research Continued",
+    "abstract": "FAR replaces KSP's stock part-centered aerodynamics model with one based on real-life physics.",
     "$kref": "#/ckan/github/dkavolis/Ferram-Aerospace-Research",
     "$vref": "#/ckan/ksp-avc",
     "x_netkan_epoch": "3",
     "x_netkan_version_edit": "^[vV]?(?<version>\\d+(?:\\.\\d+){0,3}[A-Za-z]?)(?:_[A-Za-z0-9_]+)?$",
-    "name": "Ferram Aerospace Research Continued",
-    "abstract": "FAR replaces KSP's stock part-centered aerodynamics model with one based on real-life physics.",
-    "author": [ "ferram4", "dkavolis" ],
     "license": "GPL-3.0",
     "resources" : {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/179445-*",

--- a/NetKAN/GravityTurnContinued.netkan
+++ b/NetKAN/GravityTurnContinued.netkan
@@ -3,14 +3,13 @@
     "identifier": "GravityTurnContinued",
     "$kref": "#/ckan/github/AndyMt/GravityTurn",
     "name": "GravityTurn Continued",
-    "author": [ "AndyMt", "Overengineer1" ],
     "abstract": "Automated highly efficient launches",
     "ksp_version_min": "1.3",
     "ksp_version_max": "1.6",
     "license": "GPL-3.0",
     "x_netkan_epoch": 2,
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/148448-12161-gravityturn-continued-automated-efficient-launches/",
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/148448-*",
         "repository": "https://github.com/AndyMt/GravityTurn/"
     },
     "conflicts": [

--- a/NetKAN/HangarExtender.frozen
+++ b/NetKAN/HangarExtender.frozen
@@ -4,7 +4,6 @@
     "$kref"        : "#/ckan/github/Alewx/FShangarExtender",
     "name"         : "Hangar Extender",
     "abstract"     : "Extends the usable area when building in the SPH or VAB, so you can build outside or above the building. Useful for building large aircraft carriers or tall rockets.",
-    "author"       : [ "Snjo", "Alewx" ],
     "license"      : "CC-BY-4.0",
     "ksp_version"  : "1.2",
     "resources": {

--- a/NetKAN/KerbalEngineerRedux.netkan
+++ b/NetKAN/KerbalEngineerRedux.netkan
@@ -3,7 +3,6 @@
     "identifier":   "KerbalEngineerRedux",
     "name":         "Kerbal Engineer Redux",
     "abstract":     "Reveals important statistics about your ship and its orbit during building and flight",
-    "author":       [ "CYBUTEK", "jrbudda" ],
     "$kref":        "#/ckan/github/jrbudda/KerbalEngineer",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "GPL-3.0",

--- a/NetKAN/KerbalFlightIndicators.netkan
+++ b/NetKAN/KerbalFlightIndicators.netkan
@@ -1,14 +1,13 @@
 {
     "spec_version" : 1,
     "identifier"   : "KerbalFlightIndicators",
-    "$kref"        : "#/ckan/github/PapaJoesSoup/KerbalFlightIndicators",
-    "$vref"        : "#/ckan/ksp-avc",
     "name"         : "Kerbal Flight Indicators",
     "abstract"     : "Displays indicators for the flight vector and other things. Works like a HUD. In external view, too!",
+    "$kref"        : "#/ckan/github/PapaJoesSoup/KerbalFlightIndicators",
+    "$vref"        : "#/ckan/ksp-avc",
     "license"      : "CC-BY-NC-SA-3.0",
     "resources" : {
-        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/172904-141-kerbal-flight-indicators-release-16-2018-03-23/"
+        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/172904-*"
     },
-    "author" : [ "DaMichel", "Papa_Joe" ],
     "release_status" : "stable"
 }

--- a/NetKAN/MapResourceOverlay.netkan
+++ b/NetKAN/MapResourceOverlay.netkan
@@ -1,13 +1,12 @@
 {
     "spec_version"  : 1,
-    "$kref"         : "#/ckan/github/sawyerap/MapResourceOverlay",
-    "x_broken_vref" : "#/ckan/ksp-avc",
     "identifier"    : "MapResourceOverlay",
     "name"          : "Map Resource Overlay",
     "abstract"      : "MapResourceOverlay for Science, Karbonite/MKS and biomes",
-    "license"       : "CC-BY-NC-SA",
-    "author"        : [ "Cyrik", "atomicfury" ],
     "description"   : "MapResourceOverlay for Science, Karbonite/MKS and biomes",
+    "$kref"         : "#/ckan/github/sawyerap/MapResourceOverlay",
+    "x_broken_vref" : "#/ckan/ksp-avc",
+    "license"       : "CC-BY-NC-SA",
     "ksp_version"   : "0.90",
     "release_status": "stable",
     "depends": [
@@ -19,6 +18,6 @@
         { "name": "SCANsat" }
     ],
     "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/83356-0242mapresourceoverlay-for-sciencekarbonitemks-and-biomes-version-027/"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/83356-*"
     }
 }

--- a/NetKAN/NehemiahEngineeringOrbitalScience.netkan
+++ b/NetKAN/NehemiahEngineeringOrbitalScience.netkan
@@ -1,12 +1,11 @@
 {
 	"spec_version"      : "v1.4",
 	"identifier"        : "NehemiahEngineeringOrbitalScience",
-	"$kref"             : "#/ckan/github/mwerle/OrbitalMaterialScience/asset_match/NehemiahEngineeringOrbitalScience_.*.zip",
-	"$vref"             : "#/ckan/ksp-avc/NehemiahInc/NEOS.version",
 	"name"              : "Nehemiah Engineering Orbital Science",
 	"abstract"          : "Nehemiah Engineering Orbital Science is a collection of orbital science experiments aimed at prolonged station keeping.",
 	"description"       : "Nehemiah Engineering Orbital Science is a collection of orbital science experiments aimed at prolonged station keeping. It consists of three distinct sets of experiments:\n* Kemini Research Program (KRP) - early-game experiments run from within a capsule based on real-life experiments run during the Gemini program.\n* Kerbal Environmental Effects Study (KEES) - mid-game experiments for attaching to the outside of a small station based on real-life material exposure experiments run on the MIR station.\n* Orbital Station Science (OSS) - Kerbal Life Science (KLS) and Orbital Material Science (OMS) - late-game large-scale station experiments based on real-life ISS experiments. These require modular station construction and maintenance.\n\nAll of the experiments are designed to be run in the background while the player performs other missions.",
-	"author"            : [ "N3h3miah", "Micha" ],
+	"$kref"             : "#/ckan/github/mwerle/OrbitalMaterialScience/asset_match/NehemiahEngineeringOrbitalScience_.*.zip",
+	"$vref"             : "#/ckan/ksp-avc/NehemiahInc/NEOS.version",
 	"license"           : "GPL-3.0",
 	"resources"         : {
 		"homepage"           : "http://forum.kerbalspaceprogram.com/index.php?showtopic=149298",

--- a/NetKAN/PilotAssistant.netkan
+++ b/NetKAN/PilotAssistant.netkan
@@ -1,13 +1,12 @@
 {
     "spec_version" : 1,
     "identifier"   : "PilotAssistant",
-    "$kref"        : "#/ckan/github/zolotiyeruki/Pilot-Assistant",
-    "$vref"        : "#/ckan/ksp-avc",
     "name"         : "Pilot Assistant",
     "abstract"     : "Helpful tool which controls planes altitude, heading, and airspeed via autopilot or custom SAS",
-    "author"       : [ "Crzyrndm", "zolotiyeruki" ],
+    "$kref"        : "#/ckan/github/zolotiyeruki/Pilot-Assistant",
+    "$vref"        : "#/ckan/ksp-avc",
     "license"      : "CC-BY-SA-4.0",
-   "resources" : {
+    "resources": {
         "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/184277-*"
     },
     "install": [

--- a/NetKAN/PlanetShine-Config-Default.netkan
+++ b/NetKAN/PlanetShine-Config-Default.netkan
@@ -3,7 +3,6 @@
     "identifier":   "PlanetShine-Config-Default",
     "name":         "PlanetShine - Default configuration",
     "abstract":     "Planets and moons reflects their light to your vessel + other ambient light improvements",
-    "author":       [ "Valerian", "Papa_Joe" ],
     "$kref":        "#/ckan/github/PapaJoesSoup/ksp-planetshine",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "Apache-2.0",

--- a/NetKAN/PlanetShine.netkan
+++ b/NetKAN/PlanetShine.netkan
@@ -3,7 +3,6 @@
     "identifier":   "PlanetShine",
     "name":         "PlanetShine",
     "abstract":     "Planets and moons reflects their light to your vessel + other ambient light improvements",
-    "author":       [ "Valerian", "Papa_Joe" ],
     "$kref":        "#/ckan/github/PapaJoesSoup/ksp-planetshine",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "Apache-2.0",

--- a/NetKAN/RCSLandAid.netkan
+++ b/NetKAN/RCSLandAid.netkan
@@ -1,20 +1,19 @@
 {
     "spec_version" : 1,
     "identifier"   : "RCSLandAid",
-    "$kref"        : "#/ckan/github/linuxgurugamer/RCSLandAid",
-    "$vref": "#/ckan/ksp-avc",
     "name"         : "Horizontal Landing Aid Redux",
     "abstract"     : "Kill your horizontal velocity to land, or hover over a specific point on the ground",
+    "$kref"        : "#/ckan/github/linuxgurugamer/RCSLandAid",
+    "$vref"        : "#/ckan/ksp-avc",
     "license"      : "GPL-3.0",
     "release_status" : "stable",
-    "author"       : [ "Diazo", "linuxgurugamer" ],
     "depends" : [
-        { "name": "ModuleManager" },
-	{ "name" : "ToolbarController" },
+        { "name" : "ModuleManager" },
+        { "name" : "ToolbarController" },
         { "name" : "ClickThroughBlocker" }
     ],
     "resources" : {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/175403-14-horizontal-landing-aid-redux/",
+        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/175403-*",
         "repository": "https://github.com/linuxgurugamer/RCSLandAid"
     },
     "install" : [

--- a/NetKAN/Science-Full-Reward.netkan
+++ b/NetKAN/Science-Full-Reward.netkan
@@ -2,10 +2,9 @@
     "spec_version"     : 1,
     "identifier"       : "Science-Full-Reward",
     "name"             : "Science - Full Reward! (Continued)",
-    "author"           : [ "maculator", "Tekaoh" ],
     "$kref"            : "#/ckan/github/tekaohksp/Science-Full-Reward",
-    "license"          : "MIT",
     "ksp_version"      : "any",
+    "license"          : "MIT",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/185199-*"
     },

--- a/NetKAN/SemiSaturatableRW.netkan
+++ b/NetKAN/SemiSaturatableRW.netkan
@@ -3,11 +3,10 @@
     "identifier"     : "SemiSaturatableRW",
     "name"           : "Semi-Saturable Reaction Wheels",
     "abstract"       : "Saturable Reaction Wheels makes stock reaction wheels more realistic by adding momentum management",
-    "author"         : [ "PhineasFreak", "Crzyrndm" ],
     "$kref"          : "#/ckan/github/PhineasFreak/SaturableRW",
-    "x_netkan_license_ok": true,
     "$vref"          : "#/ckan/ksp-avc",
-    "x_netkan_epoch": 1,
+    "x_netkan_epoch" : 1,
+    "license"        : "GPL-3.0",
     "release_status" : "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/105289-*"

--- a/NetKAN/TWR1.netkan
+++ b/NetKAN/TWR1.netkan
@@ -5,7 +5,6 @@
     "$vref": "#/ckan/ksp-avc",
     "name": "Vertical Velocity Controller Redux",
     "abstract": "Control your descent speed in discreet increments for soft, controlled skycrane landings.",
-    "author": [ "Diazo", "linuxgurugamer" ],
     "license": "GPL-3.0",
     "release_status": "stable",
     "resources": {

--- a/NetKAN/VenStockRevamp-Core.netkan
+++ b/NetKAN/VenStockRevamp-Core.netkan
@@ -3,7 +3,6 @@
     "identifier"   : "VenStockRevamp-Core",
     "name"         : "Ven's Stock Part Revamp Core",
     "abstract"     : "Shared resources for Ven's Stock Revamp and Ven's New Parts",
-    "author"       : [ "VenVen", "Kerbas-ad-astra" ],
     "$kref"        : "#/ckan/github/Kerbas-ad-astra/Stock-Revamp",
     "$vref"        : "#/ckan/ksp-avc",
     "license"      : "CC-BY-4.0",

--- a/NetKAN/VenStockRevamp-NewParts.netkan
+++ b/NetKAN/VenStockRevamp-NewParts.netkan
@@ -3,7 +3,6 @@
     "identifier"   : "VenStockRevamp-NewParts",
     "name"         : "Ven's New Parts",
     "abstract"     : "New parts from Ven's Stock Part Revamp",
-    "author"       : [ "VenVen", "Kerbas-ad-astra" ],
     "$kref"        : "#/ckan/github/Kerbas-ad-astra/Stock-Revamp",
     "$vref"        : "#/ckan/ksp-avc",
     "license"      : "CC-BY-4.0",

--- a/NetKAN/VenStockRevamp.netkan
+++ b/NetKAN/VenStockRevamp.netkan
@@ -3,7 +3,6 @@
     "identifier"   : "VenStockRevamp",
     "name"         : "Ven's Stock Part Revamp",
     "abstract"     : "With this part pack, your rockets/planes/racecars will look at least 20% cooler as they tumble into the ground!",
-    "author"       : [ "VenVen", "Kerbas-ad-astra" ],
     "$kref"        : "#/ckan/github/Kerbas-ad-astra/Stock-Revamp",
     "$vref"        : "#/ckan/ksp-avc",
     "license"      : "CC-BY-4.0",

--- a/NetKAN/VesselMoverContinued.netkan
+++ b/NetKAN/VesselMoverContinued.netkan
@@ -3,7 +3,6 @@
     "identifier":   "VesselMoverContinued",
     "name":         "VesselMover Continued",
     "abstract":     "A continuation of BahamutoD's Vessel Mover.",
-    "author":       [ "BahamutoD", "Papa_Joe", "jrodrigv" ],
     "$kref":        "#/ckan/github/jrodrigv/VesselMover",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "MIT",

--- a/NetKAN/VesselSwitcher.netkan
+++ b/NetKAN/VesselSwitcher.netkan
@@ -4,7 +4,6 @@
     "$kref": "#/ckan/github/PapaJoesSoup/BDALoadedVesselSwitcher",
     "name": "VesselSwitcher",
     "abstract": "Switch between fired missiles of DBArmory.",
-    "author": [ "BahamutoD", "Papa_Joe" ],
     "license": "MIT",
     "ksp_version": "1.1.3",
     "depends": [


### PR DESCRIPTION
After KSP-CKAN/CKAN#2922 we include owners of parent repos on GitHub as authors, which makes some of the manually maintained author lists in netkans redundant. This PR removes them.