### PR TITLE
Update RPM depends for ChakaMonkeyExplorationSystems

### DIFF
--- a/NetKAN/ChakaMonkeyExplorationSystems.netkan
+++ b/NetKAN/ChakaMonkeyExplorationSystems.netkan
@@ -12,11 +12,11 @@
         { "any_of": [
             { "name": "KerbalJointReinforcement" },
             { "name": "KerbalJointReinforcementNext" }
-        ]},
+        ] },
         { "name": "ProceduralFairings" },
         { "name": "ASETProps" },
         { "name": "MK12PodIVAReplacementbyASET" },
-        { "name": "RasterPropMonitor-Core", "min_version" : "0.21.2" }
+        { "name": "RasterPropMonitor", "min_version" : "0.21.2" }
     ],
     "install": [ {
         "find": "CMES",


### PR DESCRIPTION
Spiritual successor to KSP-CKAN/CKAN-meta#1738.

ChakaMonkeyExplorationSystems currently depends on RasterPropMonitor-Core, however it uses RasterPropMonitorBasicMFD internally which is only provided by the full RasterPropMonitor module. Now it depends on that. Will update the historical versions afterwards.

ckan compat add 1.7