### PR TITLE
Override ProbeControlRoom compatibility

### DIFF
--- a/NetKAN/ProbeControlRoom.netkan
+++ b/NetKAN/ProbeControlRoom.netkan
@@ -29,5 +29,11 @@
         { "name"  : "DockingPortAlignment" },
         { "name"  : "kOS" },
         { "name"  : "KPS-AVC" }
-    ]
+    ],
+    "x_netkan_override": [ {
+        "version": "1.2.2.4",
+        "override": {
+            "ksp_version_max": "1.2.2"
+        }
+    } ]
 }


### PR DESCRIPTION
A user reports that this mod's compatibility is too broad:

https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1270-bussard/&do=findComment&comment=3779968

Now it's overridden to just the major version it was compiled for.

![image](https://user-images.githubusercontent.com/1559108/80917974-e873ec00-8d51-11ea-9814-d0705f4d7f2a.png)

We can remove this if icedown/KSP-ProbeControlRoom#7 gets merged.