### PR TITLE
Fix ribbon mods install paths

### DIFF
--- a/NetKAN/STMsFFRibbonPackExpeditionRibbons.netkan
+++ b/NetKAN/STMsFFRibbonPackExpeditionRibbons.netkan
@@ -8,7 +8,7 @@
         "crewed"
     ],
     "install": [ {
-        "find": "GameData/STMRibbons",
+        "find": "STMRibbons",
         "install_to": "GameData"
     } ],
     "depends": [

--- a/NetKAN/ScienceRolesFinalFrontierRibbonPack.netkan
+++ b/NetKAN/ScienceRolesFinalFrontierRibbonPack.netkan
@@ -8,7 +8,7 @@
         "crewed"
     ],
     "install": [ {
-        "find": "GameData/STMRibbons",
+        "find": "STMRibbons",
         "install_to": "GameData"
     } ],
     "depends": [


### PR DESCRIPTION
## Problem

New inflation error for ScienceRolesFinalFrontierRibbonPack: Could not find GameData/STMRibbons entry in zipfile to install
New inflation error for STMsFFRibbonPackExpeditionRibbons: Could not find GameData/STMRibbons entry in zipfile to install

## Cause

The ZIP for these mods used to have a GameData folder, now it doesn't.

## Changes

GameData removed from install stanzas.