### PR TITLE
Turn off auto-epoching for KerbalowAerospace and UnKerballedStart

### DIFF
--- a/NetKAN/KerbalowAerospace.netkan
+++ b/NetKAN/KerbalowAerospace.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.16",
     "identifier":   "KerbalowAerospace",
     "$kref":        "#/ckan/spacedock/1755",
+    "x_netkan_allow_out_of_order": true,
     "license":      "CC-BY-4.0",
     "x_via":        "Automated SpaceDock CKAN submission",
     "install": [{

--- a/NetKAN/UnKerballedStart.netkan
+++ b/NetKAN/UnKerballedStart.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "UnKerballedStart",
     "$kref":        "#/ckan/spacedock/2074",
+    "x_netkan_allow_out_of_order": true,
     "license":      "CC-BY-NC-SA-4.0",
     "depends": [
         { "name": "ModuleManager"     },


### PR DESCRIPTION
These modules both intentionally released out of order versions. One was done to allow CKAN to index a (presumably missed) version:

![KerbalowAerospace](https://user-images.githubusercontent.com/1559108/69880865-19438700-12c3-11ea-879e-6cc64186f920.png)

The other is a backport:

![UnKerballedStart](https://user-images.githubusercontent.com/1559108/69883836-d509b400-12cd-11ea-9882-12c64767c29e.png)

This indicates that these authors understand how versioning works and are prepared to use it in creative ways to achieve specific goals. Therefore this PR disables auto-epoching for these modules.

Closes KSP-CKAN/CKAN-meta#1577.
Closes KSP-CKAN/CKAN-meta#1588.