### PR TITLE
Add ModuleManager depends for mods with MM syntax cfgs

### DIFF
--- a/NetKAN/AnimatedAttachment.netkan
+++ b/NetKAN/AnimatedAttachment.netkan
@@ -10,5 +10,8 @@
     "tags": [
         "plugin",
         "library"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/AntaresCygnus.netkan
+++ b/NetKAN/AntaresCygnus.netkan
@@ -29,6 +29,9 @@
             "install_to": "Ships"
         }
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
 	"conflicts"     : [
 		{ "name"    : "ROCapsules" },
 		{ "name"    : "ROEngines" }

--- a/NetKAN/B9-PWings-Fork.netkan
+++ b/NetKAN/B9-PWings-Fork.netkan
@@ -16,6 +16,9 @@
     "tags": [
         "parts"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "conflicts": [
         { "name": "B9AerospaceProceduralParts" }
     ],

--- a/NetKAN/B9-PWings-Modified.netkan
+++ b/NetKAN/B9-PWings-Modified.netkan
@@ -15,6 +15,9 @@
     "tags": [
         "parts"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "conflicts": [
         { "name": "B9AerospaceProceduralParts" },
         { "name": "B9-PWings-Fork" }

--- a/NetKAN/B9HXReconfig.netkan
+++ b/NetKAN/B9HXReconfig.netkan
@@ -9,6 +9,7 @@
         "install_to": "GameData"
     } ],
     "depends": [
+        { "name": "ModuleManager"         },
         { "name": "B9AerospaceHX"         },
         { "name": "B9PartSwitch"          },
         { "name": "CommunityResourcePack" }

--- a/NetKAN/BDArmoryContinued.netkan
+++ b/NetKAN/BDArmoryContinued.netkan
@@ -26,6 +26,7 @@
         { "name": "BDArmory" }
     ],
     "depends": [
+        { "name": "ModuleManager"        },
         { "name": "PhysicsRangeExtender" }
     ],
     "suggests": [

--- a/NetKAN/BetterLookingOceans-HighRes.netkan
+++ b/NetKAN/BetterLookingOceans-HighRes.netkan
@@ -15,14 +15,15 @@
         "graphics"
     ],
     "depends": [
-        { "name": "Kopernicus" }
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus"    }
     ],
     "conflicts": [
         { "name": "BetterLookingOceans-MedRes" },
         { "name": "BetterLookingOceans-LowRes" }
     ],
     "install": [ {
-        "find": "GameData/BLO",
+        "find":       "GameData/BLO",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/BetterLookingOceans-LowRes.netkan
+++ b/NetKAN/BetterLookingOceans-LowRes.netkan
@@ -15,14 +15,15 @@
         "graphics"
     ],
     "depends": [
-        { "name": "Kopernicus" }
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus"    }
     ],
     "conflicts": [
         { "name": "BetterLookingOceans-HighRes" },
         { "name": "BetterLookingOceans-MedRes" }
     ],
     "install": [ {
-        "find": "GameData/BLO",
+        "find":       "GameData/BLO",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/BetterLookingOceans-MedRes.netkan
+++ b/NetKAN/BetterLookingOceans-MedRes.netkan
@@ -15,14 +15,15 @@
         "graphics"
     ],
     "depends": [
-        { "name": "Kopernicus" }
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus"    }
     ],
     "conflicts": [
         { "name": "BetterLookingOceans-HighRes" },
         { "name": "BetterLookingOceans-LowRes" }
     ],
     "install": [ {
-        "find": "GameData/BLO",
+        "find":       "GameData/BLO",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/BeyondHome.netkan
+++ b/NetKAN/BeyondHome.netkan
@@ -16,6 +16,7 @@
         "graphics"
     ],
     "depends": [
+        { "name": "ModuleManager"              },
         { "name": "Kopernicus"                 },
         { "name": "Scatterer-sunflare-default" }
     ],

--- a/NetKAN/Bureaucracy.netkan
+++ b/NetKAN/Bureaucracy.netkan
@@ -14,6 +14,7 @@
         "career"
     ],
     "depends" : [
+        { "name": "ModuleManager" },
         { "name" : "KerbalChangelog" },
         { "name" : "FlightTracker" },
         { "name" : "CustomBarnKit" }
@@ -26,7 +27,6 @@
         { "name" : "MonthlyBudgets" },
         { "name" : "SpaceProgramFunding" }
     ],
-    
     "install" : [ {
         "find" : "Bureaucracy",
         "install_to" : "GameData"

--- a/NetKAN/CommNetAntennasInfo.netkan
+++ b/NetKAN/CommNetAntennasInfo.netkan
@@ -19,6 +19,9 @@
     "conflicts": [
         { "name": "RemoteTech" }
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "recommends": [
         { "name": "CommNetAntennasExtension" },
         { "name": "CommNetAntennasConsumptor" }

--- a/NetKAN/CommunityPartsTitles.netkan
+++ b/NetKAN/CommunityPartsTitles.netkan
@@ -14,6 +14,9 @@
         "convenience",
         "editor"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "recommends": [
         { "name": "CommunityPartsTitlesExtrasCategory" },
         { "name": "CommunityPartsTitlesExtrasNoCCKDup" },

--- a/NetKAN/CrewQueue.netkan
+++ b/NetKAN/CrewQueue.netkan
@@ -15,6 +15,7 @@
         "crewed"
     ],
     "depends": [
+        { "name": "ModuleManager"   },
         { "name": "FingerboxesCore" }
     ],
      "install": [

--- a/NetKAN/CustomAsteroids-Pops-OPM-Reconfig.netkan
+++ b/NetKAN/CustomAsteroids-Pops-OPM-Reconfig.netkan
@@ -18,6 +18,7 @@
         "planet-pack"
     ],
     "depends": [
+        { "name": "ModuleManager" },
         {
             "name": "OuterPlanetsMod",
             "min_version": "2:2.2.2",

--- a/NetKAN/DMagicOrbitalScience.netkan
+++ b/NetKAN/DMagicOrbitalScience.netkan
@@ -21,6 +21,9 @@
         "career",
         "uncrewed"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "recommends": [
         { "name": "ContractsWindowPlus" }
     ],

--- a/NetKAN/DynamicDeflection.netkan
+++ b/NetKAN/DynamicDeflection.netkan
@@ -13,6 +13,9 @@
         "plugin",
         "control"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install" : [
         {
             "file"       : "GameData/Dynamic Controls",

--- a/NetKAN/EVAStruts.netkan
+++ b/NetKAN/EVAStruts.netkan
@@ -4,6 +4,9 @@
     "$kref":        "#/ckan/spacedock/553",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "MIT",
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "tags": [
         "plugin",
         "parts",

--- a/NetKAN/ElephantEngine.netkan
+++ b/NetKAN/ElephantEngine.netkan
@@ -10,6 +10,9 @@
     "tags": [
         "parts"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
         "file"       : "ElephantEngine",
         "install_to" : "GameData"

--- a/NetKAN/FASALaunchClampsContinued.netkan
+++ b/NetKAN/FASALaunchClampsContinued.netkan
@@ -11,6 +11,9 @@
 	"tags": [
 		"parts"
 	],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "suggests": [
         { "name": "AlmostFreeLaunchClamps" }
     ],

--- a/NetKAN/GPO.netkan
+++ b/NetKAN/GPO.netkan
@@ -16,6 +16,7 @@
         "graphics"
     ],
     "depends": [
+        { "name": "ModuleManager"               },
         { "name": "Kopernicus"                  },
         { "name": "CommunityTerrainTexturePack" },
         { "name": "Scatterer"                   },

--- a/NetKAN/GPWS.netkan
+++ b/NetKAN/GPWS.netkan
@@ -14,7 +14,7 @@
         "information",
         "sound"
     ],
-    "suggests"     : [
+    "depends"      : [
         { "name": "ModuleManager" }
     ],
     "install"      : [

--- a/NetKAN/GrannusExpansionPack-CommNet.netkan
+++ b/NetKAN/GrannusExpansionPack-CommNet.netkan
@@ -15,6 +15,7 @@
         "comms"
     ],
     "depends": [
+        { "name": "ModuleManager"        },
         { "name": "GrannusExpansionPack" },
         { "name": "CustomBarnKit"        }
     ],

--- a/NetKAN/GrannusExpansionPack-JNSQ.netkan
+++ b/NetKAN/GrannusExpansionPack-JNSQ.netkan
@@ -14,6 +14,7 @@
         "planet-pack"
     ],
     "depends": [
+        { "name": "ModuleManager"        },
         { "name": "GrannusExpansionPack" },
         { "name": "JNSQ"                 }
     ],

--- a/NetKAN/GrannusExpansionPack-Primary.netkan
+++ b/NetKAN/GrannusExpansionPack-Primary.netkan
@@ -14,6 +14,7 @@
         "planet-pack"
     ],
     "depends": [
+        { "name": "ModuleManager"        },
         { "name": "GrannusExpansionPack" }
     ],
     "conflicts": [

--- a/NetKAN/HeatPump.netkan
+++ b/NetKAN/HeatPump.netkan
@@ -12,6 +12,9 @@
         "parts",
         "physics"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
         "file"       : "GameData/000_HeatPump",
         "install_to" : "GameData"

--- a/NetKAN/IR-Model-Rework-Core.netkan
+++ b/NetKAN/IR-Model-Rework-Core.netkan
@@ -15,6 +15,7 @@
         "parts"
     ],
     "depends": [
+        { "name": "ModuleManager" },
         { "name": "InfernalRobotics", "min_version": "0.19.4" }
     ],
     "recommends": [

--- a/NetKAN/IR-Model-Rework-Expansion.netkan
+++ b/NetKAN/IR-Model-Rework-Expansion.netkan
@@ -15,6 +15,7 @@
         "parts"
     ],
     "depends": [
+        { "name": "ModuleManager" },
         { "name": "InfernalRobotics", "min_version": "0.19.4" },
         { "name": "IR-Model-Rework-Core" }
     ],

--- a/NetKAN/ISRUThanksButNoTanks.netkan
+++ b/NetKAN/ISRUThanksButNoTanks.netkan
@@ -14,6 +14,9 @@
         "config",
         "resources"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
         "install_to": "GameData",
         "find_regexp": "ISRUThanksButNoTanks.*"

--- a/NetKAN/InfernalRoboticsNext.netkan
+++ b/NetKAN/InfernalRoboticsNext.netkan
@@ -20,6 +20,9 @@
         { "name": "InfernalRobotics"         },
         { "name": "KerbalJointReinforcement" }
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "recommends"     : [
         { "name": "KerbalJointReinforcementNext" }
     ],

--- a/NetKAN/InterstellarFuelSwitch-Core.netkan
+++ b/NetKAN/InterstellarFuelSwitch-Core.netkan
@@ -30,7 +30,8 @@
         "DeadskinsMeshSwitch"
     ],
     "depends": [
-        { "name": "TweakScale" }
+        { "name": "ModuleManager" },
+        { "name": "TweakScale"    }
     ],
     "recommends": [
         { "name" : "CommunityResourcePack", "min_version" : "0.7.1" }

--- a/NetKAN/JoolianDiscovery.netkan
+++ b/NetKAN/JoolianDiscovery.netkan
@@ -10,8 +10,11 @@
     "tags": [
         "parts"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
-        "find": "JoolianDiscovery",
+        "find":       "JoolianDiscovery",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/KAINET.netkan
+++ b/NetKAN/KAINET.netkan
@@ -18,6 +18,9 @@
         "find"      : "NoAstronautsNeedApply",
         "install_to": "GameData"
     } ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "recommends"    : [
         { "name"    : "InfernalRobotics" },
         { "name"    : "ShipManifest" }

--- a/NetKAN/KWRocketry-CommunityFixes-interstage.netkan
+++ b/NetKAN/KWRocketry-CommunityFixes-interstage.netkan
@@ -15,13 +15,14 @@
         "config"
     ],
     "depends": [
+        { "name": "ModuleManager"             },
         { "name": "KWRocketry-CommunityFixes" }
     ],
     "install": [
         {
-            "find": "KWPatch-interstage.cfg",
-            "find_matches_files": true,
-            "install_to": "GameData/KWCommunityFixes"
+            "find":       "KWPatch-interstage.cfg",
+            "install_to": "GameData/KWCommunityFixes",
+            "find_matches_files": true
         }
     ]
 }

--- a/NetKAN/KerbalPlanetaryBaseSystems.netkan
+++ b/NetKAN/KerbalPlanetaryBaseSystems.netkan
@@ -16,8 +16,9 @@
         }
     ],
     "depends" : [
-        { "name" : "CommunityCategoryKit" },
-        { "name" : "CommunityResourcePack" }
+        { "name": "ModuleManager"         },
+        { "name": "CommunityCategoryKit"  },
+        { "name": "CommunityResourcePack" }
     ],
     "x_netkan_force_v": true
 }

--- a/NetKAN/Kerbalism-Config-Default.netkan
+++ b/NetKAN/Kerbalism-Config-Default.netkan
@@ -13,9 +13,12 @@
         "crewed",
         "science"
     ],
-    "provides": [ "Kerbalism-Config" ],
+    "provides": [
+        "Kerbalism-Config"
+    ],
     "depends": [
-        { "name": "Kerbalism" }
+        { "name": "ModuleManager" },
+        { "name": "Kerbalism"     }
     ],
     "conflicts": [
         { "name": "Kerbalism-Config" },
@@ -26,7 +29,7 @@
         { "name": "BackgroundProcessing" }
     ],
     "install": [ {
-        "find": "KerbalismConfig",
+        "find":       "KerbalismConfig",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/Kerbalism-Config-RO.netkan
+++ b/NetKAN/Kerbalism-Config-RO.netkan
@@ -11,12 +11,15 @@
         "science",
         "crewed"
     ],
-    "provides": [ "Kerbalism-Config" ],
+    "provides": [
+        "Kerbalism-Config"
+    ],
     "conflicts": [
         { "name": "Kerbalism-Config" }
     ],
     "depends": [
-        { "name": "Kerbalism" }
+        { "name": "ModuleManager" },
+        { "name": "Kerbalism"     }
     ],
     "recommends": [
         { "name": "RealismOverhaul" }

--- a/NetKAN/KerbinSideGAP.netkan
+++ b/NetKAN/KerbinSideGAP.netkan
@@ -13,6 +13,7 @@
         "buildings"
     ],
     "depends": [
+        { "name": "ModuleManager"    },
         { "name": "KerbalKonstructs" },
         { "name": "ContractConfigurator", "min_version": "1.21.0" }
     ],

--- a/NetKAN/Kethane.netkan
+++ b/NetKAN/Kethane.netkan
@@ -15,5 +15,8 @@
     "tags": [
         "plugin",
         "resources"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/MoarFEConfigs.netkan
+++ b/NetKAN/MoarFEConfigs.netkan
@@ -10,10 +10,11 @@
         "convenience"
     ],
     "install": [ {
-        "find": "MoarFilterExtensionConfigs",
+        "find":       "MoarFilterExtensionConfigs",
         "install_to": "GameData"
     } ],
     "depends": [
-        { "name"     : "FilterExtensions" }
+        { "name": "ModuleManager"    },
+        { "name": "FilterExtensions" }
     ]
 }

--- a/NetKAN/ModularRocketSystem.netkan
+++ b/NetKAN/ModularRocketSystem.netkan
@@ -1,9 +1,9 @@
 {
-    "spec_version" : 1,
-    "identifier" : "ModularRocketSystem",
-    "$kref" : "#/ckan/spacedock/86",
-    "$vref" : "#/ckan/ksp-avc",
-    "license" : "CC-BY-NC-SA",
+    "spec_version": 1,
+    "identifier":   "ModularRocketSystem",
+    "$kref":        "#/ckan/spacedock/86",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "CC-BY-NC-SA",
     "tags": [
         "parts"
     ],
@@ -25,10 +25,11 @@
     "conflicts": [
         { "name": "ModularRocketSystemsLITE" }
     ],
-    "install": [
-        {
-            "file": "ModRocketSys",
-            "install_to": "GameData"
-        }
-    ]
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
+    "install": [ {
+        "file":       "ModRocketSys",
+        "install_to": "GameData"
+    } ]
 }

--- a/NetKAN/MonthlyBudgets.netkan
+++ b/NetKAN/MonthlyBudgets.netkan
@@ -6,21 +6,22 @@
     "$kref"        : "#/ckan/github/severedsolo/MonthlyBudgets",
     "$vref"        : "#/ckan/ksp-avc",
     "license"      : "MIT",
-    "resources" : {
-        "homepage" : "http://forum.kerbalspaceprogram.com/index.php?/topic/147010-*"
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/147010-*"
     },
     "tags": [
         "plugin",
         "career"
     ],
-    "depends" : [
-        { "name" : "KerbalChangelog" }
+    "depends": [
+        { "name": "ModuleManager"   },
+        { "name": "KerbalChangelog" }
     ],
     "recommends": [
         { "name": "KerbalConstructionTime" }
     ],
-    "install" : [ {
-        "find" : "MonthlyBudgets",
-        "install_to" : "GameData"
+    "install": [ {
+        "find":       "MonthlyBudgets",
+        "install_to": "GameData"
     } ]
 }

--- a/NetKAN/NewTantares.netkan
+++ b/NetKAN/NewTantares.netkan
@@ -14,6 +14,9 @@
         "parts",
         "crewed"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "recommends": [
         { "name": "NewTantaresLV" }
     ],

--- a/NetKAN/OPTReconfig.netkan
+++ b/NetKAN/OPTReconfig.netkan
@@ -16,8 +16,9 @@
         "install_to": "GameData"
     } ],
     "depends": [
+        { "name": "ModuleManager"      },
         { "name": "OPTSpacePlaneParts" },
-        { "name": "B9PartSwitch" }
+        { "name": "B9PartSwitch"       }
     ],
     "recommends": [
         { "name": "CommunityResourcePack" }

--- a/NetKAN/OutlawRacingInc.netkan
+++ b/NetKAN/OutlawRacingInc.netkan
@@ -7,6 +7,9 @@
     "tags": [
         "parts"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
         "find":       "ORinc",
         "install_to": "GameData"

--- a/NetKAN/PangolinMechanicsToolkit.netkan
+++ b/NetKAN/PangolinMechanicsToolkit.netkan
@@ -10,5 +10,8 @@
     "tags": [
         "plugin",
         "physics"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/ParkingBrake.netkan
+++ b/NetKAN/ParkingBrake.netkan
@@ -6,5 +6,8 @@
     "license":      "GPL-3.0",
     "tags": [
         "config"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/ProceduralDynamics.netkan
+++ b/NetKAN/ProceduralDynamics.netkan
@@ -12,5 +12,8 @@
     "tags": [
         "plugin",
         "parts"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/Pteron.netkan
+++ b/NetKAN/Pteron.netkan
@@ -7,7 +7,7 @@
     "tags": [
         "parts"
     ],
-    "recommends": [
+    "depends": [
         { "name": "ModuleManager" }
     ],
     "suggests": [

--- a/NetKAN/RLARecontinued.netkan
+++ b/NetKAN/RLARecontinued.netkan
@@ -9,10 +9,13 @@
     ],
     "conflicts": [
         { "name": "RLA-Stockalike" },
-        { "name": "RLAContinued" }
+        { "name": "RLAContinued"   }
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ],
     "install": [ {
-        "install_to": "GameData",
-        "find": "RLA_Stockalike"
+        "find":       "RLA_Stockalike",
+        "install_to": "GameData"
     } ]
 }

--- a/NetKAN/RSS-Airports.netkan
+++ b/NetKAN/RSS-Airports.netkan
@@ -14,7 +14,8 @@
         "config"
     ],
     "depends": [
-        { "name": "KSCSwitcher" },
+        { "name": "ModuleManager"   },
+        { "name": "KSCSwitcher"     },
         { "name": "RealSolarSystem" }
     ],
     "recommends": [

--- a/NetKAN/RSS-FictionalKSC.netkan
+++ b/NetKAN/RSS-FictionalKSC.netkan
@@ -14,14 +14,15 @@
         "config"
     ],
     "depends": [
-        { "name": "KSCSwitcher" },
+        { "name": "ModuleManager"   },
+        { "name": "KSCSwitcher"     },
         { "name": "RealSolarSystem" }
     ],
     "recommends": [
         { "name": "RSS-Airports" }
     ],
     "install": [ {
-        "file" : "RSS-FictionalKSC",
+        "file" :       "RSS-FictionalKSC",
         "install_to" : "GameData"
     } ]
 }

--- a/NetKAN/RationalResourcesParts.netkan
+++ b/NetKAN/RationalResourcesParts.netkan
@@ -12,6 +12,7 @@
         "resources"
     ],
     "depends": [
+        { "name": "ModuleManager"         },
         { "name": "B9PartSwitch"          },
         { "name": "CommunityResourcePack" },
         { "name": "RationalResources"     }

--- a/NetKAN/RealChute.netkan
+++ b/NetKAN/RealChute.netkan
@@ -16,7 +16,7 @@
         "physics",
         "sound"
     ],
-    "recommends" : [
+    "depends" : [
         { "name" : "ModuleManager" }
     ],
     "x_netkan_override": [

--- a/NetKAN/Rescale-10.netkan
+++ b/NetKAN/Rescale-10.netkan
@@ -20,15 +20,16 @@
         }
     ],
     "depends": [
+        { "name": "ModuleManager"   },
         { "name": "SigmaDimensions" }
     ],
     "recommends": [
 		{ "name": "Kronometer" }
     ],
     "conflicts": [
-        { "name": "Rescale-25" },
-        { "name": "Rescale-32" },
-        { "name": "Rescale-64" },
+        { "name": "Rescale-25"    },
+        { "name": "Rescale-32"    },
+        { "name": "Rescale-64"    },
         { "name": "Rescale-10625" }
     ]
 }

--- a/NetKAN/Rescale-10625.netkan
+++ b/NetKAN/Rescale-10625.netkan
@@ -20,6 +20,7 @@
         }
     ],
     "depends": [
+        { "name": "ModuleManager"   },
         { "name": "SigmaDimensions" }
     ],
     "recommends": [

--- a/NetKAN/Rescale-25.netkan
+++ b/NetKAN/Rescale-25.netkan
@@ -20,15 +20,16 @@
         }
     ],
     "depends": [
+        { "name": "ModuleManager"   },
         { "name": "SigmaDimensions" }
     ],
     "recommends": [
 		{ "name": "Kronometer" }
     ],
     "conflicts": [
-        { "name": "Rescale-32" },
-        { "name": "Rescale-64" },
-        { "name": "Rescale-10" },
+        { "name": "Rescale-32"    },
+        { "name": "Rescale-64"    },
+        { "name": "Rescale-10"    },
         { "name": "Rescale-10625" }
     ]
 }

--- a/NetKAN/Rescale-32.netkan
+++ b/NetKAN/Rescale-32.netkan
@@ -20,15 +20,16 @@
         }
     ],
     "depends": [
+        { "name": "ModuleManager"   },
         { "name": "SigmaDimensions" }
     ],
     "recommends": [
 		{ "name": "Kronometer" }
     ],
     "conflicts": [
-        { "name": "Rescale-25" },
-        { "name": "Rescale-64" },
-        { "name": "Rescale-10" },
+        { "name": "Rescale-25"    },
+        { "name": "Rescale-64"    },
+        { "name": "Rescale-10"    },
         { "name": "Rescale-10625" }
     ]
 }

