### PR TITLE
Remove unnecessary vrefs

### DIFF
--- a/NetKAN/KScale2.netkan
+++ b/NetKAN/KScale2.netkan
@@ -2,7 +2,6 @@
     "spec_version" : "v1.4",
     "identifier"   : "KScale2",
     "$kref"        : "#/ckan/spacedock/349",
-    "$vref"        : "#/ckan/ksp-avc",
     "license"      : "public-domain",
     "resources"    : {
         "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/112905-*"

--- a/NetKAN/OPTSpacePlaneMain.netkan
+++ b/NetKAN/OPTSpacePlaneMain.netkan
@@ -2,7 +2,6 @@
     "spec_version" : "v1.9",
     "identifier"   : "OPTSpacePlaneMain",
     "$kref"        : "#/ckan/spacedock/1028",
-    "$vref"        : "#/ckan/ksp-avc",
     "license"      : "CC-BY-NC-SA-4.0",
     "abstract"     : "Over 50 stock-a-like, large space plane oriented parts",
     "resources"    : {

--- a/NetKAN/SSRSS-Rescale.netkan
+++ b/NetKAN/SSRSS-Rescale.netkan
@@ -4,7 +4,6 @@
     "name":         "Stock Size Real Solar System - Rescale",
     "abstract":     "Rescales the system to stock size.",
     "$kref":        "#/ckan/github/Sigma88/Sigma-Dimensions",
-    "$vref":        "#/ckan/ksp-avc",
     "license":      "restricted",
     "tags": [
         "config",

--- a/NetKAN/newReactionWheels.netkan
+++ b/NetKAN/newReactionWheels.netkan
@@ -2,7 +2,6 @@
     "spec_version": "v1.4",
     "identifier":   "newReactionWheels",
     "$kref":        "#/ckan/spacedock/1270",
-    "$vref":        "#/ckan/ksp-avc",
     "license":      "CC-BY-NC-SA",
     "tags": [
         "parts",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/83359144-ee9fbd00-a33d-11ea-8462-ea965dcfbc27.png)

These mods have vrefs but no version files. Now the vrefs are removed.

The other mods with this error:

- Have a version file but the extension isn't all lowercase (`.VERSION` or `.Version`)
  - Amusingly these also have glaring syntax errors, so skipping the file is helping them
- Used to have a version file but dropped it and hopefully will bring it back