### PR TITLE
Tag twenty-fourth group of mods

### DIFF
--- a/NetKAN/CLLS.netkan
+++ b/NetKAN/CLLS.netkan
@@ -1,7 +1,11 @@
-
-    {
-        "spec_version" : "v1.16",
-        "identifier" : "CLLS",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/mmoench/CLLS/master/CLLS.netkan",
-        "x_netkan_license_ok": true
-    }
+{
+    "spec_version" : "v1.16",
+    "identifier" : "CLLS",
+    "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/mmoench/CLLS/master/CLLS.netkan",
+    "x_netkan_license_ok": true,
+    "tags": [
+        "plugin",
+        "parts",
+        "manned"
+    ]
+}

--- a/NetKAN/KRnD.netkan
+++ b/NetKAN/KRnD.netkan
@@ -1,5 +1,9 @@
 {
     "spec_version" : "v1.4",
     "identifier"   : "KRnD",
-    "$kref"        : "#/ckan/netkan/https://raw.githubusercontent.com/mmoench/KRnD/master/KRnD.netkan"
+    "$kref"        : "#/ckan/netkan/https://raw.githubusercontent.com/mmoench/KRnD/master/KRnD.netkan",
+    "tags": [
+        "plugin",
+        "science"
+    ]
 }

--- a/NetKAN/KSPDev-LogConsole.netkan
+++ b/NetKAN/KSPDev-LogConsole.netkan
@@ -2,5 +2,9 @@
     "spec_version"    : 1,
     "identifier"      : "KSPDev-LogConsole",
     "$kref"           : "#/ckan/netkan/https://raw.githubusercontent.com/ihsoft/KSPDev_LogConsole/master/KSPDev_LogConsole.netkan",
-    "license"         : "public-domain"
+    "license"         : "public-domain",
+    "tags"            : [
+        "plugin",
+        "library"
+    ]
 }

--- a/NetKAN/KSTS.netkan
+++ b/NetKAN/KSTS.netkan
@@ -1,5 +1,8 @@
 {
     "spec_version" : 1,
     "identifier"   : "KSTS",
-    "$kref"        : "#/ckan/netkan/https://raw.githubusercontent.com/mmoench/KSTS/master/KSTS.netkan"
+    "$kref"        : "#/ckan/netkan/https://raw.githubusercontent.com/mmoench/KSTS/master/KSTS.netkan",
+    "tags": [
+        "plugin"
+    ]
 }

--- a/NetKAN/KerbalSimpit.netkan
+++ b/NetKAN/KerbalSimpit.netkan
@@ -1,6 +1,14 @@
 {
-  "spec_version": "v1.16",
-  "identifier": "KerbalSimpit",
-  "$kref": "#/ckan/netkan/https://bitbucket.org/pjhardy/kerbalsimpit/downloads/KerbalSimpit.netkan",
-  "x_netkan_license_ok": true
+    "spec_version": "v1.16",
+    "identifier": "KerbalSimpit",
+    "$kref": "#/ckan/netkan/https://bitbucket.org/pjhardy/kerbalsimpit/downloads/KerbalSimpit.netkan",
+    "x_netkan_license_ok": true,
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/155796-*"
+    },
+    "tags": [
+        "plugin",
+        "app",
+        "control"
+    ]
 }

--- a/NetKAN/KerbalSports.netkan
+++ b/NetKAN/KerbalSports.netkan
@@ -1,7 +1,13 @@
-
 {
     "spec_version" : "v1.16",
     "identifier" : "KerbalSports",
     "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/jrossignol/KerbalSports/master/KerbalSports.netkan",
-    "x_netkan_license_ok" : true
+    "x_netkan_license_ok" : true,
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/135728-*"
+    },
+    "tags": [
+        "plugin",
+        "manned"
+    ]
 }

--- a/NetKAN/LTechContinued.netkan
+++ b/NetKAN/LTechContinued.netkan
@@ -3,6 +3,11 @@
     "identifier": "LTechContinued",
     "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Olympic1/L-Tech/master/LTechContinued.netkan",
     "x_netkan_license_ok": true,
