### PR TITLE
Set unknown or missing licenses

### DIFF
--- a/NetKAN/AdvancedFlyByWire-Linux.netkan
+++ b/NetKAN/AdvancedFlyByWire-Linux.netkan
@@ -4,8 +4,8 @@
     "name":         "Advanced Fly-By-Wire (Linux)",
     "$kref":        "#/ckan/spacedock/1870",
     "$vref":        "#/ckan/ksp-avc",
+    "license":      "MIT",
     "release_status": "stable",
-    "x_netkan_license_ok": true,
     "resources": {
         "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/175359-*",
         "repository": "https://github.com/linuxgurugamer/ksp-advanced-flybywire"

--- a/NetKAN/AdvancedFlyByWire-OSX.netkan
+++ b/NetKAN/AdvancedFlyByWire-OSX.netkan
@@ -4,8 +4,8 @@
     "name":         "Advanced Fly-By-Wire (OSX)",
     "$kref":        "#/ckan/spacedock/1878",
     "$vref":        "#/ckan/ksp-avc",
+    "license":      "MIT",
     "release_status": "stable",
-    "x_netkan_license_ok": true,
     "resources": {
         "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/175359-*",
         "repository": "https://github.com/linuxgurugamer/ksp-advanced-flybywire"

--- a/NetKAN/AdvancedFlyByWire.netkan
+++ b/NetKAN/AdvancedFlyByWire.netkan
@@ -4,6 +4,7 @@
     "name":         "Advanced Fly-By-Wire (Windows)",
     "$kref":        "#/ckan/spacedock/1869",
     "$vref":        "#/ckan/ksp-avc",
+    "license":      "MIT",
     "release_status": "stable",
     "resources": {
         "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/175359-*",
@@ -41,6 +42,5 @@
     ],
     "recommends": [
         { "name": "KSP-AVC" }
-    ],
-    "x_netkan_license_ok": true
+    ]
 }

--- a/NetKAN/AoATechnologies.netkan
+++ b/NetKAN/AoATechnologies.netkan
@@ -3,7 +3,7 @@
     "identifier":   "AoATechnologies",
     "$kref":        "#/ckan/spacedock/1116",
     "$vref":        "#/ckan/ksp-avc",
