### PR TITLE
Update ScottManleyHeadPack repo

### DIFF
--- a/NetKAN/ScottManleyHeadPack.netkan
+++ b/NetKAN/ScottManleyHeadPack.netkan
@@ -4,7 +4,7 @@
     "name":         "Scott Manley Head Pack",
     "abstract":     "Are you tired of not having Scott Manley in game? Are you tired of not looking at his pretty face while you playing KSP? ENOUGH! NOW YOU CAN LOOK AT HIM AS MUCH AS YOU WANT! Download our Scott Manley Head Pack today and get 50% more Scott!!!",
     "author":       [ "Potatto", "HebaruSan", "Messierr" ],
-    "$kref":        "#/ckan/github/messierr/SMHPContinued",
+    "$kref":        "#/ckan/github/heirloom27/SMHPContinued",
     "license":      "CC-BY-SA-4.0",
     "ksp_version_min": "1.4",
     "ksp_version_max": "1.7",
@@ -17,7 +17,7 @@
         "crewed"
     ],
     "depends": [
-        { "name": "DiRT"          }
+        { "name": "DiRT" }
     ],
     "install": [ {
         "find":       "SMHPContinued",


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/75825485-60975300-5d9d-11ea-95f8-180b9817dc86.png)

## Cause

The GitHub API does this when we access a repo that has moved.
Click here:

- http://github.com/messierr/SMHPContinued

It goes here:

- https://github.com/heirloom27/SMHPContinued

## Changes

Now the current repo name is used.