### PR TITLE
Manual updates for 1.8 for taniwha's mods

### DIFF
--- a/NetKAN/KerbalStats.netkan
+++ b/NetKAN/KerbalStats.netkan
@@ -1,21 +1,25 @@
 {
     "spec_version"   : 1,
+    "identifier"     : "KerbalStats",
     "name"           : "Kerbal Stats",
     "abstract"       : "KerbalStats is a KSP mod for keeping track of extra information about the kerbals in your game.",
-    "identifier"     : "KerbalStats",
     "author"         : "taniwha",
+    "$kref"          : "#/ckan/http/http://taniwha.org/~bill/KerbalStats_v3.1.0.zip",
+    "version"        : "3.1.0",
+    "ksp_version"    : "1.8",
     "license"        : "GPL-3.0",
     "release_status" : "stable",
     "resources"      : {
-        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/89285-14-kerbalstats-v303/",
+        "homepage"   : "https://forum.kerbalspaceprogram.com/index.php?/topic/89285-*",
 		"repository" : "https://github.com/taniwha-qf/KerbalStats"
     },
-    "install" : [{
+    "tags"           : [
+        "plugin",
+        "manned"
+    ],
+    "install": [ {
         "file"       : "KerbalStats",
         "install_to" : "GameData",
 		"filter"	:	"KerbalStatsWrapper.cs"
-    }],
-    "version"        : "3.0.2",
-    "ksp_version"    : "1.3.0",
-    "download"       : "http://taniwha.org/~bill/KerbalStats_v3.0.2.zip"
+    } ]
 }

--- a/NetKAN/ModularFuelTanks.netkan
+++ b/NetKAN/ModularFuelTanks.netkan
@@ -1,16 +1,23 @@
 {
     "spec_version"   : 1,
+    "identifier"     : "ModularFuelTanks",
     "name"           : "Modular Fuel Tanks",
     "abstract"       : "Refit tank with different fuel or other contents",
-    "identifier"     : "ModularFuelTanks",
+    "description"    : "Modular Fuel Tanks allows any supported tank to be filled with exactly how much or how little fuel you want, of whatever type you want (though different tanks may allow or disallow certain fuels; jet fuel tanks won't take oxidizer for instance).",
+    "author"         : ["taniwha", "NathanKell", "Swamp Ig", "ChestBurster", "ialdabaoth"],
+    "$kref"          : "#/ckan/http/http://taniwha.org/~bill/ModularFuelTanks_v5.13.0.zip",
+    "version"        : "5.13.0",
+    "ksp_version"    : "1.8",
     "license"        : "CC-BY-SA",
     "release_status" : "stable",
-    "author"         : ["taniwha", "NathanKell", "Swamp Ig", "ChestBurster", "ialdabaoth"],
-    "description"    : "Modular Fuel Tanks allows any supported tank to be filled with exactly how much or how little fuel you want, of whatever type you want (though different tanks may allow or disallow certain fuels; jet fuel tanks won't take oxidizer for instance).",
     "resources" : {
         "homepage"     : "http://forum.kerbalspaceprogram.com/index.php?/topic/58235-*",
         "repository"   : "https://github.com/NathanKell/ModularFuelSystem"
     },
+    "tags": [
+        "plugin",
+        "convenience"
+    ],
     "depends": [
         { "name": "ModuleManager" }
     ],
@@ -25,9 +32,5 @@
         { "name" : "RLA-Stockalike"           },
         { "name" : "SDHI-ServiceModuleSystem" },
         { "name" : "SpaceShuttleEngines"      }
-    ],
-    "version"        : "5.12.3",
-    "ksp_version_min" : "1.6",
-    "ksp_version_max" : "1.7",
-    "download"       : "http://taniwha.org/~bill/ModularFuelTanks_v5.12.3.zip"
+    ]
 }

--- a/NetKAN/SurveyTransponder.netkan
+++ b/NetKAN/SurveyTransponder.netkan
@@ -5,12 +5,16 @@
     "abstract"     : "A transponder to make air-drops a little easier",
     "description"  : "A small mod for keeping track of your air-drop packages until they hit the ground. Very good for those surface survey contracts in awkward locations.",
     "author"       : "taniwha",
-    "$kref"        : "#/ckan/http/http://taniwha.org/~bill/SurveyTransponder_v0.5.2a.zip",
+    "$kref"        : "#/ckan/http/http://taniwha.org/~bill/SurveyTransponder_v0.6.0.zip",
+    "ksp_version"  : "1.8",
+    "version"      : "0.6.0",
     "license"      : "GPL-3.0",
-    "ksp_version"  : "1.4",
-    "version"      : "0.5.2a",
     "resources": {
         "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/111834-*",
         "repository": "https://github.com/taniwha/SurveyTransponder"
-    }
+    },
+    "tags": [
+        "parts",
+        "unmanned"
+    ]
 }

--- a/NetKAN/TalisarParts.netkan
+++ b/NetKAN/TalisarParts.netkan
@@ -1,15 +1,17 @@
 {
-    "spec_version":    "v1.4",
-    "identifier":      "TalisarParts",
-    "name":            "Talisar Parts",
-    "abstract":        "Update of Talisar's Spherical and Toroidal Tanks pack",
-    "author":          [ "Talisar", "Olympic1", "taniwha" ],
-    "$kref":           "#/ckan/http/http://taniwha.org/~bill/TalisarParts-1.2.1.zip",
-    "license":         "CC-BY-SA-3.0",
-    "version":         "v1.2.1",
-    "ksp_version_min": "1.4",
-    "ksp_version_max": "1.5",
+    "spec_version": "v1.4",
+    "identifier":   "TalisarParts",
+    "name":         "Talisar Parts",
+    "abstract":     "Update of Talisar's Spherical and Toroidal Tanks pack",
+    "author":       [ "Talisar", "Olympic1", "taniwha" ],
+    "$kref":        "#/ckan/http/http://taniwha.org/~bill/TalisarParts-1.3.0.zip",
+    "license":      "CC-BY-SA-3.0",
+    "version":      "v1.3.0",
+    "ksp_version":  "1.8",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/116849-*"
-    }
+    },
+    "tags": [
+        "parts"
+    ]
 }


### PR DESCRIPTION
taniwha.org is back up, and some of his mods are updated for KSP 1.8:

- https://forum.kerbalspaceprogram.com/index.php?/profile/57176-taniwha/

This PR makes the necessary manual updates. Exceptions:
- EarlyBird has a remote version file, but it's wrong, so [I pointed this out on the thread](https://forum.kerbalspaceprogram.com/index.php?/topic/162477-18-early-bird-020/&do=findComment&comment=3720010)
- ExtraPlanetaryLaunchpads is already updated in https://github.com/KSP-CKAN/CKAN-meta/commit/36fef24583eb739fdf225bb185c94869c1261604
- Kethane is still being worked on

Side changes:
- `download` replaced with `$kref` of type `http`
- Tags added