### PR TITLE
Add Long March mods from SpaceDock

### DIFF
--- a/NetKAN/LongMarch11CZ11.netkan
+++ b/NetKAN/LongMarch11CZ11.netkan
@@ -15,8 +15,16 @@
         "filter":     [ "Assets", "Flags", "FX", "Icons", "WanhuTools.dll", "WanhuCategory.cfg" ],
         "filter_regexp": [ ".*\\.craft$" ]
     }, {
-        "find_regexp": ".*\\.craft$",
+        "find":       "CZ-11.craft",
         "find_matches_files": true,
-        "install_to":  "Ships/VAB"
+        "install_to": "Ships/VAB"
+    }, {
+        "find":       "CZ-11-StyleA.craft",
+        "find_matches_files": true,
+        "install_to": "Ships/VAB"
+    }, {
+        "find":       "CZ-11-StyleB.craft",
+        "find_matches_files": true,
+        "install_to": "Ships/VAB"
     } ]
 }

--- a/NetKAN/LongMarch11CZ11.netkan
+++ b/NetKAN/LongMarch11CZ11.netkan
@@ -1,0 +1,7 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "LongMarch11CZ11",
+    "$kref": "#/ckan/spacedock/2362",
+    "license": "CC-BY-NC-ND-4.0",
+    "x_via": "Automated SpaceDock CKAN submission"
+}

--- a/NetKAN/LongMarch11CZ11.netkan
+++ b/NetKAN/LongMarch11CZ11.netkan
@@ -1,7 +1,13 @@
 {
     "spec_version": "v1.4",
-    "identifier": "LongMarch11CZ11",
-    "$kref": "#/ckan/spacedock/2362",
-    "license": "CC-BY-NC-ND-4.0",
-    "x_via": "Automated SpaceDock CKAN submission"
+    "identifier":   "LongMarch11CZ11",
+    "$kref":        "#/ckan/spacedock/2362",
+    "license":      "CC-BY-NC-ND-4.0",
+    "tags": [
+        "parts"
+    ],
+    "install": [ {
+        "find":       "Wanhu",
+        "install_to": "GameData"
+    } ]
 }

--- a/NetKAN/LongMarch11CZ11.netkan
+++ b/NetKAN/LongMarch11CZ11.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.16",
     "identifier":   "LongMarch11CZ11",
     "$kref":        "#/ckan/spacedock/2362",
     "license":      "CC-BY-NC-ND-4.0",
@@ -12,6 +12,11 @@
     "install": [ {
         "find":       "Wanhu",
         "install_to": "GameData",
-        "filter":     [ "Assets", "Flags", "FX", "Icons", "WanhuTools.dll", "WanhuCategory.cfg" ]
+        "filter":     [ "Assets", "Flags", "FX", "Icons", "WanhuTools.dll", "WanhuCategory.cfg" ],
+        "filter_regexp": [ ".*\\.craft$" ]
+    }, {
+        "find_regexp": ".*\\.craft$",
+        "find_matches_files": true,
+        "install_to":  "Ships/VAB"
     } ]
 }

--- a/NetKAN/LongMarch11CZ11.netkan
+++ b/NetKAN/LongMarch11CZ11.netkan
@@ -4,15 +4,14 @@
     "$kref":        "#/ckan/spacedock/2362",
     "license":      "CC-BY-NC-ND-4.0",
     "tags": [
-        "parts",
-        "plugin"
+        "parts"
     ],
-    "conflicts": [
-        { "name": "LongMarch5CZ5" }
+    "depends": [
+        { "name": "Wanhu-Common" }
     ],
     "install": [ {
         "find":       "Wanhu",
         "install_to": "GameData",
-        "filter":     [ "Assets", "Flags" ]
+        "filter":     [ "Assets", "Flags", "FX", "Icons", "WanhuTools.dll", "WanhuCategory.cfg" ]
     } ]
 }

--- a/NetKAN/LongMarch11CZ11.netkan
+++ b/NetKAN/LongMarch11CZ11.netkan
@@ -4,10 +4,15 @@
     "$kref":        "#/ckan/spacedock/2362",
     "license":      "CC-BY-NC-ND-4.0",
     "tags": [
-        "parts"
+        "parts",
+        "plugin"
+    ],
+    "conflicts": [
+        { "name": "LongMarch5CZ5" }
     ],
     "install": [ {
         "find":       "Wanhu",
-        "install_to": "GameData"
+        "install_to": "GameData",
+        "filter":     [ "Assets", "Flags" ]
     } ]
 }

