### PR TITLE
De-meta BeyondHome

### DIFF
--- a/NetKAN/BeyondHome.netkan
+++ b/NetKAN/BeyondHome.netkan
@@ -1,11 +1,39 @@
-{
+{ 
     "spec_version": "v1.4",
-    "identifier": "BeyondHome",
-    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Gameslinx/BeyondHomePlanetMod/master/GameData/BeyondHome/BeyondHome.netkan",
-    "license": "restricted",
+    "identifier":   "BeyondHome",
+    "name":         "Beyond Home",
+    "author":       "Gameslinx",
+    "abstract":     "A planet mod that takes place after the Kerbol system has died. Kerbals have escaped to another star system. Beyond Home adds a unique suite of over 28 planets each with their own high quality visuals.",
+    "$kref":        "#/ckan/github/Gameslinx/BeyondHomePlanetMod",
+    "ksp_version":  "1.7.3",
+    "license":      "restricted",
+    "resources": {
+        "homepage":"https://forum.kerbalspaceprogram.com/index.php?/topic/182708-*"
+    },
     "tags": [
         "config",
         "planet-pack",
         "graphics"
-    ]
+    ],
+    "depends": [
+        { "name": "Kopernicus" }
+    ],
+    "conflicts": [
+        { "name": "GPP"                     },
+        { "name": "StockVisualEnhancements" }
+    ],
+    "recommends": [
+        { "name": "SigmaReplacements-SkyBox"        },
+        { "name": "EnvironmentalVisualEnhancements" },
+        { "name": "Scatterer"                       }
+    ],
+    "provides": [
+        "Scatterer-config",
+        "Scatterer-sunflare",
+        "EnvironmentalVisualEnhancements-Config"
+    ],
+    "install": [ { 
+        "find":       "BeyondHome",
+        "install_to": "GameData"
+    } ]
 }


### PR DESCRIPTION
This mod's metanetkan was just deleted in https://github.com/Gameslinx/BeyondHomePlanetMod/commit/0f3949be15c71dd507ad7e0e5789b6df3e571fa3.

The author seems enthusiastic about CKAN:

![thread](https://cdn.discordapp.com/attachments/601455398553387008/668534737610080283/unknown.png)

Now the metadata from the last copy of the metanetkan is copied into the netkan, restoring the mod. Note that the compatibility is likely to change from 1.7.3 to 1.8.1 with the next release, so we'll hold off on merging this till then to be sure.