### PR TITLE
Fix ManeuverD version regex

### DIFF
--- a/NetKAN/ManeuverD.netkan
+++ b/NetKAN/ManeuverD.netkan
@@ -8,7 +8,7 @@
     "x_netkan_jenkins": {
         "use_filename_version": true
     },
-    "x_netkan_version_edit": "^ManeuverD-(?<version>\\d+\\.\\d+\\.\\d+)\\.zip$",
+    "x_netkan_version_edit": "^ManeuverD-(?<version>\\d+\\.\\d+\\.\\d+\\.\\d+)\\.zip$",
     "ksp_version_min": "1.8.0",
     "ksp_version_max": "1.8.3",
     "license": "BSD-2-clause",


### PR DESCRIPTION
## Problem

@sarbian just pushed this module to master without a pull request, and thus with no validation. It has this inflation error:

```
Could not match version ManeuverD-1.0.0.0.zip with find pattern ^ManeuverD-(?<version>\d+\.\d+\.\d+)\.zip$
```

http://status.ksp-ckan.space/

## Cause

The version has four pieces and the regex is only matching three.

## Changes

Now it will match the fourth piece.