### PR TITLE
Extend KerbalOccupationColors compatibility override

### DIFF
--- a/NetKAN/KerbalOccupationColors.netkan
+++ b/NetKAN/KerbalOccupationColors.netkan
@@ -24,7 +24,6 @@
     "x_netkan_override": [
         {
             "version": [ ">=v1.2.0", "<=v1.2.0.1" ],
-            "delete":  [ "ksp_version", "ksp_version_min" ],
             "override": {
                 "ksp_version_min": "1.7.3"
             }

--- a/NetKAN/KerbalOccupationColors.netkan
+++ b/NetKAN/KerbalOccupationColors.netkan
@@ -23,7 +23,7 @@
     } ],
     "x_netkan_override": [
         {
-            "version":"v1.2.0",
+            "version": [ ">=v1.2.0", "<=v1.2.0.1" ],
             "delete":  [ "ksp_version", "ksp_version_min" ],
             "override": {
                 "ksp_version_min": "1.7.3"


### PR DESCRIPTION
This mod has always had a broken .version file with a KSP_VERSION_MIN of 1.99999.99999. Its netkan started out in #7384 with an override to fix this, but it has an inflation error again now because a new version came out that doesn't match the override.

It doesn't look like Starwaster/Kerbal-Occupation-Colors#2 will be merged anytime soon, so this PR extends the override to cover the latest release. I didn't want to presume that future versions will be broken, so we'll have to continue extending the override if they are.

Also the override is wrong, it changes ksp_version_min and then deletes it. We'll fix that as well, and have to update the previous .ckan later.