### PR TITLE
Spectra shouldn't provide Scatterer-config

### DIFF
--- a/NetKAN/Spectra.netkan
+++ b/NetKAN/Spectra.netkan
@@ -18,13 +18,11 @@
     "provides": [
         "PlanetShine-Config",
         "EnvironmentalVisualEnhancements-Config",
-        "Scatterer-config",
         "Scatterer-sunflare"
     ],
     "conflicts": [
         { "name": "PlanetShine-Config"                     },
         { "name": "EnvironmentalVisualEnhancements-Config" },
-        { "name": "Scatterer-config"                       },
         { "name": "Scatterer-sunflare"                     },
         { "name": "GreenSkullRevived"                      }
     ],


### PR DESCRIPTION
## Problem

https://forum.kerbalspaceprogram.com/index.php?/topic/159443-12-181-spectra-v124-visual-compilation-10th-february-20/&do=findComment&comment=3740161

> I found that Scatterer did not load properly with Spectra when I installed Scatterer from CKAN, but it did work when I installed manually.

https://forum.kerbalspaceprogram.com/index.php?/topic/159443-12-181-spectra-v124-visual-compilation-10th-february-20/&do=findComment&comment=3741753

> Spectra and Scatterer have been behaving weird with me when I installed via CKAN

## Cause

Currently Spectra provides Scatterer-config as of #7663, but it does not actually contain complete configs. Instead it uses a ModuleManager patch to modify the default configs. So when CKAN installs Spectra without Scatterer-config, some things are missing.

### Scatterer

![image](https://user-images.githubusercontent.com/1559108/74596696-55f86200-5018-11ea-86e0-2e1fce0c44c5.png)

![image](https://user-images.githubusercontent.com/1559108/74596698-5e509d00-5018-11ea-8188-1f427ca2e376.png)

### Spectra

![image](https://user-images.githubusercontent.com/1559108/74596703-70324000-5018-11ea-9a7d-fc522ec6d674.png)

![image](https://user-images.githubusercontent.com/1559108/74596706-7aecd500-5018-11ea-8230-eb4e2b68a3d1.png)

## Changes

Now Scatterer-config is removed from Spectra's provides and conflicts, so users can install a full config (presumably the default).