### PR TITLE
Fix KWS install

### DIFF
--- a/NetKAN/KWSKerbalWeaponsSystem.netkan
+++ b/NetKAN/KWSKerbalWeaponsSystem.netkan
@@ -9,8 +9,8 @@
         "combat"
     ],
     "install": [ {
-        "find_regexp": "KWS$",
-        "install_to":  "GameData"
+        "find":       "KWS",
+        "install_to": "GameData"
     } ],
     "depends": [
         { "name": "BDArmoryContinued" }


### PR DESCRIPTION
This is a follow-up to #7969, there was never any need to use a regexp here because `find` matches whole folder names. I just didn't know what I was doing in #6019.

This change should also be applied historically before the full release of v1.28.0.