### PR TITLE
Sunflare fix for GameslinxPlanetOverhaul

### DIFF
--- a/NetKAN/GPO.netkan
+++ b/NetKAN/GPO.netkan
@@ -16,25 +16,25 @@
         "graphics"
     ],
     "depends": [
-        { "name": "Kopernicus"                      },
-        { "name": "CommunityTerrainTexturePack"     },
-        { "name": "Scatterer"                       },
-        { "name": "Scatterer-config"                },
-        { "name": "INSTANTIATOR"                    }
+        { "name": "Kopernicus"                  },
+        { "name": "CommunityTerrainTexturePack" },
+        { "name": "Scatterer"                   },
+        { "name": "Scatterer-config"            },
+        { "name": "Scatterer-sunflare-default"  },
+        { "name": "INSTANTIATOR"                }
     ],
     "conflicts": [
         { "name": "GPP" }
     ],
     "recommends": [
-        { "name": "SigmaReplacements-SkyBox"        }
+        { "name": "SigmaReplacements-SkyBox" }
     ],
     "suggests": [
         { "name": "EnvironmentalVisualEnhancements" },
         { "name": "KS3P"                            }
     ],
     "provides": [
-        "EnvironmentalVisualEnhancements-Config",
-        "Scatterer-sunflare"
+        "EnvironmentalVisualEnhancements-Config"
     ],
     "install": [ {
         "find":       "GPO",


### PR DESCRIPTION
This is #7741 and #7794 for another mod by the same author, since it contains two files that assume a sunflare config is already installed:

GameData\GPO\scatterer\config\Sunflares\UrsaMinor

```
@Scatterer_sunflare:NEEDS[GPO]
{
```

GameData\GPO\scatterer\config\Sunflares\UrsaMinor\Ursa_L\Sun.cfg

```
@Scatterer_sunflare:NEEDS[GPO]
{
```

Might need to apply #7794 historically, depending on how up to date this is.