### PR TITLE
Fix install for HyperDriveMod

### DIFF
--- a/NetKAN/HyperDriveMod.netkan
+++ b/NetKAN/HyperDriveMod.netkan
@@ -9,5 +9,9 @@
     ],
     "depends": [
         { "name": "ModuleManager" }
+    ],
+    "recommends": [
+        { "name": "KerbalEngineerRedux" },
+        { "name": "TweakScale" }
     ]
 }

--- a/NetKAN/HyperDriveMod.netkan
+++ b/NetKAN/HyperDriveMod.netkan
@@ -9,9 +9,5 @@
     ],
     "depends": [
         { "name": "ModuleManager" }
-    ],
-    "install": [ {
-        "find_regexp": "HYPERMOD.*",
-        "install_to":  "GameData"
-    } ]
+    ]
 }


### PR DESCRIPTION
The first release of this mod installed into a folder called `HYPERMOD 2.4  10k SPECIAL`.
Now it's just the identifier, so we can use the default install stanza.
Also the author wants KER and TweakScale recommended, fixes #7806.