### PR TITLE
Undelete RoutineMissionManager's license

### DIFF
--- a/NetKAN/RoutineMissionManager.netkan
+++ b/NetKAN/RoutineMissionManager.netkan
@@ -3,7 +3,7 @@
     "identifier":   "RoutineMissionManager",
     "$kref":        "#/ckan/spacedock/362",
     "$vref":        "#/ckan/ksp-avc",
-    "license":      "BSD-3-clause",
+    "license":      "BSD-2-clause",
     "tags": [
         "plugin",
         "career",

--- a/NetKAN/RoutineMissionManager.netkan
+++ b/NetKAN/RoutineMissionManager.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "RoutineMissionManager",
     "$kref":        "#/ckan/spacedock/362",
-	"$vref":        "#/ckan/ksp-avc",
+    "$vref":        "#/ckan/ksp-avc",
     "license":      "BSD-3-clause",
     "tags": [
         "plugin",

--- a/NetKAN/RoutineMissionManager.netkan
+++ b/NetKAN/RoutineMissionManager.netkan
@@ -1,25 +1,23 @@
 {
     "spec_version": "v1.4",
-	"x_netkan_license_ok": true,
     "identifier":   "RoutineMissionManager",
     "$kref":        "#/ckan/spacedock/362",
 	"$vref":        "#/ckan/ksp-avc",
+    "license":      "BSD-3-clause",
     "tags": [
         "plugin",
         "career",
         "convenience"
     ],
-    "install": [
-        {
-            "file"          : "GameData/RoutineMissionManager",
-            "install_to"    : "GameData",
-            "filter_regexp" : "Licences and Source"
-        }
-    ],
+    "install": [ {
+        "file"          : "GameData/RoutineMissionManager",
+        "install_to"    : "GameData",
+        "filter_regexp" : "Licences and Source"
+    } ],
     "depends" : [
-        { "name" : "ModuleManager" },
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
+        { "name": "ModuleManager" },
+        { "name": "ToolbarController" },
+        { "name": "ClickThroughBlocker" }
     ],
 	"x_netkan_epoch": "1"
 }


### PR DESCRIPTION
#7778 replaced this mod's license with `"x_netkan_license_ok": true,` for unspecified reasons.
Now the license is back.