### PR TITLE
Updating the description of the Add'On. Stating the current need of Module Manager 4.0.2 at minimum.

### DIFF
--- a/NetKAN/KSP-Recall.netkan
+++ b/NetKAN/KSP-Recall.netkan
@@ -4,7 +4,7 @@
     "$vref"            : "#/ckan/ksp-avc",
     "identifier"       : "KSP-Recall",
     "name"             : "KSP Recall",
-    "abstract"         : "KSP Recall - a bag of tricks and stunts to work around KSP bugs while editing Resources on Editor, and more to come...",
+    "abstract"         : "KSP Recall - a bag of tricks and stunts to work around KSP bugs. Currently soves the Resource resetting on KSP 1.9.x, the heading drift on grounded crafts on KSP >= 1.8, and more to come...",
     "license"          : [ "GPL-2.0", "restricted" ],
     "release_status"   : "stable",
     "x_netkan_force_v" : true,
@@ -22,7 +22,7 @@
         "repository": "https://github.com/net-lisias-ksp/KSP-Recall"
     },
     "depends" : [
-        { "name" : "ModuleManager", "min_version" : "3.1.1" }
+        { "name" : "ModuleManager", "min_version" : "4.0.2" }
     ],
     "tags": [
         "plugin",

--- a/NetKAN/KSP-Recall.netkan
+++ b/NetKAN/KSP-Recall.netkan
@@ -4,7 +4,7 @@
     "$vref"            : "#/ckan/ksp-avc",
     "identifier"       : "KSP-Recall",
     "name"             : "KSP Recall",
-    "abstract"         : "KSP Recall - a bag of tricks and stunts to work around KSP bugs. Currently soves the Resource resetting on KSP 1.9.x, the heading drift on grounded crafts on KSP >= 1.8, and more to come...",
+    "abstract"         : "KSP Recall - Solves the resource resetting on KSP 1.9.x, the heading drift on grounded crafts on KSP >= 1.8, and more to come...",
     "license"          : [ "GPL-2.0", "restricted" ],
     "release_status"   : "stable",
     "x_netkan_force_v" : true,


### PR DESCRIPTION
Yep, now it work around the heading drifting of parked crafts on KSP 1.8 and newer :) 

(does not fixes the drift induced by the wheels and landing legs - yet)