### PR TITLE
Make ASETProps compatible with all game versions

### DIFF
--- a/NetKAN/ASETProps.netkan
+++ b/NetKAN/ASETProps.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "ASETProps",
     "$kref":        "#/ckan/spacedock/1204",
+    "ksp_version":  "any",
     "license":      "CC-BY-NC-SA-3.0",
     "tags": [
         "plugin",
@@ -22,17 +23,7 @@
         { "name": "TACLS" }
     ],
     "install": [ {
-        "find": "ASET/ASET_Props",
+        "find":       "ASET/ASET_Props",
         "install_to": "GameData/ASET"
-    } ],
-    "x_netkan_override": [ {
-        "version": "1.5",
-        "delete": [
-            "ksp_version"
-        ],
-        "override": {
-            "ksp_version_min": "1.4",
-            "ksp_version_max": "1.8"
-        }
     } ]
 }


### PR DESCRIPTION
See #7908, these are also just data files that can be used on any game version where the dependencies are available.

There is a "plugin", but it's an oddity with no code or references, supposedly just so ModuleManager can print out the version number. Should be version independent.