### PR TITLE
Add ModuleManager depends for fourth pass of mods using MM syntax

### DIFF
--- a/NetKAN/Contares-Common.netkan
+++ b/NetKAN/Contares-Common.netkan
@@ -10,15 +10,15 @@
     "tags": [
         "agency"
     ],
-    "install": [
-        {
-            "find": "Agencies",
-            "install_to": "GameData/Contares"
-        },
-        {
-            "find": "CONTARES_TweakScale.cfg",
-            "find_matches_files": true,
-            "install_to": "GameData/Contares/Patches"
-        }
-    ]
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
+    "install": [ {
+        "find":       "Agencies",
+        "install_to": "GameData/Contares"
+    }, {
+        "find":       "CONTARES_TweakScale.cfg",
+        "install_to": "GameData/Contares/Patches",
+        "find_matches_files": true
+    } ]
 }

--- a/NetKAN/Contares.netkan
+++ b/NetKAN/Contares.netkan
@@ -7,6 +7,7 @@
         "parts"
     ],
     "depends": [
+        { "name": "ModuleManager"             },
         { "name": "RealPlume"                 },
         { "name": "TweakScale"                },
         { "name": "RetractableLiftingSurface" },
@@ -21,11 +22,9 @@
     "recommends": [
         { "name": "DMagicScienceAnimate" }
     ],
-    "install": [
-        {
-            "find":       "Contares",
-            "install_to": "GameData",
-            "filter":     [ "Agencies", "CONTARES_TweakScale.cfg" ]
-        }
-    ]
+    "install": [ {
+        "find":       "Contares",
+        "install_to": "GameData",
+        "filter":     [ "Agencies", "CONTARES_TweakScale.cfg" ]
+    } ]
 }

--- a/NetKAN/KKsDeltaPack.netkan
+++ b/NetKAN/KKsDeltaPack.netkan
@@ -13,8 +13,11 @@
         "find":       "Ships/VAB",
         "install_to": "Ships"
     } ],
-	"conflicts"     : [
-		{ "name"    : "ROCapsules" },
-		{ "name"    : "ROEngines" }
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
+	"conflicts": [
+		{ "name": "ROCapsules" },
+		{ "name": "ROEngines" }
     ]
 }

--- a/NetKAN/KOOSE.netkan
+++ b/NetKAN/KOOSE.netkan
@@ -7,6 +7,9 @@
         "parts",
         "crewed"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
         "find":       "KOOSE",
         "install_to": "GameData"

--- a/NetKAN/KerbinRoverOffRoadVehicles.netkan
+++ b/NetKAN/KerbinRoverOffRoadVehicles.netkan
@@ -6,10 +6,11 @@
     "tags": [
         "parts"
     ],
-    "install": [
-        {
-            "find"       : "KerbinRover",
-            "install_to" : "GameData"
-        }
-    ]
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
+    "install": [ {
+        "find"       : "KerbinRover",
+        "install_to" : "GameData"
+    } ]
 }

