### PR TITLE
Add ModuleManager depends for third pass of mods using MM syntax

### DIFF
--- a/NetKAN/ASETProps.netkan
+++ b/NetKAN/ASETProps.netkan
@@ -11,6 +11,7 @@
         "control"
     ],
     "depends": [
+        { "name": "ModuleManager" },
         { "name": "ASETAgency" },
         { "name": "RasterPropMonitor-Core", "min_version" : "1:v0.30.2" }
     ],

--- a/NetKAN/AbovetheSkySoyuzTMAandR7.netkan
+++ b/NetKAN/AbovetheSkySoyuzTMAandR7.netkan
@@ -10,17 +10,18 @@
         "parts"
     ],
     "depends": [
+        { "name": "ModuleManager"      },
         { "name": "SpaceShuttleSystem" }
     ],
     "recommends": [
-        { "name": "ASETProps" },
+        { "name": "ASETProps"         },
         { "name": "RasterPropMonitor" }
     ],
     "install": [ {
-        "file": "DECQ_R7",
+        "file":       "DECQ_R7",
         "install_to": "GameData"
     }, {
-        "file": "SOYUZ_SPACECRAFT",
+        "file":       "SOYUZ_SPACECRAFT",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/Airlocks.netkan
+++ b/NetKAN/Airlocks.netkan
@@ -6,5 +6,8 @@
     "tags": [
         "parts",
         "crewed"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/AlmostRealSolarSystem.netkan
+++ b/NetKAN/AlmostRealSolarSystem.netkan
@@ -8,12 +8,13 @@
         "planet-pack"
     ],
     "install": [ {
-        "find": "(Almost)RealSolarSystem",
+        "find":       "(Almost)RealSolarSystem",
         "install_to": "GameData"
     } ],
     "depends": [
-        { "name": "SigmaDimensions" },
-        { "name": "Kopernicus" }
+        { "name": "ModuleManager"   },
+        { "name": "Kopernicus"      },
+        { "name": "SigmaDimensions" }
     ],
     "recommends": [
         { "name": "OPM-Galileo" }

--- a/NetKAN/AlphaMensaeMobileLauncher.netkan
+++ b/NetKAN/AlphaMensaeMobileLauncher.netkan
@@ -6,6 +6,9 @@
     "tags": [
         "parts"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "recommends": [
         { "name": "KerbalJointReinforcement" }
     ]

--- a/NetKAN/AutomatedAerialRefueling.netkan
+++ b/NetKAN/AutomatedAerialRefueling.netkan
@@ -13,6 +13,9 @@
         "find":       "AARS",
         "install_to": "GameData"
     } ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "recommends": [
         { "name": "BDArmoryContinued" }
     ]

--- a/NetKAN/AutomaticFuelCells.netkan
+++ b/NetKAN/AutomaticFuelCells.netkan
@@ -7,6 +7,9 @@
         "plugin",
         "convenience"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
         "find":       "XyphosAerospace",
         "install_to": "GameData"

--- a/NetKAN/BackInBlackTexturePack.netkan
+++ b/NetKAN/BackInBlackTexturePack.netkan
@@ -13,6 +13,7 @@
         "find":       "BackInBlack"
     } ],
     "depends": [
-        { "name": "BackInBlack" }
+        { "name": "ModuleManager" },
+        { "name": "BackInBlack"   }
     ]
 }

--- a/NetKAN/BetterBurnTime.netkan
+++ b/NetKAN/BetterBurnTime.netkan
@@ -7,6 +7,9 @@
         "plugin",
         "information"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "x_netkan_override": [ {
         "version":  "1.6.1",
         "delete":   [ "ksp_version" ],

--- a/NetKAN/BonVoyage.netkan
+++ b/NetKAN/BonVoyage.netkan
@@ -8,5 +8,7 @@
         "plugin",
         "convenience"
     ],
-    "x_via": "Automated SpaceDock CKAN submission"
+    "depends": [
+        { "name": "ModuleManager" }
+    ]
 }

--- a/NetKAN/BuoyancyControl.netkan
+++ b/NetKAN/BuoyancyControl.netkan
@@ -5,5 +5,8 @@
     "license":      "MIT",
     "tags": [
         "plugin"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/CAMk3BlockII.netkan
+++ b/NetKAN/CAMk3BlockII.netkan
@@ -8,6 +8,7 @@
         "parts"
     ],
     "depends": [
+        { "name": "ModuleManager"                         },
         { "name": "ShuttleLiftingBodyCormorantAeronology" }
     ],
     "install": [

--- a/NetKAN/CVX.netkan
+++ b/NetKAN/CVX.netkan
@@ -8,8 +8,9 @@
         "combat"
     ],
     "depends": [
+        { "name": "ModuleManager"         },
         { "name": "CommunityResourcePack" },
-        { "name": "FirespitterCore" }
+        { "name": "FirespitterCore"       }
     ],
     "recommends": [
         { "name": "BDArmoryContinued" },
@@ -21,12 +22,10 @@
         { "name": "KerbalJointReinforcement" },
         { "name": "AircraftCarrierAccessories" }
     ],
