### PR TITLE
Mark WhirligigWorld as providing EVE config

### DIFF
--- a/NetKAN/WhirligigWorld.netkan
+++ b/NetKAN/WhirligigWorld.netkan
@@ -16,9 +16,10 @@
         { "name": "EnvironmentalVisualEnhancements-Config" }
     ],
     "depends": [
-        { "name": "ModuleManager" },
-        { "name": "Kopernicus"    },
-        { "name": "SciRev"        }
+        { "name": "ModuleManager"              },
+        { "name": "Kopernicus"                 },
+        { "name": "SciRev"                     },
+        { "name": "Scatterer-sunflare-default" }
     ],
     "recommends": [
         { "name": "EnvironmentalVisualEnhancements" },

--- a/NetKAN/WhirligigWorld.netkan
+++ b/NetKAN/WhirligigWorld.netkan
@@ -9,6 +9,12 @@
         "parts",
         "plugin"
     ],
+    "provides": [
+        "EnvironmentalVisualEnhancements-Config"
+    ],
+    "conflicts": [
+        { "name": "EnvironmentalVisualEnhancements-Config" }
+    ],
     "depends": [
         { "name": "ModuleManager" },
         { "name": "Kopernicus"    },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/83343768-587b8080-a2c4-11ea-928e-539a924c0c0a.png)

We didn't have it as providing an EVE config. I took a look and it really does create a bunch of EVE_* nodes, not just patch existing ones.

Also it edits the default Scatterer sunflare, so we need that workaround as well.