### PR TITLE
Add Grannus Expansion Pack

### DIFF
--- a/NetKAN/GrannusExpansionPack-CommNet.netkan
+++ b/NetKAN/GrannusExpansionPack-CommNet.netkan
@@ -1,0 +1,20 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "GrannusExpansionPack-CommNet",
+    "name":         "Grannus Expansion Pack CommNet",
+    "abstract":     "Grannus Expansion Pack with level 4 Tracking Station and a powerful new antenna to increase communications range",
+    "$kref":        "#/ckan/github/OhioBob/Grannus-Expansion-Pack",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "CC-BY-NC-ND",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/169664-*"
+    },
+    "depends": [
+        { "name": "GrannusExpansionPack" },
+        { "name": "CustomBarnKit"        }
+    ],
+    "install": [ {
+        "find":       "GEP_CommNet/GameData/GEP",
+        "install_to": "GameData"
+    } ]
+}

--- a/NetKAN/GrannusExpansionPack-JNSQ.netkan
+++ b/NetKAN/GrannusExpansionPack-JNSQ.netkan
@@ -1,0 +1,20 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "GrannusExpansionPack-JNSQ",
+    "name":         "Grannus Expansion Pack JNSQ",
+    "abstract":     "Grannus Expansion Pack rescaled 2.5x to provide compatibility with the JNSQ planet pack",
+    "$kref":        "#/ckan/github/OhioBob/Grannus-Expansion-Pack",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "CC-BY-NC-ND",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/169664-*"
+    },
+    "depends": [
+        { "name": "GrannusExpansionPack" },
+        { "name": "JNSQ"                 }
+    ],
+    "install": [ {
+        "find":       "GEP_JNSQ/GameData/GEP_JNSQ",
+        "install_to": "GameData"
+    } ]
+}

--- a/NetKAN/GrannusExpansionPack-Primary.netkan
+++ b/NetKAN/GrannusExpansionPack-Primary.netkan
@@ -1,0 +1,30 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "GrannusExpansionPack-Primary",
+    "name":         "Grannus Expansion Pack Primary",
+    "abstract":     "Grannus Expansion Pack as a primary star system, with Grannus as the central star and Nodens the home world",
+    "$kref":        "#/ckan/github/OhioBob/Grannus-Expansion-Pack",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "CC-BY-NC-ND",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/169664-*"
+    },
+    "depends": [
+        { "name": "GrannusExpansionPack" }
+    ],
+    "conflicts": [
+        { "name": "GPP" }
+    ],
+    "suggests": [
+        { "name": "GPPSecondary" }
+    ],
+    "recommends": [
+        { "name": "PlanetShine" },
+        { "name": "Kerbalism"   },
+        { "name": "Kronometer"  }
+    ],
+    "install": [ {
+        "find":       "GEP_Primary/GameData/GEP_Primary",
+        "install_to": "GameData"
+    } ]
+}

--- a/NetKAN/GrannusExpansionPack.netkan
+++ b/NetKAN/GrannusExpansionPack.netkan
@@ -1,0 +1,35 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "GrannusExpansionPack",
+    "$kref":        "#/ckan/github/OhioBob/Grannus-Expansion-Pack",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "CC-BY-NC-ND",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/169664-*"
+    },
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus"    }
+    ],
+    "recommends": [
+        { "name": "EnvironmentalVisualEnhancements" },
+        { "name": "Scatterer"                       },
+        { "name": "DistantObject"                   },
+        { "name": "ResearchBodies"                  },
+        { "name": "FinalFrontier"                   },
+        { "name": "KerbalHealth"                    }
+    ],
+    "suggests": [
+        { "name": "GPP"                          },
+        { "name": "GrannusExpansionPack-Primary" },
+        { "name": "GrannusExpansionPack-JNSQ"    },
+        { "name": "GrannusExpansionPack-CommNet" }
+    ],
+    "install": [ {
+        "file":       "GameData/GEP",
+        "install_to": "GameData"
+    }, {
+        "find":       "GameData/Nereid",
+        "install_to": "GameData"
+    } ]
+}


### PR DESCRIPTION
This is a planet pack with some optional components, originally grew out of GPP, now available in standalone mode but also with JNSQ compatibility.

Permission requested here, monitor for responses:

https://forum.kerbalspaceprogram.com/index.php?/topic/169664-173-grannus-expansion-pack-v111-7-dec-2019/&do=findComment&comment=3715014

Note Galileo88/Galileos-Planet-Pack/issues/59, which currently makes a functional GPPSecondary+GEP_Primary install impossible. Need GPPSecondary updated to actually install its needed files.