### PR TITLE
Add ModuleManager depends for sixth pass of mods using MM syntax

### DIFF
--- a/NetKAN/JanitorsCloset.netkan
+++ b/NetKAN/JanitorsCloset.netkan
@@ -13,6 +13,7 @@
         { "name": "KSP-AVC"          }
     ],
     "depends": [
+        { "name": "ModuleManager"       },
         { "name": "ClickThroughBlocker" }
     ],
     "install": [ {

--- a/NetKAN/KerbalActuators.netkan
+++ b/NetKAN/KerbalActuators.netkan
@@ -8,6 +8,9 @@
         "plugin",
         "parts"
     ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
     "install": [ {
         "find":       "WildBlueIndustries",
         "install_to": "GameData"


### PR DESCRIPTION
Next pass of #7936.
Most of the remaining warnings are caused by syntax errors.