### PR TITLE
Add ToolbarController and CTB dependency to UNDOCKINATOR

### DIFF
--- a/NetKAN/UNDOCKINATOR.netkan
+++ b/NetKAN/UNDOCKINATOR.netkan
@@ -4,6 +4,17 @@
     "$kref":        "#/ckan/spacedock/984",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "MIT",
+    "x_netkan_override":[
+       {
+          "version":">=1.1",
+          "override":{
+             "depends":[
+                { "name":"ToolbarController" },
+                { "name":"ClickThroughBlocker" }
+             ]
+          }
+       }
+    ],
     "tags": [
         "plugin",
         "convenience"

--- a/NetKAN/UNDOCKINATOR.netkan
+++ b/NetKAN/UNDOCKINATOR.netkan
@@ -4,16 +4,9 @@
     "$kref":        "#/ckan/spacedock/984",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "MIT",
-    "x_netkan_override":[
-       {
-          "version":">=1.1",
-          "override":{
-             "depends":[
-                { "name":"ToolbarController" },
-                { "name":"ClickThroughBlocker" }
-             ]
-          }
-       }
+    "depends":[
+       { "name":"ToolbarController" },
+       { "name":"ClickThroughBlocker" }
     ],
     "tags": [
         "plugin",


### PR DESCRIPTION
Hard dependency added in Undockinator 1.1.  Previous versions don't need it.

ckan compat add 1.8