### PR TITLE
Remove unnecessary author arrays and tag some modules

### DIFF
--- a/NetKAN/AlmostRealSolarSystem.netkan
+++ b/NetKAN/AlmostRealSolarSystem.netkan
@@ -1,18 +1,21 @@
 {
-    "$kref": "#/ckan/spacedock/1596",
+    "spec_version": "v1.4",
+    "identifier":   "AlmostRealSolarSystem",
+    "$kref":        "#/ckan/spacedock/1596",
+    "license":      "MIT",
+    "tags": [
+        "config",
+        "planet-pack"
+    ],
+    "install": [ {
+        "find": "(Almost)RealSolarSystem",
+        "install_to": "GameData"
+    } ],
     "depends": [
         { "name": "SigmaDimensions" },
         { "name": "Kopernicus" }
     ],
     "recommends": [
         { "name": "OPM-Galileo" }
-    ],
-    "x_via": "Automated SpaceDock CKAN submission",
-    "license": "MIT",
-    "identifier": "AlmostRealSolarSystem",
-    "spec_version": "v1.4",
-    "install": [{
-        "find": "(Almost)RealSolarSystem",
-        "install_to": "GameData"
-    }]
+    ]
 }

--- a/NetKAN/Asclepius.netkan
+++ b/NetKAN/Asclepius.netkan
@@ -2,24 +2,26 @@
 {
     "spec_version"  : "v1.4",
     "identifier"    : "Asclepius",
-    "$kref"         : "#/ckan/github/MrChumley/Asclepius",
-    "x_netkan_epoch": "2",
     "name"          : "Asclepius",
     "abstract"      : "Asclepius a Kopernicus planet SSTO playground",
+    "$kref"         : "#/ckan/github/MrChumley/Asclepius",
+    "ksp_version"   : "any",
+    "x_netkan_epoch": "2",
     "license"       : "CC0",
-    "author": [
-        "MrChumley"
-    ],
+    "author"        : "MrChumley",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/113949-105-asclepius-a-kopernicus-planet-ssto-playground/"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/113949-*"
     },