+    "tags": [
+        "plugin",
+        "parts",
+        "science"
+    ],
     "x_netkan_override": [
         {
             "version": "v4.1",

--- a/NetKAN/PlaneMode.netkan
+++ b/NetKAN/PlaneMode.netkan
@@ -2,5 +2,9 @@
     "spec_version": 1,
     "identifier": "PlaneMode",
     "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Apokee/PlaneMode/master/PlaneMode.netkan",
-    "x_netkan_license_ok": true
+    "x_netkan_license_ok": true,
+    "tags": [
+        "plugin",
+        "control"
+    ]
 }

--- a/NetKAN/ROEngines.netkan
+++ b/NetKAN/ROEngines.netkan
@@ -2,5 +2,8 @@
     "spec_version": "v1.10",
     "identifier": "ROEngines",
     "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/KSP-RO/ROEngines/master/ROEngines.netkan",
-    "x_netkan_license_ok": true
+    "x_netkan_license_ok": true,
+    "tags": [
+        "config"
+    ]
 }

--- a/NetKAN/RadioFreeKerbin.netkan
+++ b/NetKAN/RadioFreeKerbin.netkan
@@ -1,5 +1,9 @@
 {
     "spec_version"   : "v1.2",
     "identifier"     : "RadioFreeKerbin",
-    "$kref"          : "#/ckan/netkan/https://raw.githubusercontent.com/benjwgarner/RadioFreeKerbin/master/RadioFreeKerbin.ckan"
+    "$kref"          : "#/ckan/netkan/https://raw.githubusercontent.com/benjwgarner/RadioFreeKerbin/master/RadioFreeKerbin.ckan",
+    "tags": [
+        "config",
+        "science"
+    ]
 }

--- a/NetKAN/RecoverAll.netkan
+++ b/NetKAN/RecoverAll.netkan
@@ -2,5 +2,9 @@
     "spec_version" : "v1.2",
     "identifier"   : "RecoverAll",
     "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/KerboKatz/Netkan/master/RecoverAll.netkan",
-    "x_netkan_license_ok": true
+    "x_netkan_license_ok": true,
+    "tags": [
+        "plugin",
+        "convenience"
+    ]
 }

--- a/NetKAN/SASS-DRP.netkan
+++ b/NetKAN/SASS-DRP.netkan
@@ -1,6 +1,10 @@
 {
-	"spec_version": "v1.4",
-	"identifier": "SASS-DRP",
-	"$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-DRP.netkan",
-	"x_netkan_license_ok": true
+    "spec_version": "v1.4",
+    "identifier": "SASS-DRP",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-DRP.netkan",
+    "x_netkan_license_ok": true,
+    "tags": [
+        "config",
+        "planet-pack"
+    ]
 }

--- a/NetKAN/SASS-ER.netkan
+++ b/NetKAN/SASS-ER.netkan
@@ -1,6 +1,10 @@
 {
-	"spec_version": "v1.4",
-	"identifier": "SASS-ER",
-	"$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-ER.netkan",
-	"x_netkan_license_ok": true
+    "spec_version": "v1.4",
+    "identifier": "SASS-ER",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-ER.netkan",
+    "x_netkan_license_ok": true,
+    "tags": [
+        "config",
+        "planet-pack"
+    ]
 }

--- a/NetKAN/SASS-NH.netkan
+++ b/NetKAN/SASS-NH.netkan
@@ -1,6 +1,10 @@
 {
-	"spec_version": "v1.4",
-	"identifier": "SASS-NH",
-	"$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-NH.netkan",
-	"x_netkan_license_ok": true
+    "spec_version": "v1.4",
+    "identifier": "SASS-NH",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-NH.netkan",
+    "x_netkan_license_ok": true,
+    "tags": [
+        "config",
+        "planet-pack"
+    ]
 }

--- a/NetKAN/SASS-OPM.netkan
+++ b/NetKAN/SASS-OPM.netkan
@@ -1,6 +1,10 @@
 {
-	"spec_version": "v1.4",
-	"identifier": "SASS-OPM",
-	"$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-OPM.netkan",
-	"x_netkan_license_ok": true
+    "spec_version": "v1.4",
+    "identifier": "SASS-OPM",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-OPM.netkan",
+    "x_netkan_license_ok": true,
+    "tags": [
+        "config",
+        "planet-pack"
+    ]
 }

--- a/NetKAN/SASS-RevJ.netkan
+++ b/NetKAN/SASS-RevJ.netkan
@@ -1,6 +1,10 @@
 {
-	"spec_version": "v1.4",
-	"identifier": "SASS-RevJ",
-	"$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-RevJ.netkan",
-	"x_netkan_license_ok": true
+    "spec_version": "v1.4",
+    "identifier": "SASS-RevJ",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-RevJ.netkan",
+    "x_netkan_license_ok": true,
+    "tags": [
+        "config",
+        "planet-pack"
+    ]
 }

