### PR TITLE
Remove outdated LanderCanMk12 dependencies

### DIFF
--- a/NetKAN/LanderCanMk12.netkan
+++ b/NetKAN/LanderCanMk12.netkan
@@ -13,8 +13,6 @@
         "install_to": "GameData"
     } ],
     "depends": [
-        { "name": "JSIPartUtilities"        },
-        { "name": "Mk1CockpitIVAReplbyASET" },
-        { "name": "ModuleManager"           }
+        { "name": "ModuleManager" }
     ]
 }


### PR DESCRIPTION
Forum user Krzeszny [made us aware](https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1272-chandrasekhar/&do=findComment&comment=3789751) of a [comment from the mod author](https://forum.kerbalspaceprogram.com/index.php?/topic/165240-181-landercan-mk12-v20/&do=findComment&comment=3789564) about wrong relationships:
> I'm not sure how it ended up on CKAN, and have even less of a clue on why it should be depended on anything other than module manager.

I suspect they have been correct for version 1.0 which bundled `JSIPartUtilities` and `Mk1CockpitIVAReplbyASET`, but the mod no longer bundles them:
![image](https://user-images.githubusercontent.com/28812678/82727412-ae5f8f80-9cea-11ea-9886-9fd253d6410c.png)
![grafik](https://user-images.githubusercontent.com/28812678/82727822-20d16f00-9ced-11ea-8f7e-a2220c81b2fa.png)

This PR removes these two relationships and only keeps the ModuleManager one.

---

[SpaceDock quick-link](https://spacedock.info/mod/1520/LanderCanMk12)