-    "install": [
-        {
-            "find": "Eskandare_Heavy_Industries",
-            "install_to": "GameData"
-        }
-    ],
+    "install": [ {
+        "find":       "Eskandare_Heavy_Industries",
+        "install_to": "GameData"
+    } ],
     "x_netkan_override": [
         {
             "version": "0.12",

--- a/NetKAN/CapsuleCorporationEndeavourMarsBaseCamp.netkan
+++ b/NetKAN/CapsuleCorporationEndeavourMarsBaseCamp.netkan
@@ -8,6 +8,9 @@
         "parts",
         "crewed"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
         "find":       "CapsuleCorp",
         "install_to": "GameData"

--- a/NetKAN/ChakaMonkeyExplorationSystems.netkan
+++ b/NetKAN/ChakaMonkeyExplorationSystems.netkan
@@ -8,6 +8,7 @@
         "parts"
     ],
     "depends": [
+        { "name": "ModuleManager"      },
         { "name": "AnimatedDecouplers" },
         { "any_of": [
             { "name": "KerbalJointReinforcement" },

--- a/NetKAN/ControlSurfaceToggle.netkan
+++ b/NetKAN/ControlSurfaceToggle.netkan
@@ -6,5 +6,8 @@
     "tags": [
         "plugin",
         "control"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/CxAerospace.netkan
+++ b/NetKAN/CxAerospace.netkan
@@ -6,5 +6,8 @@
     "tags": [
         "parts",
         "crewed"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/DeepSkyCore.netkan
+++ b/NetKAN/DeepSkyCore.netkan
@@ -7,6 +7,9 @@
         "config",
         "library"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
         "find":       "DeepSky",
         "install_to": "GameData"

--- a/NetKAN/DerivativeTextures.netkan
+++ b/NetKAN/DerivativeTextures.netkan
@@ -12,6 +12,7 @@
         "install_to": "GameData"
     } ],
     "depends": [
+        { "name": "ModuleManager"   },
         { "name": "ProceduralParts" }
     ]
 }

--- a/NetKAN/EVATransfer.netkan
+++ b/NetKAN/EVATransfer.netkan
@@ -6,5 +6,8 @@
     "tags": [
         "plugin",
         "crewed"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/Explainer.netkan
+++ b/NetKAN/Explainer.netkan
@@ -9,7 +9,8 @@
         "crewed"
     ],
     "depends": [
-        { "name": "UKS" },
-        { "name": "USI-LS" }
+        { "name": "ModuleManager" },
+        { "name": "UKS"           },
+        { "name": "USI-LS"        }
     ]
 }

--- a/NetKAN/FlexibleDocking.netkan
+++ b/NetKAN/FlexibleDocking.netkan
@@ -8,11 +8,11 @@
         "parts",
         "crewed"
     ],
-    "recommends": [
+    "depends": [
          { "name": "ModuleManager" }
     ],
     "install": [ {
-        "find" : "FlexoDocking",
-        "install_to" : "GameData"
+        "find":       "FlexoDocking",
+        "install_to": "GameData"
     } ]
 }

--- a/NetKAN/GreenSkullRevived.netkan
+++ b/NetKAN/GreenSkullRevived.netkan
@@ -3,13 +3,14 @@
     "identifier":   "GreenSkullRevived",
     "$kref":        "#/ckan/spacedock/2317",
     "license":      "MIT",
-    "depends": [
-        { "name": "TextureReplacer" }
-    ],
     "tags": [
         "config",
         "graphics",
         "crewed"
+    ],
+    "depends": [
+        { "name": "ModuleManager"   },
+        { "name": "TextureReplacer" }
     ],
     "install": [ {
         "find":       "TextureReplacer",

--- a/NetKAN/HooliganLabsAirships.netkan
+++ b/NetKAN/HooliganLabsAirships.netkan
@@ -7,11 +7,12 @@
         "plugin",
         "parts"
     ],
-    "install": [
-        {
-          "find"       : "HLAirships",
-          "install_to" : "GameData",
-          "filter"     : "thumbs.db"
-        }
-    ]
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
+    "install": [ {
+      "find"       : "HLAirships",
+      "install_to" : "GameData",
+      "filter"     : "thumbs.db"
+    } ]
 }

--- a/NetKAN/HydrogenCompression.netkan
+++ b/NetKAN/HydrogenCompression.netkan
@@ -7,6 +7,9 @@
         "plugin",
         "resources"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "recommends": [
         { "name": "KerbalPlanetaryBaseSystems" },
         { "name": "CryoEngines" },

--- a/NetKAN/IONRCS.netkan
+++ b/NetKAN/IONRCS.netkan
@@ -7,13 +7,12 @@
         "parts"
     ],
     "depends": [
+        { "name": "ModuleManager"         },
         { "name": "REPOSoftTech-Agencies" }
     ],
-    "install": [
-        {
-            "find"       : "REPOSoftTech",
-            "install_to" : "GameData",
-            "filter"     : "Agencies"
-        }
-    ]
+    "install": [ {
+        "find":       "REPOSoftTech",
+        "install_to": "GameData",
+        "filter":     "Agencies"
+    } ]
 }

