### PR TITLE
Filter JSIPartUtilities files out of RPM install

### DIFF
--- a/NetKAN/RasterPropMonitor.netkan
+++ b/NetKAN/RasterPropMonitor.netkan
@@ -43,7 +43,7 @@
     ],
     "install": [ {
         "find"      : "JSI",
-        "filter"    : [ "RasterPropMonitor", "BasicMFD" ],
+        "filter"    : [ "RasterPropMonitor", "BasicMFD", "README.md", "LICENSE.md", "Agencies" ],
         "install_to": "GameData"
     } ]
 }


### PR DESCRIPTION
## Problem

https://github.com/KSP-CKAN/NetKAN/pull/7608#issuecomment-577273818

The latest RPM download unintentionally included files from JSIPartUtilities, so those modules now conflict if you try to install both.

## Changes

Now RasterPropMonitor won't install the files from JSIPartUtilities.