### PR TITLE
Freeze Mk2Essentials

### DIFF
--- a/NetKAN/Mk2Essentials.frozen
+++ b/NetKAN/Mk2Essentials.frozen
@@ -4,19 +4,19 @@
 	"name" : "Mk 2 Essentials",
 	"abstract" : "Some Mk2 parts which I felt were missing from the game",
 	"author" : "JoePatrick1",
-	"license" : "restricted",
+	"license" : "MIT",
 	"version" : "6",
 	"release_status" : "stable",
 	"ksp_version_min" : "0.90",
 	"ksp_version_max" : "1.0.5",
-	"resources" : 
+	"resources" :
 	{
 		"homepage"	: "http://forum.kerbalspaceprogram.com/index.php?/topic/89875-104",
 		"x_curse"	: "http://kerbal.curseforge.com/ksp-mods/225706-mk2-essentials"
 	},
-	"install" : [ 
-		{ 
-			"file" : "Mk2Essentials",  
+	"install" : [
+		{
+			"file" : "Mk2Essentials",
 			"install_to" : "GameData",
 			"filter" : "Thumbs.db"
 		}


### PR DESCRIPTION
This mod is hosted on CurseForge.
It uses a direct download link instead of asking querying API for it, which seems to be the reason why it still worked until a few days ago, whereas all other CurseForge mods stopped working a long time ago.

The mod [author announced](https://forum.kerbalspaceprogram.com/index.php?/topic/89875-104-mk2-essentials/&do=findComment&comment=3124227) that he no longer wants to maintain this mod a long time ago, and there is also a replacement for it by LGG. Very unlikely that we will ever see a new release.

He also changed the license to MIT, see the linked comment and the [mod page on CF](https://www.curseforge.com/kerbal/ksp-mods/mk2-essentials).
I changed it in the netkan too despite it being frozen, to reflect the last state before freezing.