### PR TITLE
Update AVP textures to 1.8 compat

### DIFF
--- a/NetKAN/AVP-2kTextures.netkan
+++ b/NetKAN/AVP-2kTextures.netkan
@@ -5,7 +5,7 @@
     "abstract"       : "Textures for Astronomer's Visual pack",
     "comment"        : "Textures only",
     "$kref"          : "#/ckan/github/themaster402/AstronomersVisualPack/asset_match/AVP_2kTextures.zip",
-    "ksp_version_min": "1.2",
+    "ksp_version_min": "1.8",
     "license"        : "LGPL-3.0",
     "release_status" : "stable",
     "resources": {

--- a/NetKAN/AVP-4kTextures.netkan
+++ b/NetKAN/AVP-4kTextures.netkan
@@ -5,7 +5,7 @@
     "abstract"       : "Textures for Astronomer's Visual pack",
     "comment"        : "Textures only",
     "$kref"          : "#/ckan/github/themaster402/AstronomersVisualPack/asset_match/AVP_4kTextures.zip",
-    "ksp_version_min": "1.2",
+    "ksp_version_min": "1.8",
     "license"        : "LGPL-3.0",
     "release_status" : "stable",
     "resources": {


### PR DESCRIPTION
See KSP-CKAN/CKAN-meta#1812 and KSP-CKAN/CKAN-meta#1813, these modules have a min game version of 1.2, but the forum thread says 1.8. Now the netkans are updated to match.