### PR TITLE
Remove unnecessary ModuleManager depends

### DIFF
--- a/NetKAN/BOPN.netkan
+++ b/NetKAN/BOPN.netkan
@@ -11,8 +11,5 @@
     "install": [ {
         "find":       "BetterOrderPartsNumbered",
         "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ]
+    } ]
 }

--- a/NetKAN/BasicProceduralTextures.netkan
+++ b/NetKAN/BasicProceduralTextures.netkan
@@ -11,9 +11,6 @@
         "find":       "GameData/BasicProceduralTextures",
         "install_to": "GameData"
     } ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
     "recommends": [
         { "name": "ProceduralParts" },
         { "name": "DecouplerShroud" }

--- a/NetKAN/CEDA-AeronauticsDivision.netkan
+++ b/NetKAN/CEDA-AeronauticsDivision.netkan
@@ -11,7 +11,6 @@
         "install_to": "GameData"
     } ],
     "depends": [
-        { "name": "ModuleManager" },
-        { "name": "Firespitter"   }
+        { "name": "Firespitter" }
     ]
 }

--- a/NetKAN/CEDA-Aethon-ITS.netkan
+++ b/NetKAN/CEDA-Aethon-ITS.netkan
@@ -8,8 +8,7 @@
         "parts"
     ],
     "depends": [
-        { "name": "ModuleManager" },
-        { "name": "B9PartSwitch"  }
+        { "name": "B9PartSwitch" }
     ],
     "recommends": [
         { "name": "SpaceXLegs" }

--- a/NetKAN/CameraTools.netkan
+++ b/NetKAN/CameraTools.netkan
@@ -11,8 +11,5 @@
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/84938-*",
         "x_screenshot": "https://spacedock.info/content/BahamutoD_222/Camera_Tools/Camera_Tools-1456425830.4879806.jpg"
-    },
-    "depends": [
-        { "name": "ModuleManager" }
-    ]
+    }
 }

--- a/NetKAN/ContractConfigurator-ContractPackHistoricalProgression.netkan
+++ b/NetKAN/ContractConfigurator-ContractPackHistoricalProgression.netkan
@@ -12,7 +12,6 @@
         "career"
     ],
     "depends": [
-        { "name": "ModuleManager"        },
         { "name": "ContractConfigurator" }
     ],
     "suggests": [

--- a/NetKAN/ContractConfigurator-FarOutContracts.netkan
+++ b/NetKAN/ContractConfigurator-FarOutContracts.netkan
@@ -18,7 +18,6 @@
     ],
     "depends": [
         { "name" : "Kopernicus", "min_version": "2:release-1.3.0-5" },
-        { "name" : "ModuleManager", "min_version": "2.8.0" },
         { "name" : "ContractConfigurator" }
     ],
     "recommends": [
@@ -26,10 +25,8 @@
         { "name" : "Kronkus" },
         { "name" : "SpudMoon" }
     ],
-    "install": [
-        {
-            "find"      : "ContractPacks",
-            "install_to": "GameData"
-        }
-    ]
+    "install": [ {
+        "find"      : "ContractPacks",
+        "install_to": "GameData"
+    } ]
 }

--- a/NetKAN/CriticalTemperatureGauge.netkan
+++ b/NetKAN/CriticalTemperatureGauge.netkan
@@ -15,8 +15,7 @@
         "information"
     ],
     "depends"      : [
-        { "name": "ModuleManager" },
         { "name": "ClickThroughBlocker" },
-        { "name": "ToolbarController" }
+        { "name": "ToolbarController"   }
     ]
 }

--- a/NetKAN/DecalStickers.netkan
+++ b/NetKAN/DecalStickers.netkan
@@ -12,7 +12,6 @@
     } ],
     "depends": [
         { "name": "FirespitterResourcesConfig" },
-        { "name": "ModuleManager"              },
         { "name": "FirespitterCore"            }
     ]
 }