--- a/NetKAN/LongMarch5CZ5.netkan
+++ b/NetKAN/LongMarch5CZ5.netkan
@@ -4,10 +4,15 @@
     "$kref":        "#/ckan/spacedock/2351",
     "license":      "CC-BY-NC-ND-4.0",
     "tags": [
-        "parts"
+        "parts",
+        "plugin"
+    ],
+    "conflicts": [
+        { "name": "LongMarch11CZ11" }
     ],
     "install": [ {
         "find":       "Wanhu",
-        "install_to": "GameData"
+        "install_to": "GameData",
+        "filter":     [ "Assets", "Flags" ]
     } ]
 }

--- a/NetKAN/LongMarch5CZ5.netkan
+++ b/NetKAN/LongMarch5CZ5.netkan
@@ -4,15 +4,14 @@
     "$kref":        "#/ckan/spacedock/2351",
     "license":      "CC-BY-NC-ND-4.0",
     "tags": [
-        "parts",
-        "plugin"
+        "parts"
     ],
-    "conflicts": [
-        { "name": "LongMarch11CZ11" }
+    "depends": [
+        { "name": "Wanhu-Common" }
     ],
     "install": [ {
         "find":       "Wanhu",
         "install_to": "GameData",
-        "filter":     [ "Assets", "Flags" ]
+        "filter":     [ "Assets", "Flags", "FX", "Icons", "WanhuTools.dll", "WanhuCategory.cfg" ]
     } ]
 }

--- a/NetKAN/LongMarch5CZ5.netkan
+++ b/NetKAN/LongMarch5CZ5.netkan
@@ -1,7 +1,13 @@
 {
     "spec_version": "v1.4",
-    "identifier": "LongMarch5CZ5",
-    "$kref": "#/ckan/spacedock/2351",
-    "license": "CC-BY-NC-ND-4.0",
-    "x_via": "Automated SpaceDock CKAN submission"
+    "identifier":   "LongMarch5CZ5",
+    "$kref":        "#/ckan/spacedock/2351",
+    "license":      "CC-BY-NC-ND-4.0",
+    "tags": [
+        "parts"
+    ],
+    "install": [ {
+        "find":       "Wanhu",
+        "install_to": "GameData"
+    } ]
 }

--- a/NetKAN/LongMarch5CZ5.netkan
+++ b/NetKAN/LongMarch5CZ5.netkan
@@ -1,0 +1,7 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "LongMarch5CZ5",
+    "$kref": "#/ckan/spacedock/2351",
+    "license": "CC-BY-NC-ND-4.0",
+    "x_via": "Automated SpaceDock CKAN submission"
+}

--- a/NetKAN/Wanhu-Common.netkan
+++ b/NetKAN/Wanhu-Common.netkan
@@ -4,6 +4,7 @@
     "name":         "Wanhu Common",
     "abstract":     "Shared files for the Long March mods",
     "$kref":        "#/ckan/spacedock/2362",
+    "license":      "CC-BY-NC-ND-4.0",
     "tags": [
         "library",
         "plugin"

--- a/NetKAN/Wanhu-Common.netkan
+++ b/NetKAN/Wanhu-Common.netkan
@@ -1,0 +1,32 @@
+{
+    "spec_version": "v1.16",
+    "identifier":   "Wanhu-Common",
+    "name":         "Wanhu Common",
+    "abstract":     "Shared files for the Long March mods",
+    "$kref":        "#/ckan/spacedock/2362",
+    "tags": [
+        "library",
+        "plugin"
+    ],
+    "install": [ {
+        "find":       "Wanhu/Wanhu_Parts/Assets",
+        "install_to": "GameData/Wanhu/Wanhu_Parts"
+    }, {
+        "find":       "Wanhu/Wanhu_Parts/Flags",
+        "install_to": "GameData/Wanhu/Wanhu_Parts"
+    }, {
+        "find":       "Wanhu/Wanhu_Parts/FX",
+        "install_to": "GameData/Wanhu/Wanhu_Parts"
+    }, {
+        "find":       "Wanhu/Wanhu_Parts/Icons",
+        "install_to": "GameData/Wanhu/Wanhu_Parts"
+    }, {
+        "find":       "Wanhu/Wanhu_Parts/WanhuTools.dll",
+        "find_matches_files": true,
+        "install_to": "GameData/Wanhu/Wanhu_Parts"
+    }, {
+        "find":       "Wanhu/Wanhu_Parts/WanhuCategory.cfg",
+        "find_matches_files": true,
+        "install_to": "GameData/Wanhu/Wanhu_Parts"
+    } ]
+}


### PR DESCRIPTION
These mods were somehow included in the initial commits of #7749 and #7767, in what looks like a SpaceDock bug, see KSP-SpaceDock/SpaceDock#249. I removed them from those PRs so the primary mod of each could be indexed.

- https://spacedock.info/mod/2351/LongMarch-5%EF%BC%88CZ-5%EF%BC%89
- https://spacedock.info/mod/2362/LongMarch-11%EF%BC%88CZ-11%EF%BC%89

Now they have their own PR.