### PR TITLE
ColorCodedCans conflicts with mods that change stock tanks

### DIFF
--- a/NetKAN/ColorCodedCans.netkan
+++ b/NetKAN/ColorCodedCans.netkan
@@ -22,5 +22,9 @@
         { "name": "SpaceY-Lifters" },
         { "name": "ColorfulFuelLines" },
         { "name": "LithobrakeExplorationTechnologies" }
+    ],
+    "conflicts": [
+        { "name": "ReStock"        },
+        { "name": "VenStockRevamp" }
     ]
 }


### PR DESCRIPTION
https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1270-bussard/&do=findComment&comment=3769391

Confirmed; CCC uses MM patches to change the meshes of stock parts, which ReStock and Vens also do. Now it conflicts with those mods.