### PR TITLE
Conflict with InfernalRobotics-LegacyParts

### DIFF
--- a/NetKAN/InfernalRoboticsRealismOverhaul.netkan
+++ b/NetKAN/InfernalRoboticsRealismOverhaul.netkan
@@ -13,7 +13,8 @@
         "InfernalRobotics"
     ],
     "conflicts": [
-        { "name": "InfernalRobotics" }
+        { "name": "InfernalRobotics"             },
+        { "name": "InfernalRobotics-LegacyParts" }
     ],
     "depends": [
         { "name": "ModuleManager" }


### PR DESCRIPTION
```
GameData/MagicSmokeIndustries/Parts/Legacy/IR_Gantry/gantrynorm.dds
Installing Mod : InfernalRoboticsRealismOverhaul 2.2.0
Owning Mod: InfernalRobotics-LegacyParts
CKAN Version   : v1.27.0
Your GameData has been returned to its original state.
Error during installation!
An unknown error occurred, please try again!
```

Now there's an explicit conflict relation between these mods.
Fixes #7747.