### PR TITLE
Fix WindowShineTR for new release

### DIFF
--- a/NetKAN/WindowShineTR.netkan
+++ b/NetKAN/WindowShineTR.netkan
@@ -1,42 +1,20 @@
 {
-	"spec_version": 1,
-	"identifier":   "WindowShineTR",
-	"name":         "WindowShine",
-	"abstract":     "Stock reflective windows and solar panels + mod support!",
-	"author":       "Avera9eJoe",
-	"$kref":        "#/ckan/spacedock/1504",
-	"license":      "CC-BY-NC-4.0",
-	"resources": {
-		"homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/110080-*"
-	},
-	"tags": [
-		"config",
-		"graphics"
-	],
-	"depends": [
-		{ "name": "TextureReplacerReplaced" },
-		{ "name": "ModuleManager" }
-	],
-	"install": [ {
-		"file": "GameData/WindowShine",
-		"install_to": "GameData"
-	} ],
-	"x_netkan_override": [ {
-		"version": "v15",
-		"delete": ["ksp_version"],
-		"override": {
-			"ksp_version_min": "1.3",
-			"ksp_version_max": "1.3.99"
-		}
-	}, {
-		"version": ["v11", "v12"],
-		"override": {
-			"depends": [ {
-				"name": "TextureReplacer"
-			},
-			{
-				"name": "ModuleManager"
-			} ]
-		}
-	} ]
+    "spec_version": "v1.4",
+    "identifier":   "WindowShineTR",
+    "name":         "WindowShine",
+    "abstract":     "Stock reflective windows and solar panels + mod support!",
+    "$kref":        "#/ckan/spacedock/1504",
+    "license":      "CC-BY-NC-4.0",
+    "tags": [
+        "config",
+        "graphics"
+    ],
+    "depends": [
+        { "name": "ModuleManager"   },
+        { "name": "TextureReplacer" }
+    ],
+    "install": [ {
+        "find":       "WindowShine",
+        "install_to": "GameData"
+    } ]
 }


### PR DESCRIPTION
The GameData folder is gone, and the dependency is back to TextureReplacer.
A few fields are removed so they can be sourced from SpaceDock.