--- a/NetKAN/IndicatorLightsCommunityExtensions.netkan
+++ b/NetKAN/IndicatorLightsCommunityExtensions.netkan
@@ -7,12 +7,13 @@
         "config"
     ],
     "depends": [
+        { "name": "ModuleManager"   },
         { "name": "IndicatorLights" }
     ],
     "supports": [
         { "name": "ImpossibleInnovations" },
-        { "name": "Mk1CabinHatch" },
-        { "name": "PartOverhauls" },
-        { "name": "VenStockRevamp" }
+        { "name": "Mk1CabinHatch"         },
+        { "name": "PartOverhauls"         },
+        { "name": "VenStockRevamp"        }
     ]
 }

--- a/NetKAN/InterKalactic2.netkan
+++ b/NetKAN/InterKalactic2.netkan
@@ -8,6 +8,7 @@
         "planet-pack"
     ],
     "depends": [
+        { "name": "ModuleManager"  },
         { "name": "Kopernicus"     },
         { "name": "KerbolPlusPlus" }
     ]

--- a/NetKAN/InternalRCS.netkan
+++ b/NetKAN/InternalRCS.netkan
@@ -6,6 +6,9 @@
     "tags": [
         "parts"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "suggests": [
         { "name": "RCSBuildAidCont" }
     ]

--- a/NetKAN/JPL-RSS.netkan
+++ b/NetKAN/JPL-RSS.netkan
@@ -7,10 +7,11 @@
         "config"
     ],
     "depends": [
+        { "name": "ModuleManager"   },
         { "name": "RealSolarSystem" }
     ],
     "install": [ {
-        "find": "Jimbodiah",
+        "find":       "Jimbodiah",
         "install_to": "GameData"
     } ],
     "x_netkan_override": [

--- a/NetKAN/JSat.netkan
+++ b/NetKAN/JSat.netkan
@@ -7,6 +7,9 @@
         "parts",
         "uncrewed"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "suggests": [
         { "name": "B9PartSwitch" }
     ]

--- a/NetKAN/JX2Antenna.netkan
+++ b/NetKAN/JX2Antenna.netkan
@@ -8,11 +8,14 @@
         "uncrewed",
         "comms"
     ],
-    "supports" : [
-        { "name" : "IndicatorLights"      },
-        { "name" : "OuterPlanetsMod"      },
-        { "name" : "GPP"                  },
-        { "name" : "GrannusExpansionPack" },
-        { "name" : "RemoteTech"           }
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
+    "supports": [
+        { "name": "IndicatorLights"      },
+        { "name": "OuterPlanetsMod"      },
+        { "name": "GPP"                  },
+        { "name": "GrannusExpansionPack" },
+        { "name": "RemoteTech"           }
     ]
 }

