### PR TITLE
Add TweakScale depends to InterstellarFuelSwitch-Core

### DIFF
--- a/NetKAN/InterstellarFuelSwitch-Core.netkan
+++ b/NetKAN/InterstellarFuelSwitch-Core.netkan
@@ -25,7 +25,13 @@
             "install_to" : "GameData/InterstellarFuelSwitch"
         }
     ],
-    "provides": [ "DeadskinsTextureSwitch", "DeadskinsMeshSwitch" ],
+    "provides": [
+        "DeadskinsTextureSwitch",
+        "DeadskinsMeshSwitch"
+    ],
+    "depends": [
+        { "name": "TweakScale" }
+    ],
     "recommends": [
         { "name" : "CommunityResourcePack", "min_version" : "0.7.1" },
         { "name" : "TweakScale",            "min_version" : "2.3.6" }

--- a/NetKAN/InterstellarFuelSwitch.netkan
+++ b/NetKAN/InterstellarFuelSwitch.netkan
@@ -15,7 +15,6 @@
         }
     ],
     "depends" : [
-        { "name" : "CommunityResourcePack", "min_version" : "0.5.1" },
         { "name" : "InterstellarFuelSwitch-Core", "min_version" : "1.28" },
         { "name" : "ModuleManager" },
         { "name" : "CommunityTechTree" }

--- a/NetKAN/InterstellarFuelSwitch.netkan
+++ b/NetKAN/InterstellarFuelSwitch.netkan
@@ -17,7 +17,8 @@
     "depends" : [
         { "name" : "CommunityResourcePack", "min_version" : "0.5.1" },
         { "name" : "InterstellarFuelSwitch-Core", "min_version" : "1.28" },
-        { "name" : "ModuleManager" }
+        { "name" : "ModuleManager" },
+        { "name" : "CommunityTechTree" }
     ],
     "recommends": [
         { "name"         : "KSPInterstellarExtended" },


### PR DESCRIPTION
InterstellarFuelSwitch bundles TweakScale and references it in code:

https://github.com/sswelm/KSP-Interstellar-Extended/blob/413b6815dfefad3023d9d3eca22da269464767db/FuelSwitch/InterstellarFuelSwitch.cs#L8

Discord user Aivech reports this exception on loading:

```
[ERR 18:40:41.076] AssemblyLoader: Exception loading 'InterstellarFuelSwitch': System.Reflection.ReflectionTypeLoadException: Exception of type 'System.Reflection.ReflectionTypeLoadException' was thrown.
  at (wrapper managed-to-native) System.Reflection.Assembly.GetTypes(System.Reflection.Assembly,bool)
  at System.Reflection.Assembly.GetTypes () [0x00000] in <ad04dee02e7e4a85a1299c7ee81c79f6>:0 
  at AssemblyLoader.LoadAssemblies () [0x000e6] in <2c9e31d65a604d1980fb0cb89728fc1e>:0 

Additional information about this exception:

 System.IO.FileNotFoundException: Could not load file or assembly 'Scale_Redist, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies.
File name: 'Scale_Redist, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'
```

![image](https://user-images.githubusercontent.com/1559108/81326400-4c1b5380-9089-11ea-9afc-2befb42d2679.png)

![image](https://user-images.githubusercontent.com/1559108/81326798-da8fd500-9089-11ea-8771-b0c0c5873fb4.png)

Now it's added as a dependency.

Also, the CommunityResourcePack dependency is replaced with CommunityTechTree, reflecting a change that happened in IFS 3.13.0.5.

Historical versions will need updating in CKAN-meta.