### PR TITLE
Remove hardcoded ksp_version from SeparatorDestroyer

### DIFF
--- a/NetKAN/SeparatorDestroyer.netkan
+++ b/NetKAN/SeparatorDestroyer.netkan
@@ -2,7 +2,6 @@
     "spec_version": "v1.4",
     "identifier":   "SeparatorDestroyer",
     "$kref":        "#/ckan/spacedock/1379",
-    "ksp_version":  "1.3",
     "license":      "public-domain",
     "tags": [
         "plugin",


### PR DESCRIPTION
See https://github.com/KSP-CKAN/CKAN-meta/pull/1922
The compatibility history in CKAN is a bit messed up and not matching SpaceDock's data.

I suspect they are like this:
| Mod version | KSP range |
| ----------- | --------- |
| 1.0.0.0     | 1.2.2 - 1.3 |
| 1.0.0.1     | 1.3 - 1.7 |
| 1.0.2.0     | 1.8.0     |

This PR removes the hardcoded `ksp_version` so netkan pulls it from SpaceDock for the latest and future versions. A CKAN-meta PR will follow changing the two older versions to how I listed it above.

Closes https://github.com/KSP-CKAN/CKAN-meta/pull/1922