### PR TITLE
ModularLaunchPads dependencies

### DIFF
--- a/NetKAN/ModularLaunchPads.netkan
+++ b/NetKAN/ModularLaunchPads.netkan
@@ -2,8 +2,16 @@
     "spec_version": "v1.4",
     "identifier":   "ModularLaunchPads",
     "$kref":        "#/ckan/spacedock/1767",
-    "license":      "CC-BY-NC-SA",
+    "license":      "CC-BY-NC-SA-4.0",
     "tags": [
         "parts"
+    ],
+    "depends": [
+        { "name": "B9PartSwitch" }
+    ],
+    "recommends": [
+        { "name": "AnimatedDecouplers"   },
+        { "name": "CommunityCategoryKit" },
+        { "name": "KSCExtended"          }
     ]
 }


### PR DESCRIPTION
This mod has some missing dependencies:

https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1270-bussard/&do=findComment&comment=3776365

The forum thread also recommends KSCExtended:

https://forum.kerbalspaceprogram.com/index.php?/topic/173008-19x18x17x-modular-launch-pads-v208-launch-clamps-evolved-mix-and-match-parts-for-complete-launch-infrastructure-15-feb-2020/

ckan compat add 1.9.1