### PR TITLE
Make ASETAvionics compatible with all game versions

### DIFF
--- a/NetKAN/ASETAvionics.netkan
+++ b/NetKAN/ASETAvionics.netkan
@@ -2,20 +2,21 @@
     "spec_version": "v1.4",
     "identifier":   "ASETAvionics",
     "$kref":        "#/ckan/spacedock/1213",
+    "ksp_version":  "any",
     "license":      "CC-BY-NC-SA-3.0",
     "tags": [
         "config",
         "crewed"
     ],
     "install": [ {
-        "find": "ASET",
+        "find":       "ASET",
         "install_to": "GameData"
     } ],
     "depends": [
         { "name": "ASETAgency" },
         { "name": "ModuleManager" },
-        { "name": "ASETProps",  "min_version" : "1.4" },
-        { "name": "RasterPropMonitor-Core", "min_version" : "0.28.0" }
+        { "name": "ASETProps",  "min_version": "1.5" },
+        { "name": "RasterPropMonitor-Core", "min_version" : "1:v0.30.2" }
     ],
     "recommends": [
         { "name": "FAR" , "min_version": "0.15.7.2" }


### PR DESCRIPTION
This mod's forum thread announces no game version limitations, since in principle it's just data files that are used by other mods. It has such limits in the metadata because it's on SpaceDock. However, the mod version dependencies have changed.