### PR TITLE
Force default sunflare for BeyondHome

### DIFF
--- a/NetKAN/BeyondHome.netkan
+++ b/NetKAN/BeyondHome.netkan
@@ -8,7 +8,7 @@
     "ksp_version":  "1.8",
     "license":      "restricted",
     "resources": {
-        "homepage":"https://forum.kerbalspaceprogram.com/index.php?/topic/182708-*"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/182708-*"
     },
     "tags": [
         "config",
@@ -16,7 +16,8 @@
         "graphics"
     ],
     "depends": [
-        { "name": "Kopernicus" }
+        { "name": "Kopernicus"                 },
+        { "name": "Scatterer-sunflare-default" }
     ],
     "conflicts": [
         { "name": "GPP"                     },

--- a/NetKAN/Scatterer-sunflare.netkan
+++ b/NetKAN/Scatterer-sunflare.netkan
@@ -3,7 +3,7 @@
     "identifier":   "Scatterer-sunflare",
     "name":         "Scatterer Sunflare",
     "abstract":     "The sunflare component of scatterer",
-    "$kref": "#/ckan/spacedock/141",
+    "$kref":        "#/ckan/spacedock/141",
     "x_netkan_force_v": true,
     "x_netkan_epoch": "2",
     "release_status": "development",
@@ -12,33 +12,30 @@
         "graphics",
         "config"
     ],
+    "provides": [
+        "Scatterer-sunflare-default"
+    ],
     "conflicts": [
         { "name": "Scatterer-sunflare" }
     ],
-    "install": [
-        {
-            "find"       : "Sunflares",
-            "install_to" : "GameData/scatterer/config"
+    "install": [ {
+        "find":       "Sunflares",
+        "install_to": "GameData/scatterer/config"
+    } ],
+    "x_netkan_override": [ {
+        "version": "2:v0.0256",
+        "override": {
+            "ksp_version" : "1.2"
         }
-    ],
-    "x_netkan_override": [
-        {
-            "version": "2:v0.0256",
-            "override": {
-                "ksp_version" : "1.2"
-            }
-        },
-        {
-            "version": "2:v0.0320b",
-            "override": {
-                "ksp_version" : "1.3"
-            }
-        },
-        {
-            "version": "2:v0.0329_for_1.4.2",
-            "override": {
-                "ksp_version" : "1.4.2"
-            }
+    }, {
+        "version": "2:v0.0320b",
+        "override": {
+            "ksp_version" : "1.3"
         }
-    ]
+    }, {
+        "version": "2:v0.0329_for_1.4.2",
+        "override": {
+            "ksp_version" : "1.4.2"
+        }
+    } ]
 }


### PR DESCRIPTION
## Background

Scatterer overrides the sunflare based on config in the `scatterer/config/Sunflares` folder.

![image](https://user-images.githubusercontent.com/1559108/77705946-f39c6500-6fb8-11ea-81fe-5366288809fb.png)

The established way to provide a custom sunflare was to replace this folder, including one or more .cfg files defining `Scatterer_sunflare` config nodes. CKAN handles this by splitting the default sunflare into its own `Scatterer-sunflare` module, which is added to the `provides` list of any modules containing their own sunflares (see #3950). The user is then prompted to choose a sunflare when installing Scatterer.

## Problem

Some mods instead choose to patch the default config nodes with ModuleManager. This only works if the default `Scatterer-sunflare` module is installed, which won't be the case if such a mod provides `Scatterer-sunflare` (see #7741).

Now the user is prompted to select a sunflare, but it will only work as intended if they choose the default sunflare.

## Changes

Now:

- `Scatterer-sunflare` provides `Scatterer-sunflare-default`
- `BeyondHome` depends on `Scatterer-sunflare-default`

This should force only the default sunflare to be installed when installing `BeyondHome`. (If we had it to do all over again from the beginning, `Scatterer-sunflare` should probably be named `Scatterer-sunflare-default` and provide `Scatterer-sunflare`, but this should work also.)

Note that the default sunflare will be installed even if the user doesn't choose to install Scatterer. This is similar to how a full sunflare config in a normal module would be installed even if the user didn't install Scatterer. This won't cause any problems, and the sunflare does not itself depend upon Scatterer.