--- a/NetKAN/DuoPods.netkan
+++ b/NetKAN/DuoPods.netkan
@@ -9,9 +9,6 @@
         "parts",
         "crewed"
     ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
     "supports": [
         { "name": "KerbalChangelog" }
     ]

--- a/NetKAN/FanRadiator.netkan
+++ b/NetKAN/FanRadiator.netkan
@@ -8,9 +8,6 @@
         "plugin",
         "parts"
     ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
     "install": [ {
         "find":       "Kunedo",
         "install_to": "GameData"

--- a/NetKAN/FlatBtmShtlSys.netkan
+++ b/NetKAN/FlatBtmShtlSys.netkan
@@ -9,12 +9,11 @@
         "crewed"
     ],
     "depends": [
-        { "name": "B9PartSwitch" },
-        { "name": "RasterPropMonitor" },
-        { "name": "ModuleManager" }
+        { "name": "B9PartSwitch"      },
+        { "name": "RasterPropMonitor" }
     ],
     "install": [ {
-        "find": "TriCrossSection",
+        "find":       "TriCrossSection",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/Insight.netkan
+++ b/NetKAN/Insight.netkan
@@ -7,9 +7,6 @@
     "tags": [
         "parts"
     ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
     "recommends": [
         { "name": "Toolbar" },
         { "name": "ToolbarController" }

--- a/NetKAN/JDLiquidFuelCell.netkan
+++ b/NetKAN/JDLiquidFuelCell.netkan
@@ -7,8 +7,7 @@
         "parts"
     ],
     "depends": [
-        { "name": "FirespitterCore" },
-        { "name": "ModuleManager"   }
+        { "name": "FirespitterCore" }
     ],
     "install": [ {
         "file":       "JatwaaDemolitionsCo",

--- a/NetKAN/KerbalActuators.netkan
+++ b/NetKAN/KerbalActuators.netkan
@@ -8,9 +8,6 @@
         "plugin",
         "parts"
     ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
     "install": [ {
         "find":       "WildBlueIndustries",
         "install_to": "GameData"

--- a/NetKAN/KerbalHotSeatCont.netkan
+++ b/NetKAN/KerbalHotSeatCont.netkan
@@ -9,11 +9,10 @@
         "crewed"
     ],
     "install": [ {
-        "find": "KerbalHotSeat",
+        "find":       "KerbalHotSeat",
         "install_to": "GameData"
     } ],
     "depends": [
-        { "name": "ConnectedLivingSpace" },
-        { "name": "ModuleManager" }
+        { "name": "ConnectedLivingSpace" }
     ]
 }

--- a/NetKAN/KerbalKonstructs.netkan
+++ b/NetKAN/KerbalKonstructs.netkan
@@ -16,16 +16,13 @@
         "buildings"
     ],
     "depends"      : [
-        { "name"   : "ModuleManager"         },
         { "name"   : "CustomPreLaunchChecks" }
     ],
     "suggests": [
         { "name"   : "KKtoSD" }
     ],
-    "install": [
-        {
-            "find"       : "KerbalKonstructs",
-            "install_to" : "GameData"
-        }
-    ]
+    "install": [ {
+        "find"       : "KerbalKonstructs",
+        "install_to" : "GameData"
+    } ]
 }

--- a/NetKAN/Kerbalism.netkan
+++ b/NetKAN/Kerbalism.netkan
@@ -18,7 +18,6 @@
         "resources"
     ],
     "depends": [
-        { "name": "ModuleManager" },
         { "name": "CommunityResourcePack" },
         { "name": "Kerbalism-Config" }
     ],

--- a/NetKAN/LudicrousPropulsionSystems.netkan
+++ b/NetKAN/LudicrousPropulsionSystems.netkan
@@ -15,9 +15,6 @@
     "tags": [
         "parts"
     ],
-    "depends": [
-        { "name": "ModuleManager"}
-    ],
     "install": [ {
         "find"       : "GameData/LudicrousPropulsionSystems",
         "install_to" : "GameData"

--- a/NetKAN/MSP3000.netkan
+++ b/NetKAN/MSP3000.netkan
@@ -10,8 +10,5 @@
     "tags": [
         "parts",
         "science"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/NovaPunchRebalanced-Freyja.netkan
+++ b/NetKAN/NovaPunchRebalanced-Freyja.netkan
@@ -13,7 +13,6 @@
         "parts"
     ],
     "depends": [
-        { "name": "ModuleManager"       },
         { "name": "NovaPunchRebalanced" }
     ],
     "install": [ {

--- a/NetKAN/NovaPunchRebalanced-Odin.netkan
+++ b/NetKAN/NovaPunchRebalanced-Odin.netkan
@@ -13,7 +13,6 @@
         "parts"
     ],
     "depends": [
-        { "name": "ModuleManager"       },
         { "name": "NovaPunchRebalanced" }
     ],
     "install": [ {

--- a/NetKAN/NovaPunchRebalanced-Thor.netkan
+++ b/NetKAN/NovaPunchRebalanced-Thor.netkan
@@ -13,7 +13,6 @@
         "parts"
     ],
     "depends": [
-        { "name": "ModuleManager"       },
         { "name": "NovaPunchRebalanced" }
     ],
     "install": [ {

--- a/NetKAN/ORIONMonkeyBusinessIncParts.netkan
+++ b/NetKAN/ORIONMonkeyBusinessIncParts.netkan
@@ -6,9 +6,6 @@
     "tags": [
         "parts"
     ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
     "recommends": [
         { "name": "TweakScale" },
         { "name": "InterstellarFuelSwitch-Core" },
@@ -23,7 +20,7 @@
         { "name": "NearFutureSpacecraft" }
     ],
     "install": [ {
-        "file": "MBI",
+        "file":       "MBI",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/PatentPurchase.netkan
+++ b/NetKAN/PatentPurchase.netkan
@@ -6,8 +6,5 @@
     "tags": [
         "plugin",
         "career"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
     ]
 }

--- a/NetKAN/PlayYourWay.netkan
+++ b/NetKAN/PlayYourWay.netkan
@@ -12,9 +12,6 @@
         "config",
         "career"
     ],
-    "depends": [
-        { "name" : "ModuleManager" }
-    ],
     "recommends": [
         { "name": "ContractConfigurator" }
     ]

--- a/NetKAN/ProceduralParts-Textures-BattleTechAerospace.netkan
+++ b/NetKAN/ProceduralParts-Textures-BattleTechAerospace.netkan
@@ -7,13 +7,10 @@
         "graphics"
     ],
     "depends": [
-        { "name": "ProceduralParts" },
-        { "name": "ModuleManager" }
+        { "name": "ProceduralParts" }
     ],
-    "install": [
-        {
-            "file"       : "BTAProceduralPartsTextures",
-            "install_to" : "GameData"
-        }
-    ]
+    "install": [ {
+        "file"       : "BTAProceduralPartsTextures",
+        "install_to" : "GameData"
+    } ]
 }

--- a/NetKAN/ROLib.netkan
+++ b/NetKAN/ROLib.netkan
@@ -15,7 +15,6 @@
         "plugin"
     ],
     "depends" : [
-        { "name" : "ModuleManager" },
         { "name" : "TexturesUnlimited" }
     ],
     "recommends" : [

--- a/NetKAN/SigmaSciDefRenamer.netkan
+++ b/NetKAN/SigmaSciDefRenamer.netkan
@@ -14,9 +14,6 @@
         "plugin",
         "science"
     ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
     "install": [ {
         "find": "SciDefRenamer",
         "install_to": "GameData/Sigma"

--- a/NetKAN/TRR-Guide.netkan
+++ b/NetKAN/TRR-Guide.netkan
@@ -23,7 +23,6 @@
         "install_to" : "GameData"
     } ],
     "depends": [
-        { "name" : "ModuleManager"    },
         { "name" : "TextureReplacerReplaced" }
     ],
     "suggests": [

--- a/NetKAN/TRR-MyTextureMod.netkan
+++ b/NetKAN/TRR-MyTextureMod.netkan
@@ -23,7 +23,6 @@
         "install_to" : "GameData"
     } ],
     "depends": [
-        { "name" : "ModuleManager"    },
         { "name" : "TextureReplacerReplaced" }
     ],
     "suggests": [

--- a/NetKAN/TestFlight.netkan
+++ b/NetKAN/TestFlight.netkan
@@ -24,7 +24,6 @@
         }
     ],
     "depends": [
-        { "name" : "ModuleManager", "min_version" : "2.6.1" },
         { "name" : "TestFlightConfig" }
     ],
     "x_netkan_override": [

--- a/NetKAN/TestFlightConfigStock.netkan
+++ b/NetKAN/TestFlightConfigStock.netkan
@@ -24,7 +24,6 @@
         }
     ],
     "depends": [
-        { "name": "ModuleManager", "min_version": "2.6.1" },
         { "name": "TestFlight",    "min_version": "1.3.1" }
     ],
     "provides": [

--- a/NetKAN/TextureReplacerReplaced.netkan
+++ b/NetKAN/TextureReplacerReplaced.netkan
@@ -17,7 +17,9 @@
         "plugin",
         "graphics"
     ],
-    "provides": [ "TextureReplacer" ],
+    "provides": [
+        "TextureReplacer"
+    ],
 	"conflicts": [
         { "name": "TextureReplacer" }
     ],
@@ -28,9 +30,6 @@
         "find"       : "TextureReplacerReplaced",
         "install_to" : "GameData"
     } ],
-    "depends" : [
-        { "name" : "ModuleManager"	}
-    ],
     "recommends" : [
         { "name" : "WindowShine" }
     ],

--- a/NetKAN/TexturesUnlimited.netkan
+++ b/NetKAN/TexturesUnlimited.netkan
@@ -13,9 +13,6 @@
         "graphics",
         "library"
     ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
     "install": [ {
         "find":       "000_TexturesUnlimited",
         "install_to": "GameData"

--- a/NetKAN/VenStockRevamp-NewParts.netkan
+++ b/NetKAN/VenStockRevamp-NewParts.netkan
@@ -14,7 +14,6 @@
         "graphics"
     ],
     "depends": [
-        { "name" : "ModuleManager"       },
         { "name" : "VenStockRevamp-Core" }
     ],
     "recommends": [

--- a/NetKAN/Wraithforge.netkan
+++ b/NetKAN/Wraithforge.netkan
@@ -8,8 +8,7 @@
         "combat"
     ],
     "depends": [
-        { "name": "BDArmoryContinued" },
-        { "name": "ModuleManager" }
+        { "name": "BDArmoryContinued" }
     ],
     "install": [ {
         "find"       : "Wraithforge",

--- a/NetKAN/newReactionWheels.netkan
+++ b/NetKAN/newReactionWheels.netkan
@@ -9,12 +9,11 @@
         "crewed"
     ],
     "install": [ {
-        "filter": [ ".DS_Store", "__MACOSX" ],
-        "find": "AAI",
-        "install_to": "GameData"
+        "find":       "AAI",
+        "install_to": "GameData",
+        "filter":     [ ".DS_Store", "__MACOSX" ]
     } ],
     "depends": [
-        { "name": "ModuleManager" },
         { "name": "FirespitterCore" }
     ]
 }


### PR DESCRIPTION
I finally got around to having a look at these.

![image](https://user-images.githubusercontent.com/1559108/82763127-f1912f80-9dca-11ea-9178-4f6e89193b6e.png)

This is netkan telling us that a mod depends on ModuleManager but doesn't actually need it. Upon investigating, I found that a few of these were simply using MM syntax that our regexp currently doesn't detect (future PR likely), but most really don't use MM syntax. These latter are updated accordingly.