### PR TITLE
Split out Grannus ribbons

### DIFF
--- a/NetKAN/Grannus-RibbonPack-FromGEP.netkan
+++ b/NetKAN/Grannus-RibbonPack-FromGEP.netkan
@@ -1,0 +1,25 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "Grannus-RibbonPack-FromGEP",
+    "name":         "Grannus Ribbons from GEP",
+    "abstract":     "GPP and GEP both have Grannus ribbons; these are the ones from GEP",
+    "$kref":        "#/ckan/github/OhioBob/Grannus-Expansion-Pack",
+    "ksp_version":  "any",
+    "license":      "CC-BY-NC-ND",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/169664-*"
+    },
+    "tags": [
+        "config"
+    ],
+    "provides": [
+        "Grannus-RibbonPack"
+    ],
+    "conflicts": [
+        { "name": "Grannus-RibbonPack" }
+    ],
+    "install": [ {
+        "find":       "GameData/Nereid/FinalFrontier/Ribbons/Grannus",
+        "install_to": "GameData/Nereid/FinalFrontier/Ribbons"
+    } ]
+}

--- a/NetKAN/Grannus-RibbonPack-FromGPP.netkan
+++ b/NetKAN/Grannus-RibbonPack-FromGPP.netkan
@@ -1,0 +1,25 @@
+{
+    "spec_version": "v1.4",
+    "name":         "Grannus Ribbons from GPP",
+    "identifier":   "Grannus-RibbonPack-FromGPP",
+    "abstract":     "GPP and GEP both have Grannus ribbons; these are the ones from GPP",
+    "$kref":        "#/ckan/github/Galileo88/Galileos-Planet-Pack/asset_match/Galileo.*?\\.zip",
+    "ksp_version":  "any",
+    "license":      "CC-BY-NC-ND",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-*"
+    },
+    "tags": [
+        "config"
+    ],
+    "provides": [
+        "Grannus-RibbonPack"
+    ],
+    "conflicts": [
+        { "name": "Grannus-RibbonPack" }
+    ],
+    "install": [ {
+        "find":       "GameData/Nereid/FinalFrontier/Ribbons/Grannus",
+        "install_to": "GameData/Nereid/FinalFrontier/Ribbons"
+    } ]
+}

--- a/NetKAN/GrannusExpansionPack.netkan
+++ b/NetKAN/GrannusExpansionPack.netkan
@@ -21,7 +21,8 @@
         { "name": "DistantObject"                   },
         { "name": "ResearchBodies"                  },
         { "name": "FinalFrontier"                   },
-        { "name": "KerbalHealth"                    }
+        { "name": "KerbalHealth"                    },
+        { "name": "Grannus-RibbonPack"              }
     ],
     "suggests": [
         { "name": "GPP"                          },
@@ -34,6 +35,7 @@
         "install_to": "GameData"
     }, {
         "find":       "GameData/Nereid",
-        "install_to": "GameData"
+        "install_to": "GameData",
+        "filter":     [ "Grannus" ]
     } ]
 }


### PR DESCRIPTION
## Problem

GPP and GrannusExpansionPack can't be installed together even though that's what GrannusExpansionPack was designed for.

## Cause

Both modules install ribbons for Grannus, a CelestialBody that they share.

## Changes

- Grannus-RibbonPack-FromGEP installs the ribbons from GEP
- Grannus-RibbonPack-FromGPP installs the ribbons from GPP
- GrannusExpansionPack no longer installs the ribbons itself
- GrannusExpansionPack recommends Grannus-RibbonPack, which both of the ribbon pack modules provide
- Galileo88/Galileos-Planet-Pack#64 will make the same filtering and relationship changes to GPP

This way a user installing GPP can install the ribbons from GPP, a user installing GEP can install the ribbons from GPP, a user installing both GPP and GEP can pick randomly, and nobody has to download a 300+ MB mod they're not going to use.

Fixes #8023.