### PR TITLE
Remove utility tag from AQSS

### DIFF
--- a/NetKAN/AQSS.netkan
+++ b/NetKAN/AQSS.netkan
@@ -21,8 +21,7 @@
   ],
   "tags": [
     "plugin",
-    "convenience",
-    "utility"
+    "convenience"
   ],
   "install": [
     {


### PR DESCRIPTION
Similar to #8025, no other mod has this tag, let's not start new categories by accident.