### PR TITLE
vref for SimpleLogistics

### DIFF
--- a/NetKAN/SimpleLogistics.netkan
+++ b/NetKAN/SimpleLogistics.netkan
@@ -3,6 +3,7 @@
     "identifier":   "SimpleLogistics",
     "author":       [ "RealGecko", "zer0Kerbal" ],
     "$kref":        "#/ckan/spacedock/2312",
+    "$vref":        "#/ckan/ksp-avc",
     "license":      "GPL-3.0",
      "tags": [
        "plugin",


### PR DESCRIPTION
While investigating a hash mismatch for this mod...

https://forum.kerbalspaceprogram.com/index.php?/topic/191045-181-simplelogistics-2032-deployable-serenity-2020-03-20/&do=findComment&comment=3759431

... I noticed it has a version file but no vref. Now a vref is added, which also ought to update the hash.