### PR TITLE
Add tags to the 32 most popular mods

### DIFF
--- a/NetKAN/B9-props.netkan
+++ b/NetKAN/B9-props.netkan
@@ -1,6 +1,10 @@
 {
-  "spec_version" : 1,
-  "identifier"   : "B9-props",
-  "$kref"        : "#/ckan/netkan/https://raw.githubusercontent.com/blowfishpro/B9-Aerospace/master/NetKAN/B9-props.netkan",
-  "x_netkan_license_ok": true
+    "spec_version" : 1,
+    "identifier"   : "B9-props",
+    "$kref"        : "#/ckan/netkan/https://raw.githubusercontent.com/blowfishpro/B9-Aerospace/master/NetKAN/B9-props.netkan",
+    "tags": [
+        "config",
+        "manned"
+    ],
+    "x_netkan_license_ok": true
 }

--- a/NetKAN/B9.netkan
+++ b/NetKAN/B9.netkan
@@ -1,6 +1,9 @@
 {
-  "spec_version" : 1,
-  "identifier"   : "B9",
-  "$kref"        : "#/ckan/netkan/https://raw.githubusercontent.com/blowfishpro/B9-Aerospace/master/NetKAN/B9.netkan",
-  "x_netkan_license_ok": true
+    "spec_version" : 1,
+    "identifier"   : "B9",
+    "$kref"        : "#/ckan/netkan/https://raw.githubusercontent.com/blowfishpro/B9-Aerospace/master/NetKAN/B9.netkan",
+    "tags": [
+        "parts"
+    ],
+    "x_netkan_license_ok": true
 }

--- a/NetKAN/B9AerospaceHX.netkan
+++ b/NetKAN/B9AerospaceHX.netkan
@@ -1,6 +1,9 @@
 {
-  "spec_version" : 1,
-  "identifier"   : "B9AerospaceHX",
-  "$kref"        : "#/ckan/netkan/https://raw.githubusercontent.com/blowfishpro/B9-Aerospace/master/NetKAN/B9AerospaceHX.netkan",
-  "x_netkan_license_ok": true
+    "spec_version" : 1,
+    "identifier"   : "B9AerospaceHX",
+    "$kref"        : "#/ckan/netkan/https://raw.githubusercontent.com/blowfishpro/B9-Aerospace/master/NetKAN/B9AerospaceHX.netkan",
+    "tags": [
+        "parts"
+    ],
+    "x_netkan_license_ok": true
 }

--- a/NetKAN/B9AerospaceLegacy.netkan
+++ b/NetKAN/B9AerospaceLegacy.netkan
@@ -1,6 +1,9 @@
 {
-  "spec_version" : 1,
-  "identifier"   : "B9AerospaceLegacy",
-  "$kref"        : "#/ckan/netkan/https://raw.githubusercontent.com/blowfishpro/B9-Aerospace/master/NetKAN/B9AerospaceLegacy.netkan",
-  "x_netkan_license_ok": true
+    "spec_version" : 1,
+    "identifier"   : "B9AerospaceLegacy",
+    "$kref"        : "#/ckan/netkan/https://raw.githubusercontent.com/blowfishpro/B9-Aerospace/master/NetKAN/B9AerospaceLegacy.netkan",
+    "tags": [
+        "parts"
+    ],
+    "x_netkan_license_ok": true
 }

--- a/NetKAN/CommunityResourcePack.netkan
+++ b/NetKAN/CommunityResourcePack.netkan
@@ -3,5 +3,10 @@
         "spec_version" : "v1.16",
         "identifier" : "CommunityResourcePack",
         "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/BobPalmer/CKAN/master/CommunityResourcePack.netkan",
+        "tags": [
+            "config",
+            "library",
+            "resources"
+        ],
         "x_netkan_license_ok": true
     }

--- a/NetKAN/EnvironmentalVisualEnhancements-HR.netkan
+++ b/NetKAN/EnvironmentalVisualEnhancements-HR.netkan
@@ -9,6 +9,10 @@
         "homepage"   : "http://forum.kerbalspaceprogram.com/index.php?/topic/149733-EVE",
         "repository" : "https://github.com/WazWaz/EnvironmentalVisualEnhancements"
     },
