### PR TITLE
Remove flight tag from ResourceMonitors

### DIFF
--- a/NetKAN/ResourceMonitors.netkan
+++ b/NetKAN/ResourceMonitors.netkan
@@ -16,7 +16,6 @@
   "tags": [
     "plugin",
     "information",
-    "flight",
     "resources"
   ],
   "install": [


### PR DESCRIPTION
This is the only mod with the `flight` tag. If we want to have this tag, we need to analyze the existing mods and figure out which ones belong in it.

Now it's removed.