### PR TITLE
New RPM fork

### DIFF
--- a/NetKAN/RasterPropMonitor-Core.netkan
+++ b/NetKAN/RasterPropMonitor-Core.netkan
@@ -2,28 +2,30 @@
     "spec_version"   : "v1.4",
     "identifier"     : "RasterPropMonitor-Core",
     "name"           : "RasterPropMonitor Core",
-    "abstract"       : "RasterPropMonitor is a plugin and toolkit that provides functional props within your IVA.",
+    "abstract"       : "Plugin and props for use in IVAs",
     "comment"        : "This package contains the plugin, and the standard parts library.",
-    "author"         : [ "MOARdV", "Mihara" ],
-    "$kref"          : "#/ckan/github/Mihara/RasterPropMonitor",
+    "author"         : [ "Mihara", "MOARdV", "JonnyOThan" ],
+    "$kref"          : "#/ckan/github/JonnyOThan/RasterPropMonitor",
     "$vref"          : "#/ckan/ksp-avc",
     "x_netkan_epoch" : "1",
     "license"        : "GPL-3.0",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/190737-*",
+        "repository": "https://github.com/JonnyOThan/RasterPropMonitor/releases"
+    },
     "tags": [
         "plugin",
         "crewed"
     ],
-    "depends" : [
-        { "name" : "ModuleManager" }
+    "depends": [
+        { "name": "ModuleManager" }
     ],
-    "install" : [
-        {
-            "find"       : "JSI/RasterPropMonitor",
-            "install_to" : "GameData/JSI"
-        }
-    ],
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/105821-14x-rasterpropmonitor-still-putting-the-a-in-iva-v0300-14-march-2018/",
-        "repository": "https://github.com/Mihara/RasterPropMonitor"
-    }
+    "install": [ {
+        "find"      : "JSI/RasterPropMonitor",
+        "install_to": "GameData/JSI"
+    }, {
+        "find":       "JSI/RPMPodPatches/BasicMFD",
+        "install_to": "GameData/JSI/RPMPodPatches",
+        "comment":    "This folder contains the multi-function display props, which belong in this module along with the other props"
+    } ]
 }

--- a/NetKAN/RasterPropMonitor.netkan
+++ b/NetKAN/RasterPropMonitor.netkan
@@ -1,35 +1,49 @@
 {
     "spec_version"   : "v1.4",
     "identifier"     : "RasterPropMonitor",
-    "$kref"          : "#/ckan/github/Mihara/RasterPropMonitor",
-    "$vref"          : "#/ckan/ksp-avc",
     "name"           : "RasterPropMonitor",
-    "abstract"       : "RasterPropMonitor is a plugin and toolkit that provides functional props within your IVA.",
-    "author"         : [ "MOARdV", "Mihara" ],
+    "abstract"       : "Modifies stock and some modded IVAs with functional props",
+    "author"         : [ "Mihara", "MOARdV", "JonnyOThan" ],
+    "$kref"          : "#/ckan/github/JonnyOThan/RasterPropMonitor",
+    "$vref"          : "#/ckan/ksp-avc",
     "license"        : "GPL-3.0",
     "x_netkan_epoch" : "1",
     "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/105821-*",
-        "repository": "https://github.com/Mihara/RasterPropMonitor"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/190737-*",
+        "repository": "https://github.com/JonnyOThan/RasterPropMonitor/releases"
     },
     "tags": [
         "config",
         "crewed"
     ],
-    "depends" : [
-        { "name" : "ModuleManager" },
-        { "name" : "RasterPropMonitor-Core" }
+    "depends": [
+        { "name": "ModuleManager"          },
+        { "name": "RasterPropMonitor-Core" }
     ],
-    "suggests" : [
-        { "name" : "VesselView"},
-        { "name" : "JSIAdvancedTransparentPods"},
-        { "name" : "SCANsat"}
+    "suggests": [
+        { "name": "JSIAdvancedTransparentPods"       },
+        { "name": "Astrogator"                       },
+        { "name": "DockingPortAlignmentIndicator"    },
+        { "name": "NavUtilitiesContinued"            },
+        { "name": "SCANsat"                          },
+        { "name": "VesselView"                       },
+        { "name": "ProbeControlRoomRecontrolled"     },
+        { "name": "kOSPropMonitor"                   },
+        { "name": "Chatterer"                        },
+        { "name": "FerramAerospaceResearchContinued" },
+        { "name": "MechJeb2"                         },
+        { "name": "RealChute"                        },
+        { "name": "ASETProps"                        },
+        { "name": "ASETAvionics"                     },
+        { "name": "Mk1LanderCanIVAReplbyASET"        },
+        { "name": "MK12PodIVAReplacementbyASET"      },
+        { "name": "ALCORIVAPatch"                    },
+        { "name": "ThroughTheEyesOfaKerbal"          },
+        { "name": "QuickIVA"                         }
     ],
-    "install" : [
-        {
-            "find"       : "JSI",
-            "filter"     : ["RasterPropMonitor"],
-            "install_to" : "GameData"
-        }
-    ]
+    "install": [ {
+        "find"      : "JSI",
+        "filter"    : [ "RasterPropMonitor", "BasicMFD" ],
+        "install_to": "GameData"
+    } ]
 }


### PR DESCRIPTION
## Problem

~~We're creating RasterPropMonitor-Legacy as part of a plan to fix an issue with how RPM is organized. The problem is this folder:~~

- `JSI/RPMPodPatches/BasicMFD`

This folder contains the multi-function display prop. But props should be in `JSI/RasterPropMonitor/Library/Props`.

The RasterPropMonitor-Core module is supposed to include the plugin and props, while RasterPropMonitor installs the IVAs. But RasterPropMonitor-Core only installs the `JSI/RasterPropMonitor` directory, so the MFD prop is in RasterPropMonitor instead.

The B9 and Deltaglider modules use the current paths of the MFD files directly, so the files cannot simply be moved without breaking these mods.

## Changes

Now the `JSI/RPMPodPatches/BasicMFD` folder is installed by RasterPropMonitor-Core and excluded from RasterPropMonitor.

ckan compat add 1.8