--- a/NetKAN/KerbobulusSpaceIndustriesMiscellaneousPartsDivision.netkan
+++ b/NetKAN/KerbobulusSpaceIndustriesMiscellaneousPartsDivision.netkan
@@ -6,6 +6,9 @@
     "tags": [
         "parts"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
         "find":       "KerbobulusSpaceTechnologies",
         "install_to": "GameData"

--- a/NetKAN/KrakenScience.netkan
+++ b/NetKAN/KrakenScience.netkan
@@ -9,8 +9,11 @@
         "uncrewed",
         "career"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
-        "find": "KrakenScience",
+        "find":       "KrakenScience",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/LargeBoatPartsPack.netkan
+++ b/NetKAN/LargeBoatPartsPack.netkan
@@ -9,18 +9,19 @@
     "tags": [
         "parts"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "recommends": [
         { "name": "WasdEditorCameraContinued" },
         { "name": "VesselMover" },
         { "name": "LargeBoatPartsPack-Modern" },
         { "name": "LargeBoatPartsPack-WW2" }
     ],
-    "install": [
-        {
-            "find": "LShipPartsRequired",
-            "install_to": "GameData/LShipParts"
-        }
-    ],
+    "install": [ {
+        "find":       "LShipPartsRequired",
+        "install_to": "GameData/LShipParts"
+    } ],
     "x_netkan_override": [
         {
             "version": "3.2",

--- a/NetKAN/Leviathanclass.netkan
+++ b/NetKAN/Leviathanclass.netkan
@@ -5,5 +5,8 @@
     "license":      "GPL-3.0",
     "tags": [
         "parts"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/MiporiaPlanetPack.netkan
+++ b/NetKAN/MiporiaPlanetPack.netkan
@@ -12,6 +12,7 @@
         "install_to": "GameData"
     } ],
     "depends": [
-        { "name": "Kopernicus" }
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus"    }
     ]
 }

--- a/NetKAN/MkerbIncScienceInstruments.netkan
+++ b/NetKAN/MkerbIncScienceInstruments.netkan
@@ -7,8 +7,11 @@
         "parts",
         "science"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
-        "file": "Mkerb",
+        "file":       "Mkerb",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/MoS-AeronauticDepartment.netkan
+++ b/NetKAN/MoS-AeronauticDepartment.netkan
@@ -6,8 +6,11 @@
     "tags": [
         "parts"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
-        "find": "MoS",
+        "find":       "MoS",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/ModularLaunchPads.netkan
+++ b/NetKAN/ModularLaunchPads.netkan
@@ -7,7 +7,8 @@
         "parts"
     ],
     "depends": [
-        { "name": "B9PartSwitch" }
+        { "name": "ModuleManager" },
+        { "name": "B9PartSwitch"  }
     ],
     "recommends": [
         { "name": "AnimatedDecouplers"   },

--- a/NetKAN/ModularPods.netkan
+++ b/NetKAN/ModularPods.netkan
@@ -8,10 +8,11 @@
         "crewed"
     ],
     "install": [ {
-        "find": "ModPods",
+        "find":       "ModPods",
         "install_to": "GameData"
     } ],
     "depends": [
-        { "name": "TDProps" }
+        { "name": "ModuleManager" },
+        { "name": "TDProps"       }
     ]
 }

--- a/NetKAN/ModularRocketSystemsLITE.netkan
+++ b/NetKAN/ModularRocketSystemsLITE.netkan
@@ -6,6 +6,9 @@
     "tags": [
         "parts"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "supports": [
         { "name": "SpaceY-Lifters" },
         { "name": "ColorCodedCans" },

--- a/NetKAN/NKRsDEM.netkan
+++ b/NetKAN/NKRsDEM.netkan
@@ -21,6 +21,7 @@
         }
     ],
     "depends": [
-        { "name": "TDProps" }
+        { "name": "ModuleManager" },
+        { "name": "TDProps"       }
     ]
 }

--- a/NetKAN/OPTUSILifeSupportPatch.netkan
+++ b/NetKAN/OPTUSILifeSupportPatch.netkan
@@ -12,6 +12,7 @@
         "install_to": "GameData"
     } ],
     "depends": [
+        { "name": "ModuleManager"     },
         { "name": "OPTSpacePlaneMain" },
         { "name": "USI-LS"            }
     ]

--- a/NetKAN/OrbitalColony.netkan
+++ b/NetKAN/OrbitalColony.netkan
@@ -8,7 +8,7 @@
         "parts",
         "crewed"
     ],
