### PR TITLE
Sort and fix Spectra NetKAN Provides/conflicts/depends/suggests/rec

### DIFF
--- a/NetKAN/Spectra.netkan
+++ b/NetKAN/Spectra.netkan
@@ -19,10 +19,10 @@
         "EnvironmentalVisualEnhancements-Config"
     ],
     "conflicts": [
-        { "name": "EnvironmentalVisualEnhancements-Config" },
+        { "name": "EnvironmentalVisualEnhancements-Config" }
     ],
     "depends": [
-        { "name": "ModuleManager" },
+        { "name": "ModuleManager" }
     ],
     "suggests": [
         { "name": "DistantObject"              },

--- a/NetKAN/Spectra.netkan
+++ b/NetKAN/Spectra.netkan
@@ -22,7 +22,8 @@
         { "name": "EnvironmentalVisualEnhancements-Config" }
     ],
     "depends": [
-        { "name": "ModuleManager" }
+        { "name": "ModuleManager" },
+        { "name": "Scatterer-sunflare-default" }
     ],
     "suggests": [
         { "name": "CollisionFXReUpdated"               },
@@ -58,11 +59,11 @@
         "install_to": "GameData"
     } ],
     "x_netkan_override": [{
-        "version": "1.3",
+        "version": "v1.3",
         "delete":  [ "ksp_version" ],
         "override": {
             "ksp_version_min": "1.3",
-            "ksp_version_max": "1.9.99"
+            "ksp_version_max": "1.9"
         }
     } ]
 }

--- a/NetKAN/Spectra.netkan
+++ b/NetKAN/Spectra.netkan
@@ -16,7 +16,7 @@
         "graphics"
     ],
     "provides": [
-        "EnvironmentalVisualEnhancements-Config"
+        { "name": "EnvironmentalVisualEnhancements-Config" }
     ],
     "conflicts": [
         { "name": "EnvironmentalVisualEnhancements-Config" }
@@ -25,17 +25,27 @@
         { "name": "ModuleManager" }
     ],
     "suggests": [
-        { "name": "DistantObject"              },
-        { "name": "RealPlume-StockConfigs"     },
-        { "name": "ReStock"                    },
-        { "name": "PlanetShine-Config-Default" },
-        { "name": "SpaceplaneCorrections"      }
+        { "name": "CollisionFXReUpdated"               },
+        { "name": "CrewLight"                          },
+        { "name": "EngineLightRelit"                   },
+        { "name": "HafCoSpaceCenter"                   },
+        { "name": "IndicatorLights"                    },
+        { "name": "IndicatorLightsCommunityExtensions" },
+        { "name": "KSPRC-CityLights"                   },
+        { "name": "PlanetShine"                        },
+        { "name": "RealPlume-StockConfigs"             },
+        { "name": "ReentryParticleEffect"              },
+        { "name": "ReStock"                            },
+        { "name": "ShipEffectsContinued"               },
+        { "name": "PlanetShine-Config-Default"         },
+        { "name": "SpaceplaneCorrections"              }
     ],
     "recommends": [
         { "name": "EnvironmentalVisualEnhancements" },
         { "name": "Scatterer"                       },
+        { "name": "Kopernicus"                      },
         { "name": "TextureReplacer"                 },
-        { "name": "Kopernicus"                      }
+        { "name": "DistantObject"                   }
     ],
     "install": [ {
         "file":       "Step 2 - Spectra/GameData/TextureReplacer",
@@ -54,5 +64,5 @@
             "ksp_version_min": "1.3",
             "ksp_version_max": "1.9.99"
         }
-    }]
+    } ]
 }

--- a/NetKAN/Spectra.netkan
+++ b/NetKAN/Spectra.netkan
@@ -16,7 +16,7 @@
         "graphics"
     ],
     "provides": [
-        { "name": "EnvironmentalVisualEnhancements-Config" }
+        "EnvironmentalVisualEnhancements-Config"
     ],
     "conflicts": [
         { "name": "EnvironmentalVisualEnhancements-Config" }

--- a/NetKAN/Spectra.netkan
+++ b/NetKAN/Spectra.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "Spectra",
     "name":         "Spectra",
-    "abstract":     "A well optimized and yet breathtakingly beautiful revamp of all celestial bodies in KSP",
+    "abstract":     "A well optimized and breathtakingly beautiful revamp of all celestial bodies in KSP",
     "$kref":        "#/ckan/spacedock/1505",
     "x_netkan_force_v": true,
     "license":      "MIT",
@@ -16,33 +16,30 @@
         "graphics"
     ],
     "provides": [
-        "PlanetShine-Config",
         "EnvironmentalVisualEnhancements-Config"
     ],
     "conflicts": [
-        { "name": "PlanetShine-Config"                     },
         { "name": "EnvironmentalVisualEnhancements-Config" },
-        { "name": "GreenSkullRevived"                      }
     ],
     "depends": [
-        { "name": "ModuleManager"              },
-        { "name": "Scatterer-sunflare-default" }
+        { "name": "ModuleManager" },
+    ],
+    "suggests": [
+        { "name": "DistantObject"              },
+        { "name": "RealPlume-StockConfigs"     },
+        { "name": "ReStock"                    },
+        { "name": "PlanetShine-Config-Default" },
+        { "name": "SpaceplaneCorrections"      }
     ],
     "recommends": [
         { "name": "EnvironmentalVisualEnhancements" },
         { "name": "Scatterer"                       },
         { "name": "TextureReplacer"                 },
-        { "name": "Kopernicus"                      },
-        { "name": "DistantObject"                   },
-        { "name": "RealPlume-StockConfigs"          },
-        { "name": "ReStock"                         },
-        { "name": "PlanetShine"                     },
-        { "name": "SpaceplaneCorrections"           }
+        { "name": "Kopernicus"                      }
     ],
     "install": [ {
         "file":       "Step 2 - Spectra/GameData/TextureReplacer",
-        "install_to": "GameData",
-        "filter":     "logoFullRed_alt.dds"
+        "install_to": "GameData"
     }, {
         "file":       "Step 2 - Spectra/GameData/Spectra",
         "install_to": "GameData"
@@ -51,11 +48,11 @@
         "install_to": "GameData"
     } ],
     "x_netkan_override": [{
-        "version": "v1.1.3",
+        "version": "1.3",
         "delete":  [ "ksp_version" ],
         "override": {
             "ksp_version_min": "1.3",
-            "ksp_version_max": "1.3.99"
+            "ksp_version_max": "1.9.99"
         }
     }]
 }


### PR DESCRIPTION

I updated Spectra used this time to fix its NetKAN. I moved minor mods from Recommends to Suggests (added suggests), removed PlanetShine-config from Provides (No longer providing), removed GreenSkullRevived and PlanetShine-config from Conflicts (no longer conflicting), and removed Scatterer-sunflare-default from Depends (no longer depends).

I hope this looks in order, the file did not have suggests before this change, I added it from scratch based on the NetKAN of other mods. The goal is for all the mods in "recommends" to be auto-ticked when you install, and the mods in "suggests" to not.

I also reworked x_netkan_override. This might be set up incorrectly, though it doesn't matter as much as the rest. The current release of Spectra (1.3) is backwards compatible all the way to KSP version 1.3. Is this set up correctly?