### PR TITLE
Fix PlanetWiki find regex and epoch, move contents to own folder

### DIFF
--- a/NetKAN/PlanetWiki.netkan
+++ b/NetKAN/PlanetWiki.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.16",
     "identifier":   "PlanetWiki",
     "$kref":        "#/ckan/spacedock/780",
+    "x_netkan_epoch": 1,
     "license":      "CC-BY-NC-ND-4.0",
     "tags": [
         "config",
@@ -9,9 +10,9 @@
     ],
     "install": [
         {
-            "find_regexp": "GameData/planetwikiv[0-9]*.ksp",
+            "find_regexp": "GameData/.*\\.ksp",
             "find_matches_files": true,
-            "install_to": "GameData"
+            "install_to": "GameData/PlanetWiki"
         }
     ]
 }


### PR DESCRIPTION
> Could not find GameData/planetwikiv[0-9]*.ksp entry in zipfile to install

The mod has a very inconsistent file naming scheme. What has been `planetwikiv4.ksp` is now `PlanetWiki_v4.1.ksp`.

To save us from even more future fix-ups, I decided to go with a "just get everything that looks like it could belong to the mod"-regex:
`"GameData/.*\\.ksp"`

Since it also completely broke the version ordering with the previous release (ironically named `making_CKAN_happy`), I epoched it.

I also moved the mod contents into its own `GameData/PlanetWiki` subfolder for installation.