-    "ksp_version": "1.3",
+    "tags": [
+        "config",
+        "planet-pack"
+    ],
     "depends": [
         { "name" : "ModuleManager", "min_version": "2.8.0" },
         { "name" : "Kopernicus", "min_version": "2:release-1.3.0-5" }
     ],
     "recommends": [
-        { "name": "ContractConfigurator-FarOutContracts"}
+        { "name": "ContractConfigurator-FarOutContracts" }
     ],
     "install": [
         {

--- a/NetKAN/ContractConfigurator-FarOutContracts.netkan
+++ b/NetKAN/ContractConfigurator-FarOutContracts.netkan
@@ -4,7 +4,7 @@
     "identifier"    : "ContractConfigurator-FarOutContracts",
     "name"          : "ContractConfigurator-FarOutContracts",
     "abstract"      : "Adds custom Contract Configurator contracts to Kronkus, Asclepius, and Spud",
-    "author"        : [ "MrChumley" ],
+    "author"        : "MrChumley",
     "$kref"         : "#/ckan/github/MrChumley/Farout",
     "ksp_version"   : "1.3",
     "x_netkan_epoch": "2",

--- a/NetKAN/EngineIgniter.netkan
+++ b/NetKAN/EngineIgniter.netkan
@@ -3,7 +3,7 @@
     "identifier":   "EngineIgniter",
     "name":         "Engine Igniter",
     "abstract":     "This mod limits the number of times an engine may restart. Configuration is provided for stock/Squad engines and a few popular mods' engines, and may be extended through the use of ModuleManager patches.",
-    "author":       [ "nadseh" ],
+    "author":       "nadseh",
     "$kref":        "#/ckan/github/jamesharling/EngineIgniter",
     "license":      "CC-BY-4.0",
     "ksp_version":  "1.2.2",

--- a/NetKAN/HalfRSS-Textures2048.netkan
+++ b/NetKAN/HalfRSS-Textures2048.netkan
@@ -1,16 +1,15 @@
 {
     "spec_version": "v1.4",
-    "identifier": "HalfRSS-Textures2048",
-    "$kref": "#/ckan/github/pap1723/ScaledRSS-Textures/asset_match/HalfRSS-Textures2048",
-    "name": "Half Size Real Solar System Textures - 2048 x 1024",
-    "author": [ "pap1723" ],
-    "abstract": "HalfRSS textures for HalfRSS",
-    "license": "CC-BY-NC-SA",
+    "identifier":   "HalfRSS-Textures2048",
+    "name":         "Half Size Real Solar System Textures - 2048 x 1024",
+    "abstract":     "HalfRSS textures for HalfRSS",
+    "author":       "pap1723",
+    "$kref":        "#/ckan/github/pap1723/ScaledRSS-Textures/asset_match/HalfRSS-Textures2048",
+    "ksp_version":  "any",
+    "license":      "CC-BY-NC-SA",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142336-113-half-size-rss-v10/"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142336-*"
     },
-    "ksp_version_min": "1.1.0",
-    "ksp_version_max": "1.2.99",
     "tags": [
         "config",
         "graphics"

--- a/NetKAN/HalfRSS-Textures4096.netkan
+++ b/NetKAN/HalfRSS-Textures4096.netkan
@@ -1,16 +1,15 @@
 {
     "spec_version": "v1.4",
-    "identifier": "HalfRSS-Textures4096",
-    "$kref": "#/ckan/github/pap1723/ScaledRSS-Textures/asset_match/HalfRSS-Textures4096",
-    "name": "Half Size Real Solar System Textures - 4096 x 2048",
-    "author": [ "pap1723" ],
-    "abstract": "HalfRSS textures for HalfRSS",
-    "license": "CC-BY-NC-SA",
+    "identifier":   "HalfRSS-Textures4096",
+    "name":         "Half Size Real Solar System Textures - 4096 x 2048",
+    "abstract":     "HalfRSS textures for HalfRSS",
+    "author":       "pap1723",
+    "$kref":        "#/ckan/github/pap1723/ScaledRSS-Textures/asset_match/HalfRSS-Textures4096",
+    "license":      "CC-BY-NC-SA",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142336-113-half-size-rss-v10/"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142336-*"
     },
-    "ksp_version_min": "1.1.0",
-    "ksp_version_max": "1.2.99",
+    "ksp_version": "any",
     "tags": [
         "config",
         "graphics"

--- a/NetKAN/HalfRSS-Textures8192.netkan
+++ b/NetKAN/HalfRSS-Textures8192.netkan
@@ -1,16 +1,15 @@
 {
     "spec_version": "v1.4",
-    "identifier": "HalfRSS-Textures8192",
-    "$kref": "#/ckan/github/pap1723/ScaledRSS-Textures/asset_match/HalfRSS-Textures8192",
-    "name": "Half Size Real Solar System Textures - 8192 x 4096",
-    "author": [ "pap1723" ],
-    "abstract": "HalfRSS textures for HalfRSS",
-    "license": "CC-BY-NC-SA",
+    "identifier":   "HalfRSS-Textures8192",
+    "name":         "Half Size Real Solar System Textures - 8192 x 4096",
+    "abstract":     "HalfRSS textures for HalfRSS",
+    "author":       "pap1723",
+    "$kref":        "#/ckan/github/pap1723/ScaledRSS-Textures/asset_match/HalfRSS-Textures8192",
+    "license":      "CC-BY-NC-SA",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142336-113-half-size-rss-v10/"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142336-*"
     },
-    "ksp_version_min": "1.1.0",
-    "ksp_version_max": "1.2.99",
+    "ksp_version": "any",
     "tags": [
         "config",
         "graphics"

--- a/NetKAN/HalfRSS.netkan
+++ b/NetKAN/HalfRSS.netkan
@@ -1,15 +1,19 @@
 {
     "spec_version": "v1.4",
-    "identifier": "HalfRSS",
-    "$kref": "#/ckan/github/pap1723/HalfRSS/asset_match/HalfRSS-v.*.zip",
-    "$vref": "#/ckan/ksp-avc",
-    "name": "Half Size Real Solar System",
-    "author": [ "pap1723" ],
-    "abstract": "HalfRSS is a mod that uses the great work from NathanKell and creates our Real Solar System at half the size. HalfRSS is still 5 times larger than stock KSP and provides a huge challenge to players, but can be achieved with stock parts.",
-    "license": "CC-BY-NC-SA",
+    "identifier":   "HalfRSS",
+    "name":         "Half Size Real Solar System",
+    "author":       "pap1723",
+    "abstract":     "HalfRSS is a mod that uses the great work from NathanKell and creates our Real Solar System at half the size. HalfRSS is still 5 times larger than stock KSP and provides a huge challenge to players, but can be achieved with stock parts.",
+    "$kref":        "#/ckan/github/pap1723/HalfRSS/asset_match/HalfRSS-v.*.zip",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "CC-BY-NC-SA",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142336-113-half-size-rss-v10/"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/142336-*"
     },
+    "tags": [
+        "config",
+        "planet-pack"
+    ],
     "depends": [
         { "name": "ModularFlightIntegrator" },
         { "name": "ModuleManager" },

--- a/NetKAN/Kerbalism-Config-Default.netkan
+++ b/NetKAN/Kerbalism-Config-Default.netkan
@@ -1,27 +1,33 @@
 {
-	"spec_version": "v1.18",
-	"$kref": "#/ckan/github/Kerbalism/Kerbalism/asset_match/Kerbalism-Config*",
-	"$vref": "#/ckan/ksp-avc",
-	"license": "Unlicense",
-	"identifier": "Kerbalism-Config-Default",
-	"name": "Kerbalism - Default Config",
-	"abstract": "Default configuration for Kerbalism",
-	"author": ["Kerbalism Contributors"],
-	"provides": ["Kerbalism-Config"],
-	"depends": [{
-		"name": "Kerbalism"
-	}],
-	"conflicts": [
-		{ "name": "Kerbalism-Config" },
-		{ "name": "UKS" },
-		{ "name": "TACLS" },
-		{ "name": "Snacks" },
-		{ "name": "USI-LS" },
-		{ "name": "BackgroundResources" },
-		{ "name": "BackgroundProcessing" }
-	],
-	"install": [{
-		"find": "KerbalismConfig",
-		"install_to": "GameData"
-	}]
+    "spec_version": "v1.18",
+    "identifier":   "Kerbalism-Config-Default",
+    "name":         "Kerbalism - Default Config",
+    "abstract":     "Default configuration for Kerbalism",
+    "author":       "Kerbalism Contributors",
+    "$kref":        "#/ckan/github/Kerbalism/Kerbalism/asset_match/Kerbalism-Config*",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "Unlicense",
+    "tags": [
+        "config",
+        "physics",
+        "manned",
+        "science"
+    ],
+    "provides": [ "Kerbalism-Config" ],
+    "depends": [
+        { "name": "Kerbalism" }
+    ],
+    "conflicts": [
+        { "name": "Kerbalism-Config" },
+        { "name": "UKS" },
+        { "name": "TACLS" },
+        { "name": "Snacks" },
+        { "name": "USI-LS" },
+        { "name": "BackgroundResources" },
+        { "name": "BackgroundProcessing" }
+    ],
+    "install": [ {
+        "find": "KerbalismConfig",
+        "install_to": "GameData"
+    } ]
 }

--- a/NetKAN/Kerbalism-Config-ScienceOnly.netkan
+++ b/NetKAN/Kerbalism-Config-ScienceOnly.netkan
@@ -1,22 +1,26 @@
 {
     "spec_version": "v1.18",
-    "$kref": "#/ckan/github/Kerbalism/KerbalismScienceOnly",
-    "$vref": "#/ckan/ksp-avc",
-    "license": "Unlicense",
-    "identifier": "Kerbalism-Config-ScienceOnly",
-    "name": "Kerbalism - Science-Only Config",
-    "abstract": "Science-Only configuration for Kerbalism. Disables life support, radiation and all other features",
-    "author": ["Kerbalism Contributors"],
-    "provides": ["Kerbalism-Config"],
+    "identifier":   "Kerbalism-Config-ScienceOnly",
+    "name":         "Kerbalism - Science-Only Config",
+    "abstract":     "Science-Only configuration for Kerbalism. Disables life support, radiation and all other features",
+    "author":       "Kerbalism Contributors",
+    "$kref":        "#/ckan/github/Kerbalism/KerbalismScienceOnly",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "Unlicense",
+    "tags": [
+        "config",
+        "science"
+    ],
+    "provides": [ "Kerbalism-Config" ],
     "depends": [
         { "name": "ModuleManager" },
         { "name": "Kerbalism" }
     ],
-    "conflicts": [{
-        "name": "Kerbalism-Config"
-    }],
-    "install": [{
+    "conflicts": [
+        { "name": "Kerbalism-Config" }
+    ],
+    "install": [ {
         "find": "KerbalismScienceOnly",
         "install_to": "GameData"
-    }]
+    } ]
 }

--- a/NetKAN/Kerbalism.netkan
+++ b/NetKAN/Kerbalism.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.18",
     "identifier":   "Kerbalism",
     "abstract":     "Add life support, quality-of-life, radiation, malfunctions, signals and space weather mechanics.",
-    "author":       ["Kerbalism Contributors"],
+    "author":       "Kerbalism Contributors",
     "$kref":        "#/ckan/github/Kerbalism/Kerbalism/asset_match/Kerbalism-Core*",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "Unlicense",

--- a/NetKAN/Kronkus.netkan
+++ b/NetKAN/Kronkus.netkan
@@ -1,19 +1,20 @@
-
 {
     "spec_version"  : "v1.4",
     "identifier"    : "Kronkus",
-    "$kref"         : "#/ckan/github/MrChumley/Kronkus",
-    "x_netkan_epoch": "2",
     "name"          : "Kronkus",
     "abstract"      : "Kronkus is a Kopernicus planet pack",
+    "author"        : "MrChumley",
+    "$kref"         : "#/ckan/github/MrChumley/Kronkus",
+    "ksp_version"   : "any",
+    "x_netkan_epoch": "2",
     "license"       : "CC0",
-    "author": [
-        "MrChumley"
-    ],
     "resources" : {
-        "homepage" : "http://forum.kerbalspaceprogram.com/index.php?/topic/119202-13-kronkus-a-kopernicus-planet-pack/"
+        "homepage" : "http://forum.kerbalspaceprogram.com/index.php?/topic/119202-*"
     },
-    "ksp_version": "1.3",
+    "tags": [
+        "config",
+        "planet-pack"
+    ],
     "depends": [
         { "name" : "ModuleManager", "min_version": "2.8.0" },
         { "name" : "Kopernicus", "min_version": "2:release-1.3.0-5" }

--- a/NetKAN/KspCraftOrganizer.netkan
+++ b/NetKAN/KspCraftOrganizer.netkan
@@ -2,9 +2,12 @@
     "spec_version" : 1,
     "identifier"   : "KspCraftOrganizer",
     "$kref"        : "#/ckan/spacedock/866",
-    "license"      : "MIT",
     "$vref"        : "#/ckan/ksp-avc",
-
+    "license"      : "MIT",
+    "tags": [
+        "plugin",
+        "convenience"
+    ],
     "install": [
         {
             "file"       : "KspCraftOrganizer",

--- a/NetKAN/M-ISPx2.netkan
+++ b/NetKAN/M-ISPx2.netkan
@@ -4,19 +4,22 @@
     "$kref"        : "#/ckan/github/miki-g/M-ISPx2",
     "$vref"        : "#/ckan/ksp-avc",
     "name"         : "Engine ISP x2",
-    "author"       : [ "Miki" ],
+    "author"       : "Miki",
     "abstract"     : "Simple engine tweak for improved efficiency.",
     "license"      : "WTFPL",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/139827-*/#comment-2583173"
+    },
+    "tags": [
+        "config"
+    ],
     "depends": [
-    { "name" : "ModuleManager" }
+        { "name" : "ModuleManager" }
     ],
     "install": [
        {
           "file" : "M-ISPx2",
           "install_to" : "GameData"
        }
-    ],
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/139827-*/#comment-2583173"
-    }
+    ]
 }

--- a/NetKAN/ModuleSequentialAnimateGeneric.netkan
+++ b/NetKAN/ModuleSequentialAnimateGeneric.netkan
@@ -1,20 +1,21 @@
 {
-    "license": "MIT",
-    "name": "Sequential Animate Generic Module",
-    "identifier": "ModuleSequentialAnimateGeneric",
-    "x_via": "Automated Linuxgurugamer CKAN script",
-    "author": [
-        "linuxgurugamer"
-    ],
-    "$kref": "#/ckan/github/linuxgurugamer/ModuleSequentialAnimateGeneric",
-    "$vref": "#/ckan/ksp-avc",
+    "spec_version": "v1.4",
+    "identifier":   "ModuleSequentialAnimateGeneric",
+    "name":         "Sequential Animate Generic Module",
+    "author":       "linuxgurugamer",
+    "$kref":        "#/ckan/github/linuxgurugamer/ModuleSequentialAnimateGeneric",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "MIT",
     "release_status": "stable",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/184488-*"
+    },
+    "tags": [
+        "plugin",
+        "library"
+    ],
     "install": [ {
         "find": "ModuleSequentialAnimateGeneric",
         "install_to": "GameData"
-    } ],
-    "spec_version": "v1.4",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/184488-*"
-    }
+    } ]
 }

--- a/NetKAN/PolishFlagPack.netkan
+++ b/NetKAN/PolishFlagPack.netkan
@@ -1,20 +1,18 @@
 {
     "spec_version": 1,
-    "identifier": "PolishFlagPack",
-    "$kref": "#/ckan/github/Venthe/KSP-Polish-Flag-Pack",
-    "name": "Polish Flag Pack",
-    "author": [
-        "Venthe"
-    ],
-    "abstract": "Small pack of Polish flags",
-    "license": "MIT",
-    "ksp_version": "any",
+    "identifier":   "PolishFlagPack",
+    "name":         "Polish Flag Pack",
+    "abstract":     "Small pack of Polish flags",
+    "author":       "Venthe",
+    "$kref":        "#/ckan/github/Venthe/KSP-Polish-Flag-Pack",
+    "ksp_version":  "any",
+    "x_netkan_force_v": true,
+    "license":      "MIT",
     "comment": "flagmod",
     "resources": {
         "homepage": "https://github.com/Venthe/KSP-Polish-Flag-Pack"
     },
     "tags": [
         "config"
-    ],
-    "x_netkan_force_v": true
+    ]
 }

--- a/NetKAN/QuarterRSS-Textures2048.netkan
+++ b/NetKAN/QuarterRSS-Textures2048.netkan
@@ -1,16 +1,15 @@
 {
     "spec_version": "v1.4",
-    "identifier": "QuarterRSS-Textures2048",
-    "$kref": "#/ckan/github/pap1723/ScaledRSS-Textures/asset_match/ScaledRSS-2048",
-    "name": "Quarter Size Real Solar System Textures - 2048 x 1024",
-    "author": [ "pap1723" ],
-    "abstract": "QuarterRSS textures for QuarterRSS",
-    "license": "CC-BY-NC-SA",
+    "identifier":   "QuarterRSS-Textures2048",
+    "name":         "Quarter Size Real Solar System Textures - 2048 x 1024",
+    "abstract":     "QuarterRSS textures for QuarterRSS",
+    "author":       "pap1723",
+    "$kref":        "#/ckan/github/pap1723/ScaledRSS-Textures/asset_match/ScaledRSS-2048",
+    "ksp_version":  "any",
+    "license":      "CC-BY-NC-SA",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160191-122-quarter-size-rss-v10/"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160191-*"
     },
-    "ksp_version_min": "1.1.0",
-    "ksp_version_max": "1.2.99",
     "tags": [
         "config",
         "graphics"

--- a/NetKAN/QuarterRSS-Textures4096.netkan
+++ b/NetKAN/QuarterRSS-Textures4096.netkan
@@ -1,16 +1,15 @@
 {
     "spec_version": "v1.4",
-    "identifier": "QuarterRSS-Textures4096",
-    "$kref": "#/ckan/github/pap1723/ScaledRSS-Textures/asset_match/ScaledRSS-4096",
-    "name": "Quarter Size Real Solar System Textures - 4096 x 2048",
-    "author": [ "pap1723" ],
-    "abstract": "QuarterRSS textures for QuarterRSS",
-    "license": "CC-BY-NC-SA",
+    "identifier":   "QuarterRSS-Textures4096",
+    "name":         "Quarter Size Real Solar System Textures - 4096 x 2048",
+    "abstract":     "QuarterRSS textures for QuarterRSS",
+    "author":       "pap1723",
+    "$kref":        "#/ckan/github/pap1723/ScaledRSS-Textures/asset_match/ScaledRSS-4096",
+    "ksp_version":  "any",
+    "license":      "CC-BY-NC-SA",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160191-122-quarter-size-rss-v10/"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160191-*"
     },
-    "ksp_version_min": "1.1.0",
-    "ksp_version_max": "1.2.99",
     "tags": [
         "config",
         "graphics"

--- a/NetKAN/QuarterRSS-Textures8192.netkan
+++ b/NetKAN/QuarterRSS-Textures8192.netkan
@@ -1,16 +1,15 @@
 {
     "spec_version": "v1.4",
-    "identifier": "QuarterRSS-Textures8192",
-    "$kref": "#/ckan/github/pap1723/ScaledRSS-Textures/asset_match/ScaledRSS-8192",
-    "name": "Quarter Size Real Solar System Textures - 8192 x 4096",
-    "author": [ "pap1723" ],
-    "abstract": "QuarterRSS textures for QuarterRSS",
-    "license": "CC-BY-NC-SA",
+    "identifier":   "QuarterRSS-Textures8192",
+    "name":         "Quarter Size Real Solar System Textures - 8192 x 4096",
+    "abstract":     "QuarterRSS textures for QuarterRSS",
+    "author":       "pap1723",
+    "$kref":        "#/ckan/github/pap1723/ScaledRSS-Textures/asset_match/ScaledRSS-8192",
+    "ksp_version":  "any",
+    "license":      "CC-BY-NC-SA",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160191-122-quarter-size-rss-v10/"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160191-*"
     },
-    "ksp_version_min": "1.1.0",
-    "ksp_version_max": "1.2.99",
     "tags": [
         "config",
         "graphics"

--- a/NetKAN/QuarterRSS.netkan
+++ b/NetKAN/QuarterRSS.netkan
@@ -1,15 +1,19 @@
 {
     "spec_version": "v1.4",
-    "identifier": "QuarterRSS",
-    "$kref": "#/ckan/github/pap1723/Quarter-RSS/asset_match/Quarter-RSS-v.*.zip",
-    "$vref": "#/ckan/ksp-avc",
-    "name": "Quarter Size Real Solar System",
-    "author": [ "pap1723" ],
-    "abstract": "QuarterRSS is a mod that uses the great work from NathanKell and creates our Real Solar System at 1/4 the size. QuarterRSS is still 2.5 times larger than stock KSP and provides a huge challenge to players, but can be achieved with stock parts.",
-    "license": "CC-BY-NC-SA",
+    "identifier":   "QuarterRSS",
+    "name":         "Quarter Size Real Solar System",
+    "author":       "pap1723",
+    "abstract":     "QuarterRSS is a mod that uses the great work from NathanKell and creates our Real Solar System at 1/4 the size. QuarterRSS is still 2.5 times larger than stock KSP and provides a huge challenge to players, but can be achieved with stock parts.",
+    "$kref":        "#/ckan/github/pap1723/Quarter-RSS/asset_match/Quarter-RSS-v.*.zip",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "CC-BY-NC-SA",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160191-122-quarter-size-rss-v10/"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160191-*"
     },
+    "tags": [
+        "config",
+        "planet-pack"
+    ],
     "depends": [
         { "name": "ModularFlightIntegrator" },
         { "name": "ModuleManager" },

--- a/NetKAN/RSS-Airports.netkan
+++ b/NetKAN/RSS-Airports.netkan
@@ -1,20 +1,22 @@
 {
     "spec_version" : "v1.2",
     "identifier"   : "RSS-Airports",
+    "name"         : "RSS Airports",
+    "abstract"     : "Add launch sites on real airports locations (for Real Solar System & KSC Switcher)",
+    "author"       : "Miki",
     "$kref"        : "#/ckan/github/miki-g/RSS-Airports",
     "$vref"        : "#/ckan/ksp-avc",
-    "name"         : "RSS Airports",
-    "author"       : [ "Miki" ],
-    "abstract"     : "Add launch sites on real airports locations (for Real Solar System & KSC Switcher)",
     "license"      : "WTFPL",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/139827-*/#comment-2583173"
+    },
+    "tags": [
+        "config"
+    ],
     "depends": [
-            {
-                "name": "KSCSwitcher"
-            },
-            {
-                "name": "RealSolarSystem"
-            }
-        ],
+        { "name": "KSCSwitcher" },
+        { "name": "RealSolarSystem" }
+    ],
     "recommends": [
         { "name": "RSS-FictionalKSC" }
     ],
@@ -23,8 +25,5 @@
           "file" : "RSS-Airports",
           "install_to" : "GameData"
        }
-    ],
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/139827-*/#comment-2583173"
-    }
+    ]
 }

