### PR TITLE
Fix CollisionFXReUpdated install stanza

### DIFF
--- a/NetKAN/CollisionFXReUpdated.netkan
+++ b/NetKAN/CollisionFXReUpdated.netkan
@@ -11,5 +11,11 @@
     ],
     "depends": [
         { "name": "ModuleManager" }
+    ],
+    "install": [
+        {
+            "find"       : "GameData/CollisionFXReUpdated",
+            "install_to" : "GameData"
+        }
     ]
 }


### PR DESCRIPTION
> GameData directory found within GameData: GameData/CollisionFXReUpdated/GameData/CollisionFXReUpdated

This mod needs a custom install stanza, because the latest release changed the folder structure from `CollisionFX-ReUpdated/GameData/CollisionFXReUpdated` to `CollisionFXReUpdated/GameData/CollisionFXReUpdated`, so the default stanza is now ambiguous.

After adding the new install stanza, the inflations now throws a warning:
> WARN CKAN.NetKAN.Transformers.AvcTransformer (null) - Error parsing remote version file https://forum.kerbalspaceprogram.com/index.php?/topic/193803-19x-collisionfx-reupdated-100-12thmay2020//: Unexpected character encountered while parsing value: <. Path '', line 0, position 0.

I wanted to do a PR to fix this but the [GitHub repository](https://github.com/VoidCosmo/CollisionFX-ReUpdated) is just a zip file of the source code uploaded via GitHubs file upload functionality (which is now also outdated since the newest release).