### PR TITLE
Update Whirligig World dependencies

### DIFF
--- a/NetKAN/SciRev.netkan
+++ b/NetKAN/SciRev.netkan
@@ -1,0 +1,18 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "SciRev",
+    "$kref":        "#/ckan/github/StollD/SciRev",
+    "license":      "MIT",
+    "tags": [
+        "plugin",
+        "library",
+        "science"
+    ],
+    "install": [ {
+        "file":       "Kopernicus.Parser.dll",
+        "install_to": "GameData/SciRev"
+    }, {
+        "file":       "SciRev.dll",
+        "install_to": "GameData/SciRev"
+    } ]
+}

--- a/NetKAN/WhirligigWorld.netkan
+++ b/NetKAN/WhirligigWorld.netkan
@@ -5,7 +5,9 @@
     "license":      "restricted",
     "tags": [
         "config",
-        "planet-pack"
+        "planet-pack",
+        "parts",
+        "plugin"
     ],
     "depends": [
         { "name": "ModuleManager" },

--- a/NetKAN/WhirligigWorld.netkan
+++ b/NetKAN/WhirligigWorld.netkan
@@ -8,10 +8,9 @@
         "planet-pack"
     ],
     "depends": [
-        { "name": "ModuleManager"                                },
-        { "name": "Kopernicus"                                   },
-        { "name": "KopernicusExpansionContinued-EmissiveFX"      },
-        { "name": "KopernicusExpansionContinued-RegionalPQSMods" }
+        { "name": "ModuleManager" },
+        { "name": "Kopernicus"    },
+        { "name": "SciRev"        }
     ],
     "recommends": [
         { "name": "EnvironmentalVisualEnhancements" },


### PR DESCRIPTION
This mod's dependencies have changed since it was indexed in #7116.

![image](https://user-images.githubusercontent.com/1559108/83062693-aa9e7680-a024-11ea-8bc7-582cff8e69a7.png)

![image](https://user-images.githubusercontent.com/1559108/83063504-e0902a80-a025-11ea-950d-f130408c0aff.png)

![image](https://user-images.githubusercontent.com/1559108/83063932-8d6aa780-a026-11ea-9453-0627e7ad5760.png)

- KopernicusExpansion dependencies are removed (will need historical updates back to 0.12)
- SciRev dependency is added (will need historical updates back to 0.10.0)

I have a PM in progress to see if there are any other known issues.

@StollD, is it OK with you if we index SciRev in CKAN?