### PR TITLE
Fix PersistentRotation install

### DIFF
--- a/NetKAN/PersistentRotation.netkan
+++ b/NetKAN/PersistentRotation.netkan
@@ -2,7 +2,6 @@
     "spec_version": "v1.4",
     "identifier":   "PersistentRotation",
     "$kref":        "#/ckan/spacedock/447",
-    "$vref":        "#/ckan/ksp-avc",
     "license":      "GPL-3.0",
     "tags": [
         "plugin",

--- a/NetKAN/PersistentRotation.netkan
+++ b/NetKAN/PersistentRotation.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "PersistentRotation",
     "$kref":        "#/ckan/spacedock/447",
+    "$vref":        "#/ckan/ksp-avc",
     "license":      "GPL-3.0",
     "tags": [
         "plugin",

--- a/NetKAN/PersistentRotation.netkan
+++ b/NetKAN/PersistentRotation.netkan
@@ -12,7 +12,7 @@
     ],
     "install": [
         {
-            "file":       "PersistentRotation/GameData/PersistentRotation",
+            "file":       "GameData/PersistentRotation",
             "install_to": "GameData"
         }
     ],


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/75566773-3580cc80-5a48-11ea-9459-5a54cb2c8dcf.png)

## Cause

The outer `PersistentRotation` folder is absent in the latest release.

## Change

Now we just look for `GameData/PersistentRotation`.
~~Also it has a version file, so a vref is added.~~