### PR TITLE
Make ChattererExtended indefinitely compatible

### DIFF
--- a/NetKAN/ChattererExtended.netkan
+++ b/NetKAN/ChattererExtended.netkan
@@ -1,15 +1,18 @@
 {
-  "spec_version": "v1.4",
-  "install": [
-    {
-      "install_to": "GameData",
-      "find": "Chatterer"
-    }
-  ],
-  "depends" : [ { "name" : "Chatterer" } ],
-  "$kref": "#/ckan/spacedock/1367",
-  "$vref"        : "#/ckan/ksp-avc",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "identifier": "ChattererExtended",
-  "license": "CC-BY-4.0"
+    "spec_version": "v1.4",
+    "identifier":   "ChattererExtended",
+    "$kref":        "#/ckan/spacedock/1367",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "CC-BY-4.0",
+    "depends" : [
+        { "name" : "Chatterer" }
+    ],
+    "install": [ {
+        "find":       "Chatterer",
+        "install_to": "GameData"
+    } ],
+    "x_netkan_override": [ {
+        "version": "0.6.2",
+        "delete":  [ "ksp_version_max" ]
+    } ]
 }


### PR DESCRIPTION
See KSP-CKAN/CKAN-meta#1537, this mod relies on Chatterer to perform its version-specific functions, and in theory it should be fine to support it on any version. This PR creates an override for that, so we can close that other PR while we decide whether this is a good idea.

Watch here to see if the author responds:

https://forum.kerbalspaceprogram.com/index.php?/topic/160545-142-chatterer-extended-more-kerbalized-chatter-for-chatterer-v06/&do=findComment&comment=3698839