### PR TITLE
Add RealFuels-Stock to CKAN

### DIFF
--- a/NetKAN/RealFuels-Stock.netkan
+++ b/NetKAN/RealFuels-Stock.netkan
@@ -3,6 +3,7 @@
     "identifier"   : "RealFuels-Stock",
     "name"         : "RealFuels-Stock",
     "abstract"     : "Adds RealFuels configs to stock and many mods' engines, keeping engine role as designed to fit with stock and stock-aligned mods.",
+    "author"       : [ "Raptor831", "ValiZockt" ],
     "license"      : "CC-BY-SA-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/194394-*"

--- a/NetKAN/RealFuels-Stock.netkan
+++ b/NetKAN/RealFuels-Stock.netkan
@@ -13,8 +13,6 @@
     ],
     "$kref": "#/ckan/github/ValiZockt/RealFuels-Stock",
     "$vref": "#/ckan/ksp-avc",
-    "ksp_version_min": "1.8",
-    "ksp_version_max": "1.9.1",
     "install": [
         {
             "find":       "RealFuels-Stock",

--- a/NetKAN/RealFuels-Stock.netkan
+++ b/NetKAN/RealFuels-Stock.netkan
@@ -1,6 +1,6 @@
 {
     "spec_version" : "v1.4",
-    "identifier"   : "realfuels-stock",
+    "identifier"   : "RealFuels-Stock",
     "name"         : "RealFuels-Stock",
     "abstract"     : "Adds RealFuels configs to stock and many mods' engines, keeping engine role as designed to fit with stock and stock-aligned mods.",
     "license"      : "CC-BY-SA-4.0",

--- a/NetKAN/RealFuels-Stock.netkan
+++ b/NetKAN/RealFuels-Stock.netkan
@@ -36,5 +36,5 @@
     "conflicts": [
         { "name": "RealPlume-StockConfigs" },
         { "name": "RFStockalike" }
-    ],
+    ]
 }

--- a/realfuels-stock
+++ b/realfuels-stock
@@ -1,0 +1,40 @@
+{
+    "spec_version" : "v1.4",
+    "identifier"   : "realfuels-stock",
+    "name"         : "RealFuels-Stock",
+    "abstract"     : "Adds RealFuels configs to stock and many mods' engines, keeping engine role as designed to fit with stock and stock-aligned mods.",
+    "license"      : "CC-BY-SA-4.0",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/194394-*"
+    },
+    "tags": [
+        "config",
+        "resources"
+    ],
+    "$kref": "#/ckan/github/ValiZockt/RealFuels-Stock",
+    "$vref": "#/ckan/ksp-avc",
+    "ksp_version_min": "1.8",
+    "ksp_version_max": "1.9.1",
+    "install": [
+        {
+            "find":       "RealFuels-Stock",
+            "install_to": "GameData"
+        }
+    ],
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "RealFuels" }
+    ],
+    "provides" : [
+        "RealPlumeConfigs",
+        "RealFuels-Engine-Configs"
+    ],
+
+    "recommends": [
+        { "name": "RealPlume" }
+    ],
+    "conflicts": [
+        { "name": "RealPlume-StockConfigs" },
+        { "name": "RFStockalike" }
+    ],
+}


### PR DESCRIPTION
Tested on 1.8.1, It should do following, install RealFuels-Stock with its dependencies MM and RF the mod provides RealPlumeConfigs & RealFuels-Engine-Configs, on install it recommends RealPlume, but conflicts with RealPlume-Stock and the old RFStockalike.