### PR TITLE
Rename PolandBall to NewPolandBall

### DIFF
--- a/NetKAN/NewPolandBall.netkan
+++ b/NetKAN/NewPolandBall.netkan
@@ -1,6 +1,6 @@
 {
     "spec_version": "v1.4",
-    "identifier":   "PolandBall",
+    "identifier":   "NewPolandBall",
     "$kref":        "#/ckan/spacedock/2024",
     "license":      "CC-BY-SA-2.0",
     "conflicts": [

--- a/NetKAN/NewPolandBall.netkan
+++ b/NetKAN/NewPolandBall.netkan
@@ -5,5 +5,9 @@
     "license":      "CC-BY-SA-2.0",
     "conflicts": [
         { "name": "Polandball" }
-    ]
+    ],
+    "install": [{
+        "file":       "PolandBall",
+        "install_to": "GameData"
+    }]
 }


### PR DESCRIPTION
The NetKAN files conflict with each other on Windows machines, which leads to weird behaviour.
Give this one a new identifier.

Closes #7507

Changing the identifier of a mod should normally be avoided, but since this mod doesn't have too many downloads and no special relationships or anything, it should be mostly fine.