### PR TITLE
Don't provide Scatterer-sunflare and Scatterer-config with BeyondHome

### DIFF
--- a/NetKAN/BeyondHome.netkan
+++ b/NetKAN/BeyondHome.netkan
@@ -1,4 +1,4 @@
-{ 
+{
     "spec_version": "v1.4",
     "identifier":   "BeyondHome",
     "name":         "Beyond Home",
@@ -28,11 +28,9 @@
         { "name": "Scatterer"                       }
     ],
     "provides": [
-        "Scatterer-config",
-        "Scatterer-sunflare",
         "EnvironmentalVisualEnhancements-Config"
     ],
-    "install": [ { 
+    "install": [ {
         "find":       "BeyondHome",
         "install_to": "GameData"
     } ]


### PR DESCRIPTION
## Problem
@Gameslinx made me aware of this problem on the /r/KerbalSpaceProgram Discord.

> "BeyondHome.netkan" says it provides a scatterer config but it needs to recommend the Scatterer config
Essentially, BH depends on scatterer being fully installed (Not just the DLL, the configs and sunflares too) to work, but saying that I provide a config causes CKAN to ignore scatterer's configs and sunflares

Looking at BH's code, this is indeed the case. It provides the sunflares for the added suns, but [only modifies](https://github.com/Gameslinx/BeyondHomePlanetMod/blob/ee77c403349218de1de47b6e3b2e4dcf32cf7fa3/GameData/BeyondHome/scatterer/config/Sunflares/Sunflares.cfg#L127-L144) the one for the stock sun.

The included `config.cfg` is [commented out](https://github.com/Gameslinx/BeyondHomePlanetMod/blob/ee77c403349218de1de47b6e3b2e4dcf32cf7fa3/GameData/BeyondHome/scatterer/config/config.cfg) and the `planetsList.cfg` again [modifies](https://github.com/Gameslinx/BeyondHomePlanetMod/blob/ee77c403349218de1de47b6e3b2e4dcf32cf7fa3/GameData/BeyondHome/scatterer/config/planetsList.cfg#L1-L5) default scatterer config.

## Changes
BeyondHome now no longer provides `Scatterer-config` and `Scatterer-sunflare`.
It recommends Scatterer as before, and if somebody decides to install Scatterer, the default config+sunflare are pulled in.