### PR TITLE
Fix new Angel-125 installs

### DIFF
--- a/NetKAN/DSEV.netkan
+++ b/NetKAN/DSEV.netkan
@@ -1,50 +1,43 @@
 {
-  "license": "unknown",
-  "identifier": "DSEV",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "$kref": "#/ckan/github/Angel-125/DSEV",
-  "$vref": "#/ckan/ksp-avc/GameData/WildBlueIndustries/DSEV/DSEV.version",
-  "resources": {
-    "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/122162-181-19x-deep-space-exploration-vessels-build-nasa-inspired-ships-in-ksp/",
-    "repository": "https://github.com/Angel-125/DSEV"
-  },
-  "depends": [
-    { "name": "NearFutureProps" },
-    { "name": "ModuleManager" },
-    { "name": "WildBlueTools" },
-    { "name": "KerbalActuators" },
-    { "name": "BarisBridge" }
-  ],
-  "recommends": [
-    { "name": "Snacks" },
-    { "name": "ClassicStockResources" },
-    { "name": "ExtraPlanetaryLaunchpads" },
-    { "name": "KIS" },
-    { "name": "KAS" },
-    { "name": "ASET" },
-    { "name": "ASETAvionics" }
-  ],
-  "tags": [
-    "parts",
-    "plugin",
-    "crewed"
-  ],
-  "install": [
-    {
-      "find": "WildBlueIndustries/DSEV",
-      "install_to": "GameData",
-      "filter_regexp": [
-        ".*\\.pdb$"
-      ]
+    "spec_version": "v1.4",
+    "identifier":   "DSEV",
+    "$kref":        "#/ckan/github/Angel-125/DSEV",
+    "$vref":        "#/ckan/ksp-avc/GameData/WildBlueIndustries/DSEV/DSEV.version",
+    "license":      "restricted",
+    "resources": {
+        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/122162-*",
+        "repository": "https://github.com/Angel-125/DSEV"
     },
-    {
-      "find": "VAB",
-      "install_to": "Ships"
-    },
-    {
-      "find": "SPH",
-      "install_to": "Ships"
-    }
-  ],
-  "spec_version": "v1.4"
+    "tags": [
+        "parts",
+        "plugin",
+        "crewed"
+    ],
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "WildBlueTools" },
+        { "name": "NearFutureProps" },
+        { "name": "KerbalActuators" },
+        { "name": "ClassicStockResources" },
+        { "name": "BarisBridge" }
+    ],
+    "recommends": [
+        { "name": "RasterPropMonitor-Core" },
+        { "name": "ASETProps" },
+        { "name": "InfernalRobotics" }
+    ],
+    "suggests": [
+        { "name": "ASET" }
+    ],
+    "install": [ {
+        "find":          "WildBlueIndustries/DSEV",
+        "install_to":    "GameData/WildBlueIndustries",
+        "filter_regexp": [ ".*\\.pdb$", "ReferenceDesigns" ]
+    }, {
+        "find":       "VAB",
+        "install_to": "Ships"
+    }, {
+        "find":       "SPH",
+        "install_to": "Ships"
+    } ]
 }

--- a/NetKAN/Heisenberg.netkan
+++ b/NetKAN/Heisenberg.netkan
@@ -1,43 +1,42 @@
 {
-  "license": "unknown",
-  "identifier": "Heisenberg",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "$kref": "#/ckan/github/Angel-125/Airships",
-  "$vref": "#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version",
-  "resources": {
-    "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/150702-181-19x-heisenberg-airships-part-pack/",
-    "repository": "https://github.com/Angel-125/Airships"
-  },
-  "depends": [
-    { "name": "ModuleManager" },
-    { "name": "HooliganLabsAirships" },
-    { "name": "FirespitterCore" },
-    { "name": "WildBlueTools" },
-    { "name": "KerbalActuators" },
-    { "name": "BarisBridge" }
-
-  ],
-  "recommends": [
-    { "name": "Snacks" },
-    { "name": "ClassicStockResources" },
-    { "name": "ExtraPlanetaryLaunchpads" },
-    { "name": "KIS" },
-    { "name": "KAS" },
-    { "name": "ASET" },
-    { "name": "ASETAvionics" }
-  ],
-  "tags": [
-    "parts",
-    "crewed"
-  ],
-  "install": [
-    {
-      "find": "WildBlueIndustries/Heisenberg",
-      "install_to": "GameData",
-      "filter_regexp": [
-        ".*\\.pdb$"
-      ]
-    }
-  ],
-  "spec_version": "v1.4"
+    "spec_version": "v1.4",
+    "identifier":   "Heisenberg",
+    "$kref":        "#/ckan/github/Angel-125/Airships",
+    "$vref":        "#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version",
+    "license":      "restricted",
+    "resources": {
+        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*",
+        "repository": "https://github.com/Angel-125/Airships"
+    },
+    "tags": [
+        "parts",
+        "plugin",
+        "crewed"
+    ],
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "WildBlueTools" },
+        { "name": "HooliganLabsAirships" },
+        { "name": "KerbalActuators" },
+        { "name": "ClassicStockResources" },
+        { "name": "BarisBridge" }
+    ],
+    "recommends": [
+        { "name": "AirParkContinued" },
+        { "name": "ASETProps" },
+        { "name": "AircraftCarrierAccessories" }
+    ],
+    "suggests": [
+        { "name": "Pathfinder" },
+        { "name": "KIS" },
+        { "name": "KAS" },
+        { "name": "kOS" },
+        { "name": "Snacks" },
+        { "name": "TACLS" }
+    ],
+    "install": [ {
+        "find":          "WildBlueIndustries/Heisenberg",
+        "install_to":    "GameData/WildBlueIndustries",
+        "filter_regexp": [ ".*\\.pdb$" ]
+    } ]
 }

