### PR TITLE
Rename one of the modules currently called Ariane 6

### DIFF
--- a/NetKAN/Ariane6-RealFuels.netkan
+++ b/NetKAN/Ariane6-RealFuels.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "Ariane6-RealFuels",
     "name":         "Ariane 6 RealFuels",
-    "abstract":     "Future launcher of the European Space Agency, with RealFuels support"
+    "abstract":     "Future launcher of the European Space Agency, with RealFuels support",
     "$kref":        "#/ckan/spacedock/2185",
     "license":      "WTFPL",
     "tags": [

--- a/NetKAN/Ariane6-RealFuels.netkan
+++ b/NetKAN/Ariane6-RealFuels.netkan
@@ -1,6 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier":   "Ariane6-RealFuels",
+    "name":         "Ariane 6 RealFuels",
     "$kref":        "#/ckan/spacedock/2185",
     "license":      "WTFPL",
     "tags": [

--- a/NetKAN/Ariane6-RealFuels.netkan
+++ b/NetKAN/Ariane6-RealFuels.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "Ariane6-RealFuels",
     "name":         "Ariane 6 RealFuels",
+    "abstract":     "Future launcher of the European Space Agency, with RealFuels support"
     "$kref":        "#/ckan/spacedock/2185",
     "license":      "WTFPL",
     "tags": [


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/72195984-ea98f000-33da-11ea-8aae-d5fc09901bd5.png)

## Cause

Ariane6 and Ariane6-RealFuels share a `$kref` and don't override `name`.

## Changes

Now Ariane6-RealFuels has a custom `name` and `abstract`.

ckan compat add 1.7