### PR TITLE
Tag and de-metanetkan HebaruSan's mods

### DIFF
--- a/NetKAN/Astrogator.netkan
+++ b/NetKAN/Astrogator.netkan
@@ -2,6 +2,7 @@
     "spec_version": 1,
     "identifier":   "Astrogator",
     "$kref":        "#/ckan/github/HebaruSan/Astrogator",
+    "license":      "GPL-3.0",
     "tags": [
         "plugin",
         "information",

--- a/NetKAN/Astrogator.netkan
+++ b/NetKAN/Astrogator.netkan
@@ -1,5 +1,10 @@
 {
     "spec_version": 1,
-    "identifier": "Astrogator",
-    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/HebaruSan/Astrogator/master/Astrogator.netkan"
+    "identifier":   "Astrogator",
+    "$kref":        "#/ckan/github/HebaruSan/Astrogator",
+    "tags": [
+        "plugin",
+        "information",
+        "control"
+    ]
 }

--- a/NetKAN/Ringworld.netkan
+++ b/NetKAN/Ringworld.netkan
@@ -1,5 +1,29 @@
 {
-    "spec_version": 1,
-    "identifier": "Ringworld",
-    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/HebaruSan/Ringworld/master/Ringworld.netkan"
+    "spec_version":   "v1.18",
+    "identifier":     "Ringworld",
+    "name":           "Ringworld",
+    "abstract":       "A planetary orbit-sized surface modeled after the eponymous body from Larry Niven's novel 'Ringworld'",
+    "description":    "200 light years from Earth, a huge ring revolves around its lonely star. The inner surface hosts a biosphere millions of times the area of Earth's, but otherwise similar in its distance to its sun, spin gravity, and even its day-night cycle, thanks to enormous 'shadow squares' selectively blocking the sun. Now you can observe this incredible artifact from your favorite Kerbal vessel!",
+    "comment":        "Indexed by author. Please report any problems at the repository bugtracker.",
+    "$kref":          "#/ckan/github/HebaruSan/Ringworld",
+    "$vref":          "#/ckan/ksp-avc",
+    "license":        "Unlicense",
+    "resources": {
+        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/167549-*",
+        "repository": "https://github.com/HebaruSan/Ringworld",
+        "bugtracker": "https://github.com/HebaruSan/Ringworld/issues"
+    },
+    "tags": [
+        "config",
+        "planet-pack"
+    ],
+    "depends": [
+        { "name": "ModuleManager" },
+        {
+            "name":        "Kopernicus",
+            "min_version": "2:release-1.3.0-8"
+        }
+    ], "recommends": [
+        { "name": "LoadingTipsPlus" }
+    ]
 }

--- a/NetKAN/SmartTank.netkan
+++ b/NetKAN/SmartTank.netkan
@@ -1,5 +1,9 @@
 {
     "spec_version": 1,
-    "identifier": "SmartTank",
-    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/HebaruSan/SmartTank/master/SmartTank.netkan"
+    "identifier":   "SmartTank",
+    "$kref":        "#/ckan/github/HebaruSan/SmartTank",
+    "tags": [
+        "plugin",
+        "convenience"
+    ]
 }

--- a/NetKAN/SmartTank.netkan
+++ b/NetKAN/SmartTank.netkan
@@ -2,6 +2,7 @@
     "spec_version": 1,
     "identifier":   "SmartTank",
     "$kref":        "#/ckan/github/HebaruSan/SmartTank",
+    "license":      "GPL-3.0",
     "tags": [
         "plugin",
         "convenience"


### PR DESCRIPTION
Since #5234, #5717, and #6036, my mods have used metanetkans hosted on the mods' repos.

I think this sets a bad example for others who might look at them to see how to index a mod. Hosting a netkan directly in the main NetKAN repo has several advantages:

- I can run recursive grep searches to get basic info about them
- Easier maintenance by the CKAN team when we need to make a similar change to many mods at once
- Probably a slight performance improvement for netkan since one network call is cut out
- Automated validation scripts for pull requests when making changes

(And of course I can edit the main repo just as easily as my own nowadays, but that's not the case for most mod authors.)

Now my mods no longer use metanetkans, and they also have tags added.

Note that two of them are still quite minimal because most of their metdata lives in "internal .ckan" files inside the downloads. I plan to keep this for the time being, but it might make sense to migrate some properties to the main netkan at some point.