--- a/NetKAN/RSS-FictionalKSC.netkan
+++ b/NetKAN/RSS-FictionalKSC.netkan
@@ -1,34 +1,27 @@
 {
     "spec_version" : "v1.2",
     "identifier"   : "RSS-FictionalKSC",
+    "name"         : "RSS Fictional KSC",
+    "abstract"     : "Add fictional launch sites (for Real Solar System & KSC Switcher)",
+    "author"       : "Miki",
     "$kref"        : "#/ckan/github/miki-g/RSS-FictionalKSC",
     "$vref"        : "#/ckan/ksp-avc",
-    "name"         : "RSS Fictional KSC",
-    "author"       : [ "Miki" ],
-    "abstract"     : "Add fictional launch sites (for Real Solar System & KSC Switcher)",
     "license"      : "WTFPL",
-
-    "depends": [
-          {
-        "name": "KSCSwitcher"
-        },
-        {
-        "name": "RealSolarSystem"
-        }
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/139827-*/#comment-2583173"
+    },
+    "tags": [
+        "config"
     ],
-
+    "depends": [
+        { "name": "KSCSwitcher" },
+        { "name": "RealSolarSystem" }
+    ],
     "recommends": [
         { "name": "RSS-Airports" }
     ],
-
-    "install": [
-          {
-           "file" : "RSS-FictionalKSC",
-           "install_to" : "GameData"
-          }
-    ],
-
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/139827-*/#comment-2583173"
-    }
+    "install": [ {
+        "file" : "RSS-FictionalKSC",
+        "install_to" : "GameData"
+    } ]
 }

