### PR TITLE
Override some ASET compatibilities

### DIFF
--- a/NetKAN/ASETProps.netkan
+++ b/NetKAN/ASETProps.netkan
@@ -24,5 +24,15 @@
     "install": [ {
         "find": "ASET/ASET_Props",
         "install_to": "GameData/ASET"
+    } ],
+    "x_netkan_override": [ {
+        "version": "1.5",
+        "delete": [
+            "ksp_version"
+        ],
+        "override": {
+            "ksp_version_min": "1.4",
+            "ksp_version_max": "1.7"
+        }
     } ]
 }

--- a/NetKAN/MK12PodIVAReplacementbyASET.netkan
+++ b/NetKAN/MK12PodIVAReplacementbyASET.netkan
@@ -24,5 +24,15 @@
         { "name": "VesselView" },
         { "name": "DockingPortAlignmentIndicator" },
         { "name": "Astrogator" }
-    ]
+    ],
+    "x_netkan_override": [ {
+        "version": "1:0.3",
+        "delete": [
+            "ksp_version"
+        ],
+        "override": {
+            "ksp_version_min": "1.4",
+            "ksp_version_max": "1.7"
+        }
+    } ]
 }


### PR DESCRIPTION
In KSP-CKAN/CKAN-meta#1739, I updated the .ckans for these modules to reflect their actual compatibility based on their release dates and forum threads.

The bot reverted this in https://github.com/KSP-CKAN/CKAN-meta/compare/72936b2300...1465b9931e.

Now there's an override to make it stick.