### PR TITLE
Update OPT relationships

### DIFF
--- a/NetKAN/OPTReconfig.netkan
+++ b/NetKAN/OPTReconfig.netkan
@@ -16,12 +16,33 @@
         "install_to": "GameData"
     } ],
     "depends": [
-        { "name": "ModuleManager"      },
-        { "name": "OPTSpacePlaneParts" },
-        { "name": "B9PartSwitch"       }
+        { "name": "ModuleManager" },
+        { "name": "B9PartSwitch"  }
     ],
     "recommends": [
-        { "name": "CommunityResourcePack" }
+        { "name": "CommunityResourcePack" },
+        { "name": "OPTSpacePlaneMain"     }
+    ],
+    "supports": [
+        { "name": "ClassicStockResources"  },
+        { "name": "CommunityTechTree"      },
+        { "name": "ConfigurableContainers" },
+        { "name": "ConnectedLivingSpace"   },
+        { "name": "CryoEngines"            },
+        { "name": "CryoTanks"              },
+        { "name": "KerbalAtomics"          },
+        { "name": "Kerbalism"              },
+        { "name": "KIS"                    },
+        { "name": "ModularFuelTanks"       },
+        { "name": "Pathfinder"             },
+        { "name": "RationalResources"      },
+        { "name": "RealFuels"              },
+        { "name": "Snacks"                 },
+        { "name": "TacLifeSupport"         },
+        { "name": "TETRIXTechTree"         },
+        { "name": "UnKerballedStart"       },
+        { "name": "USI-LS"                 },
+        { "name": "WildBlueTools"          }
     ],
     "conflicts": [
         { "name": "OPTWBIintegrationpatch" },

--- a/NetKAN/OPTSpacePlaneMain.netkan
+++ b/NetKAN/OPTSpacePlaneMain.netkan
@@ -9,22 +9,21 @@
         "crewed"
     ],
     "depends": [
-        { "name": "OPTReconfig"           },
-        { "name": "CommunityResourcePack" },
-        { "name": "B9PartSwitch"          }
+        { "name": "OPTReconfig" }
     ],
     "recommends": [
-        { "name": "RasterPropMonitor"  },
-        { "name": "OPTSpacePlaneParts" }
+        { "name": "KerbalFoundriesContinued" },
+        { "name": "RasterPropMonitor"        },
+        { "name": "OPTSpacePlaneParts"       }
     ],
     "supports": [
         { "name": "ConnectedLivingSpace" },
-        { "name": "ModularFuelTanks" },
-        { "name": "RealFuels" },
-        { "name": "TacLifeSupport" }
+        { "name": "ModularFuelTanks"     },
+        { "name": "RealFuels"            },
+        { "name": "TacLifeSupport"       }
     ],
     "install": [ {
-        "find"      : "OPT",
+        "find":       "OPT",
         "install_to": "GameData"
     } ],
     "x_netkan_override": [

--- a/NetKAN/OPTSpacePlaneParts.netkan
+++ b/NetKAN/OPTSpacePlaneParts.netkan
@@ -1,8 +1,8 @@
 {
     "spec_version": "v1.4",
     "identifier"  : "OPTSpacePlaneParts",
-    "name"        : "Orbit Portal Technology [OPT] Spaceplane Parts (Legacy)",
-    "abstract"    : "Parts from previous OPT versions, recommended to avoid game breaking if you used v1.8.6",
+    "name"        : "OPT Spaceplane (Legacy)",
+    "abstract"    : "Retired parts such as Stail fuselage, and expansion pack containing many wings and engines",
     "license"     : "CC-BY-NC-SA-4.0",
     "$kref"       : "#/ckan/spacedock/711",
     "$vref"       : "#/ckan/ksp-avc/OPTLegacy.version",
@@ -11,19 +11,21 @@
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/87956-*"
     },
     "tags": [
-        "parts"
+        "parts",
+        "crewed"
     ],
-    "install": [
-        {
-            "find": "OPT_Legacy",
-            "install_to": "GameData"
-        }
-    ],
-    "recommends": [
-        { "name": "OPTSpacePlaneMain" }
-    ],
+    "install": [ {
+        "find":       "OPT_Legacy",
+        "install_to": "GameData"
+    } ],
     "depends": [
         { "name": "ModuleManager" },
         { "name": "OPTReconfig"   }
+    ],
+    "recommends": [
+        { "name": "KerbalFoundriesContinued" },
+        { "name": "OPTSpacePlaneMain"        },
+        { "name": "RasterPropMonitor"        },
+        { "name": "KerbalActuators"          }
     ]
 }


### PR DESCRIPTION
This is kind of a successor to #8081. Request from author:


> 7 hours ago, JadeOfMaar said:
> Hey LGG. Someone just pointed out that OPT Reconfig is dependent on Legacy. That needs to change. Related, I'd like these changes to happen too, including add/update of abstract, update of tags for Legacy, and if possible, changes to name (not identifier). Legacy's CKAN/SpaceDock name is absurdly long.
> 
> (Unlisted items, like Reconfig's conflicts, don't need to be touched.)
> 
> Reconfig
> ```json
>     "depends": [
>         { "name": "ModuleManager" },
>         { "name": "B9PartSwitch"  }
>     ],
>     "recommends": [
>         { "name": "CommunityResourcePack" },
>         { "name": "OPTSpacePlaneMain" }
>     ],
>     "supports": [
>         { "name": "ClassicStockResources" },
>         { "name": "CommunityTechTree" },
>         { "name": "ConfigurableContainers" },
>         { "name": "ConnectedLivingSpace" },
>         { "name": "CryoEngines" },
>         { "name": "CryoTanks" },
>         { "name": "KerbalAtomics" },
>         { "name": "Kerbalism" },
>         { "name": "KIS" },
>         { "name": "ModularFuelTanks" },
>         { "name": "Pathfinder" },
>         { "name": "RationalResources" },
>         { "name": "RealFuels" },
>         { "name": "Snacks" },
>         { "name": "TacLifeSupport" },
>         { "name": "TETRIXTechTree" },
>         { "name": "UnKerballedStart" },
>         { "name": "USI-LS" },
>         { "name": "WildBlueTools" }
>     ],
> ```
> 
> ---
> 
> Legacy
> ```json
>     "name"        : "OPT Spaceplane (Legacy)",
>     "abstract"    : "Retired parts such as Stail fuselage, and expansion pack containing many wings and engines.",
>     "tags": [
>         "parts",
>         "crewed"
>     ],
>     "depends": [
>         { "name": "OPTReconfig" }
>     ],
>     "recommends": [
>         { "name": "KerbalFoundriesContinued", }
>         { "name": "OPTSpacePlaneMain" },
>         { "name": "RasterPropMonitor" },
>         { "name": "KerbalActuators"   }
>     ],
> ```
> 
> ---
> 
> Main / Continued
> ```json
>     "depends": [
>         { "name": "OPTReconfig" }
>     ],
>     "recommends": [
>         { "name": "KerbalFoundriesContinued", }
>         { "name": "RasterPropMonitor" },
>         { "name": "OPTSpacePlaneParts" }
>     ],
> ```

This should cover all of those changes, with the exception of removing the ModuleManager dependency for OPTSpacePlaneParts, because it contains a "MM_Patches" folder containing many files that use MM syntax.