### PR TITLE
Update ProjectManager compatibility

### DIFF
--- a/NetKAN/ProjectManager.netkan
+++ b/NetKAN/ProjectManager.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "ProjectManager",
     "$kref":        "#/ckan/github/Tantares/ProjectManager",
-    "ksp_version_min": "1.8",
+    "ksp_version_min": "1.9",
     "license":      "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/184785-*"


### PR DESCRIPTION
KSP-CKAN/CKAN-meta#1889 has ProjectManager 2.4 compatible with KSP 1.8, but the release announcement says it's for 1.9.