### PR TITLE
Fix MissionController2 install

### DIFF
--- a/NetKAN/MissionController2.netkan
+++ b/NetKAN/MissionController2.netkan
@@ -20,8 +20,8 @@
     ],
     "install": [
         {
-            "find" : "MissionControllerEC",
-            "install_to" : "GameData"
+            "find":       "MissionController",
+            "install_to": "GameData"
         }
     ],
     "x_netkan_override": [


### PR DESCRIPTION
The folder is renamed in the latest release.