### PR TITLE
Override InfernalRoboticsNext max compat to 1.6

### DIFF
--- a/NetKAN/InfernalRoboticsNext.netkan
+++ b/NetKAN/InfernalRoboticsNext.netkan
@@ -26,5 +26,11 @@
     "install"        : [ {
         "file"       : "GameData/MagicSmokeIndustries",
         "install_to" : "GameData"
+    } ],
+    "x_netkan_override": [ {
+        "version": "v3.0.0",
+        "override": {
+            "ksp_version_max": "1.6"
+        }
     } ]
 }

--- a/NetKAN/InfernalRoboticsNext.netkan
+++ b/NetKAN/InfernalRoboticsNext.netkan
@@ -30,7 +30,7 @@
     "x_netkan_override": [ {
         "version": "v3.0.0",
         "override": {
-            "ksp_version_max": "1.6"
+            "ksp_version_max": "1.7.0"
         }
     } ]
 }


### PR DESCRIPTION
This mod's version file says it's compatible with KSP 1.4.0 and up, which is kind of impossible for a plugin, and consequently users have been reporting problems with it on recent versions on the forum thread. The author hasn't been responsive.

So far only one user has a specific recollection about the mod's actual compatibility: it worked up until Breaking Ground was released, which was with KSP 1.7.1. So now we will set the upper bound of compatibility to 1.6.

https://forum.kerbalspaceprogram.com/index.php?/topic/184787-infernal-robotics-next/&do=findComment&comment=3767687

FYI to @meirumeiru in case he's still active.