-    "recommends": [
+    "depends": [
         { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/PhoenixIndustriesSpaceTug.netkan
+++ b/NetKAN/PhoenixIndustriesSpaceTug.netkan
@@ -10,6 +10,9 @@
         "find":       "IntegratedPhoenixIndustries",
         "install_to": "GameData"
     } ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "suggests": [
         { "name": "BluedogDB"            },
         { "name": "ConnectedLivingSpace" },

--- a/NetKAN/PlanetaryDomes.netkan
+++ b/NetKAN/PlanetaryDomes.netkan
@@ -4,10 +4,13 @@
     "$kref":        "#/ckan/spacedock/958",
     "license":      "GPL-3.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/148678-113-planetary-domes/"
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/148678-*"
     },
     "tags": [
         "parts",
         "crewed"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/PureElectricEngines.netkan
+++ b/NetKAN/PureElectricEngines.netkan
@@ -6,6 +6,9 @@
     "tags": [
         "parts"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
         "find":       "JDSA",
         "install_to": "GameData"

--- a/NetKAN/RealEngines.netkan
+++ b/NetKAN/RealEngines.netkan
@@ -7,6 +7,9 @@
     "tags": [
         "parts"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
         "find":       "RealEnginesPack",
         "install_to": "GameData"

--- a/NetKAN/RealSolarSystemExpanded-UnofficialPatch.netkan
+++ b/NetKAN/RealSolarSystemExpanded-UnofficialPatch.netkan
@@ -8,13 +8,14 @@
         "planet-pack"
     ],
     "depends": [
-        { "name": "Kopernicus" },
-        { "name": "RealSolarSystem" },
+        { "name": "ModuleManager"           },
+        { "name": "Kopernicus"              },
+        { "name": "RealSolarSystem"         },
         { "name": "RealSolarSystemExpanded" },
-        { "name": "SigmaBinary-core" }
+        { "name": "SigmaBinary-core"        }
     ],
     "install": [ {
-        "file": "RSSExpansion",
+        "file":        "RSSExpansion",
         "install_to" : "GameData/RSSEx-Patch"
     } ]
 }

--- a/NetKAN/SeparatorDestroyer.netkan
+++ b/NetKAN/SeparatorDestroyer.netkan
@@ -8,8 +8,11 @@
         "plugin",
         "convenience"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
-        "find": "XyphosAerospace",
+        "find":       "XyphosAerospace",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/ShadowWorksStockalikeSLSandMore.netkan
+++ b/NetKAN/ShadowWorksStockalikeSLSandMore.netkan
@@ -6,6 +6,9 @@
     "tags": [
         "parts"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "recommends": [
         { "name": "BaconLabs" },
         { "name": "NewTantares"}

--- a/NetKAN/SpaceOpera.netkan
+++ b/NetKAN/SpaceOpera.netkan
@@ -6,5 +6,8 @@
     "tags": [
         "parts",
         "resources"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/StockalikeMiningExtension.netkan
+++ b/NetKAN/StockalikeMiningExtension.netkan
@@ -7,10 +7,11 @@
         "parts",
         "resources"
     ],
-    "install": [
-        {
-            "find": "MiningExpansion",
-            "install_to": "GameData"
-        }
-    ]
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
+    "install": [ {
+        "find": "MiningExpansion",
+        "install_to": "GameData"
+    } ]
 }

--- a/NetKAN/StockishProjectOrion.netkan
+++ b/NetKAN/StockishProjectOrion.netkan
@@ -7,6 +7,9 @@
         "plugin",
         "parts"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
         "find":       "Orion",
         "install_to": "GameData"

--- a/NetKAN/Switch-All.netkan
+++ b/NetKAN/Switch-All.netkan
@@ -6,9 +6,12 @@
     "tags": [
         "parts"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
-        "find": "Switch-All",
+        "find":       "Switch-All",
         "install_to": "GameData",
-        "filter": [ ".directory", "BeamedPower.xlsx", "KSPIE Brandwidths.xlsx" ]
+        "filter":     [ ".directory", "BeamedPower.xlsx", "KSPIE Brandwidths.xlsx" ]
     } ]
 }

--- a/NetKAN/TDIndustriesRCSandHypergolicengines.netkan
+++ b/NetKAN/TDIndustriesRCSandHypergolicengines.netkan
@@ -5,5 +5,8 @@
     "license":      "MIT",
     "tags": [
         "parts"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/TantaresAndBDBNowinColors.netkan
+++ b/NetKAN/TantaresAndBDBNowinColors.netkan
@@ -8,8 +8,9 @@
         "graphics"
     ],
     "depends": [
-        { "name": "NewTantares" },
-        { "name": "BluedogDB"   }
+        { "name": "ModuleManager" },
+        { "name": "NewTantares"   },
+        { "name": "BluedogDB"     }
     ],
     "install": [ {
         "find":       "BDBNIC",

--- a/NetKAN/TheMartianforKSP.netkan
+++ b/NetKAN/TheMartianforKSP.netkan
@@ -8,6 +8,9 @@
         "parts",
         "crewed"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
         "find":       "TM4KSP",
         "install_to": "GameData"

--- a/NetKAN/ThorTech.netkan
+++ b/NetKAN/ThorTech.netkan
@@ -7,6 +7,7 @@
         "parts"
     ],
     "depends": [
+        { "name": "ModuleManager"         },
         { "name": "B9PartSwitch"          },
         { "name": "CommunityResourcePack" },
         { "name": "DeepSkyCore"           }

--- a/NetKAN/USAFOrionMod-TD-subedition.netkan
+++ b/NetKAN/USAFOrionMod-TD-subedition.netkan
@@ -17,6 +17,9 @@
         "find"       : "USAFOrionTD",
         "install_to" : "GameData"
     } ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "recommends": [
         { "name" : "TDIndustrysOrionbits10m" }
     ],

--- a/NetKAN/VentralDrill.netkan
+++ b/NetKAN/VentralDrill.netkan
@@ -7,6 +7,9 @@
         "parts",
         "resources"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
         "find":       "VentralDrill",
         "install_to": "GameData"

--- a/NetKAN/notes.netkan
+++ b/NetKAN/notes.netkan
@@ -11,11 +11,11 @@
         "convenience"
     ],
     "depends": [
+        { "name": "ModuleManager"     },
         { "name": "ToolbarController" }
     ],
     "suggests": [
-        { "name": "RasterPropMonitor" },
-        { "name": "ModuleManager" }
+        { "name": "RasterPropMonitor" }
     ],
     "x_netkan_override" : [
         {


### PR DESCRIPTION
Next pass of #7907. These mods install cfg files with ModuleManager syntax, so now they depend on ModuleManager. This group is approximately the second half of the ones caught by the SpaceDock-only pass.