### PR TITLE
Add author to EarlyBird

### DIFF
--- a/NetKAN/EarlyBird.netkan
+++ b/NetKAN/EarlyBird.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "EarlyBird",
     "abstract": "Early Bird is a mod for better warp-to-morning functionality. Currently, it modifies the warp-to-morning feature such that warp ends five minutes before sunrise, taking the space center latitude into account (not relevant for stock Kerbin, but relevant for any planet mod that fakes axial tilt",
+    "author":       "taniwha",
     "$kref":        "#/ckan/ksp-avc/http://taniwha.org/~bill/EarlyBird.version",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "GPL-3.0",


### PR DESCRIPTION
EarlyBird's netkan has not `author` specified, and since it has a `#/ckan/ksp-avc/` kref it doesn't autogenerate it.
Now I added "taniwha" as author.