### PR TITLE
Add SpaceTuxLibrary depends to KerbalConstructionTime

### DIFF
--- a/NetKAN/KerbalConstructionTime.netkan
+++ b/NetKAN/KerbalConstructionTime.netkan
@@ -10,8 +10,8 @@
         "career"
     ],
     "install": [ {
-      "file":       "GameData/KerbalConstructionTime",
-      "install_to": "GameData"
+        "file":       "GameData/KerbalConstructionTime",
+        "install_to": "GameData"
     } ],
     "depends": [
         { "name": "ModuleManager"       },

--- a/NetKAN/KerbalConstructionTime.netkan
+++ b/NetKAN/KerbalConstructionTime.netkan
@@ -9,29 +9,28 @@
         "plugin",
         "career"
     ],
-    "install" : [
-        {
-          "file"       : "GameData/KerbalConstructionTime",
-          "install_to" : "GameData"
-        }
+    "install": [ {
+      "file":       "GameData/KerbalConstructionTime",
+      "install_to": "GameData"
+    } ],
+    "depends": [
+        { "name": "ModuleManager"       },
+        { "name": "MagiCore"            },
+        { "name": "ClickThroughBlocker" },
+        { "name": "ToolbarController"   },
+        { "name": "SpaceTuxLibrary"     }
     ],
-    "depends" : [
-        { "name" : "ModuleManager" },
-        { "name" : "MagiCore" },
-        { "name" : "ClickThroughBlocker" },
-        { "name" : "ToolbarController" }
+    "recommends": [
+        { "name": "ScrapYard"     },
+        { "name": "KRASH"         },
+        { "name": "StageRecovery" },
+        { "name": "CrewQueueTwo"  },
+        { "name": "OhScrap"       }
     ],
-    "recommends" : [
-        { "name" : "ScrapYard" },
-        { "name" : "KRASH" },
-        { "name" : "StageRecovery" },
-        { "name" : "CrewQueueTwo" },
-        { "name" : "OhScrap" }
+    "suggests": [
+        { "name": "KerbalAlarmClock" }
     ],
-    "suggests" : [
-        { "name" : "KerbalAlarmClock" }
-    ],
-	"conflicts" : [
-		{ "name": "KerbalConstructionTime-173" }
-	]
+    "conflicts": [
+        { "name": "KerbalConstructionTime-173" }
+    ]
 }


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/87593754-920c1d80-c6b1-11ea-8005-76c46f4940f4.png)

![image](https://user-images.githubusercontent.com/1559108/87593809-a6e8b100-c6b1-11ea-8a3a-d1e4a049b2ec.png)

## Cause

https://github.com/linuxgurugamer/KCT/commit/d076e1b7d5608340a199d6b50348e38856e54477#diff-591541463655671910e84e570d967cd4

## Changes

Now the missing dependency is added. FYI to @linuxgurugamer.