### PR TITLE
Remove TweakScale rec from InterstellarFuelSwitch-Core (now a dep)

### DIFF
--- a/NetKAN/InterstellarFuelSwitch-Core.netkan
+++ b/NetKAN/InterstellarFuelSwitch-Core.netkan
@@ -33,7 +33,6 @@
         { "name": "TweakScale" }
     ],
     "recommends": [
-        { "name" : "CommunityResourcePack", "min_version" : "0.7.1" },
-        { "name" : "TweakScale",            "min_version" : "2.3.6" }
+        { "name" : "CommunityResourcePack", "min_version" : "0.7.1" }
     ]
 }


### PR DESCRIPTION
#7883 made TweakScale a depends, but I didn't notice it was already a recommendation.
Now the recommendation is removed.