### PR TITLE
Remove version override for SpaceplaneCorrections

### DIFF
--- a/NetKAN/SpaceplaneCorrections.netkan
+++ b/NetKAN/SpaceplaneCorrections.netkan
@@ -14,13 +14,5 @@
 	"install": [ {
 		"file": "GameData/SPC",
 		"install_to": "GameData"
-	} ],
-	"x_netkan_override": [ {
-		"version": "v0.19",
-		"delete": ["ksp_version"],
-		"override": {
-			"ksp_version_min": "1.3",
-			"ksp_version_max": "1.3.99"
-		}
 	} ]
 }


### PR DESCRIPTION
The override limits it to KSP 1.3. This is long outdated, the SpaceDock entry now says 1.8.1.

This PR removes the override, so the version is pulled from SpaceDock. There's no AVC file present to use.

Not closing #7672 yet, there's another point open.