### PR TITLE
Fix RecycledParts craft installs

### DIFF
--- a/NetKAN/RecycledPartsAtomicAge.netkan
+++ b/NetKAN/RecycledPartsAtomicAge.netkan
@@ -9,8 +9,11 @@
         "parts"
     ],
     "install": [ {
-        "find": "SpaceTuxIndustries/RecycledParts/AtomicAge",
+        "find":       "SpaceTuxIndustries/RecycledParts/AtomicAge",
         "install_to": "GameData/SpaceTuxIndustries/RecycledParts"
+    }, {
+        "find":       "SPH/A Nuke Cruiser-Skalou-03.craft",
+        "install_to": "Ships/SPH"
     } ],
     "depends": [
         { "name": "ModuleManager" }

--- a/NetKAN/RecycledPartsAtomicAge.netkan
+++ b/NetKAN/RecycledPartsAtomicAge.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.12",
     "identifier":   "RecycledPartsAtomicAge",
     "name":         "Recycled Parts Atomic Age",
     "$kref":        "#/ckan/spacedock/1507",
@@ -13,7 +13,8 @@
         "install_to": "GameData/SpaceTuxIndustries/RecycledParts"
     }, {
         "find":       "SPH/A Nuke Cruiser-Skalou-03.craft",
-        "install_to": "Ships/SPH"
+        "install_to": "Ships/SPH",
+        "find_matches_files": true
     } ],
     "depends": [
         { "name": "ModuleManager" }

--- a/NetKAN/RecycledPartsAtomicAge.netkan
+++ b/NetKAN/RecycledPartsAtomicAge.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.12",
+    "spec_version": "v1.16",
     "identifier":   "RecycledPartsAtomicAge",
     "name":         "Recycled Parts Atomic Age",
     "$kref":        "#/ckan/spacedock/1507",

--- a/NetKAN/RecycledPartsFarscape.netkan
+++ b/NetKAN/RecycledPartsFarscape.netkan
@@ -13,7 +13,8 @@
         "install_to": "GameData/SpaceTuxIndustries/RecycledParts"
     }, {
         "find":       "SPH",
-        "install_to": "Ships"
+        "install_to": "Ships",
+        "filter":     [ "A Nuke Cruiser-Skalou-03.craft" ]
     } ],
     "depends": [
         { "name": "ModuleManager" },

--- a/NetKAN/RecycledPartsRSCapsuledyne.netkan
+++ b/NetKAN/RecycledPartsRSCapsuledyne.netkan
@@ -11,9 +11,6 @@
     "install": [ {
         "find": "RSCapsuledyne",
         "install_to": "GameData/SpaceTuxIndustries/RecycledParts"
-    }, {
-        "find": "SPH",
-        "install_to": "Ships"
     } ],
     "depends": [
         { "name": "ModuleManager" },


### PR DESCRIPTION
RecycledParts contains 3 crafts.

Craft file | Modded parts | Mod
:-- | :-- | :--
A Nuke Cruiser-Skalou-03.craft | NuclearJetEngine | RecycledPartsAtomicAge
Farscape 1.craft | MNZFarscape MNZFarscapeWingLH MNZFarscapeWingRH MNZFARENG MNZFarscapeGearNose MNZFarscapeGearLH MNZFarscapeGearRH | RecycledPartsFarScape
Farscape (Hetch).craft | MNZFarscape MNZFarscapeWingLH MNZFarscapeWingRH MNZFARENG MNZFarscapeGearNose MNZFarscapeGearLH MNZFarscapeGearRH | RecycledPartsFarScape

Currently RecycledPartsRSCapsuledyne installs the craft files, even though it doesn't provide the modded parts they need. Now that's removed.

Currently RecycledPartsAtomicAge doesn't install any craft files, even though that's what A Nuke Cruiser-Skalou-03.craft is for. Now it installs that file.

Currently RecycledPartsFarscape installs all the craft files, even though it doesn't provide the modded part that A Nuke Cruiser-Skalou-03.craft needs. Now this file is filtered out.

Fixes #7992.