### PR TITLE
Fix SpaceXLaunchVehicles install and recommends

### DIFF
--- a/NetKAN/SpaceXLaunchVehicles.netkan
+++ b/NetKAN/SpaceXLaunchVehicles.netkan
@@ -9,14 +9,19 @@
     "depends": [
         { "name": "ModuleManager" }
     ],
-    "install": [
-        {
-            "find": "Launchers Pack",
-            "install_to": "GameData"
-        },
-        {
-            "find": "Ships/VAB",
-            "install_to": "Ships"
-        }
-    ]
+    "recommends": [
+        { "name": "TexturesUnlimited"         },
+        { "name": "AnimatedDecouplers"        },
+        { "name": "RetractableLiftingSurface" }
+    ],
+    "install": [ {
+        "find":       "Kartoffelkuchen",
+        "install_to": "GameData"
+    }, {
+        "find":       "Launchers Pack",
+        "install_to": "GameData"
+    }, {
+        "find":       "Ships/VAB",
+        "install_to": "Ships"
+    } ]
 }


### PR DESCRIPTION
A new folder was added at some point and isn't being installed, which makes the mod not work correctly. Also the readme recommends several mods.

![image](https://user-images.githubusercontent.com/1559108/82608157-bfd85880-9b7f-11ea-8faa-e899127d44c3.png)

Now the install is complete and the recommended mods are updated.