--- a/NetKAN/RetractableLiftingSurface.netkan
+++ b/NetKAN/RetractableLiftingSurface.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "RetractableLiftingSurface",
     "name":         "Retractable Lifting Surface Module",
-    "author":       [ "linuxgurugamer" ],
+    "author":       "linuxgurugamer",
     "$kref":        "#/ckan/github/linuxgurugamer/RetractableLiftingSurface",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "MIT",

--- a/NetKAN/SETI-CareerChallenge.netkan
+++ b/NetKAN/SETI-CareerChallenge.netkan
@@ -9,6 +9,11 @@
     "resources"     : {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*"
     },
+    "tags"          : [
+        "config",
+        "career",
+        "science"
+    ],
     "depends"       : [
         { "name"    : "ModuleManager" }
     ],

--- a/NetKAN/STMsFFRibbonPackEngineeringRoles.netkan
+++ b/NetKAN/STMsFFRibbonPackEngineeringRoles.netkan
@@ -1,16 +1,20 @@
 {
-    "license": "CC-BY-NC-SA-4.0",
-    "$kref": "#/ckan/spacedock/398",
     "spec_version": "v1.4",
-    "identifier": "STMsFFRibbonPackEngineeringRoles",
-    "install": [
-      {
+    "identifier":   "STMsFFRibbonPackEngineeringRoles",
+    "$kref":        "#/ckan/spacedock/398",
+    "license":      "CC-BY-NC-SA-4.0",
+    "tags": [
+        "config",
+        "manned"
+    ],
+    "install": [ {
         "find": "GameData/STMRibbons",
         "install_to": "GameData"
-      }
-    ],
+    } ],
     "depends": [
-      { "name": "FinalFrontier",
-        "min_version": "0.9.1" }
+        {
+            "name": "FinalFrontier",
+            "min_version": "0.9.1"
+        }
     ]
 }

