### PR TITLE
Add JNSQ-RibbonPack

### DIFF
--- a/NetKAN/JNSQ-RibbonPack.netkan
+++ b/NetKAN/JNSQ-RibbonPack.netkan
@@ -1,0 +1,24 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "JNSQ-RibbonPack",
+    "name":         "JNSQ Ribbon Pack",
+    "abstract":     "Final Frontier Ribbons for JNSQ",
+    "$kref":        "#/ckan/github/Galileo88/JNSQ/asset_match/JNSQ_FinalFrontier\\.zip",
+    "ksp_version":  "any",
+    "license":      "CC-BY-NC-ND-3.0",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/184880-*"
+    },
+    "tags": [
+        "graphics",
+        "crewed"
+    ],
+    "install": [ {
+        "find":       "Nereid",
+        "install_to": "GameData"
+    } ],
+    "depends": [
+        { "name": "JNSQ"          },
+        { "name": "FinalFrontier" }
+    ]
+}


### PR DESCRIPTION
## Problem

#7264 added JNSQ, but if you install it alongside FinalFrontier, you'll get 263 errors like this:

```
[ERR 20:25:03.335] FF: cannot find image file '/media/DataTrove/Games/KSP-1.8.1/KSP_Data/../GameData/Nereid/FinalFrontier/Ribbons/Edna/SphereOfInfluence.png'
[ERR 20:25:03.337] FF: cannot find image file '/media/DataTrove/Games/KSP-1.8.1/KSP_Data/../GameData/Nereid/FinalFrontier/Ribbons/Edna/OrbitCapsule.png'
[ERR 20:25:03.337] FF: cannot find image file '/media/DataTrove/Games/KSP-1.8.1/KSP_Data/../GameData/Nereid/FinalFrontier/Ribbons/Edna/EvaSpace.png'
[ERR 20:25:03.338] FF: cannot find image file '/media/DataTrove/Games/KSP-1.8.1/KSP_Data/../GameData/Nereid/FinalFrontier/Ribbons/Edna/EvaOrbit.png'
[ERR 20:25:03.339] FF: cannot find image file '/media/DataTrove/Games/KSP-1.8.1/KSP_Data/../GameData/Nereid/FinalFrontier/Ribbons/Edna/OrbitCapsuleDocked.png'
[ERR 20:25:03.341] FF: cannot find image file '/media/DataTrove/Games/KSP-1.8.1/KSP_Data/../GameData/Nereid/FinalFrontier/Ribbons/Edna/Landing.png'
[ERR 20:25:03.343] FF: cannot find image file '/media/DataTrove/Games/KSP-1.8.1/KSP_Data/../GameData/Nereid/FinalFrontier/Ribbons/Edna/EvaGround.png'
[ERR 20:25:03.345] FF: cannot find image file '/media/DataTrove/Games/KSP-1.8.1/KSP_Data/../GameData/Nereid/FinalFrontier/Ribbons/Edna/PlantFlag.png'
[ERR 20:25:03.346] FF: cannot find image file '/media/DataTrove/Games/KSP-1.8.1/KSP_Data/../GameData/Nereid/FinalFrontier/Ribbons/Edna/Rover.png'
...
```

## Cause

FinalFrontier apparently looks for these files automatically based on the planet names. The JNSQ team created the files, but opted to put them in a separate ZIP (to save 832 KB from a download of 1.8 GB):

https://github.com/Galileo88/JNSQ/releases/download/0.9.0/JNSQ_FinalFrontier.zip

## Changes

Now a new module JNSQ-RibbonPack installs these files. It depends on JNSQ and FinalFrontier.

JNSQ's suggestion of FinalFrontier should be replaced with JNSQ-RibbonPack, so you get the needed image files when installing. We will attempt that in a separate pull request because it has a metanetkan.