### PR TITLE
Update username for ThrottleControlledAvionics metanetkan

### DIFF
--- a/NetKAN/ThrottleControlledAvionics.netkan
+++ b/NetKAN/ThrottleControlledAvionics.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.16",
-    "identifier": "ThrottleControlledAvionics",
-    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/qfeys/ThrottleControlledAvionics/master/ThrottleControlledAvionics.netkan",
+    "identifier":   "ThrottleControlledAvionics",
+    "$kref":        "#/ckan/netkan/https://raw.githubusercontent.com/allista/ThrottleControlledAvionics/master/ThrottleControlledAvionics.netkan",
     "x_netkan_license_ok": true,
     "tags": [
         "plugin",


### PR DESCRIPTION
## Problem

This mod errors out currently with an API rate limit exceeded message:

![image](https://user-images.githubusercontent.com/1559108/72375487-cf2b2f00-36d1-11ea-81e0-6e81f8bcfc87.png)

## Cause

As usual with GitHub rate limit errors, little is known and much is mysterious, so we can only speculate. However, I noticed that if you open the path to the repo where the metanetkan is located:

https://github.com/qfeys/ThrottleControlledAvionics

It redirects to:

https://github.com/allista/ThrottleControlledAvionics

So allista must have changed his GitHub username at some point, and the API is accounting for that. Maybe GitHub doesn't like having to perform that redirection, and counts it against us somehow?

## Changes

Now this module is updated to use the newer path for the metanetkan.

(I found no other occurrences of "qfeys" in NetKAN.)