### PR TITLE
Fix SpacedocksRedeployed install

### DIFF
--- a/NetKAN/SpacedocksRedeployed.netkan
+++ b/NetKAN/SpacedocksRedeployed.netkan
@@ -10,5 +10,8 @@
     "install": [ {
         "find":       "SpaceDockReBoxed",
         "install_to": "GameData"
-    } ]
+    } ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ]
 }

--- a/NetKAN/SpacedocksRedeployed.netkan
+++ b/NetKAN/SpacedocksRedeployed.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "SpacedocksRedeployed",
     "$kref":        "#/ckan/spacedock/1585",
+    "$vref":        "#/ckan/ksp-avc",
     "license":      "CC-BY-NC-SA-4.0",
     "tags": [
         "parts"

--- a/NetKAN/SpacedocksRedeployed.netkan
+++ b/NetKAN/SpacedocksRedeployed.netkan
@@ -7,7 +7,7 @@
         "parts"
     ],
     "install": [ {
-        "find":       "SpaceDock",
+        "find":       "SpaceDockReBoxed",
         "install_to": "GameData"
     } ]
 }


### PR DESCRIPTION
ZIP file structure changed, and there's a version file, and it uses ModuleManager syntax in some of the cfg files.