--- a/NetKAN/Rescale-64.netkan
+++ b/NetKAN/Rescale-64.netkan
@@ -20,15 +20,16 @@
         }
     ],
     "depends": [
+        { "name": "ModuleManager"   },
         { "name": "SigmaDimensions" }
     ],
     "recommends": [
 		{ "name": "Kronometer" }
     ],
     "conflicts": [
-        { "name": "Rescale-25" },
-        { "name": "Rescale-32" },
-        { "name": "Rescale-10" },
+        { "name": "Rescale-25"    },
+        { "name": "Rescale-32"    },
+        { "name": "Rescale-10"    },
         { "name": "Rescale-10625" }
     ]
 }

--- a/NetKAN/RocketEmporium.netkan
+++ b/NetKAN/RocketEmporium.netkan
@@ -11,6 +11,7 @@
         "parts"
     ],
     "depends": [
+        { "name": "ModuleManager"      },
         { "name": "AnimatedAttachment" }
     ]
 }

--- a/NetKAN/SVE-Terrain.netkan
+++ b/NetKAN/SVE-Terrain.netkan
@@ -14,7 +14,8 @@
         "graphics"
     ],
     "depends": [
-        { "name": "Kopernicus" }
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus"    }
     ],
     "recommends": [
         { "name": "StockVisualEnhancements" }

--- a/NetKAN/ShangshengOrbital.netkan
+++ b/NetKAN/ShangshengOrbital.netkan
@@ -16,7 +16,8 @@
         "install_to": "Ships"
     } ],
     "depends": [
-        { "name": "SpaceXLegs" }
+        { "name": "ModuleManager" },
+        { "name": "SpaceXLegs"    }
     ],
     "recommends": [
         { "name": "Smokescreen" },

--- a/NetKAN/SigmaBinary-DunaIke.netkan
+++ b/NetKAN/SigmaBinary-DunaIke.netkan
@@ -16,11 +16,12 @@
         "planet-pack"
     ],
     "depends": [
+        { "name": "ModuleManager"    },
         { "name": "SigmaBinary-core" }
     ],
     "install": [
         {
-            "find": "SigmaDunaIke",
+            "find":       "SigmaDunaIke",
             "install_to": "GameData/Sigma"
         }
     ]

