### PR TITLE
Remove FirespitterCore depends from LithobrakeExplorationTechnologies

### DIFF
--- a/NetKAN/LithobrakeExplorationTechnologies.netkan
+++ b/NetKAN/LithobrakeExplorationTechnologies.netkan
@@ -12,7 +12,6 @@
         "crewed"
     ],
     "depends": [
-        { "name": "FirespitterCore" },
         { "name": "ModuleManager"}
     ],
     "supports": [


### PR DESCRIPTION
#2034 indexed this module with a dependency that isn't reflected on the forum thread, SpaceDock page, README, bundled mods, etc.

Now it's removed.

https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1270-bussard/&do=findComment&comment=3767463

https://forum.kerbalspaceprogram.com/index.php?/topic/117527-12-14-lithobrake-exploration-technologies-04-2016-10-12/&do=findComment&comment=3647761