### PR TITLE
Update Kerbalism conflicts and tags

### DIFF
--- a/NetKAN/Kerbalism.netkan
+++ b/NetKAN/Kerbalism.netkan
@@ -1,42 +1,51 @@
 {
-	"spec_version": "v1.18",
-	"identifier": "Kerbalism",
-	"abstract": "Add life support, quality-of-life, radiation, malfunctions, signals and space weather mechanics.",
-	"$kref": "#/ckan/github/Kerbalism/Kerbalism/asset_match/Kerbalism-Core*",
-	"$vref": "#/ckan/ksp-avc",
-	"license": "Unlicense",
-	"author": ["Kerbalism Contributors"],
-	"resources": {
-		"homepage": "https://kerbalism.github.io/Kerbalism",
-		"repository": "https://github.com/Kerbalism/Kerbalism"
-	},
-	"depends": [
-		{ "name": "ModuleManager" },
-		{ "name": "CommunityResourcePack" },
-		{ "name": "Kerbalism-Config" }
-	],
-	"recommends": [
-		{ "name": "KerbalChangelog" }
-	],
-	"supports": [
-		{ "name": "ConnectedLivingSpace" },
-		{ "name": "CryoTanks" },
-		{ "name": "KerbalAtomics" },
-		{ "name": "KerbalPlanetaryBaseSystems" },
-		{ "name": "NearFutureElectrical" },
-		{ "name": "NearFutureSolar" },
-		{ "name": "NearFutureSpacecraft" },
-		{ "name": "SCANsat" }
-	],
-	"conflicts": [
-		{ "name": "UKS" },
-		{ "name": "TACLS" },
-		{ "name": "Snacks" },
-		{ "name": "USI-LS" }
-	], 
-	"install": [{
-		"find": "Kerbalism",
-		"install_to": "GameData"
-	}]
-
+    "spec_version": "v1.18",
+    "identifier":   "Kerbalism",
+    "abstract":     "Add life support, quality-of-life, radiation, malfunctions, signals and space weather mechanics.",
+    "author":       ["Kerbalism Contributors"],
+    "$kref":        "#/ckan/github/Kerbalism/Kerbalism/asset_match/Kerbalism-Core*",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "Unlicense",
+    "resources": {
+        "homepage": "https://kerbalism.github.io/Kerbalism",
+        "repository": "https://github.com/Kerbalism/Kerbalism"
+    },
+    "tags": [
+        "plugin",
+        "parts",
+        "manned",
+        "science",
+        "resources"
+    ],
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "CommunityResourcePack" },
+        { "name": "Kerbalism-Config" }
+    ],
+    "recommends": [
+        { "name": "KerbalChangelog" }
+    ],
+    "supports": [
+        { "name": "ConnectedLivingSpace" },
+        { "name": "CryoTanks" },
+        { "name": "KerbalAtomics" },
+        { "name": "KerbalPlanetaryBaseSystems" },
+        { "name": "NearFutureElectrical" },
+        { "name": "NearFutureSolar" },
+        { "name": "NearFutureSpacecraft" },
+        { "name": "SCANsat" }
+    ],
+    "conflicts": [
+        { "name": "UKS" },
+        { "name": "TACLS" },
+        { "name": "Snacks" },
+        { "name": "USI-LS" },
+        { "name": "BackgroundResources" },
+        { "name": "BackgroundProcessing" },
+        { "name": "DynamicBatteryStorage" }
+    ], 
+    "install": [ {
+        "find": "Kerbalism",
+        "install_to": "GameData"
+    } ]
 }


### PR DESCRIPTION
A user on the CKAN Discord reported that Kerbalism showed this message on launch:

![screenshot](https://cdn.discordapp.com/attachments/601456737203126281/653815061214789656/unknown.png)

Sure enough, Kerbalism has code to check the loaded assemblies and look for specific ones it doesn't like:

https://github.com/Kerbalism/Kerbalism/blob/155d2b02c947c285163b116ca0b1aa5f2dc84736/src/Kerbalism/System/Settings.cs#L20

Kerbalism string | CKAN identifier | CKAN conflict?
 --- | --- | ---
BackgroundResources | BackgroundResources | No
BackgroundProcessing | BackgroundProcessing | No
DynamicBatteryStorage | DynamicBatteryStorage | No
KolonyTools | UKS | Yes
TacLifeSupport | TACLS | Yes
Snacks | Snacks | Yes
USILifeSupport | USI-LS | Yes

Now the missing ones are added to the metadata. And tags are added.