### PR TITLE
Remove manual staging for hard coded compatibility

### DIFF
--- a/NetKAN/AlternisKerbolRekerjiggered.netkan
+++ b/NetKAN/AlternisKerbolRekerjiggered.netkan
@@ -6,8 +6,6 @@
     "author":       "GregroxMun",
     "$kref":        "#/ckan/github/GregroxMun/Alternis-Kerbol-Rekerjiggered",
     "ksp_version":  "1.7.3",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard-coded in netkan. Please confirm that it still matches the forum thread.",
     "license":      "CC-BY-NC-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/120246-*"

--- a/NetKAN/AutomatedScienceSampler.netkan
+++ b/NetKAN/AutomatedScienceSampler.netkan
@@ -6,8 +6,6 @@
     "author"        : [ "SpaceTiger", "SpaceKitty" ],
     "$kref"         : "#/ckan/github/Xarun/AutomatedScienceSampler",
     "ksp_version"   : "1.8",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard-coded in netkan. Please check that it still matches the forum thread.",
     "license"       : "restricted",
     "resources": {
         "homepage": "http://kerbokatz.github.io/",

--- a/NetKAN/ContractConfigurator-CareerEvolution.netkan
+++ b/NetKAN/ContractConfigurator-CareerEvolution.netkan
@@ -4,8 +4,6 @@
     "$kref":        "#/ckan/github/pap1723/Career-Evolution",
     "ksp_version_min": "1.2",
     "ksp_version_max": "1.3",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game versions hard coded in netkan, please check that they still match the forum thread",
     "license":      "CC-BY-NC-SA",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/162205-*"

--- a/NetKAN/CoolRockets.netkan
+++ b/NetKAN/CoolRockets.netkan
@@ -7,8 +7,6 @@
     "$kref":        "#/ckan/jenkins/https://ksp.sarbian.com/jenkins/job/ColdRockets",
     "version":      "0.08",
     "ksp_version":  "1.1",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard-coded in netkan, please confirm it matches the forum thread",
     "license":      "public-domain",
     "release_status": "development",
     "resources": {

--- a/NetKAN/CraftHistory.netkan
+++ b/NetKAN/CraftHistory.netkan
@@ -6,8 +6,6 @@
     "author"        : [ "SpaceTiger", "SpaceKitty" ],
     "$kref"         : "#/ckan/github/Xarun/CraftHistory",
     "ksp_version"   : "1.8",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard-coded in netkan. Please check that it still matches the forum thread.",
     "license"       : "restricted",
     "resources": {
         "homepage": "http://kerbokatz.github.io/#CraftHistory",

--- a/NetKAN/CustomBulkheadProfiles.netkan
+++ b/NetKAN/CustomBulkheadProfiles.netkan
@@ -7,8 +7,6 @@
     "$kref":        "#/ckan/ksp-avc/http://taniwha.org/~bill/CustomBulkheadProfiles.version",
     "$vref":        "#/ckan/ksp-avc",
     "ksp_version_min": "1.8",
-    "x_netkan_staging":        true,
-    "x_netkan_staging_reason": "Double check that the game version compatibility is still correct",
     "license":      "GPL-3.0",
     "resources": {
         "homepage":   "https://forum.kerbalspaceprogram.com/index.php?showtopic=181645",

--- a/NetKAN/DMagicScienceAnimate.netkan
+++ b/NetKAN/DMagicScienceAnimate.netkan
@@ -5,8 +5,6 @@
     "abstract"     : "A replacement for ModuleScienceExperiment and ModuleAnimateGeneric",
     "$kref"        : "#/ckan/github/DMagic1/DMModuleScienceAnimateGeneric",
     "ksp_version_min": "1.8",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard-coded in netkan. Please confirm that it still matches the forum thread.",
     "license"      : "BSD-2-clause",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/65734-*"

--- a/NetKAN/DebugStuff.netkan
+++ b/NetKAN/DebugStuff.netkan
@@ -17,8 +17,6 @@
         "plugin",
         "information"
     ],
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard coded in NetKAN. Please check that it matches the forum thread.",
     "x_netkan_override": [ {
         "version": "<1.6.0.0",
         "override": {

--- a/NetKAN/Interkosmos.frozen
+++ b/NetKAN/Interkosmos.frozen
@@ -3,8 +3,6 @@
     "identifier":   "Interkosmos",
     "$kref":        "#/ckan/github/AstroWell/Interkosmos",
     "ksp_version": "1.7.3",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game versions hard coded in netkan, please check that they still match the forum thread",
     "license":      "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/185337-*"

--- a/NetKAN/KerboKatzSmallUtilities-DailyFunds.netkan
+++ b/NetKAN/KerboKatzSmallUtilities-DailyFunds.netkan
@@ -6,8 +6,6 @@
     "author"        : [ "SpaceTiger", "SpaceKitty" ],
     "$kref"         : "#/ckan/github/Xarun/SmallUtilities/asset_match/SmallUtilities.DailyFunds.zip",
     "ksp_version"   : "1.8",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard-coded in netkan. Please check that it still matches the forum thread.",
     "license"       : "restricted",
     "resources": {
         "homepage": "http://kerbokatz.github.io/",

--- a/NetKAN/KerboKatzSmallUtilities-DestroyAll.netkan
+++ b/NetKAN/KerboKatzSmallUtilities-DestroyAll.netkan
@@ -6,8 +6,6 @@
     "author"        : [ "SpaceTiger", "SpaceKitty" ],
     "$kref"         : "#/ckan/github/Xarun/SmallUtilities/asset_match/SmallUtilities.DestroyAll.zip",
     "ksp_version"   : "1.8",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard-coded in netkan. Please check that it still matches the forum thread.",
     "license"       : "restricted",
     "resources": {
         "homepage": "http://kerbokatz.github.io/",

--- a/NetKAN/KerboKatzSmallUtilities-FPSLimiter.netkan
+++ b/NetKAN/KerboKatzSmallUtilities-FPSLimiter.netkan
@@ -6,8 +6,6 @@
     "$kref"         : "#/ckan/github/Xarun/SmallUtilities/asset_match/SmallUtilities.FPSLimiter.zip",
     "author"        : [ "SpaceTiger", "SpaceKitty" ],
     "ksp_version"   : "1.8",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard-coded in netkan. Please check that it still matches the forum thread.",
     "license"       : "restricted",
     "resources": {
         "homepage": "http://kerbokatz.github.io/",

--- a/NetKAN/KerboKatzSmallUtilities-FPSViewer.netkan
+++ b/NetKAN/KerboKatzSmallUtilities-FPSViewer.netkan
@@ -6,8 +6,6 @@
     "author"        : [ "SpaceTiger", "SpaceKitty" ],
     "$kref"         : "#/ckan/github/Xarun/SmallUtilities/asset_match/SmallUtilities.FPSViewer.zip",
     "ksp_version"   : "1.8",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard-coded in netkan. Please check that it still matches the forum thread.",
     "license"       : "restricted",
     "resources": {
         "homepage": "http://kerbokatz.github.io/",

--- a/NetKAN/KerboKatzSmallUtilities-KerbalScienceExchange.netkan
+++ b/NetKAN/KerboKatzSmallUtilities-KerbalScienceExchange.netkan
@@ -6,8 +6,6 @@
     "author"        : [ "SpaceTiger", "SpaceKitty" ],
     "$kref"         : "#/ckan/github/Xarun/SmallUtilities/asset_match/SmallUtilities.KerbalScienceExchange.zip",
     "ksp_version"   : "1.8",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard-coded in netkan. Please check that it still matches the forum thread.",
     "license"       : "restricted",
     "resources": {
         "homepage": "http://kerbokatz.github.io/",

--- a/NetKAN/KerboKatzSmallUtilities-ModifiedExplosionPotential.netkan
+++ b/NetKAN/KerboKatzSmallUtilities-ModifiedExplosionPotential.netkan
@@ -6,8 +6,6 @@
     "author"        : [ "SpaceTiger", "SpaceKitty" ],
     "$kref"         : "#/ckan/github/Xarun/SmallUtilities/asset_match/SmallUtilities.ModifiedExplosionPotential.zip",
     "ksp_version"   : "1.8",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard-coded in netkan. Please check that it still matches the forum thread.",
     "license"       : "restricted",
     "resources": {
         "homepage": "http://kerbokatz.github.io/",

--- a/NetKAN/KerboKatzSmallUtilities-PhysicalTimeRatioViewer.netkan
+++ b/NetKAN/KerboKatzSmallUtilities-PhysicalTimeRatioViewer.netkan
@@ -6,8 +6,6 @@
     "author"        : [ "SpaceTiger", "SpaceKitty" ],
     "$kref"         : "#/ckan/github/Xarun/SmallUtilities/asset_match/SmallUtilities.PhysicalTimeRatioViewer.zip",
     "ksp_version"   : "1.8",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard-coded in netkan. Please check that it still matches the forum thread.",
     "license"       : "restricted",
     "resources": {
         "homepage": "http://kerbokatz.github.io/",

--- a/NetKAN/KerboKatzSmallUtilities-RecoverAll.netkan
+++ b/NetKAN/KerboKatzSmallUtilities-RecoverAll.netkan
@@ -6,8 +6,6 @@
     "author"        : [ "SpaceTiger", "SpaceKitty" ],
     "$kref"         : "#/ckan/github/Xarun/SmallUtilities/asset_match/SmallUtilities.RecoverAll.zip",
     "ksp_version"   : "1.8",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard-coded in netkan. Please check that it still matches the forum thread.",
     "license"       : "restricted",
     "resources": {
         "homepage": "http://kerbokatz.github.io/",

--- a/NetKAN/KerboKatzSmallUtilities.netkan
+++ b/NetKAN/KerboKatzSmallUtilities.netkan
@@ -6,8 +6,6 @@
     "author"        : [ "SpaceTiger", "SpaceKitty" ],
     "$kref"         : "#/ckan/github/Xarun/SmallUtilities/asset_match/SmallUtilities.zip",
     "ksp_version"   : "1.8",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard-coded in netkan. Please check that it still matches the forum thread.",
     "license"       : "restricted",
     "resources": {
         "homepage": "http://kerbokatz.github.io/",

--- a/NetKAN/KerboKatzUtilities.netkan
+++ b/NetKAN/KerboKatzUtilities.netkan
@@ -6,8 +6,6 @@
     "author"        : [ "SpaceTiger", "SpaceKitty" ],
     "$kref"         : "#/ckan/github/Xarun/KerboKatzUtilities",
     "ksp_version"   : "1.8",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard-coded in netkan. Please check that it still matches the forum thread.",
     "license"       : "restricted",
     "resources": {
         "homepage": "http://kerbokatz.github.io/",

--- a/NetKAN/Kerbulator.netkan
+++ b/NetKAN/Kerbulator.netkan
@@ -5,8 +5,6 @@
     "abstract"     : "Calculator plugin for Kerbal Space Program",
     "$kref"        : "#/ckan/github/wmvanvliet/Kerbulator",
     "ksp_version"  : "1.4",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard coded in netkan, check that it matches the forum thread",
     "license"      : "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/62988-*"

--- a/NetKAN/MechJeb2.netkan
+++ b/NetKAN/MechJeb2.netkan
@@ -20,8 +20,6 @@
         "control"
     ],
     "ksp_version": "1.8",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game versions hard coded in NetKAN. Please check that it matches the forum thread.",
     "install": [
         {
             "find": "MechJeb2",

--- a/NetKAN/ModuleManager.netkan
+++ b/NetKAN/ModuleManager.netkan
@@ -11,8 +11,6 @@
     "x_netkan_version_edit": "^ModuleManager-(?<version>\\d+\\.\\d+\\.\\d+)\\.zip$",
     "ksp_version_min": "1.8.0",
     "ksp_version_max": "1.8.90",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game versions hard coded in netkan, please make sure they still match the forum thread",
     "license": "CC-BY-SA",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/50533-*",

--- a/NetKAN/NewTantares.netkan
+++ b/NetKAN/NewTantares.netkan
@@ -6,8 +6,6 @@
     "author"       : "Beale",
     "$kref"        : "#/ckan/github/Tantares/Tantares",
     "ksp_version"  : "1.8",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game versions hard coded in netkan, please check that they match the forum thread",
     "license"      : "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/73686-Tantares"

--- a/NetKAN/NewTantaresLV.netkan
+++ b/NetKAN/NewTantaresLV.netkan
@@ -6,8 +6,6 @@
     "author"       : "Beale",
     "$kref"        : "#/ckan/github/Tantares/TantaresLV",
     "ksp_version"  : "1.8",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game versions hard coded in netkan, please check that they match the forum thread",
     "license"      : "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/73686-Tantares"

--- a/NetKAN/ProjectManager.netkan
+++ b/NetKAN/ProjectManager.netkan
@@ -3,8 +3,6 @@
     "identifier":   "ProjectManager",
     "$kref":        "#/ckan/github/Tantares/ProjectManager",
     "ksp_version_min": "1.8",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard-coded in netkan. Please confirm it still matches the forum thread.",
     "license":      "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/184785-*"

--- a/NetKAN/RoverWheelSounds.netkan
+++ b/NetKAN/RoverWheelSounds.netkan
@@ -6,8 +6,6 @@
     "ksp_version_min": "1.2",
     "ksp_version_max": "1.5",
     "x_netkan_version_edit": "^[vV]?(?<version>.+)$",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game versions hard coded in NetKAN due to syntax error in version file. Please check that it matches the forum thread.",
     "license":      "GPL-2.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/50431-*"

--- a/NetKAN/SDHI-ServiceModuleSystem.netkan
+++ b/NetKAN/SDHI-ServiceModuleSystem.netkan
@@ -6,8 +6,6 @@
     "$kref"        : "#/ckan/github/sumghai/SDHI_ServiceModuleSystem",
     "ksp_version_min": "1.7",
     "ksp_version_max": "1.8",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game versions hard coded in NetKAN. Please check that it matches the forum thread.",
     "x_netkan_force_v": true,
     "license"      : "CC-BY-SA-4.0",
     "resources"    : {

--- a/NetKAN/SDHI-StrobeOMatic.netkan
+++ b/NetKAN/SDHI-StrobeOMatic.netkan
@@ -7,8 +7,6 @@
     "x_netkan_force_v": true,
     "ksp_version_min": "1.4",
     "ksp_version_max": "1.8",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard coded in netkan, check that it matches the forum thread",
     "license"      : "CC-BY-SA-4.0",
     "resources"    : {
         "homepage"   : "http://forum.kerbalspaceprogram.com/index.php?/topic/137804-*",

--- a/NetKAN/SeparatorDestroyer.netkan
+++ b/NetKAN/SeparatorDestroyer.netkan
@@ -3,8 +3,6 @@
     "identifier":   "SeparatorDestroyer",
     "$kref":        "#/ckan/spacedock/1379",
     "ksp_version":  "1.3",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Game version hard coded in netkan. Please check that it matches the forum thread.",
     "license":      "public-domain",
     "tags": [
         "plugin",


### PR DESCRIPTION
These netkans had staging enabled due to hard coded compatibility info.

After KSP-CKAN/CKAN#2970, the Inflator will do this automatically, so it no longer needs to be in the metadata.