### PR TITLE
Add SSCEP NetKAN metadata to the index

### DIFF
--- a/NetKAN/Stock-Scatter-Collider-Enabler-Patch
+++ b/NetKAN/Stock-Scatter-Collider-Enabler-Patch
@@ -1,0 +1,5 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "SSCEP",
+    "$kref":        "#/ckan/netkan/https://raw.githubusercontent.com/Poodmund/Stock-Scatter-Collider-Enabler-Patch/master/CKAN/SSCEP.netkan"
+}

--- a/NetKAN/Stock-Scatter-Collider-Enabler-Patch
+++ b/NetKAN/Stock-Scatter-Collider-Enabler-Patch
@@ -1,5 +1,0 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "SSCEP",
-    "$kref":        "#/ckan/netkan/https://raw.githubusercontent.com/Poodmund/Stock-Scatter-Collider-Enabler-Patch/master/CKAN/SSCEP.netkan"
-}

--- a/NetKAN/StockScatterColliderEnablerPatch.netkan
+++ b/NetKAN/StockScatterColliderEnablerPatch.netkan
@@ -1,0 +1,9 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "StockScatterColliderEnablerPatch",
+    "$kref":        "#/ckan/netkan/https://raw.githubusercontent.com/Poodmund/Stock-Scatter-Collider-Enabler-Patch/master/CKAN/SSCEP.netkan",
+    "license":      "GPL-3.0",
+    "tags": [
+        "config"
+    ]
+}


### PR DESCRIPTION
I think the NetKAN file I have remotely hosted is correct. If not, please let me know here and I'll rectify it before this merge.

https://raw.githubusercontent.com/Poodmund/Stock-Scatter-Collider-Enabler-Patch/master/CKAN/SSCEP.netkan