### PR TITLE
Fix HooliganLabsAirships install

### DIFF
--- a/NetKAN/HooliganLabsAirships.netkan
+++ b/NetKAN/HooliganLabsAirships.netkan
@@ -9,7 +9,7 @@
     ],
     "install": [
         {
-          "file"       : "HLAirships",
+          "find"       : "HLAirships",
           "install_to" : "GameData",
           "filter"     : "thumbs.db"
         }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/82122826-79d45c80-975b-11ea-978f-6d406ffb6ae7.png)

There's a GameData folder now.