### PR TITLE
Remove StockishProjectOrion vref

### DIFF
--- a/NetKAN/StockishProjectOrion.netkan
+++ b/NetKAN/StockishProjectOrion.netkan
@@ -2,7 +2,6 @@
     "spec_version": "v1.4",
     "identifier":   "StockishProjectOrion",
     "$kref":        "#/ckan/spacedock/2384",
-    "$vref":        "#/ckan/ksp-avc",
     "license":      "MIT",
     "tags": [
         "plugin",
@@ -14,5 +13,8 @@
     "install": [ {
         "find":       "Orion",
         "install_to": "GameData"
+    }, {
+        "find":       "Ships/VAB",
+        "install_to": "Ships"
     } ]
 }


### PR DESCRIPTION
This mod doesn't have its own version file. We were using the one from its bundled copy of CommunityResourcePack.
Also now installing its ships.