--- a/NetKAN/SpaceDock.netkan
+++ b/NetKAN/SpaceDock.netkan
@@ -20,19 +20,20 @@
         "find"       : "GameData/SpaceDock",
         "install_to" : "GameData"
     } ],
-    "depends" : [
-        { "name" : "CommunityTechTree" }
+    "depends": [
+        { "name": "ModuleManager"     },
+        { "name": "CommunityTechTree" }
     ],
-    "recommends" : [
-        { "name" : "ExtraPlanetaryLaunchpads" }
+    "recommends": [
+        { "name": "ExtraPlanetaryLaunchpads" }
     ],
-    "suggests" : [
-        { "name" : "KIS" },
-        { "name" : "KAS" },
-        { "name" : "Konstruction" },
-        { "name" : "USI-Core" }
+    "suggests": [
+        { "name": "KIS" },
+        { "name": "KAS" },
+        { "name": "Konstruction" },
+        { "name": "USI-Core" }
     ],
-    "supports" : [
-        { "name" : "ConnectedLivingSpace" }
+    "supports": [
+        { "name": "ConnectedLivingSpace" }
     ]
 }

--- a/NetKAN/SpaceProgramFunding.netkan
+++ b/NetKAN/SpaceProgramFunding.netkan
@@ -13,5 +13,8 @@
     ],
     "conflicts": [
         { "name": "MonthlyBudgets" }
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/StationScienceContinued.netkan
+++ b/NetKAN/StationScienceContinued.netkan
@@ -22,6 +22,9 @@
     "conflicts": [
         { "name": "StationScience" }
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
         "find":       "StationScience",
         "install_to": "GameData"

--- a/NetKAN/StockDragFix.netkan
+++ b/NetKAN/StockDragFix.netkan
@@ -13,5 +13,8 @@
     "tags": [
         "plugin",
         "physics"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/StorkDeliverySystem.netkan
+++ b/NetKAN/StorkDeliverySystem.netkan
@@ -8,6 +8,9 @@
     "tags": [
         "parts"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "suggests": [
         { "name": "MoarKerbals"             },
         { "name": "MFS"                     },

--- a/NetKAN/SurfaceExperimentPack.netkan
+++ b/NetKAN/SurfaceExperimentPack.netkan
@@ -15,8 +15,9 @@
         "crewed"
     ],
     "depends": [
-        { "name": "KAS" },
-        { "name": "KIS" }
+        { "name": "ModuleManager" },
+        { "name": "KAS"           },
+        { "name": "KIS"           }
     ],
     "supports": [
         { "name": "OuterPlanetsMod" },

--- a/NetKAN/TRAILSPlus.netkan
+++ b/NetKAN/TRAILSPlus.netkan
@@ -11,7 +11,10 @@
     "tags": [
         "parts"
     ],
-    "recommended": [
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
+    "recommends": [
         { "name": "BluedogDB"     },
         { "name": "EVAParachutes" }
     ]

--- a/NetKAN/TarsierSpaceTechnologyWithGalaxies.netkan
+++ b/NetKAN/TarsierSpaceTechnologyWithGalaxies.netkan
@@ -16,14 +16,16 @@
     ],
     "install": [
         {
-            "find": "TarsierSpaceTech",
+            "find":       "TarsierSpaceTech",
             "install_to": "GameData"
         }
     ],
     "recommends": [
-        { "name": "KAS" },
-        { "name": "KIS" },
-        { "name": "ModuleManager" },
+        { "name": "KAS"     },
+        { "name": "KIS"     },
         { "name": "Toolbar" }
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/TelemachusReborn.netkan
+++ b/NetKAN/TelemachusReborn.netkan
@@ -18,17 +18,22 @@
         "information",
         "app"
     ],
-    "provides" : [ "Telemachus" ],
-    "conflicts" : [
-         { "name" : "Telemachus" },
-         { "name" : "TelemachusContinued" },
-         { "name" : "Telemachus-2" }
+    "provides": [
+        "Telemachus"
     ],
-    "recommends" : [
+    "conflicts": [
+         { "name": "Telemachus" },
+         { "name": "TelemachusContinued" },
+         { "name": "Telemachus-2" }
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
+    "recommends": [
         { "name": "RasterPropMonitor" }
     ],
-    "install" : [ {
-        "file"   : "GameData/Telemachus",
+    "install": [ {
+        "file":        "GameData/Telemachus",
         "install_to" : "GameData"
     } ],
     "x_netkan_override": [

--- a/NetKAN/TundraTechnologies.netkan
+++ b/NetKAN/TundraTechnologies.netkan
@@ -10,6 +10,7 @@
         "parts"
     ],
     "depends": [
+        { "name": "ModuleManager"      },
         { "name": "TundraExploration"  }
     ],
     "install": [

--- a/NetKAN/ZeroPointInlineFairings.netkan
+++ b/NetKAN/ZeroPointInlineFairings.netkan
@@ -11,19 +11,20 @@
         "parts"
     ],
     "install": [ {
-        "file": "0PinlineFairings",
+        "file":       "0PinlineFairings",
         "install_to": "GameData"
     } ],
     "conflicts": [
         { "name": "ZeroPointInlineFairings-Lite" }
     ],
     "depends": [
-        { "name": "FerramAerospaceResearch"}
+        { "name": "ModuleManager"           },
+        { "name": "FerramAerospaceResearch" }
     ],
     "suggests": [
         { "name": "ModularRocketSystem" },
-        { "name": "SpaceY-Lifters" },
-        { "name": "ColorCodedCans"},
-        { "name": "FuelTanksPlus"}
+        { "name": "SpaceY-Lifters"      },
+        { "name": "ColorCodedCans"      },
+        { "name": "FuelTanksPlus"       }
     ]
 }

--- a/NetKAN/kRPC.netkan
+++ b/NetKAN/kRPC.netkan
@@ -13,5 +13,8 @@
         "plugin",
         "app",
         "control"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }


### PR DESCRIPTION
## Background

I have a new toy.

![image](https://user-images.githubusercontent.com/1559108/82172037-a5a42f00-988e-11ea-8e4a-a2158bd4bac4.png)

## Problem

It's common for mods to include .cfg files using ModuleManager syntax to make tweaks or enable themselves. Some mods even do _only_ this.

Naturally, this only works if you install ModuleManager, which means such mods should depend on ModuleManager. Many don't, but as of KSP-CKAN/CKAN#3045, we have the ability to detect this.

## Changes

Now these mods depend on ModuleManager. This should clear a bunch of warnings on the status page and ensure that these mods work correctly when installed.