### PR TITLE
Set x_netkan_allow_out_of_order for backporting mods

### DIFF
--- a/NetKAN/Backports/Kopernicus.netkan
+++ b/NetKAN/Backports/Kopernicus.netkan
@@ -11,6 +11,7 @@
         "strict":  true
     },
     "x_netkan_epoch": "2",
+    "x_netkan_allow_out_of_order": true,
     "release_status": "development",
     "license"       : "LGPL-3.0",
     "author": [

--- a/NetKAN/KSPInterstellarExtended.netkan
+++ b/NetKAN/KSPInterstellarExtended.netkan
@@ -3,6 +3,7 @@
     "identifier"        : "KSPInterstellarExtended",
     "$kref"             : "#/ckan/spacedock/172",
     "$vref"             : "#/ckan/ksp-avc",
+    "x_netkan_allow_out_of_order": true,
     "resources": {
         "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/172026-*",
         "repository": "https://github.com/sswelm/KSP-Interstellar-Extended"
@@ -18,13 +19,13 @@
         }
     ],
     "depends": [
-        { "name"        : "InterstellarFuelSwitch-Core"},
-        { "name"        : "TweakScale"                 },
-        { "name"        : "ModuleManager"              }
+        { "name"        : "InterstellarFuelSwitch-Core" },
+        { "name"        : "TweakScale"                  },
+        { "name"        : "ModuleManager"               }
     ],
     "recommends": [
         { "name"        : "PatchManager"             },
-        { "name"        : "InterstellarFuelSwitch"   },        
+        { "name"        : "InterstellarFuelSwitch"   },
         { "name"        : "PersistentRotation"       },
         { "name"        : "FilterExtensions"         },
         { "name"        : "PhotonSailor"             },
@@ -33,7 +34,7 @@
     ],
     "suggests": [
         { "name"        : "CommunityResourcePack"    },
-        { "name"        : "CommunityTechTree"        },         
+        { "name"        : "CommunityTechTree"        },
         { "name"        : "HeatControl"              },
         { "name"        : "TexturesUnlimited"        },
         { "name"        : "UniversalStorage"         },


### PR DESCRIPTION
## Motivation

In KSP-CKAN/CKAN#2824 and KSP-CKAN/NetKAN-Infra#102, we are automating version "epoch" management so that mod versions will be interpreted in chronological order.

This is undesirable for a few mods, specifically those that sometimes intentionally release a lower version of a mod after a later version, for example to backport fixes to earlier game versions.

## Changes

Now the following mods have `x_netkan_allow_out_of_order` set to true because they have a history of intentional/valid out of order releases:

- `Backports/Kopernicus`
- `KSPInterstellarExtended`

This will ensure that these mods will not be auto-epoched.

Note that this property is not in the spec yet, but it will be after KSP-CKAN/CKAN#2824 is merged. It is important to set it before then, though, to prevent backports from accidentally being auto-epoched after merge.