### PR TITLE
Fix Spectra install

### DIFF
--- a/NetKAN/Spectra.netkan
+++ b/NetKAN/Spectra.netkan
@@ -49,7 +49,7 @@
         { "name": "DistantObject"                   }
     ],
     "install": [ {
-        "file":       "Step 2 - Spectra/GameData/Spectra",
+        "file":       "Step 2 - Spectra/Spectra",
         "install_to": "GameData"
     } ]
 }

--- a/NetKAN/Spectra.netkan
+++ b/NetKAN/Spectra.netkan
@@ -45,18 +45,11 @@
     "recommends": [
         { "name": "EnvironmentalVisualEnhancements" },
         { "name": "Scatterer"                       },
-        { "name": "Kopernicus"                      },
         { "name": "TextureReplacer"                 },
         { "name": "DistantObject"                   }
     ],
     "install": [ {
-        "file":       "Step 2 - Spectra/GameData/TextureReplacer",
-        "install_to": "GameData"
-    }, {
         "file":       "Step 2 - Spectra/GameData/Spectra",
-        "install_to": "GameData"
-    }, {
-        "file":       "Step 2 - Spectra/GameData/KSPRC",
         "install_to": "GameData"
     } ]
 }


### PR DESCRIPTION
The TextureReplacer and KSPRC folders are removed in the latest release, and the release announcement says Kopernicus is no longer needed.