+    "tags": [
+        "config",
+        "graphics"
+    ],
     "install": [
         {
             "file"       : "GameData/BoulderCo",

--- a/NetKAN/EnvironmentalVisualEnhancements.netkan
+++ b/NetKAN/EnvironmentalVisualEnhancements.netkan
@@ -11,6 +11,10 @@
         "homepage"   : "http://forum.kerbalspaceprogram.com/index.php?/topic/149733-EVE",
         "repository" : "https://github.com/WazWaz/EnvironmentalVisualEnhancements"
     },
+    "tags": [
+        "plugin",
+        "graphics"
+    ],
     "install": [
         {
             "file"       : "GameData/EnvironmentalVisualEnhancements",

--- a/NetKAN/Firespitter.netkan
+++ b/NetKAN/Firespitter.netkan
@@ -17,6 +17,11 @@
         "homepage" : "http://snjo.github.io/",
         "repository"  : "https://github.com/snjo/Firespitter"
     },
+    "tags": [
+        "parts",
+        "manned",
+        "sound"
+    ],
     "depends" : [
         {
             "name"        : "FirespitterCore",

--- a/NetKAN/FirespitterCore.netkan
+++ b/NetKAN/FirespitterCore.netkan
@@ -18,6 +18,10 @@
         "homepage" : "http://snjo.github.io/",
         "repository"  : "https://github.com/snjo/Firespitter"
     },
+    "tags": [
+        "plugin",
+        "library"
+    ],
     "provides": [ "DeadskinsTextureSwitch" ],
     "install"  : [
         {

--- a/NetKAN/FirespitterResourcesConfig.netkan
+++ b/NetKAN/FirespitterResourcesConfig.netkan
@@ -17,6 +17,10 @@
         "homepage" : "http://snjo.github.io/",
         "repository"  : "https://github.com/snjo/Firespitter"
     },
+    "tags": [
+        "config",
+        "resources"
+    ],
     "install"  : [
         {
             "find"       : "Firespitter/Resources",

--- a/NetKAN/InterstellarFuelSwitch-Core.netkan
+++ b/NetKAN/InterstellarFuelSwitch-Core.netkan
@@ -6,6 +6,11 @@
     "name"         : "Interstellar Fuel Switch Core",
     "abstract"     : "Core plugin for Interstellar Fuel Switch",
     "license"      : "GPL-2.0",
+    "tags": [
+        "plugin",
+        "resources",
+        "library"
+    ],
     "install": [
         {
             "find"       : "InterstellarFuelSwitch/Plugins",

--- a/NetKAN/InterstellarFuelSwitch.netkan
+++ b/NetKAN/InterstellarFuelSwitch.netkan
@@ -3,6 +3,10 @@
     "$kref"        : "#/ckan/spacedock/175",
     "identifier"   : "InterstellarFuelSwitch",
     "license"      : "GPL-2.0",
+    "tags": [
+        "manned",
+        "parts"
+    ],
     "install": [
         {
             "find" : "InterstellarFuelSwitch",

--- a/NetKAN/KerbalAlarmClock.netkan
+++ b/NetKAN/KerbalAlarmClock.netkan
@@ -15,6 +15,10 @@
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
         "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
+    "tags": [
+        "plugin",
+        "information"
+    ],
     "recommends"  :[
         { "name" : "TriggerAu-Flags" }
     ],

--- a/NetKAN/KerbalEngineerRedux.netkan
+++ b/NetKAN/KerbalEngineerRedux.netkan
@@ -10,6 +10,10 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/17833-*"
     },
+    "tags": [
+        "plugin",
+        "information"
+    ],
     "install": [
         {
             "file":       "KerbalEngineer",

--- a/NetKAN/KerbalJointReinforcementContinued.netkan
+++ b/NetKAN/KerbalJointReinforcementContinued.netkan
@@ -8,6 +8,14 @@
     "author"         : [ "ferram4", "Starwaster" ],
     "license"        : "GPL-3.0",
     "release_status" : "stable",
+    "resources": {
+        "homepage":  "https://forum.kerbalspaceprogram.com/index.php?/topic/184019-*",
+        "repository": "https://github.com/KSP-RO/Kerbal-Joint-Reinforcement-Continued"
+    },
+    "tags": [
+        "plugin",
+        "physics"
+    ],
     "x_netkan_override" : [
         {
             "version" : "v3.1.4",
@@ -27,9 +35,5 @@
     "provides"      : [ "KerbalJointReinforcement" ],
     "conflicts"     : [
         { "name"    : "KerbalJointReinforcement" }
-    ],
-    "resources": {
-        "homepage":  "https://forum.kerbalspaceprogram.com/index.php?/topic/184019-*",
-        "repository": "https://github.com/KSP-RO/Kerbal-Joint-Reinforcement-Continued"
-    }
+    ]
 }

--- a/NetKAN/NearFutureSolar-Core.netkan
+++ b/NetKAN/NearFutureSolar-Core.netkan
@@ -1,5 +1,8 @@
 {
-  "spec_version"  : "v1.4",
-  "identifier"    : "NearFutureSolar-Core",
-  "$kref"         : "#/ckan/netkan/https://github.com/ChrisAdderley/NearFutureSolar/raw/master/CKAN/NearFutureSolar-Core.netkan"
+    "spec_version"  : "v1.4",
+    "identifier"    : "NearFutureSolar-Core",
+    "$kref"         : "#/ckan/netkan/https://github.com/ChrisAdderley/NearFutureSolar/raw/master/CKAN/NearFutureSolar-Core.netkan",
+    "tags": [
+        "plugin"
+    ]
 }

--- a/NetKAN/NearFutureSolar.netkan
+++ b/NetKAN/NearFutureSolar.netkan
@@ -1,5 +1,8 @@
 {
     "spec_version"  : "v1.4",
     "identifier"    : "NearFutureSolar",
-    "$kref"         : "#/ckan/netkan/https://github.com/ChrisAdderley/NearFutureSolar/raw/master/CKAN/NearFutureSolar.netkan"
+    "$kref"         : "#/ckan/netkan/https://github.com/ChrisAdderley/NearFutureSolar/raw/master/CKAN/NearFutureSolar.netkan",
+    "tags": [
+        "parts"
+    ]
 }

--- a/NetKAN/ProceduralFairings.netkan
+++ b/NetKAN/ProceduralFairings.netkan
@@ -2,6 +2,12 @@
     "spec_version": "v1.4",
     "identifier": "ProceduralFairings",
     "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/KSP-RO/ProceduralFairings/master/ProceduralFairings.netkan",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/184187-*"
+    },
+    "tags": [
+        "parts"
+    ],
     "x_netkan_license_ok": true,
     "x_netkan_epoch": 1
 }

--- a/NetKAN/RasterPropMonitor-Core.netkan
+++ b/NetKAN/RasterPropMonitor-Core.netkan
@@ -2,13 +2,17 @@
     "spec_version"   : "v1.4",
     "identifier"     : "RasterPropMonitor-Core",
     "name"           : "RasterPropMonitor Core",
+    "abstract"       : "RasterPropMonitor is a plugin and toolkit that provides functional props within your IVA.",
+    "comment"        : "This package contains the plugin, and the standard parts library.",
+    "author"         : [ "MOARdV", "Mihara" ],
     "$kref"          : "#/ckan/github/Mihara/RasterPropMonitor",
     "$vref"          : "#/ckan/ksp-avc",
-    "abstract"       : "RasterPropMonitor is a plugin and toolkit that provides functional props within your IVA.",
-    "author"         : [ "MOARdV", "Mihara" ],
-    "comment"        : "This package contains the plugin, and the standard parts library.",
-    "license"        : "GPL-3.0",
     "x_netkan_epoch" : "1",
+    "license"        : "GPL-3.0",
+    "tags": [
+        "plugin",
+        "manned"
+    ],
     "depends" : [
         { "name" : "ModuleManager" }
     ],

--- a/NetKAN/RasterPropMonitor.netkan
+++ b/NetKAN/RasterPropMonitor.netkan
@@ -8,6 +8,14 @@
     "author"         : [ "MOARdV", "Mihara" ],
     "license"        : "GPL-3.0",
     "x_netkan_epoch" : "1",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/105821-*",
+        "repository": "https://github.com/Mihara/RasterPropMonitor"
+    },
+    "tags": [
+        "config",
+        "manned"
+    ],
     "depends" : [
         { "name" : "ModuleManager" },
         { "name" : "RasterPropMonitor-Core" }
@@ -23,9 +31,5 @@
             "filter"     : ["RasterPropMonitor"],
             "install_to" : "GameData"
         }
-    ],
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/105821-14x-rasterpropmonitor-still-putting-the-a-in-iva-v0300-14-march-2018/",
-        "repository": "https://github.com/Mihara/RasterPropMonitor"
-    }
+    ]
 }

--- a/NetKAN/RealSolarSystem.netkan
+++ b/NetKAN/RealSolarSystem.netkan
@@ -12,6 +12,12 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177216-*"
     },
+    "tags": [
+        "planet-pack",
+        "config",
+        "plugin",
+        "resources"
+    ],
     "depends": [
         { "name": "ModuleManager" },
         { "name": "Kopernicus", "min_version": "2:release-1.3.1-7" },

--- a/NetKAN/SCANsat.netkan
+++ b/NetKAN/SCANsat.netkan
@@ -1,15 +1,24 @@
 {
     "spec_version": 1,
-    "identifier": "SCANsat",
-    "$kref": "#/ckan/spacedock/129",
-    "$vref": "#/ckan/ksp-avc",
-    "license": "restricted",
+    "identifier":   "SCANsat",
+    "$kref":        "#/ckan/spacedock/129",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "restricted",
     "x_netkan_force_v": true,
+    "resources": {
+        "repository": "https://github.com/S-C-A-N/SCANsat",
+        "license": "https://github.com/S-C-A-N/SCANsat/blob/release/SCANsat/LICENSE.txt"
+    },
+    "tags": [
+        "plugin",
+        "information",
+        "resources"
+    ],
     "depends": [
         { "name": "ModuleManager" }
     ],
     "recommends": [
-        { "name": "Toolbar" },
+        { "name": "Toolbar"              },
         { "name": "ContractConfigurator" }
     ],
     "suggests": [
@@ -18,9 +27,6 @@
     "conflicts": [
         { "name": "ContractConfigurator-ScanSatLite" }
     ],
-    "resources": {
-        "repository": "https://github.com/S-C-A-N/SCANsat"
-    },
     "x_netkan_override": [
         {
             "version": "v12.1",

--- a/NetKAN/SVE-HighResolution.netkan
+++ b/NetKAN/SVE-HighResolution.netkan
@@ -1,18 +1,21 @@
 {
     "spec_version"   : "v1.4",
-    "$kref"          : "#/ckan/github/Galileo88/StockVisualEnhancements/asset_match/SVE_HighResTextures.zip",
-    "ksp_version_min": "1.2",
-    "comment"        : "Textures only",
     "identifier"     : "SVE-HighResolution",
     "name"           : "Stock Visual Enhancements-High Res Textures",
     "abstract"       : "Textures for Stock Visual Enhancements",
-    "license"        : "CC-BY-NC-SA",
-    "release_status" : "stable",
+    "comment"        : "Textures only",
+    "$kref"          : "#/ckan/github/Galileo88/StockVisualEnhancements/asset_match/SVE_HighResTextures.zip",
+    "ksp_version_min": "1.2",
     "x_netkan_epoch" : "3",
     "x_netkan_staging": true,
+    "license"        : "CC-BY-NC-SA",
+    "release_status" : "stable",
     "resources" : {
-        "homepage"     : "https://forum.kerbalspaceprogram.com/index.php?/topic/143288-*"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/143288-*"
     },
+    "tags": [
+        "graphics"
+    ],
     "provides": [
         "SVE-Textures"
      ],

--- a/NetKAN/SVE-LowResolution.netkan
+++ b/NetKAN/SVE-LowResolution.netkan
@@ -1,21 +1,24 @@
 {
     "spec_version"   : "v1.4",
-    "$kref"          : "#/ckan/github/Galileo88/StockVisualEnhancements/asset_match/SVE_LowResTextures.zip",
-    "ksp_version_min": "1.2",
-    "comment"        : "Textures only",
     "identifier"     : "SVE-LowResolution",
     "name"           : "Stock Visual Enhancements-Low Resolution Textures",
     "abstract"       : "Textures for Stock Visual Enhancements",
-    "license"        : "CC-BY-NC-SA",
-    "release_status" : "stable",
+    "comment"        : "Textures only",
+    "$kref"          : "#/ckan/github/Galileo88/StockVisualEnhancements/asset_match/SVE_LowResTextures.zip",
+    "ksp_version_min": "1.2",
     "x_netkan_epoch" : "3",
     "x_netkan_staging": true,
+    "license"        : "CC-BY-NC-SA",
+    "release_status" : "stable",
     "resources" : {
-        "homepage"     : "https://forum.kerbalspaceprogram.com/index.php?/topic/143288-*"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/143288-*"
     },
+    "tags": [
+        "graphics"
+    ],
     "provides": [
         "SVE-Textures"
-     ],
+    ],
     "conflicts": [
         { "name": "SVE-Textures" }
     ],

--- a/NetKAN/SVE-MediumResolution.netkan
+++ b/NetKAN/SVE-MediumResolution.netkan
@@ -1,21 +1,24 @@
 {
     "spec_version"   : "v1.4",
-    "$kref"          : "#/ckan/github/Galileo88/StockVisualEnhancements/asset_match/SVE_MedResTextures.zip",
-    "ksp_version_min": "1.2",
-    "comment"        : "Textures only",
     "identifier"     : "SVE-MediumResolution",
     "name"           : "Stock Visual Enhancements-Medium Resolution Textures",
     "abstract"       : "Textures for Stock Visual Enhancements",
-    "license"        : "CC-BY-NC-SA",
-    "release_status" : "stable",
+    "comment"        : "Textures only",
+    "$kref"          : "#/ckan/github/Galileo88/StockVisualEnhancements/asset_match/SVE_MedResTextures.zip",
+    "ksp_version_min": "1.2",
     "x_netkan_epoch" : "3",
     "x_netkan_staging": true,
+    "license"        : "CC-BY-NC-SA",
+    "release_status" : "stable",
     "resources" : {
-        "homepage"     : "https://forum.kerbalspaceprogram.com/index.php?/topic/143288-*"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/143288-*"
     },
+    "tags": [
+        "graphics"
+    ],
     "provides": [
         "SVE-Textures"
-     ],
+    ],
     "conflicts": [
         { "name": "SVE-Textures" }
     ],

--- a/NetKAN/SVE-Scatterer-Config.netkan
+++ b/NetKAN/SVE-Scatterer-Config.netkan
@@ -1,17 +1,21 @@
 {
     "spec_version"   : "v1.10",
-    "$kref"          : "#/ckan/github/Galileo88/StockVisualEnhancements/asset_match/(?i)Scatterer",
-    "$vref"          : "#/ckan/ksp-avc",
-    "ksp_version"    : "1.2",
     "identifier"     : "SVE-Scatterer-Config",
     "name"           : "Stock Visual Enhancements: Scatterer Configs",
     "abstract"       : "Stock Visual Enhancements configurations for scatterer",
+    "$kref"          : "#/ckan/github/Galileo88/StockVisualEnhancements/asset_match/(?i)Scatterer",
+    "$vref"          : "#/ckan/ksp-avc",
+    "ksp_version"    : "1.2",
+    "x_netkan_epoch" : "2",
     "license"        : "CC-BY-NC-SA",
     "release_status" : "stable",
-    "x_netkan_epoch" : "2",
     "resources" : {
-        "homepage"   : "https://forum.kerbalspaceprogram.com/index.php?/topic/143288-*"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/143288-*"
     },
+    "tags": [
+        "config",
+        "graphics"
+    ],
     "depends": [
         { "name": "StockVisualEnhancements" },
         { "name": "Scatterer" }

--- a/NetKAN/SVE-Sunflare.netkan
+++ b/NetKAN/SVE-Sunflare.netkan
@@ -12,6 +12,10 @@
     "resources" : {
         "homepage"   : "https://forum.kerbalspaceprogram.com/index.php?/topic/143288-*"
     },
+    "tags": [
+        "config",
+        "graphics"
+    ],
     "depends": [
         { "name": "Scatterer" }
     ],

--- a/NetKAN/SVE-Terrain.netkan
+++ b/NetKAN/SVE-Terrain.netkan
@@ -1,14 +1,18 @@
 {
     "spec_version"   : "v1.4",
-    "$kref"          : "#/ckan/github/Galileo88/Stock-Visual-Terrain",
-    "$vref"          : "#/ckan/ksp-avc",
     "identifier"     : "SVE-Terrain",
     "name"           : "Stock Visual Terrain",
     "abstract"       : "A terrain texture enhancement pack using Kopernicus for the stock planets.",
+    "$kref"          : "#/ckan/github/Galileo88/Stock-Visual-Terrain",
+    "$vref"          : "#/ckan/ksp-avc",
     "license"        : "CC-BY-NC-ND",
     "resources" : {
-        "homepage"     : "https://forum.kerbalspaceprogram.com/index.php?/topic/143828-*"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/143828-*"
     },
+    "tags": [
+        "config",
+        "graphics"
+    ],
     "depends": [
         { "name": "Kopernicus" }
     ],

--- a/NetKAN/Scatterer-config.netkan
+++ b/NetKAN/Scatterer-config.netkan
@@ -1,13 +1,17 @@
 {
-    "identifier": "Scatterer-config",
-    "license": "GPL-3.0",
-    "release_status": "development",
-    "$kref": "#/ckan/spacedock/141",
-    "name": "scatterer - default config",
-    "abstract": "The default configuration files for scatterer",
-    "x_netkan_force_v": true,
     "spec_version": "v1.4",
+    "identifier":   "Scatterer-config",
+    "name":         "Scatterer Default Config",
+    "abstract":     "The default configuration files for scatterer",
+    "$kref":        "#/ckan/spacedock/141",
+    "x_netkan_force_v": true,
     "x_netkan_epoch": "2",
+    "release_status": "development",
+    "license":      "GPL-3.0",
+    "tags": [
+        "graphics",
+        "config"
+    ],
     "conflicts": [
         { "name": "Scatterer-config" }
     ],
@@ -29,8 +33,7 @@
             "version": "2:v0.0320b",
             "override": {
                 "ksp_version" : "1.3"
-                }
-            
+            }
         },
         {
             "version": "2:v0.0329_for_1.4.2",

--- a/NetKAN/Scatterer-sunflare.netkan
+++ b/NetKAN/Scatterer-sunflare.netkan
@@ -1,13 +1,17 @@
 {
-    "identifier": "Scatterer-sunflare",
-    "license": "GPL-3.0",
-    "release_status": "development",
-    "$kref": "#/ckan/spacedock/141",
-    "name": "scatterer - sunflare",
-    "abstract": "The sunflare component of scatterer",
-    "x_netkan_force_v": true,
     "spec_version": "v1.4",
+    "identifier":   "Scatterer-sunflare",
+    "name":         "Scatterer Sunflare",
+    "abstract":     "The sunflare component of scatterer",
+    "$kref": "#/ckan/spacedock/141",
+    "x_netkan_force_v": true,
     "x_netkan_epoch": "2",
+    "release_status": "development",
+    "license":      "GPL-3.0",
+    "tags": [
+        "graphics",
+        "config"
+    ],
     "conflicts": [
         { "name": "Scatterer-sunflare" }
     ],

--- a/NetKAN/Scatterer.netkan
+++ b/NetKAN/Scatterer.netkan
@@ -1,14 +1,18 @@
 {
-    "identifier": "Scatterer",
-    "license": "GPL-3.0",
-    "release_status": "development",
-    "$kref": "#/ckan/spacedock/141",
-    "x_netkan_force_v": true,
     "spec_version": "v1.4",
+    "identifier":   "Scatterer",
+    "$kref":        "#/ckan/spacedock/141",
+    "x_netkan_force_v": true,
     "x_netkan_epoch": "2",
+    "release_status": "development",
+    "license":      "GPL-3.0",
+    "tags": [
+        "graphics",
+        "plugin"
+    ],
     "depends": [
         { "name": "Scatterer-sunflare" },
-        { "name": "Scatterer-config" }
+        { "name": "Scatterer-config"   }
     ],
     "conflicts": [
         { "name": "Scatterer" }

--- a/NetKAN/StockVisualEnhancements.netkan
+++ b/NetKAN/StockVisualEnhancements.netkan
@@ -11,24 +11,28 @@
     "x_netkan_staging": true,
     "x_netkan_staging_reason": "Tricky dependencies, make sure the SVE-Textures providers are indexed",
     "resources" : {
-        "homepage"     : "https://forum.kerbalspaceprogram.com/index.php?/topic/143288-*"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/143288-*"
     },
+    "tags": [
+        "config",
+        "graphics"
+    ],
     "provides": [
         "EnvironmentalVisualEnhancements-Config"
-     ],
+    ],
     "conflicts": [
         { "name" : "EnvironmentalVisualEnhancements-Config" },
-		{ "name" : "GPP" }
+		{ "name" : "GPP"                                    }
     ],
     "depends": [
-        { "name": "SVE-Textures" },
+        { "name": "SVE-Textures"                    },
         { "name": "EnvironmentalVisualEnhancements" },
-        { "name": "ModuleManager"}
+        { "name": "ModuleManager"                   }
     ],
     "recommends": [
-        { "name": "Scatterer" },
+        { "name": "Scatterer"     },
         { "name": "DistantObject" },
-        { "name": "PlanetShine" }
+        { "name": "PlanetShine"   }
     ],
     "install": [
         {


### PR DESCRIPTION
## Motivation

KSP-CKAN/CKAN#2034 added the ability to categorize mods in metadata, and KSP-CKAN/CKAN#2936 is finally adding a UI for it. However the number of mods with tags in their metadata is extremely scant and paltry.

## Changes

I sorted the All filter by Downloads and added tags to the most popular mods according to https://github.com/KSP-CKAN/CKAN/wiki/Suggested-Tags. 32 mods seemed like enough to get started without overwhelming the validation scripts.