### PR TITLE
Add x_netkan_allow_out_of_order for KerbalJointReinforcementNext

### DIFF
--- a/NetKAN/KerbalJointReinforcementNext.netkan
+++ b/NetKAN/KerbalJointReinforcementNext.netkan
@@ -6,6 +6,7 @@
     "author"         : [ "ferram4", "Rudolf Meier" ],
     "$kref"          : "#/ckan/github/meirumeiru/Kerbal-Joint-Reinforcement/asset_match/KerbalJointReinforcement_v[0-9]+\\.[0-9]+\\.[0-9]+\\.zip",
     "$vref"          : "#/ckan/ksp-avc",
+    "x_netkan_allow_out_of_order": true,
     "license"        : "GPL-3.0",
     "release_status" : "stable",
     "conflicts"      : [


### PR DESCRIPTION
This mod triggered the auto-epoch code, see KSP-CKAN/CKAN-meta#1561. The "Latest release" on GitHub is not the highest version:

![github](https://i.imgur.com/SrRtLPR.png)

Inflating the module produces v4.0.15, and we already have v4.1.15 indexed, so it looks like we have found a version in need of an epoch (see KSP-CKAN/CKAN#2824). This discussion addresses how this might happen:

- https://stackoverflow.com/questions/22822586/swap-latest-release-on-github

If this mod author is in the habit of manually manipulating git tags without paying special care to their timestamps **and** intends to release backports, this is likely to recur. Therefore this pull request excludes this mod from auto-epoching by setting `x_netkan_allow_out_of_order`.

Closes KSP-CKAN/CKAN-meta#1561.