### PR TITLE
Fix CST100Starliner install

### DIFF
--- a/NetKAN/CST100Starliner.netkan
+++ b/NetKAN/CST100Starliner.netkan
@@ -18,8 +18,8 @@
         "find":       "GameData/CST-100 Starliner",
         "install_to": "GameData"
     }, {
-        "find":       "Ships",
-        "install_to": "Ships",
-        "as":         "VAB"
+        "find_regexp": ".*\\.craft$",
+        "install_to":  "Ships/VAB",
+        "find_matches_files": true
     } ]
 }


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/83332943-aca24880-a263-11ea-8d60-fd4d9d933063.png)

## Cause

The ZIP contains a `Ships` folder with one craft file in it, with no VAB or SPH subfolder.

Metadata:

```json
        "find":       "Ships",
        "install_to": "Ships",
        "as":         "VAB"
```

| Mod version | Ships folder path in ZIP |
| --- | --- |
| 2.0 | `/CST-100 Starliner/Ships/` |
| 2.1 | `/Ships/` |

The `as` property isn't allowed if the install stanza is trying to install just `Ships` in the root of the ZIP. The reason for this is a bit fishy but also somewhat complex to sort out.

## Changes

We could monkey with the C# code (and still may), but that won't help users trying to install this with the current client. So now we match the file instead of the folder.