### PR TITLE
Make sure the right Ships/VAB folder is installed for SpaceXLaunchVehicles

### DIFF
--- a/NetKAN/SpaceXLaunchVehicles-StockSize.netkan
+++ b/NetKAN/SpaceXLaunchVehicles-StockSize.netkan
@@ -1,14 +1,15 @@
 {
-    "spec_version": "v1.4",
-    "identifier":   "SpaceXLaunchVehicles",
-    "name":         "SpaceX Launch Vehicles - Real Size",
+    "spec_version": "v1.18",
+    "identifier":   "SpaceXLaunchVehicles-StockSize",
+    "name":         "SpaceX Launch Vehicles - Stock Size",
     "$kref":        "#/ckan/spacedock/269",
     "license":      "restricted",
     "tags": [
         "parts"
     ],
+    "provides": [ "SpaceXLaunchVehicles" ],
     "conflicts": [
-        { "name": "SpaceXLaunchVehicles-StockSize" }
+        { "name": "SpaceXLaunchVehicles" }
     ],
     "depends": [
         { "name": "ModuleManager" }
@@ -25,7 +26,11 @@
         "find":       "Launchers Pack",
         "install_to": "GameData"
     }, {
-        "file":       "Ships/VAB",
+        "file":       "Rescaled/GameData",
+        "install_to": "GameData",
+        "as":         "Kartoffelkuchen"
+    }, {
+        "file":       "Rescaled/Ships/VAB",
         "install_to": "Ships"
     } ]
 }

--- a/NetKAN/SpaceXLaunchVehicles.netkan
+++ b/NetKAN/SpaceXLaunchVehicles.netkan
@@ -21,7 +21,7 @@
         "find":       "Launchers Pack",
         "install_to": "GameData"
     }, {
-        "find":       "Ships/VAB",
+        "file":       "Ships/VAB",
         "install_to": "Ships"
     } ]
 }


### PR DESCRIPTION
## Problem
This mods has multiple `Ships/VAB/` folders in the zip, one in the zip root for "normal" installations, and one under `Rescaled` for real-sized crafts.
Both can potentially get matched by the `"find": "Ships/VAB"` stanza.

While the current CKAN version seems to always pick the correct one, I found out about this because I am currently using a ckan.exe compiled from the branch of https://github.com/KSP-CKAN/CKAN/pull/3064.
That one tries to install both folders, which fails because there are identically named files in them.

## Solution
Change the `"find": "Ships/VAB"` to a `"file": "Ships/VAB"` to make it unambiguous and only install the stock-sized crafts.
I think this needs a historic backport too.