### PR TITLE
Update RSS-Textures compatibility

### DIFF
--- a/NetKAN/RSSTextures2048.netkan
+++ b/NetKAN/RSSTextures2048.netkan
@@ -6,8 +6,7 @@
     "abstract"        : "Textures for Real Solar Systems",
     "license"         : "CC-BY-NC-SA",
     "release_status"  : "stable",
-    "ksp_version_min" : "1.3.0",
-    "ksp_version_max" : "1.7",
+    "ksp_version_min" : "1.3.1",
     "resources": {
         "repository" : "https://github.com/KSP-RO/RSS-Textures",
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177216-*"

--- a/NetKAN/RSSTextures4096.netkan
+++ b/NetKAN/RSSTextures4096.netkan
@@ -6,8 +6,7 @@
     "abstract"        : "Textures for Real Solar Systems",
     "license"         : "CC-BY-NC-SA",
     "release_status"  : "stable",
-    "ksp_version_min" : "1.3.0",
-    "ksp_version_max" : "1.7",
+    "ksp_version_min" : "1.3.1",
     "resources": {
         "repository" : "https://github.com/KSP-RO/RSS-Textures",
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177216-*"

--- a/NetKAN/RSSTextures8192.netkan
+++ b/NetKAN/RSSTextures8192.netkan
@@ -6,8 +6,7 @@
     "abstract"        : "Textures for Real Solar Systems",
     "license"         : "CC-BY-NC-SA",
     "release_status"  : "stable",
-    "ksp_version_min" : "1.3.0",
-    "ksp_version_max" : "1.7",
+    "ksp_version_min" : "1.3.1",
     "resources": {
         "repository" : "https://github.com/KSP-RO/RSS-Textures",
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177216-*"


### PR DESCRIPTION
The README.txt says:

```
Real Solar System Texture pack (DDS Edition) for KSP 1.3.1+ (RSS-Kopernicus)
```

Currently we have it as 1.3.0–1.7.

Now the lower bound is 1.3.1 and the upper bound us unlimited.