### PR TITLE
Fix SolarScience install

### DIFF
--- a/NetKAN/SolarScience.netkan
+++ b/NetKAN/SolarScience.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "SolarScience",
     "$kref":        "#/ckan/spacedock/811",
+    "$vref":        "#/ckan/ksp-avc",
     "x_netkan_force_v": true,
     "license":      "MIT",
     "tags": [

--- a/NetKAN/SolarScience.netkan
+++ b/NetKAN/SolarScience.netkan
@@ -4,14 +4,8 @@
     "$kref":        "#/ckan/spacedock/811",
     "x_netkan_force_v": true,
     "license":      "MIT",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/142647-*"
-    },
     "tags": [
         "parts",
         "science"
-    ],
-    "install": [
-        { "find": "Solar Science", "install_to": "GameData" }
     ]
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/76981746-e933f880-6932-11ea-83f4-544fe96c3a89.png)

Folder structure changed.
Also we can pull the homepage from SpaceDock.
And it has a version file now.