### PR TITLE
Filter duplicate folders

### DIFF
--- a/NetKAN/BluedogDB.netkan
+++ b/NetKAN/BluedogDB.netkan
@@ -30,6 +30,7 @@
     ],
     "install": [ {
         "find":       "Bluedog_DB",
-        "install_to": "GameData"
+        "install_to": "GameData",
+        "filter":     [ "Realistic Retextures" ]
     } ]
 }

--- a/NetKAN/DiRT.netkan
+++ b/NetKAN/DiRT.netkan
@@ -13,7 +13,8 @@
     ],
     "install": [ {
         "find":       "GameData/DiRT",
-        "install_to": "GameData"
+        "install_to": "GameData",
+        "filter":     [ "__MACOSX" ]
     } ],
     "conflicts": [
         { "name": "TextureReplacer"         },

--- a/NetKAN/SpearofLonginus.netkan
+++ b/NetKAN/SpearofLonginus.netkan
@@ -16,6 +16,6 @@
      "install": [ {
          "find"       : "GameData/Spear of Longinus",
          "install_to" : "GameData",
-         "filter"     : [ "__MACOSX" ]
+         "filter"     : [ "__MACOSX", ".DS_Store" ]
      } ]
  }

--- a/NetKAN/SpearofLonginus.netkan
+++ b/NetKAN/SpearofLonginus.netkan
@@ -15,6 +15,7 @@
      ],
      "install": [ {
          "find"       : "GameData/Spear of Longinus",
-         "install_to" : "GameData"
+         "install_to" : "GameData",
+         "filter"     : [ "__MACOSX" ]
      } ]
  }

--- a/NetKAN/StockPlugins.netkan
+++ b/NetKAN/StockPlugins.netkan
@@ -21,5 +21,10 @@
         { "name": "Protractor" },
         { "name": "Telemachus" },
         { "name": "RocketWatch" }
-    ]
+    ],
+    "install": [ {
+        "find":       "StockPlugins",
+        "install_to": "GameData",
+        "filter":     [ "Optional" ]
+    } ]
 }


### PR DESCRIPTION
After KSP-CKAN/CKAN#3064, we have a variety of new errors to address.

This PR fixes the ones that have an extra folder with the same name as the main one to install.

Historical versions of this fix should be done before v1.28.0 is released.