### PR TITLE
Use GitHub version numbers for AstronomersVisualPack

### DIFF
--- a/NetKAN/AstronomersVisualPack.netkan
+++ b/NetKAN/AstronomersVisualPack.netkan
@@ -5,8 +5,6 @@
     "abstract"     : "The total visual overhaul for Kerbal Space Program, originally by Astronomer.",
     "$kref"        : "#/ckan/github/themaster402/AstronomersVisualPack/asset_match/AVP.v.*.zip",
     "$vref"        : "#/ckan/ksp-avc",
-    "x_netkan_trust_version_file" : true,
-    "x_netkan_epoch" : 2,
     "license"      : "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160878-*"


### PR DESCRIPTION
In #6494 we stopped using this mod's GitHub version numbers because they were non-sequential, and started using the version file instead because they were forced to be more reasonable.

Now we have a release with an outdated version file, see themaster402/AstronomersVisualPack#16. Instead of being indexed on its own, 4.0.3 has replaced 4.0.2 and will need cleanup.

https://github.com/KSP-CKAN/CKAN-meta/commit/548803b3c76a0198d12b5dd2b234ccb702710ee5

With auto-epoching, we can now handle non-sequential versions more smoothly. This PR reverts to using the GitHub release version numbers.

ckan compat add 1.8