### PR TITLE
Allow OOO releases for CommNetAntennasInfo/-Consumptor

### DIFF
--- a/NetKAN/CommNetAntennasConsumptor.netkan
+++ b/NetKAN/CommNetAntennasConsumptor.netkan
@@ -6,6 +6,7 @@
     "author"       : "flart",
     "$kref"        : "#/ckan/github/yalov/CommNetAntennasInfo",
     "$vref"        : "#/ckan/ksp-avc",
+    "x_netkan_allow_out_of_order": true,
     "license"      : "GPL-3.0",
     "release_status": "stable",
     "resources" : {

--- a/NetKAN/CommNetAntennasInfo.netkan
+++ b/NetKAN/CommNetAntennasInfo.netkan
@@ -5,6 +5,7 @@
     "author"       : "flart",
     "$kref"        : "#/ckan/github/yalov/CommNetAntennasInfo",
     "$vref"        : "#/ckan/ksp-avc",
+    "x_netkan_allow_out_of_order": true,
     "license"      : "GPL-3.0",
     "release_status": "stable",
     "resources" : {


### PR DESCRIPTION
Both mods had a backport recently:
https://github.com/KSP-CKAN/CKAN-meta/pull/1911
https://github.com/KSP-CKAN/CKAN-meta/pull/1910

They seem to have a reasonable and stable version history so far, so I think we can allow out of order releases for backports.