### PR TITLE
Update username for Telemachus kref

### DIFF
--- a/NetKAN/Telemachus.netkan
+++ b/NetKAN/Telemachus.netkan
@@ -4,7 +4,7 @@
     "name"         : "Telemachus",
     "abstract"     : "Telemetry and Flight Control in the Web Browser",
     "author"       : "Rich",
-    "$kref"        : "#/ckan/github/richardbunt/Telemachus",
+    "$kref"        : "#/ckan/github/KSP-Telemachus/Telemachus",
     "x_netkan_force_v": true,
     "ksp_version_min": "1.2.0",
     "ksp_version_max": "1.2.2",


### PR DESCRIPTION
See #7627; this module also has a rate limit error, and if you open its repo:

http://github.com/richardbunt/Telemachus

It redirects to:

https://github.com/KSP-Telemachus/Telemachus

This makes me think I might be on to something with this redirection hypothesis.
Now the kref uses the newer username.