--- a/NetKAN/Heisenberg.netkan
+++ b/NetKAN/Heisenberg.netkan
@@ -37,6 +37,12 @@
     "install": [ {
         "find":          "WildBlueIndustries/Heisenberg",
         "install_to":    "GameData/WildBlueIndustries",
-        "filter_regexp": [ ".*\\.pdb$" ]
+        "filter_regexp": [ ".*\\.pdb$", "SampleCraft" ]
+    }, {
+        "find":       "VAB",
+        "install_to": "Ships"
+    }, {
+        "find":       "SPH",
+        "install_to": "Ships"
     } ]
 }

--- a/NetKAN/MOLE.netkan
+++ b/NetKAN/MOLE.netkan
@@ -1,41 +1,44 @@
 {
-  "license": "unknown",
-  "identifier": "MOLE",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "$kref": "#/ckan/github/Angel-125/MOLE",
-  "$vref":        "#/ckan/ksp-avc/GameData/WildBlueIndustries/MOLE/MOLE.version",
-  "resources": {
-    "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/154893-181-19x-mark-one-laboratory-extensions-mole/",
-    "repository": "https://github.com/Angel-125/MOLE"
-  },
-  "depends": [
-    { "name": "ModuleManager" },
-    { "name": "WildBlueTools" },
-    { "name": "KerbalActuators" },
-    { "name": "BarisBridge" }
-  ],
-    "recommends": [
-        { "name": "Snacks" },
+    "spec_version": "v1.4",
+    "identifier":   "MOLE",
+    "$kref":        "#/ckan/github/Angel-125/MOLE",
+    "$vref":        "#/ckan/ksp-avc/GameData/WildBlueIndustries/MOLE/MOLE.version",
+    "license":      "restricted",
+    "resources": {
+        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/154893-*",
+        "repository": "https://github.com/Angel-125/MOLE"
+    },
+    "tags": [
+        "parts",
+        "plugin",
+        "crewed"
+    ],
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "WildBlueTools" },
+        { "name": "KerbalActuators" },
         { "name": "ClassicStockResources" },
-        { "name": "ExtraPlanetaryLaunchpads" },
+        { "name": "BarisBridge" }
+    ],
+    "recommends": [
+        { "name": "ASETProps" },
+        { "name": "ExtraPlanetaryLaunchpads" }
+    ],
+    "suggests": [
+        { "name": "Pathfinder" },
+        { "name": "RealChute" },
         { "name": "KIS" },
         { "name": "KAS" },
-        { "name": "ASET" },
-        { "name": "ASETAvionics" }
+        { "name": "kOS" },
+        { "name": "RasterPropMonitor-Core" },
+        { "name": "CactEyeCommunity" },
+        { "name": "Snacks" },
+        { "name": "TACLS" },
+        { "name": "Kerbalism" }
     ],
-  "tags": [
-    "parts",
-    "plugin",
-    "crewed"
-  ],
-  "install": [
-    {
-      "find": "WildBlueIndustries/MOLE",
-      "install_to": "GameData",
-      "filter_regexp": [
-        ".*\\.pdb$"
-      ]
-    }
-  ],
-  "spec_version": "v1.4"
+    "install": [ {
+        "find":          "WildBlueIndustries/MOLE",
+        "install_to":    "GameData/WildBlueIndustries",
+        "filter_regexp": [ ".*\\.pdb$" ]
+    } ]
 }

--- a/NetKAN/MOLE.netkan
+++ b/NetKAN/MOLE.netkan
@@ -39,6 +39,9 @@
     "install": [ {
         "find":          "WildBlueIndustries/MOLE",
         "install_to":    "GameData/WildBlueIndustries",
-        "filter_regexp": [ ".*\\.pdb$" ]
+        "filter_regexp": [ ".*\\.pdb$", "SampleCraft" ]
+    }, {
+        "find":       "VAB",
+        "install_to": "Ships"
     } ]
 }


### PR DESCRIPTION
#8057, #8058, and #8060 indexed these mods with incorrect install paths (missing the WildBlueTools parent folder). Now they're fixed. As well the license is set to reflect that the assets are All Rights Reserved, and the relationships are updated to match the ZIPs and forum threads.