### PR TITLE
Update kref for SmartActuation

### DIFF
--- a/NetKAN/SmartActuation.netkan
+++ b/NetKAN/SmartActuation.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier":   "SmartActuation",
-    "$kref":        "#/ckan/github/theRagingIrishman/SmartActuation",
+    "$kref":        "#/ckan/github/nagleaidan/SmartActuation",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "CC-BY-NC-SA",
     "resources": {
@@ -12,7 +12,7 @@
         "convenience"
     ],
     "install": [ {
-        "find": "SmartActuation",
+        "find":       "SmartActuation",
         "install_to": "GameData"
     } ]
 }


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/75261252-a58e1900-57e2-11ea-8ca9-db312c01e0b4.png)

## Cause

GitHub does that when you rename a repo or move it to another user name.

## Change

Now the current user name is used.