--- a/NetKAN/JackOLantern.netkan
+++ b/NetKAN/JackOLantern.netkan
@@ -6,5 +6,8 @@
     "license":      "CC-BY-NC-4.0",
     "tags": [
         "parts"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/JoolBiomes.netkan
+++ b/NetKAN/JoolBiomes.netkan
@@ -9,10 +9,11 @@
         "science"
     ],
     "depends": [
-        { "name": "Kopernicus" }
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus"    }
     ],
     "install": [ {
-        "find": "GameData/JoolBiomes",
+        "find":       "GameData/JoolBiomes",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/K2CommandPodCont.netkan
+++ b/NetKAN/K2CommandPodCont.netkan
@@ -7,17 +7,18 @@
         "parts",
         "crewed"
     ],
-    "install": [
-        {
-            "file": "GameData/JFJohnny5",
-            "install_to": "GameData"
-        }
-    ],
+    "install": [ {
+        "file":       "GameData/JFJohnny5",
+        "install_to": "GameData"
+    } ],
     "conflicts": [
         { "name": "K2CommandPod" }
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "supports": [
         { "name": "ConnectedLivingSpace" },
-        { "name": "TacLifeSupport" }
+        { "name": "TacLifeSupport"       }
     ]
 }

--- a/NetKAN/KA330InflatableSpaceHotel.netkan
+++ b/NetKAN/KA330InflatableSpaceHotel.netkan
@@ -39,6 +39,7 @@
         "find_matches_files": true
     } ],
     "depends": [
+        { "name": "ModuleManager"     },
         { "name": "TexturesUnlimited" }
     ],
     "recommends": [

--- a/NetKAN/KEAMKerbalExpandableActivityModule.netkan
+++ b/NetKAN/KEAMKerbalExpandableActivityModule.netkan
@@ -20,6 +20,7 @@
         "find_matches_files": true
     } ],
     "depends": [
+        { "name": "ModuleManager"     },
         { "name": "TexturesUnlimited" }
     ],
     "suggests": [

--- a/NetKAN/KerbalField.netkan
+++ b/NetKAN/KerbalField.netkan
@@ -9,6 +9,7 @@
         "combat"
     ],
     "depends": [
+        { "name": "ModuleManager"     },
         { "name": "BDArmoryContinued" }
     ]
 }

--- a/NetKAN/KerbalGalacticExpansion.netkan
+++ b/NetKAN/KerbalGalacticExpansion.netkan
@@ -8,10 +8,11 @@
         "planet-pack"
     ],
     "depends": [
-        { "name": "Kopernicus" }
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus"    }
     ],
     "install": [ {
-        "file": "KerbalGalacticExpansion",
+        "file":       "KerbalGalacticExpansion",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/KerbalModsOverhaul.netkan
+++ b/NetKAN/KerbalModsOverhaul.netkan
@@ -11,6 +11,7 @@
         "install_to": "GameData"
     } ],
     "depends": [
+        { "name": "ModuleManager"            },
         { "name": "PatchManager"             },
         { "name": "UKS"                      },
         { "name": "USI-LS"                   },

--- a/NetKAN/KerbalScienceInnovation.netkan
+++ b/NetKAN/KerbalScienceInnovation.netkan
@@ -8,10 +8,11 @@
         "science"
     ],
     "depends": [
+        { "name": "ModuleManager"   },
         { "name": "TextureReplacer" }
     ],
     "install": [ {
-        "find":"KSI",
+        "find":       "KSI",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/Kerbalized-SpaceX.netkan
+++ b/NetKAN/Kerbalized-SpaceX.netkan
@@ -14,16 +14,15 @@
 		"parts"
 	],
 	"depends": [
+        { "name": "ModuleManager"   },
 		{ "name": "NearFutureSolar" }
 	],
 	"recommends": [
 		{ "name": "RasterPropMonitor"        },
 		{ "name": "KerbalJointReinforcement" }
 	],
-	"install": [
-		{
-			"find":       "JNH",
-			"install_to": "GameData"
-		}
-	]
+	"install": [ {
+		"find":       "JNH",
+		"install_to": "GameData"
+	} ]
 }

--- a/NetKAN/KerbalowAerospace.netkan
+++ b/NetKAN/KerbalowAerospace.netkan
@@ -37,6 +37,7 @@
         "find_matches_files": true
     } ],
     "depends": [
+        { "name": "ModuleManager"     },
         { "name": "TexturesUnlimited" }
     ],
     "suggests": [

--- a/NetKAN/imkSushisPlanetSystem.netkan
+++ b/NetKAN/imkSushisPlanetSystem.netkan
@@ -8,11 +8,12 @@
         "planet-pack"
     ],
     "depends": [
-        { "name": "Kopernicus" },
+        { "name": "ModuleManager"    },
+        { "name": "Kopernicus"       },
         { "name": "SigmaBinary-core" }
     ],
     "install": [ {
-        "file"       : "imkSushi",
-        "install_to" : "GameData"
+        "file":       "imkSushi",
+        "install_to": "GameData"
     } ]
 }


### PR DESCRIPTION
Next round of #7906. These mods install cfg files with ModuleManager syntax, so now they depend on ModuleManager.

This group is approximately the first half of the ones caught by the SpaceDock-only pass.