### PR TITLE
Add TestLite

### DIFF
--- a/NetKAN/TestLite.netkan
+++ b/NetKAN/TestLite.netkan
@@ -1,0 +1,27 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "TestLite",
+    "$kref":        "#/ckan/github/ec429/TestLite",
+    "ksp_version_min": "1.6.1",
+    "ksp_version_max": "1.7.3",
+    "license":      "MIT",
+    "x_netkan_github": {
+        "use_source_archive": true
+    },
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/182244-*"
+    },
+    "tags": [
+        "plugin"
+    ],
+    "conflicts": [
+        { "name": "TestFlight" }
+    ],
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "RealFuels"     }
+    ],
+    "recommends": [
+        { "name": "RealismOverhaul" }
+    ]
+}


### PR DESCRIPTION
I was browsing [RP-0's mod recommendations wiki], and it mentions a few mods that aren't in CKAN, such as "TestLite", a replacement for TestFlight tailored to the needs of RP-0.

- https://github.com/KSP-RO/RP-0/wiki/TestLiteVsTestFlight

Now TestLite would be available in CKAN, and RP-0 can update their metanetkan to suggest it.

~~**NOTE**: Author permission not yet acquired, submitting this mostly to check out the validation to confirm whether it will work. Please do not merge unless/until @ec429 gives us the go-ahead.~~

Once this is merged, we can start a PR to add it here:

- https://github.com/KSP-RO/RP-0/blob/master/RP-0.netkan

[RP-0's mod recommendations wiki]:  https://github.com/KSP-RO/RP-0/wiki/Recommended-Extra-Mods