### PR TITLE
Force default Scatterer-sunflare for Spectra

### DIFF
--- a/NetKAN/Spectra.netkan
+++ b/NetKAN/Spectra.netkan
@@ -17,17 +17,16 @@
     ],
     "provides": [
         "PlanetShine-Config",
-        "EnvironmentalVisualEnhancements-Config",
-        "Scatterer-sunflare"
+        "EnvironmentalVisualEnhancements-Config"
     ],
     "conflicts": [
         { "name": "PlanetShine-Config"                     },
         { "name": "EnvironmentalVisualEnhancements-Config" },
-        { "name": "Scatterer-sunflare"                     },
         { "name": "GreenSkullRevived"                      }
     ],
     "depends": [
-        { "name": "ModuleManager" }
+        { "name": "ModuleManager"              },
+        { "name": "Scatterer-sunflare-default" }
     ],
     "recommends": [
         { "name": "EnvironmentalVisualEnhancements" },


### PR DESCRIPTION
## Background

In #7663, we tried to set up Spectra's relationships to reflect its Scatterer config and sunflare files. However, this was wrong, because Spectra does **not** provide a full config as in #3950, but instead patches the default config as in #7741.

In #7706 we fixed that problem for the Scatterer-config side of things.

## Problem

The sunflare relationship is still set up as if Spectra provided a full sunflare config, but instead it patches the default sunflare config, which then doesn't work.

## Changes

Now Spectra uses the approach we started in #7794 to pull in the default sunflare.

(Replaces KSP-CKAN/CKAN-meta#1905.)