### PR TITLE
Fix misspelled conflict

### DIFF
--- a/NetKAN/ODFC-Refueled.netkan
+++ b/NetKAN/ODFC-Refueled.netkan
@@ -12,7 +12,7 @@
         "install_to": "GameData"
     } ],
     "conflicts": [
-        { "name": "OFDC"  }
+        { "name": "ODFC"  }
     ],
     "depends": [
         { "name": "ModuleManager" }

--- a/NetKAN/ODFC-Refueled.netkan
+++ b/NetKAN/ODFC-Refueled.netkan
@@ -11,6 +11,9 @@
         "find":       "OnDemandFuelCells",
         "install_to": "GameData"
     } ],
+    "provides": [
+        "ODFC"
+    ],
     "conflicts": [
         { "name": "ODFC"  }
     ],


### PR DESCRIPTION
ODFC-Refueled conflicts with OFDC, but it's supposed to be ODFC.
Aren't acronyms grand?

And ODFC-Refueled now `provides` ODFC as well, so depending mods don't need to be updated.
Closes #7640.
Closes #7641.