### PR TITLE
Clean up resource properties

### DIFF
--- a/NetKAN/AlternateResourcePanel.netkan
+++ b/NetKAN/AlternateResourcePanel.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version"   : "v1.4",
+    "spec_version"   : "v1.20",
     "identifier"     : "AlternateResourcePanel",
     "name"           : "Alternate Resource Panel",
     "abstract"       : "An alternate view of vessel resources plugin for Kerbal Space Program",
@@ -13,7 +13,7 @@
         "license": "https://github.com/TriggerAu/AlternateResourcePanel/blob/master/LICENSE",
         "repository": "https://github.com/TriggerAu/AlternateResourcePanel",
         "manual": "https://sites.google.com/site/kspalternateresourcepanel/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220649-alternate-resource-panel"
     },
     "tags": [
         "plugin",

--- a/NetKAN/BananaForScale-large.netkan
+++ b/NetKAN/BananaForScale-large.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version" : "v1.4",
+    "spec_version" : "v1.20",
     "identifier"   : "BananaForScale-large",
     "name"         : "Banana for Scale - large",
     "abstract"     : "Banana for Scale - Analyse bananas in space!",
@@ -10,7 +10,7 @@
     "x_maintained" : "hakan42 - who loves bananas in space",
     "license"      : "restricted",
     "resources": {
-        "x_curse"  : "http://kerbal.curseforge.com/ksp-mods/223077-banana-for-scale",
+        "curse"  : "http://kerbal.curseforge.com/ksp-mods/223077-banana-for-scale",
         "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/80802-*"
     },
     "tags": [

--- a/NetKAN/BananaForScale-small.netkan
+++ b/NetKAN/BananaForScale-small.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version" : "v1.4",
+    "spec_version" : "v1.20",
     "identifier"   : "BananaForScale-small",
     "name"         : "Banana for Scale - small",
     "abstract"     : "Banana for Scale - Analyse bananas in space!",
@@ -10,7 +10,7 @@
     "x_maintained" : "hakan42 - who loves bananas in space",
     "license"      : "restricted",
     "resources": {
-        "x_curse"  : "http://kerbal.curseforge.com/ksp-mods/223077-banana-for-scale",
+        "curse"  : "http://kerbal.curseforge.com/ksp-mods/223077-banana-for-scale",
         "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/80802-*"
     },
     "tags": [

--- a/NetKAN/BoxSat-prototypes.netkan
+++ b/NetKAN/BoxSat-prototypes.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier":   "BoxSat-prototypes",
     "name":         "BoxSat prototype parts",
     "abstract":     "A modular, stackable, serviceable, & customizable satellite in a box!",
@@ -11,7 +11,7 @@
     "release_status": "development",
     "license":      "restricted",
     "resources": {
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat",
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/82643-*"
     },
     "tags": [

--- a/NetKAN/BoxSat.netkan
+++ b/NetKAN/BoxSat.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier":   "BoxSat",
     "name":         "BoxSat",
     "abstract":     "A modular, stackable, serviceable, & customizable satellite in a box!",
@@ -10,7 +10,7 @@
     "ksp_version_max": "1.0.5",
     "license":      "restricted",
     "resources": {
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat",
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/82643-*"
     },
     "tags": [

--- a/NetKAN/EntchenFlag.netkan
+++ b/NetKAN/EntchenFlag.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version" : 1,
+    "spec_version" : "v1.20",
     "identifier"   : "EntchenFlag",
     "name"         : "Entchen Flag",
     "abstract"     : "Official Flag of the Rubber Duck Empire",
@@ -8,7 +8,7 @@
     "license"      : "CC-BY",
     "comment"      : "flagmod",
     "resources": {
-        "x_curse": "http://kerbal.curseforge.com/shareables/220234-*"
+        "curse": "http://kerbal.curseforge.com/shareables/220234-*"
     },
     "tags": [
         "flags"

--- a/NetKAN/FMRS.frozen
+++ b/NetKAN/FMRS.frozen
@@ -11,7 +11,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/72605-110-flight-manager-for-reusable-stages-fmrs-x110-experimental/",
         "repository": "https://github.com/SIT89/FMRS",
-        "x_preview": "http://i.imgur.com/gTgNAPj.png?1"
+        "x_screenshot": "http://i.imgur.com/gTgNAPj.png?1"
     },
     "depends": [
         { "name": "ModuleManager" }

--- a/NetKAN/HGR-Props.frozen
+++ b/NetKAN/HGR-Props.frozen
@@ -1,12 +1,12 @@
 {
-    "spec_version"   : "v1.4",
+    "spec_version"   : "v1.20",
     "name"           : "HGR Props",
     "$kref"          : "#/ckan/kerbalstuff/869",
     "identifier"     : "HGR-Props",
     "license"        : "restricted",
     "resources" : {
         "homepage"     : "https://forum.kerbalspaceprogram.com/index.php?/topic/55521-102hgr-1875m-partsv130-released/",
-        "x_curse"      : "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts"
+        "curse"      : "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts"
     },
     "install" : [
         {

--- a/NetKAN/HGR.netkan
+++ b/NetKAN/HGR.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier"  : "HGR",
     "name"        : "HGR 1.875m Parts",
     "abstract"    : "A set of 1.875m parts to fill the gap between the basic and Rockomax size parts",
@@ -10,7 +10,7 @@
     "license"     : "restricted",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/55521-*",
-        "x_curse" : "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts"
+        "curse" : "http://kerbal.curseforge.com/ksp-mods/222583-hgr-875m-parts"
     },
     "tags": [
         "parts"

--- a/NetKAN/HullcamVDS.frozen
+++ b/NetKAN/HullcamVDS.frozen
@@ -1,11 +1,11 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier": "HullcamVDS",
     "x_netkan_license_ok": true,
     "$kref": "#/ckan/kerbalstuff/450",
     "license"        : "LGPL-3.0",
     "resources" : {
-        "x_curse"  : "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds"
+        "curse"  : "http://kerbal.curseforge.com/ksp-mods/220258-hullcam-vds"
     },
     "install" : [
         {

--- a/NetKAN/KSPTips.frozen
+++ b/NetKAN/KSPTips.frozen
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "$kref": "#/ckan/kerbalstuff/416",
     "name": "KSP Tips",
     "identifier": "KSPTips",
@@ -12,7 +12,7 @@
         "license": "https://github.com/TriggerAu/KSPTips/blob/master/LICENSE",
         "repository": "https://github.com/TriggerAu/KSPTips",
         "kerbalstuff": "https://kerbalstuff.com/mod/416/KSP%20Tips",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/226245-ksp-tips"
     },
     "x_netkan_license_ok": true
 }

--- a/NetKAN/KerbalAdventure.frozen
+++ b/NetKAN/KerbalAdventure.frozen
@@ -1,10 +1,10 @@
 {
-    "spec_version" : 1,
+    "spec_version" : "v1.20",
     "identifier"   : "KerbalAdventure",
     "$kref"        : "#/ckan/kerbalstuff/390",
     "license"      : "CC-BY-NC-SA-3.0",
     "resources": {
-        "x_curse": "http://www.curse.com/ksp-mods/kerbal/225951-kerbal-adventure"
+        "curse": "http://www.curse.com/ksp-mods/kerbal/225951-kerbal-adventure"
     },
     "install": [
         {

--- a/NetKAN/KerbalAlarmClock.netkan
+++ b/NetKAN/KerbalAlarmClock.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "$kref": "#/ckan/github/TriggerAu/KerbalAlarmClock",
     "$vref": "#/ckan/ksp-avc",
     "name": "Kerbal Alarm Clock",
@@ -13,7 +13,7 @@
         "license": "https://github.com/TriggerAu/KerbalAlarmClock/blob/master/LICENSE",
         "repository"   : "https://github.com/TriggerAu/KerbalAlarmClock",
         "manual": "http://triggerau.github.io/KerbalAlarmClock/",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220289-kerbal-alarm-clock"
     },
     "tags": [
         "plugin",

--- a/NetKAN/Mk2Essentials.frozen
+++ b/NetKAN/Mk2Essentials.frozen
@@ -1,5 +1,5 @@
 {
-	"spec_version" : 1,
+	"spec_version" : "v1.20",
 	"identifier" : "Mk2Essentials",
 	"name" : "Mk 2 Essentials",
 	"abstract" : "Some Mk2 parts which I felt were missing from the game",
@@ -12,7 +12,7 @@
 	"resources" :
 	{
 		"homepage"	: "http://forum.kerbalspaceprogram.com/index.php?/topic/89875-104",
-		"x_curse"	: "http://kerbal.curseforge.com/ksp-mods/225706-mk2-essentials"
+		"curse"	: "http://kerbal.curseforge.com/ksp-mods/225706-mk2-essentials"
 	},
 	"install" : [
 		{

--- a/NetKAN/PartWizard.frozen
+++ b/NetKAN/PartWizard.frozen
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "$kref": "#/ckan/github/ozraven/PartWizard",
     "identifier": "PartWizard",
     "release_status": "stable",
@@ -12,7 +12,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/72468-11-part-wizard-124-20-apr-2016/",
         "repository": "https://github.com/ozraven/PartWizard",
-        "x_curse": "http://kerbal.curseforge.com/projects/part-wizard"
+        "curse": "http://kerbal.curseforge.com/projects/part-wizard"
     },
     "suggests": [
         { "name": "Toolbar" }

--- a/NetKAN/ShipManifest.netkan
+++ b/NetKAN/ShipManifest.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier":   "ShipManifest",
     "abstract":     "Manages Crew, Science, & Resources on a given vessel.",
     "author":       "Papa_Joe",
@@ -10,7 +10,7 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/56643-*",
         "repository": "https://github.com/PapaJoesSoup/ShipManifest",
-        "x_curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
+        "curse": "http://kerbal.curseforge.com/plugins/220357-ship-manifest"
     },
     "tags": [
         "plugin",

--- a/NetKAN/StationScience.netkan
+++ b/NetKAN/StationScience.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.20",
     "identifier":   "StationScience",
     "name":         "Station Science",
     "abstract":     "Station Science mod adds several large parts designed to be integrated into a permanent space station.",
@@ -11,7 +11,7 @@
     "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/50145-*",
-        "x_curse": "http://kerbal.curseforge.com/ksp-mods/220216",
+        "curse": "http://kerbal.curseforge.com/ksp-mods/220216",
         "x_preview": "http://i.imgur.com/63DTlDLl.png"
     },
     "tags": [

--- a/NetKAN/StationScience.netkan
+++ b/NetKAN/StationScience.netkan
@@ -12,7 +12,7 @@
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/50145-*",
         "curse": "http://kerbal.curseforge.com/ksp-mods/220216",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "tags": [
         "parts",

--- a/NetKAN/StationScienceContinued.netkan
+++ b/NetKAN/StationScienceContinued.netkan
@@ -12,7 +12,7 @@
     "license":      "restricted",
     "resources": {
         "homepage":  "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-*",
-        "x_preview": "http://i.imgur.com/63DTlDLl.png"
+        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
     },
     "tags": [
         "parts",

--- a/NetKAN/StationScienceContinued.netkan
+++ b/NetKAN/StationScienceContinued.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier":   "StationScienceContinued",
     "name":         "Station Science Continued",
     "abstract":     "Station Science mod adds several large parts designed to be integrated into a permanent space station.",

--- a/NetKAN/TransferWindowPlanner.netkan
+++ b/NetKAN/TransferWindowPlanner.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.20",
     "identifier": "TransferWindowPlanner",
     "$kref": "#/ckan/github/TriggerAu/TransferWindowPlanner",
     "$vref": "#/ckan/ksp-avc",
@@ -9,7 +9,7 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/84005-*",
         "license": "https://github.com/TriggerAu/TransferWindowPlanner/blob/master/LICENSE",
         "manual": "http://triggerau.github.io/TransferWindowPlanner/",
-        "x_curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
+        "curse": "http://kerbal.curseforge.com/projects/transfer-window-planner"
     },
     "tags": [
         "plugin",


### PR DESCRIPTION
I plan a feature in the client to display more resources in the mod info panel.
I wanted to see which resource types are actually used in the wild, and saw that there are `x_curse` and `x_preview` additional to `curse` and `x_screenshot`.
`curse` is proper part of the spec, `x_screenshot` not entirely (it's not mentioned in the list of allowed resources, but occurs in other places), but widely used. The spec could also need an update.

CKAN-meta has more to offer, a PR for it will follow.

## Changes
I replaced every `x_curse` with `curse` and `x_preview` with `x_screenshot`.

before:
```
843 "homepage"
245 "repository"
59  "bugtracker"
17  "x_curse"
17  "kerbalstuff"
11  "x_screenshot"
9   "manual"
8   "spacedock"
8   "license"
3   "x_preview"
```
after:
```
843 "homepage"
245 "repository"
59  "bugtracker"
17  "curse"
17  "kerbalstuff"
14  "x_screenshot"
9   "manual"
8   "license"
8   "spacedock"
```

When writing this description, I realized that I'll probably have to update some spec versions...