### PR TITLE
RN KK fix conflicts

### DIFF
--- a/NetKAN/AntaresCygnus.netkan
+++ b/NetKAN/AntaresCygnus.netkan
@@ -28,5 +28,9 @@
             "file"      : "Ships/VAB",
             "install_to": "Ships"
         }
+    ],
+	"conflicts"     : [
+		{ "name"    : "ROCapsules" },
+		{ "name"    : "ROEngines" }
     ]
 }

--- a/NetKAN/KKsDeltaPack.netkan
+++ b/NetKAN/KKsDeltaPack.netkan
@@ -12,5 +12,9 @@
     }, {
         "find":       "Ships/VAB",
         "install_to": "Ships"
-    } ]
+    } ],
+	"conflicts"     : [
+		{ "name"    : "ROCapsules" },
+		{ "name"    : "ROEngines" }
+    ]
 }

--- a/NetKAN/RN-MiscParts.netkan
+++ b/NetKAN/RN-MiscParts.netkan
@@ -20,6 +20,10 @@
         "install_to": "GameData"
       }
     ],
+	"conflicts"     : [
+		{ "name"    : "ROCapsules" },
+		{ "name"    : "ROEngines" }
+    ],
 	"depends"       : [
         { "name"      : "BDAnimationModules"  }
     ]

--- a/NetKAN/RN-SalyutStations.netkan
+++ b/NetKAN/RN-SalyutStations.netkan
@@ -27,7 +27,9 @@
         }
     ],
     "conflicts"     : [
-        { "name"    : "RN-SalyutStations-SoyuzFerries" }
+        { "name"    : "RN-SalyutStations-SoyuzFerries" },
+		{ "name"    : "ROCapsules" },
+		{ "name"    : "ROEngines" }
     ],
     "depends"       : [
         { "name"      : "BDAnimationModules"  },

--- a/NetKAN/RN-Skylab.netkan
+++ b/NetKAN/RN-Skylab.netkan
@@ -26,6 +26,10 @@
             "install_to": "Ships"
         }
     ],
+	"conflicts"     : [
+		{ "name"    : "ROCapsules" },
+		{ "name"    : "ROEngines" }
+    ],
     "depends"       : [
         { "name"      : "BDAnimationModules" },
         { "name" 	  : "ModuleManager" }

--- a/NetKAN/RN-SovietProbes.netkan
+++ b/NetKAN/RN-SovietProbes.netkan
@@ -26,6 +26,10 @@
             "install_to": "Ships"
         }
     ],
+	"conflicts"     : [
+		{ "name"    : "ROCapsules" },
+		{ "name"    : "ROEngines" }
+    ],
     "depends"       : [
         { "name"      : "BDAnimationModules"  },
 		{ "name" 	  : "ModuleManager" },

--- a/NetKAN/RN-SovietRockets.netkan
+++ b/NetKAN/RN-SovietRockets.netkan
@@ -18,6 +18,10 @@
         "find"      : "RN_Soviet_Rockets",
         "install_to": "GameData"
     } ],
+	"conflicts"     : [
+		{ "name"    : "ROCapsules" },
+		{ "name"    : "ROEngines" }
+    ],
     "depends"       : [
 		{ "name"    : "BDAnimationModules" },
 		{ "name"    : "ModuleManager" },

--- a/NetKAN/RN-SovietSpacecraft.netkan
+++ b/NetKAN/RN-SovietSpacecraft.netkan
@@ -7,7 +7,7 @@
     "comment"       : "Ships installed again",
     "$kref"         : "#/ckan/github/KSP-RO/SovietSpacecraft",
     "$vref"         : "#/ckan/ksp-avc",
-	"x_netkan_epoch": 1,
+    "x_netkan_epoch": 1,
     "license"       : "CC-BY-NC-ND-3.0",
     "resources": {
         "homepage"  : "http://forum.kerbalspaceprogram.com/index.php?/topic/133579-*"
@@ -27,13 +27,13 @@
         }
     ],
     "conflicts"     : [
-        { "name"    : "RN-SalyutStations-SoyuzFerries" }
-		{ "name"    : "ROCapsules" },
-		{ "name"    : "ROEngines" }
+        { "name"    : "RN-SalyutStations-SoyuzFerries" },
+        { "name"    : "ROCapsules" },
+        { "name"    : "ROEngines" }
     ],
     "depends"       : [
-		{ "name"	  : "BDAnimationModules" },
-		{ "name" 	  : "ModuleManager" },
+        { "name"	  : "BDAnimationModules" },
+        { "name" 	  : "ModuleManager" },
         { "name"      : "TexturesUnlimited" }
     ],
     "recommends"    : [

--- a/NetKAN/RN-SovietSpacecraft.netkan
+++ b/NetKAN/RN-SovietSpacecraft.netkan
@@ -28,6 +28,8 @@
     ],
     "conflicts"     : [
         { "name"    : "RN-SalyutStations-SoyuzFerries" }
+		{ "name"    : "ROCapsules" },
+		{ "name"    : "ROEngines" }
     ],
     "depends"       : [
 		{ "name"	  : "BDAnimationModules" },

--- a/NetKAN/RN-USProbesPack.netkan
+++ b/NetKAN/RN-USProbesPack.netkan
@@ -26,6 +26,10 @@
         "install_to": "Ships"
       }
     ],
+	"conflicts"     : [
+		{ "name"    : "ROCapsules" },
+		{ "name"    : "ROEngines" }
+    ],
     "depends": [
         { "name": "BDAnimationModules" },
         { "name": "TexturesUnlimited" },

--- a/NetKAN/RN-USRockets.netkan
+++ b/NetKAN/RN-USRockets.netkan
@@ -24,6 +24,10 @@
             "install_to": "Ships"
         }
     ],
+	"conflicts"     : [
+		{ "name"    : "ROCapsules" },
+		{ "name"    : "ROEngines" }
+    ],
     "depends": [
 		{ "name": "BDAnimationModules" },
         { "name": "TexturesUnlimited" },


### PR DESCRIPTION
-Make ROxxx mods that change parts in the base mods conflict. These
should never be installed at the same time as they change the part names
of the existing meshes. This will break saves and craft files. You can
use one or the other, but not both sets of mods at once. It is already
set to conflict with ROcraftFiles, I just needed to make the cahnges
here also.