--- a/NetKAN/SASS-RevSS.netkan
+++ b/NetKAN/SASS-RevSS.netkan
@@ -1,6 +1,10 @@
 {
-	"spec_version": "v1.4",
-	"identifier": "SASS-RevSS",
-	"$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-RevSS.netkan",
-	"x_netkan_license_ok": true
+    "spec_version": "v1.4",
+    "identifier": "SASS-RevSS",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-RevSS.netkan",
+    "x_netkan_license_ok": true,
+    "tags": [
+        "config",
+        "planet-pack"
+    ]
 }

--- a/NetKAN/SASS-SE.netkan
+++ b/NetKAN/SASS-SE.netkan
@@ -1,6 +1,10 @@
 {
-	"spec_version": "v1.4",
-	"identifier": "SASS-SE",
-	"$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-SE.netkan",
-	"x_netkan_license_ok": true
+    "spec_version": "v1.4",
+    "identifier": "SASS-SE",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-SE.netkan",
+    "x_netkan_license_ok": true,
+    "tags": [
+        "config",
+        "planet-pack"
+    ]
 }

--- a/NetKAN/SASS-Saru.netkan
+++ b/NetKAN/SASS-Saru.netkan
@@ -1,6 +1,10 @@
 {
-	"spec_version": "v1.4",
-	"identifier": "SASS-Saru",
-	"$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-Saru.netkan",
-	"x_netkan_license_ok": true
+    "spec_version": "v1.4",
+    "identifier": "SASS-Saru",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-Saru.netkan",
+    "x_netkan_license_ok": true,
+    "tags": [
+        "config",
+        "planet-pack"
+    ]
 }

--- a/NetKAN/SASS-StockalikeNeptune.netkan
+++ b/NetKAN/SASS-StockalikeNeptune.netkan
@@ -1,6 +1,10 @@
 {
-	"spec_version": "v1.4",
-	"identifier": "SASS-StockalikeNeptune",
-	"$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-StockalikeNeptune.netkan",
-	"x_netkan_license_ok": true
+    "spec_version": "v1.4",
+    "identifier": "SASS-StockalikeNeptune",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-StockalikeNeptune.netkan",
+    "x_netkan_license_ok": true,
+    "tags": [
+        "config",
+        "planet-pack"
+    ]
 }

--- a/NetKAN/SASS-UL.netkan
+++ b/NetKAN/SASS-UL.netkan
@@ -1,6 +1,10 @@
 {
-	"spec_version": "v1.4",
-	"identifier": "SASS-UL",
-	"$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-UL.netkan",
-	"x_netkan_license_ok": true
+    "spec_version": "v1.4",
+    "identifier": "SASS-UL",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/SASS-UL.netkan",
+    "x_netkan_license_ok": true,
+    "tags": [
+        "config",
+        "planet-pack"
+    ]
 }

--- a/NetKAN/StockalikeSolarSystem.netkan
+++ b/NetKAN/StockalikeSolarSystem.netkan
@@ -1,6 +1,10 @@
 {
-	"spec_version": "v1.4",
-	"identifier": "StockalikeSolarSystem",
-	"$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/StockalikeSolarSystem.netkan",
-	"x_netkan_license_ok": true
+    "spec_version": "v1.4",
+    "identifier": "StockalikeSolarSystem",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Sigma88/CKAN/master/Stockalike/StockalikeSolarSystem.netkan",
+    "x_netkan_license_ok": true,
+    "tags": [
+        "config",
+        "planet-pack"
+    ]
 }

--- a/NetKAN/surfacelights.netkan
+++ b/NetKAN/surfacelights.netkan
@@ -2,5 +2,8 @@
     "spec_version"   : 1,
     "identifier"     : "surfacelights",
     "$kref"          : "#/ckan/netkan/https://raw.githubusercontent.com/ihsoft/SurfaceLights/master/SurfaceLights.netkan",
-    "license"        : "CC-BY-NC-ND-3.0"
+    "license"        : "CC-BY-NC-ND-3.0",
+    "tags": [
+        "parts"
+    ]
 }


### PR DESCRIPTION
Successor to #7575.

I was mildly concerned that metanetkans represent a loophole through which we might get odd or misspelled tags cluttering the tag list. This PR tags the remaining metanetkan modules in the main repo to discourage that.

OuterPlanetsMod is excluded because it is already setting tags, accurately. After this it will be the only mod tagged in a metanetkan.