-    "license":      "unknown",
+    "license":      "CC-BY-NC-SA-4.0",
     "tags": [
         "config",
         "parts",

--- a/NetKAN/BetterScienceLabsContinued.netkan
+++ b/NetKAN/BetterScienceLabsContinued.netkan
@@ -1,13 +1,13 @@
 {
-    "spec_version"   : "v1.4",
-    "identifier"     : "BetterScienceLabsContinued",
-    "$kref"          : "#/ckan/spacedock/45",
-    "$vref"          : "#/ckan/ksp-avc",
-    "x_netkan_license_ok" : true,
-    "release_status" : "stable",
+    "spec_version": "v1.4",
+    "identifier"  : "BetterScienceLabsContinued",
+    "$kref"       : "#/ckan/spacedock/45",
+    "$vref"       : "#/ckan/ksp-avc",
+    "license"     : "MIT",
+    "release_status": "stable",
     "resources" : {
-        "homepage"    : "https://forum.kerbalspaceprogram.com/index.php?/topic/112754-*",
-        "repository"  : "https://github.com/linuxgurugamer/BetterScienceLabsContinued"
+        "homepage"  : "https://forum.kerbalspaceprogram.com/index.php?/topic/112754-*",
+        "repository": "https://github.com/linuxgurugamer/BetterScienceLabsContinued"
     },
     "tags": [
         "parts",
@@ -18,12 +18,10 @@
     ],
     "depends" : [
         { "name": "ModuleManager" },
-        { "name": "SpacetuxSA" }
+        { "name": "SpacetuxSA"    }
     ],
-    "install": [
-        {
-            "find"       : "BetterScienceLabsContinued",
-            "install_to" : "GameData"
-        }
-    ]
+    "install": [ {
+        "find"       : "BetterScienceLabsContinued",
+        "install_to" : "GameData"
+    } ]
 }

--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -5,7 +5,7 @@
     "abstract":     "Adds asteroids inside orbit of Jool",
     "$kref":        "#/ckan/spacedock/210",
     "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_license_ok": true,
+    "license":      "MIT",
     "tags": [
         "config",
         "planet-pack"

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -5,7 +5,7 @@
     "abstract":     "Adds comets outside orbit of Jool",
     "$kref":        "#/ckan/spacedock/210",
     "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_license_ok": true,
+    "license":      "MIT",
     "tags": [
         "config",
         "planet-pack"

--- a/NetKAN/CustomAsteroids-Pops-Stock-Stockalike.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Stockalike.netkan
@@ -5,7 +5,7 @@
     "abstract":     "Emulates stock asteroids with Custom Asteroids groups.",
     "$kref":        "#/ckan/spacedock/210",
     "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_license_ok": true,
+    "license":      "MIT",
     "tags": [
         "config",
         "planet-pack"
@@ -31,13 +31,11 @@
         { "name": "StockAlikeSolarSystem", "comment": "Completely different system."},
         { "name": "UnchartedLands", "comment": "Completely different system."}
     ],
-    "install": [
-        {
-            "file": "GameData/CustomAsteroids",
-            "install_to": "GameData",
-            "filter_regexp": "(?<!Stockalike\\.cfg)$"
-        }
-    ],
+    "install": [ {
+        "file": "GameData/CustomAsteroids",
+        "install_to": "GameData",
+        "filter_regexp": "(?<!Stockalike\\.cfg)$"
+    } ],
     "x_netkan_override" : [
         {
             "version" : [ ">= v1.6.0", "< v2.0.0" ],

--- a/NetKAN/CustomAsteroids.netkan
+++ b/NetKAN/CustomAsteroids.netkan
@@ -3,7 +3,7 @@
     "identifier":   "CustomAsteroids",
     "$kref":        "#/ckan/spacedock/210",
     "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_license_ok" : true,
+    "license":      "MIT",
     "tags": [
         "plugin",
         "planet-pack"

--- a/NetKAN/DarkMultiPlayer.netkan
+++ b/NetKAN/DarkMultiPlayer.netkan
@@ -3,18 +3,16 @@
     "identifier"     : "DarkMultiPlayer",
     "$kref"          : "#/ckan/spacedock/10",
     "release_status" : "development",
-    "x_netkan_license_ok" : true,
+    "license"        : "MIT",
     "resources"      : {
-        "manual"       : "https://github.com/godarklight/DarkMultiPlayer/blob/master/README.md",
-        "repository"   : "https://github.com/godarklight/DarkMultiPlayer"
+        "manual"     : "https://github.com/godarklight/DarkMultiPlayer/blob/master/README.md",
+        "repository" : "https://github.com/godarklight/DarkMultiPlayer"
     },
     "tags": [
         "plugin"
     ],
-    "install" : [
-        {
-            "file"       : "DMPClient/GameData/DarkMultiPlayer",
-            "install_to" : "GameData"
-        }
-    ]
+    "install": [ {
+        "file"       : "DMPClient/GameData/DarkMultiPlayer",
+        "install_to" : "GameData"
+    } ]
 }

--- a/NetKAN/EditorExtensionsRedux.netkan
+++ b/NetKAN/EditorExtensionsRedux.netkan
@@ -2,9 +2,9 @@
     "spec_version"        : 1,
     "identifier"          : "EditorExtensionsRedux",
     "abstract"            : "Tweaks and features for the in-game vessel editor, e.g. alignment and symmetry aids. Now includes SelectRoot mod",
-    "x_netkan_license_ok" : true,
     "$kref"               : "#/ckan/spacedock/48",
     "$vref"               : "#/ckan/ksp-avc",
+    "license"             : "MIT",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/127378-*",
         "repository": "https://github.com/linuxgurugamer/EditorExtensionsRedux"

--- a/NetKAN/EmDriveByBeale.netkan
+++ b/NetKAN/EmDriveByBeale.netkan
@@ -2,13 +2,13 @@
     "spec_version": "v1.4",
     "identifier":   "EmDriveByBeale",
     "$kref":        "#/ckan/spacedock/1113",
-    "license":      "unknown",
+    "license":      "CC-BY-NC-SA-4.0",
     "tags": [
         "plugin",
         "parts"
     ],
     "install": [ {
-        "find": "EmDrive",
+        "find":       "EmDrive",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/EngineLightRelit.netkan
+++ b/NetKAN/EngineLightRelit.netkan
@@ -1,30 +1,31 @@
 {
-    "spec_version" : "v1.4",
-    "identifier"   : "EngineLightRelit",
-    "$kref":         "#/ckan/spacedock/2111",
-    "$vref":         "#/ckan/ksp-avc",
-    "x_netkan_license_ok": true,
-    "resources"    : {
-        "homepage"   : "https://forum.kerbalspaceprogram.com/index.php?/topic/182906-*",
-        "repository" : "https://github.com/linuxgurugamer/EngineLightRelit"
+    "spec_version": "v1.4",
+    "identifier":   "EngineLightRelit",
+    "$kref":        "#/ckan/spacedock/2111",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "MIT",
+    "resources": {
+        "homepage"  : "https://forum.kerbalspaceprogram.com/index.php?/topic/182906-*",
+        "repository": "https://github.com/linuxgurugamer/EngineLightRelit"
     },
     "tags": [
         "plugin",
         "graphics"
     ],
-    "depends"      : [
-        { "name" : "ModuleManager", "min_version" : "2.6.3" }
-    ],
-    "suggests"     : [
-        { "name" : "HotRockets" }
-    ],
-     "conflicts": [
-         { "name": "EngineLighting"    }
-     ],
-    "install"      : [
+    "depends": [
         {
-            "find"       : "EngineLightRelit",
-            "install_to" : "GameData"
+            "name": "ModuleManager",
+            "min_version": "2.6.3"
         }
-    ]
+    ],
+    "suggests": [
+        { "name": "HotRockets" }
+    ],
+    "conflicts": [
+        { "name": "EngineLighting" }
+    ],
+    "install": [ {
+        "find"      : "EngineLightRelit",
+        "install_to": "GameData"
+    } ]
 }

--- a/NetKAN/GAP.netkan
+++ b/NetKAN/GAP.netkan
@@ -2,14 +2,14 @@
     "spec_version" : "v1.4",
     "identifier"   : "GAP",
     "$kref"        : "#/ckan/spacedock/70",
-    "x_netkan_license_ok": true,
+    "license"      : "MIT",
     "tags": [
         "config",
         "career"
     ],
     "depends": [
         { "name": "ContractConfigurator" },
-        { "name": "ModuleManager" }
+        { "name": "ModuleManager"        }
     ],
     "recommends": [
         { "name": "WaypointManager" }
@@ -18,10 +18,8 @@
         { "name": "KAS" },
         { "name": "KIS" }
     ],
-    "install": [
-        {
-            "find"       : "GAP",
-            "install_to" : "GameData/ContractPacks"
-        }
-    ]
+    "install": [ {
+        "find"       : "GAP",
+        "install_to" : "GameData/ContractPacks"
+    } ]
 }

--- a/NetKAN/JanitorsCloset.netkan
+++ b/NetKAN/JanitorsCloset.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "JanitorsCloset",
     "$kref":        "#/ckan/spacedock/944",
-    "license":      "unknown",
+    "license":      "CC-BY-NC-4.0",
     "tags": [
         "plugin",
         "convenience"

--- a/NetKAN/KASFrench.netkan
+++ b/NetKAN/KASFrench.netkan
@@ -2,12 +2,12 @@
     "spec_version": "v1.4",
     "identifier":   "KASFrench",
     "$kref":        "#/ckan/spacedock/1156",
-    "license":      "unknown",
+    "license":      "restricted",
     "tags": [
         "config"
     ],
     "install": [ {
-        "find": "KAS trad fr",
+        "find":       "KAS trad fr",
         "install_to": "GameData"
     } ],
     "depends": [

--- a/NetKAN/Kerbalverse.netkan
+++ b/NetKAN/Kerbalverse.netkan
@@ -2,17 +2,17 @@
     "spec_version": "v1.4",
     "identifier":   "Kerbalverse",
     "$kref":        "#/ckan/spacedock/1321",
-    "license":      "unknown",
+    "license":      "CC0",
     "tags": [
         "config",
         "planet-pack"
     ],
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "Kopernicus"     }
+        { "name": "Kopernicus"    }
     ],
     "install": [ {
-        "file": "Kerbalverse",
+        "file":       "Kerbalverse",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/KramaxAutopilotContinued.netkan
+++ b/NetKAN/KramaxAutopilotContinued.netkan
@@ -3,17 +3,17 @@
     "identifier":   "KramaxAutopilotContinued",
     "$kref":        "#/ckan/spacedock/1019",
     "$vref":        "#/ckan/ksp-avc",
-    "license":      "unknown",
+    "license":      "CC-BY-NC-SA-4.0",
     "tags": [
         "plugin",
         "control"
     ],
     "install": [ {
-        "find": "KramaxAutoPilot",
+        "find":       "KramaxAutoPilot",
         "install_to": "GameData"
     } ],
     "depends": [
-        { "name": "ToolbarController" },
+        { "name": "ToolbarController"   },
         { "name": "ClickThroughBlocker" }
     ]
 }

--- a/NetKAN/KustomKerbals.netkan
+++ b/NetKAN/KustomKerbals.netkan
@@ -3,7 +3,7 @@
     "identifier":   "KustomKerbals",
     "$kref":        "#/ckan/spacedock/423",
     "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_license_ok": true,
+    "license":      "MIT",
     "tags": [
         "plugin",
         "crewed"

--- a/NetKAN/MechJebForAll.netkan
+++ b/NetKAN/MechJebForAll.netkan
@@ -4,7 +4,7 @@
     "name":         "MechJeb and Engineer for all!",
     "$kref":        "#/ckan/spacedock/1854",
     "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_license_ok": true,
+    "license":      "GPL-3.0",
     "tags": [
         "config",
         "control"
@@ -16,10 +16,8 @@
         { "name": "MechJeb2" },
         { "name": "KerbalEngineerRedux" }
     ],
-    "install": [
-        {
-            "find": "MechJebForAll",
-            "install_to": "GameData"
-        }
-    ]
+    "install": [ {
+        "find": "MechJebForAll",
+        "install_to": "GameData"
+    } ]
 }

--- a/NetKAN/MinAmbLightUpd.netkan
+++ b/NetKAN/MinAmbLightUpd.netkan
@@ -3,9 +3,9 @@
     "identifier":   "MinAmbLightUpd",
     "$kref":        "#/ckan/spacedock/2279",
     "$vref":        "#/ckan/ksp-avc",
-    "license":      "unknown",
+    "license":      "BSD-2-clause",
     "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/190080-*",
+        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/190080-*",
         "repository": "https://github.com/linuxgurugamer/MinimumAmbientLightingUpdated"
     },
     "tags": [
@@ -13,11 +13,11 @@
         "graphics"
     ],
     "depends": [
-        { "name": "ToolbarController" },
+        { "name": "ToolbarController"   },
         { "name": "ClickThroughBlocker" }
     ],
     "install": [ {
-        "find": "MinimumAmbientLightingUpdated",
+        "find":       "MinimumAmbientLightingUpdated",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/NavUtilitiesContinued.netkan
+++ b/NetKAN/NavUtilitiesContinued.netkan
@@ -2,14 +2,14 @@
     "spec_version": "v1.4",
     "identifier":   "NavUtilitiesContinued",
     "$kref":        "#/ckan/spacedock/1432",
-    "license":      "unknown",
+    "license":      "CC-BY-NC-SA-4.0",
     "tags": [
         "plugin",
         "information",
         "crewed"
     ],
     "install": [ {
-        "find": "NavUtilities continued",
+        "find":       "NavUtilities continued",
         "install_to": "GameData"
     } ],
     "depends": [

--- a/NetKAN/OkramSA.netkan
+++ b/NetKAN/OkramSA.netkan
@@ -6,24 +6,20 @@
     "author"         : "Orum",
     "$kref"          : "#/ckan/github/Orum/OkramSharedAssets",
     "license"        : "unknown",
-    "x_netkan_license_ok": true,
     "release_status" : "stable",
     "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/60383-*",
+        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/60383-*",
         "repository": "https://github.com/Orum/OkramSharedAssets"
     },
     "tags": [
         "flags",
         "agency"
     ],
-    "install" : [
-        {
-            "file"       : "Agencies",
-            "install_to" : "GameData/Okram"
-        },
-        {
-            "file"       : "Flags",
-            "install_to" : "GameData/Okram"
-        }
-    ]
+    "install": [ {
+        "file"       : "Agencies",
+        "install_to" : "GameData/Okram"
+    }, {
+        "file"       : "Flags",
+        "install_to" : "GameData/Okram"
+    } ]
 }

--- a/NetKAN/PartWizardContinued.netkan
+++ b/NetKAN/PartWizardContinued.netkan
@@ -1,26 +1,26 @@
 {
     "spec_version": "v1.4",
-    "identifier": "PartWizardContinued",
-    "abstract": "Part Wizard is a vehicle design utility plugin that adds a few conveniences when building your next strut/booster carrier.  It provides a list of parts with part highlighting for easier identification, allows deleting of parts from the list on eligible parts, allows complete control of symmetry on eligible parts, allows selecting parts for Action Group assignment, shows either all parts or only those that are hidden from the editor's Parts List. (Helpful in finding obsolete parts when mod authors make updates.) and shows unavailable parts in career modes with options to buy one or all necessary parts for launch.",
-    "$kref": "#/ckan/spacedock/1148",
-    "$vref": "#/ckan/ksp-avc",
-    "license": "unknown",
+    "identifier":   "PartWizardContinued",
+    "abstract":     "Part Wizard is a vehicle design utility plugin that adds a few conveniences when building your next strut/booster carrier.  It provides a list of parts with part highlighting for easier identification, allows deleting of parts from the list on eligible parts, allows complete control of symmetry on eligible parts, allows selecting parts for Action Group assignment, shows either all parts or only those that are hidden from the editor's Parts List. (Helpful in finding obsolete parts when mod authors make updates.) and shows unavailable parts in career modes with options to buy one or all necessary parts for launch.",
+    "$kref":        "#/ckan/spacedock/1148",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "BSD-3-clause",
     "tags": [
         "plugin",
         "editor",
         "convenience"
     ],
     "install": [ {
-        "install_to": "GameData",
-        "find": "PartWizard"
+        "find":       "PartWizard",
+        "install_to": "GameData"
     } ],
     "depends": [
-        { "name" : "ToolbarController" },
+        { "name" : "ToolbarController"   },
         { "name" : "ClickThroughBlocker" }
     ],
     "suggests": [
         { "name": "JanitorsCloset" },
-        { "name": "Toolbar" }
+        { "name": "Toolbar"        }
     ],
     "conflicts": [
         { "name": "PartWizard" }

--- a/NetKAN/RSSeaDragon.netkan
+++ b/NetKAN/RSSeaDragon.netkan
@@ -3,7 +3,7 @@
     "identifier"   : "RSSeaDragon",
     "$kref"        : "#/ckan/spacedock/440",
     "$vref"        : "#/ckan/ksp-avc",
-    "x_netkan_license_ok": true,
+    "license"      : "CC-BY-NC-SA-4.0",
     "tags": [
         "parts"
     ],
@@ -11,25 +11,22 @@
         { "name": "ModuleManager" }
     ],
     "recommends": [
-        { "name": "HangarExtender" },
+        { "name": "HangarExtender"           },
         { "name": "KerbalJointReinforcement" }
     ],
     "suggests": [
-        { "name": "QuickSearch" },
-        { "name": "RealScaleBoosters" },
+        { "name": "QuickSearch"             },
+        { "name": "RealScaleBoosters"       },
         { "name": "FerramAerospaceResearch" },
-        { "name": "RealSolarSystem" },
-        { "name": "CommunityTechTree" }
+        { "name": "RealSolarSystem"         },
+        { "name": "CommunityTechTree"       }
     ],
-    "install": [
-        {
-            "file"       : "RSSeaDragon",
-            "install_to" : "GameData",
-            "filter"     : "Ships"
-        },
-        {
-            "find"       : "VAB",
-            "install_to" : "Ships"
-        }
-    ]
+    "install": [ {
+        "file"       : "RSSeaDragon",
+        "install_to" : "GameData",
+        "filter"     : "Ships"
+    }, {
+        "find"       : "VAB",
+        "install_to" : "Ships"
+    } ]
 }

--- a/NetKAN/RealScaleBoosters.netkan
+++ b/NetKAN/RealScaleBoosters.netkan
@@ -3,7 +3,7 @@
     "identifier"   : "RealScaleBoosters",
     "$kref"        : "#/ckan/spacedock/90",
     "$vref"        : "#/ckan/ksp-avc",
-    "x_netkan_license_ok": true,
+    "license"      : "CC-BY-NC-SA",
     "tags": [
         "parts"
     ],
@@ -11,24 +11,21 @@
         { "name": "ModuleManager" }
     ],
     "recommends": [
-        { "name": "HangarExtender" },
+        { "name": "HangarExtender"           },
         { "name": "KerbalJointReinforcement" }
     ],
     "suggests": [
-        { "name": "RSSeaDragon" },
+        { "name": "RSSeaDragon"             },
         { "name": "FerramAerospaceResearch" },
-        { "name": "RealSolarSystem" },
-        { "name": "CommunityTechTree" }
+        { "name": "RealSolarSystem"         },
+        { "name": "CommunityTechTree"       }
     ],
-    "install": [
-        {
-            "find"       : "RealScaleBoosters",
-            "install_to" : "GameData",
-            "filter"     : "Ships"
-        },
-        {
-            "find"       : "VAB",
-            "install_to" : "Ships"
-        }
-    ]
+    "install": [ {
+        "find"       : "RealScaleBoosters",
+        "install_to" : "GameData",
+        "filter"     : "Ships"
+    }, {
+        "find"       : "VAB",
+        "install_to" : "Ships"
+    } ]
 }

--- a/NetKAN/RealScaleBoostersStockalike.netkan
+++ b/NetKAN/RealScaleBoostersStockalike.netkan
@@ -4,23 +4,20 @@
     "identifier"   : "RealScaleBoostersStockalike",
     "$kref"        : "#/ckan/spacedock/561",
     "$vref"        : "#/ckan/ksp-avc",
-    "x_netkan_license_ok": true,
+    "license"      : "CC-BY-NC-SA-4.0",
     "tags": [
         "parts"
     ],
     "depends": [
         { "name": "RealScaleBoosters" },
-        { "name": "ModuleManager" }
+        { "name": "ModuleManager"     }
     ],
-    "install": [
-        {
-            "find"       : "RealScaleBoostersStockalike",
-            "install_to" : "GameData",
-            "filter"     : "Ships"
-        },
-        {
-            "find"       : "VAB",
-            "install_to" : "Ships"
-        }
-    ]
+    "install": [ {
+        "find"       : "RealScaleBoostersStockalike",
+        "install_to" : "GameData",
+        "filter"     : "Ships"
+    }, {
+        "find"       : "VAB",
+        "install_to" : "Ships"
+    } ]
 }

--- a/NetKAN/RevampedStockSystem.netkan
+++ b/NetKAN/RevampedStockSystem.netkan
@@ -7,7 +7,7 @@
     "ksp_version"  : "1.2",
     "license"      : "unknown",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/134360-rsss/"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/134360-*"
     },
     "tags": [
         "config",
@@ -15,10 +15,10 @@
     ],
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "Kopernicus" }
+        { "name": "Kopernicus"    }
     ],
     "install": [ {
-        "find": "RevampedStockSystem",
+        "find":       "RevampedStockSystem",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/SDHI-SharedAssets.netkan
+++ b/NetKAN/SDHI-SharedAssets.netkan
@@ -8,7 +8,6 @@
     "ksp_version"    : "any",
     "comment"        : "agencymod",
     "release_status" : "stable",
-    "x_netkan_license_ok": true,
     "resources" : {
         "repository"   : "https://github.com/sumghai/SDHI_ServiceModuleSystem",
         "homepage"     : "https://forum.kerbalspaceprogram.com/index.php?/topic/48073-*"

--- a/NetKAN/Syncrio.netkan
+++ b/NetKAN/Syncrio.netkan
@@ -2,7 +2,7 @@
     "spec_version" : "v1.2",
     "identifier"   : "Syncrio",
     "$kref"        : "#/ckan/spacedock/916",
-    "x_netkan_license_ok" : true,
+    "license"      : "MIT",
     "tags": [
         "plugin",
         "career",

--- a/NetKAN/TheGoldStandard.netkan
+++ b/NetKAN/TheGoldStandard.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "TheGoldStandard",
     "$kref":        "#/ckan/spacedock/963",
-    "license":      "unknown",
+    "license":      "CC-BY-NC-SA-4.0",
     "tags": [
         "config",
         "parts",

--- a/NetKAN/Trajectories.netkan
+++ b/NetKAN/Trajectories.netkan
@@ -4,7 +4,7 @@
     "$kref"               : "#/ckan/spacedock/396",
     "$vref"               : "#/ckan/ksp-avc",
     "x_netkan_force_v"    : true,
-    "x_netkan_license_ok" : true,
+    "license"             : "GPL-3.0",
     "tags"                : [
         "plugin",
         "information"

--- a/NetKAN/UtilityWeight.netkan
+++ b/NetKAN/UtilityWeight.netkan
@@ -1,12 +1,12 @@
 {
     "spec_version" : "v1.26",
     "identifier"   : "UtilityWeight",
-    "$kref"        : "#/ckan/github/yalov/UtilityWeight",
     "name"         : "Utility Weight",
     "author"       : "flart",
-    "x_netkan_license_ok" : true,
-    "release_status" : "stable",
-    "$vref" : "#/ckan/ksp-avc",
+    "$kref"        : "#/ckan/github/yalov/UtilityWeight",
+    "$vref"        : "#/ckan/ksp-avc",
+    "license"      : "GPL-3.0",
+    "release_status": "stable",
     "resources" : {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/189536-*"
     },

--- a/NetKAN/VentralDrill.netkan
+++ b/NetKAN/VentralDrill.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "VentralDrill",
     "$kref":        "#/ckan/spacedock/1328",
-    "license":      "unknown",
+    "license":      "CC-BY-NC-SA-4.0",
     "tags": [
         "parts",
         "resources"

--- a/NetKAN/WaterLaunchSites.netkan
+++ b/NetKAN/WaterLaunchSites.netkan
@@ -1,13 +1,13 @@
 {
     "spec_version" : "v1.26",
     "identifier"   : "WaterLaunchSites",
-    "$kref"        : "#/ckan/github/yalov/WaterLaunchSites",
     "name"         : "Water Launch Sites (Kerbal-Konstructs)",
     "author"       : "flart",
-    "x_netkan_license_ok" : true,
-    "release_status" : "stable",
+    "$kref"        : "#/ckan/github/yalov/WaterLaunchSites",
     "$vref"        : "#/ckan/ksp-avc",
-    "resources" : {
+    "license"      : "GPL-3.0",
+    "release_status": "stable",
+    "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/183937-*"
     },
     "tags": [
@@ -15,15 +15,13 @@
         "convenience",
         "buildings"
     ],
-    "install" : [
-        {
-            "file"       : "GameData/KerbalKonstructs-WaterLaunchSites",
-            "install_to" : "GameData"
-        }
-    ],
+    "install": [ {
+        "file"       : "GameData/KerbalKonstructs-WaterLaunchSites",
+        "install_to" : "GameData"
+    } ],
     "depends": [
         { "name": "KerbalKonstructs" },
-        { "name": "ModuleManager" }
+        { "name": "ModuleManager"    }
     ],
     "recommends": [
     	{ "name": "MakingHistory-DLC" }


### PR DESCRIPTION
Successor to #7614. Lots of mods have a license of `"unknown"` when a license has been publicly declared or use `"x_netkan_license_ok"` when they shouldn't. This is blocking some of them from being uploaded to archive.org.

Now a first pass of them have their actual licenses set in their netkans.