### PR TITLE
Make ALCORIVAPatch depend on ALCOR

### DIFF
--- a/NetKAN/ALCORIVAPatch.netkan
+++ b/NetKAN/ALCORIVAPatch.netkan
@@ -13,9 +13,10 @@
     } ],
     "depends": [
         { "name": "ASETAgency" },
+        { "name": "ALCOR" },
         { "name": "ModuleManager" },
         { "name": "RasterPropMonitor-Core", "min_version": "0.28.0" },
-        { "name": "ASETProps" , "min_version": "1.4"}
+        { "name": "ASETProps" , "min_version": "1.4" }
     ],
     "recommends": [
         { "name": "MechJeb2" },


### PR DESCRIPTION
## Problem

ALCORIVAPatch is an IVA for ALCOR. Not much point in installing it without ALCOR.

## Changes

Now it depends on ALCOR.
This will also allow us to test the fix in #7647.

ckan compat add 1.8