--- a/NetKAN/SelectableDataTransmitter.netkan
+++ b/NetKAN/SelectableDataTransmitter.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "SelectableDataTransmitter",
     "name":         "Selectable Data Transmitter Module",
-    "author":       [ "linuxgurugamer" ],
+    "author":       "linuxgurugamer",
     "$kref":        "#/ckan/github/linuxgurugamer/SelectableDataTransmitter",
     "$vref":        "#/ckan/ksp-avc",
     "release_status": "stable",

--- a/NetKAN/SensiblePumpsCont.netkan
+++ b/NetKAN/SensiblePumpsCont.netkan
@@ -1,19 +1,18 @@
 {
-  "spec_version": "v1.4",
-  "install": [
-    {
-      "install_to": "GameData",
-      "find": "SensiblePumpsCont"
-    }
-  ],
-  "depends": [
-    {
-      "name": "ModuleManager"
-    }
-  ],
-  "$vref": "#/ckan/ksp-avc",
-  "$kref": "#/ckan/spacedock/1047",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "identifier": "SensiblePumpsCont",
-  "license": "GPL-3.0"
+    "spec_version": "v1.4",
+    "identifier":   "SensiblePumpsCont",
+    "$kref":        "#/ckan/spacedock/1047",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "GPL-3.0",
+    "tags": [
+        "plugin",
+        "physics"
+    ],
+    "install": [ {
+        "find": "SensiblePumpsCont",
+        "install_to": "GameData"
+    } ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ]
 }

