### PR TITLE
Turn off auto-epoching of ProceduralParts

### DIFF
--- a/NetKAN/ProceduralParts.netkan
+++ b/NetKAN/ProceduralParts.netkan
@@ -4,6 +4,7 @@
     "author"            :   [ "Ancient Gammoner", "NathanKell", "Swamp-Ig", "Starwaster", "Tidal-Stream", "jrodrigv", "KSP-RO" ],
     "$kref"             :   "#/ckan/github/KSP-RO/ProceduralParts",
     "$vref"             :   "#/ckan/ksp-avc",
+    "x_netkan_allow_out_of_order": true,
     "name"              :   "Procedural Parts",
     "abstract"          :   "ProceduralParts allows you to procedurally generate a number of different parts in a range of sizes and shapes.",
     "license"           :   "CC-BY-SA",


### PR DESCRIPTION
In #7497 we switched to a new fork of ProceduralParts by the RealismOverhaul team. The RO team is unfortunately focusing on 1.7.3 backports due to Kopernicus limitations. Unfortunately the fork from #7487 had already indexed a version for KSP 1.8, which places an upper limit on the versions that those backports can use.

Since this mod is going to be releasing backports for the foreseeable future, it now won't be auto-epoched.