### PR TITLE
Updated Kerbalism mod conflicts

### DIFF
--- a/NetKAN/Kerbalism-Config-Default.netkan
+++ b/NetKAN/Kerbalism-Config-Default.netkan
@@ -11,9 +11,15 @@
 	"depends": [{
 		"name": "Kerbalism"
 	}],
-	"conflicts": [{
-		"name": "Kerbalism-Config"
-	}],
+	"conflicts": [
+		{ "name": "Kerbalism-Config" },
+		{ "name": "UKS" },
+		{ "name": "TACLS" },
+		{ "name": "Snacks" },
+		{ "name": "USI-LS" },
+		{ "name": "BackgroundResources" },
+		{ "name": "BackgroundProcessing" }
+	],
 	"install": [{
 		"find": "KerbalismConfig",
 		"install_to": "GameData"

--- a/NetKAN/Kerbalism.netkan
+++ b/NetKAN/Kerbalism.netkan
@@ -36,12 +36,6 @@
         { "name": "SCANsat" }
     ],
     "conflicts": [
-        { "name": "UKS" },
-        { "name": "TACLS" },
-        { "name": "Snacks" },
-        { "name": "USI-LS" },
-        { "name": "BackgroundResources" },
-        { "name": "BackgroundProcessing" },
         { "name": "DynamicBatteryStorage" }
     ], 
     "install": [ {


### PR DESCRIPTION
Kerablism mod conflicts depend on what Kerbalism is configured to do. This moves the mod conflict definitions where they belong.

See also https://github.com/KSP-CKAN/NetKAN/pull/7546