--- a/NetKAN/SpaceAge.netkan
+++ b/NetKAN/SpaceAge.netkan
@@ -1,15 +1,19 @@
 {
     "spec_version" : 1,
     "identifier"   : "SpaceAge",
-    "$kref"        : "#/ckan/github/GarwelGarwel/SpaceAge",
     "author"       : "Garwel",
     "abstract"     : "Tracks and displays information about your campaign's progress and important events.",
-    "license"      : "MIT",
+    "$kref"        : "#/ckan/github/GarwelGarwel/SpaceAge",
     "$vref"        : "#/ckan/ksp-avc",
+    "license"      : "MIT",
     "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/164965-13-space-age-011-2017-08-31-tracking-your-progress/"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/164965-*"
     },
-	    "suggests": [
+    "tags": [
+        "plugin",
+        "information"
+    ],
+    "suggests": [
         { "name": "KSP-AVC" },
         { "name": "Toolbar" }
     ]

--- a/NetKAN/SpudMoon.netkan
+++ b/NetKAN/SpudMoon.netkan
@@ -2,18 +2,20 @@
 {
     "spec_version"  : "v1.4",
     "identifier"    : "SpudMoon",
-    "$kref"         : "#/ckan/github/MrChumley/Spud",
-    "x_netkan_epoch": "2",
     "name"          : "SpudMoon",
     "abstract"      : "Dres was once a lonely planet and then Spud showed up",
+    "author"        : "MrChumley",
+    "$kref"         : "#/ckan/github/MrChumley/Spud",
+    "ksp_version"   : "any",
+    "x_netkan_epoch": "2",
     "license"       : "CC0",
-    "author": [
-        "MrChumley"
-    ],
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/127793-*"
     },
-    "ksp_version": "1.3",
+    "tags": [
+        "config",
+        "planet-pack"
+    ],
     "depends": [
         { "name" : "ModuleManager", "min_version": "2.8.0" },
         { "name" : "Kopernicus",    "min_version": "2:release-1.3.0-5" }

--- a/NetKAN/StationKeeping.netkan
+++ b/NetKAN/StationKeeping.netkan
@@ -1,18 +1,22 @@
 {
     "spec_version" : "v1.4",
     "identifier"   : "StationKeeping",
+    "abstract"     : "Adds a button in the Tracking Station to set a ship's orbit. If you are with 1% (configurable) of your target orbit, you can simply push the button to set the orbit's semi-major axis to exactly what you want, so it won't drift out of alignment as you time warp.",
     "$kref"        : "#/ckan/github/linuxgurugamer/StationKeeping",
-    "$vref": "#/ckan/ksp-avc",
-    "license"      : "CC-BY-4.0",
+    "$vref"        : "#/ckan/ksp-avc",
     "x_netkan_epoch": 1,
+    "license"      : "CC-BY-4.0",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/173518-*"
+    },
+    "tags": [
+        "plugin",
+        "convenience"
+    ],
     "depends": [
         { "name" : "ToolbarController" },
-	{ "name" : "ClickThroughBlocker" }
+        { "name" : "ClickThroughBlocker" }
     ],
-    "abstract"     : "Adds a button in the Tracking Station to set a ship's orbit. If you are with 1% (configurable) of your target orbit, you can simply push the button to set the orbit's semi-major axis to exactly what you want, so it won't drift out of alignment as you time warp.",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/173518-141-stationkeeping-restationed-precise-synchronous-orbits/"
-    },
     "install": [
         {
             "find": "StationKeeping",

--- a/NetKAN/TRR-Guide.netkan
+++ b/NetKAN/TRR-Guide.netkan
@@ -1,29 +1,32 @@
 {
-	"spec_version": "v1.4",
-	"$kref": "#/ckan/github/HaArLiNsH/TRR_Guide",
-	"identifier": "TRR-Guide",
-	"release_status": "testing",
-	"$vref": "#/ckan/ksp-avc",
-	"author": ["HaArLiNsH"],
-	"abstract": "TRR-Guide is a collection of textures made to be used as example with TextureReplacerReplaced.",
-	"license": "MIT",
-	"resources": 	{
-							"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/161898-*",
-							"repository": "https://github.com/HaArLiNsH/TRR_Guide"
-						},
-	"provides": ["TRR-Guide"],
-	"conflicts": [ { "name": "TextureReplacer" } ],
-	"install"  : [
-						{
-							"find"       : "TRR_Guide",
-							"install_to" : "GameData"
-						}
-					],
-	"depends" : 	[
-							{ "name" : "ModuleManager"	},
-							{ "name" : "TextureReplacerReplaced" }
-						],
-	"suggests" : 	[							
-							{ "name" : "TRR-MyTextureMod" }							
-						]
+    "spec_version": "v1.4",
+    "identifier":   "TRR-Guide",
+    "abstract":     "A collection of textures made to be used as example with TextureReplacerReplaced.",
+    "author":       "HaArLiNsH",
+    "$kref":        "#/ckan/github/HaArLiNsH/TRR_Guide",
+    "$vref":        "#/ckan/ksp-avc",
+    "release_status": "testing",
+    "license":      "MIT",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/161898-*",
+        "repository": "https://github.com/HaArLiNsH/TRR_Guide"
+    },
+    "tags": [
+        "config",
+        "graphics"
+    ],
+    "conflicts": [
+        { "name": "TextureReplacer" }
+    ],
+    "install": [ {
+        "find"       : "TRR_Guide",
+        "install_to" : "GameData"
+    } ],
+    "depends": [
+        { "name" : "ModuleManager"    },
+        { "name" : "TextureReplacerReplaced" }
+    ],
+    "suggests": [
+        { "name" : "TRR-MyTextureMod" }
+    ]
 }

--- a/NetKAN/TRR-MyTextureMod.netkan
+++ b/NetKAN/TRR-MyTextureMod.netkan
@@ -1,29 +1,32 @@
 {
-	"spec_version": "v1.4",
-	"$kref": "#/ckan/github/HaArLiNsH/TRR_MyTextureMod",
-	"identifier": "TRR-MyTextureMod",
-	"release_status": "testing",
-	"$vref": "#/ckan/ksp-avc",
-	"author": ["HaArLiNsH"],
-	"abstract": "A clean and empty Custom folder for your textures , ready to use with TextureReplacerReplaced",
-	"license": "MIT",
-	"resources": 	{
-							"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/161898-*",
-							"repository": "https://github.com/HaArLiNsH/TRR_MyTextureMod"
-						},
-	"provides": ["TRR-MyTextureMod"],
-	"conflicts": [ { "name": "TextureReplacer" } ],
-	"install"  : [
-						{
-							"find"       : "TRR_MyTextureMod",
-							"install_to" : "GameData"
-						}
-					],
-	"depends" : 	[
-							{ "name" : "ModuleManager"	},
-							{ "name" : "TextureReplacerReplaced" }
-						],
-	"suggests" : 	[							
-							{ "name" : "TRRGuide" }							
-						]
+    "spec_version": "v1.4",
+    "identifier":   "TRR-MyTextureMod",
+    "abstract":     "A clean and empty Custom folder for your textures, ready to use with TextureReplacerReplaced",
+    "author":       "HaArLiNsH",
+    "$kref":        "#/ckan/github/HaArLiNsH/TRR_MyTextureMod",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "MIT",
+    "release_status": "testing",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/161898-*",
+        "repository": "https://github.com/HaArLiNsH/TRR_MyTextureMod"
+    },
+    "tags": [
+        "config",
+        "graphics"
+    ],
+    "conflicts": [
+        { "name": "TextureReplacer" }
+    ],
+    "install": [ {
+        "find"       : "TRR_MyTextureMod",
+        "install_to" : "GameData"
+    } ],
+    "depends": [
+        { "name" : "ModuleManager"    },
+        { "name" : "TextureReplacerReplaced" }
+    ],
+    "suggests": [
+        { "name" : "TRRGuide" }
+    ]
 }

--- a/NetKAN/TrackingLights.netkan
+++ b/NetKAN/TrackingLights.netkan
@@ -1,14 +1,18 @@
 {
     "spec_version": 1,
     "identifier":   "TrackingLights",
-    "$kref":        "#/ckan/github/droric/TrackingLights",
     "name":         "Tracking Lights",
-    "author":       [ "Trolllception" ],
     "abstract":     "Customizable, target tracking spotlights",
     "description":  "Includes 2 spotlight parts that are controlled via Light tracking module.  Spotlights can be manually positioned or set to track a target.  Supports Color, Intensity, Range, and cone size changes in flight.",
+    "author":       "Trolllception",
+    "$kref":        "#/ckan/github/droric/TrackingLights",
+    "ksp_version":  "1.7",
 	"license":      "CC-BY-NC-SA-3.0",
-    "ksp_version":  "1.7.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/164677-*"
-    }
+    },
+    "tags": [
+        "plugin",
+        "parts"
+    ]
 }

