### PR TITLE
Set SXTContinued license

### DIFF
--- a/NetKAN/SXTContinued.netkan
+++ b/NetKAN/SXTContinued.netkan
@@ -4,7 +4,7 @@
     "$kref":        "#/ckan/spacedock/1030",
     "$vref":        "#/ckan/ksp-avc",
     "x_netkan_epoch": 1,
-    "license":      "unknown",
+    "license":      "CC-NC-SA-4.0",
     "tags": [
         "parts"
     ],

--- a/NetKAN/SXTContinued.netkan
+++ b/NetKAN/SXTContinued.netkan
@@ -4,7 +4,7 @@
     "$kref":        "#/ckan/spacedock/1030",
     "$vref":        "#/ckan/ksp-avc",
     "x_netkan_epoch": 1,
-    "license":      "CC-NC-SA-4.0",
+    "license":      "CC-BY-NC-SA-4.0",
     "tags": [
         "parts"
     ],


### PR DESCRIPTION
A user pointed out that this mod isn't on archive.org, which was a problem during SD's recent outage.

https://forum.kerbalspaceprogram.com/index.php?/topic/190040-161-173-rp-1-realistic-progression-one-v12/&do=findComment&comment=3723520

This is because the license is CC-BY-NC-SA-4.0, but we have it as "unknown". Now it's fixed and should go to archive.org.