### PR TITLE
SmokeScreen - set compatibility with 1.8 and 1.9

### DIFF
--- a/NetKAN/SmokeScreen.netkan
+++ b/NetKAN/SmokeScreen.netkan
@@ -10,7 +10,7 @@
     },
     "x_netkan_version_edit": "^SmokeScreen-(?<version>\\d+\\.\\d+\\.\\d+\\.\\d+)\\.zip$",
     "ksp_version_min": "1.8.0",
-    "ksp_version_max": "1.8.90",
+    "ksp_version_max": "1.9.90",
     "license": "BSD-2-clause",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/64987-*",


### PR DESCRIPTION
SmokeScreen is compatible with both KSP version 1.8 and 1.9