--- a/NetKAN/TrimIndicator.netkan
+++ b/NetKAN/TrimIndicator.netkan
@@ -1,13 +1,17 @@
 {
-  "spec_version" : 1,
-  "identifier"   : "TrimIndicator",
-  "$kref"        : "#/ckan/github/formicant/TrimIndicator",
-  "$vref"        : "#/ckan/ksp-avc",
-  "name"         : "Trim Indicator",
-  "author"       : [ "Teilnehmer" ],
-  "abstract"     : "A minimalistic add-on displaying trim values inside the control gauges.",
-  "license"      : "GPL-3.0",
-  "resources"    : {
-    "homepage"   : "https://forum.kerbalspaceprogram.com/index.php?/topic/164522-trim-indicator"
-  }
+    "spec_version" : 1,
+    "identifier"   : "TrimIndicator",
+    "name"         : "Trim Indicator",
+    "abstract"     : "A minimalistic add-on displaying trim values inside the control gauges.",
+    "author"       : "Teilnehmer",
+    "$kref"        : "#/ckan/github/formicant/TrimIndicator",
+    "$vref"        : "#/ckan/ksp-avc",
+    "license"      : "GPL-3.0",
+    "resources"    : {
+        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/164522-*"
+    },
+    "tags": [
+        "plugin",
+        "information"
+    ]
 }

--- a/NetKAN/TundraSpaceCenter.netkan
+++ b/NetKAN/TundraSpaceCenter.netkan
@@ -4,8 +4,18 @@
     "$kref":        "#/ckan/spacedock/1831",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "restricted",
+    "tags": [
+        "config"
+    ],
     "depends": [
         { "name": "ModuleManager"    },
         { "name": "KerbalKonstructs" }
+    ],
+    "recommends": [
+        { "name": "KSCExtended"       },
+        { "name": "TundraExploration" },
+        { "name": "SpaceXLandingPad"  },
+        { "name": "BluedogDB"         },
+        { "name": "ModularLaunchPads" }
     ]
 }


### PR DESCRIPTION
I wanted to check the outcome of KSP-CKAN/CKAN#2942, but my search of CKAN-meta's commits was mildly obstructed by mods with author arrays with only a single element. Now they're converted to strings. The ones that didn't have tags now do, and a few more modules are also tagged to fill up the PR, which makes this a successor to #7570.