### PR TITLE
Epoch CrewLight

### DIFF
--- a/NetKAN/CrewLight.netkan
+++ b/NetKAN/CrewLight.netkan
@@ -3,6 +3,7 @@
     "identifier" : "CrewLight",
     "$kref" : "#/ckan/spacedock/2236",
     "$vref": "#/ckan/ksp-avc",
+    "x_netkan_epoch": 1,
     "name" : "Crew Light",
     "author" : [ "Li0n", "linuxgurugamer" ],
     "abstract" : "An automatic light manager",


### PR DESCRIPTION
The leading `v` has been lost in the transition to @linuxgurugamer as new maintainer.

Epoch all new versions to maintain proper version sorting.