### PR TITLE
Set compatibility for Kopernicus Expansion Continued

### DIFF
--- a/NetKAN/KopernicusExpansionContinued-CometTail.netkan
+++ b/NetKAN/KopernicusExpansionContinued-CometTail.netkan
@@ -4,6 +4,7 @@
     "name":         "Kopernicus Expansion Continued - Comet Tail",
     "author":       [ "MrHappyFace", "StollD" ],
     "$kref":        "#/ckan/github/StollD/KopernicusExpansion-Continued/asset_match/CometTail",
+    "ksp_version":  "1.7",
     "license":      "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/119211-*"

--- a/NetKAN/KopernicusExpansionContinued-Common.netkan
+++ b/NetKAN/KopernicusExpansionContinued-Common.netkan
@@ -4,6 +4,7 @@
     "name":         "Kopernicus Expansion Continued - Common",
     "author":       [ "MrHappyFace", "StollD" ],
     "$kref":        "#/ckan/github/StollD/KopernicusExpansion-Continued/asset_match/CometTail",
+    "ksp_version":  "1.7",
     "license":      "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/119211-*"

--- a/NetKAN/KopernicusExpansionContinued-EVAFootprints.netkan
+++ b/NetKAN/KopernicusExpansionContinued-EVAFootprints.netkan
@@ -4,6 +4,7 @@
     "name":         "Kopernicus Expansion Continued - EVA Footprints",
     "author":       [ "MrHappyFace", "StollD" ],
     "$kref":        "#/ckan/github/StollD/KopernicusExpansion-Continued/asset_match/EVAFootprints",
+    "ksp_version":  "1.7",
     "license":      "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/119211-*"

--- a/NetKAN/KopernicusExpansionContinued-EmissiveFX.netkan
+++ b/NetKAN/KopernicusExpansionContinued-EmissiveFX.netkan
@@ -4,6 +4,7 @@
     "name":         "Kopernicus Expansion Continued - Emissive FX",
     "author":       [ "MrHappyFace", "StollD" ],
     "$kref":        "#/ckan/github/StollD/KopernicusExpansion-Continued/asset_match/EmissiveFX",
+    "ksp_version":  "1.7",
     "license":      "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/119211-*"

--- a/NetKAN/KopernicusExpansionContinued-ModularNoise.netkan
+++ b/NetKAN/KopernicusExpansionContinued-ModularNoise.netkan
@@ -4,6 +4,7 @@
     "name":         "Kopernicus Expansion Continued - Modular Noise",
     "author":       [ "MrHappyFace", "StollD" ],
     "$kref":        "#/ckan/github/StollD/KopernicusExpansion-Continued/asset_match/ModularNoise",
+    "ksp_version":  "1.7",
     "license":      "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/119211-*"

--- a/NetKAN/KopernicusExpansionContinued-ProceduralGasGiants.netkan
+++ b/NetKAN/KopernicusExpansionContinued-ProceduralGasGiants.netkan
@@ -4,6 +4,7 @@
     "name":         "Kopernicus Expansion Continued - Procedural Gas Giants",
     "author":       [ "MrHappyFace", "StollD" ],
     "$kref":        "#/ckan/github/StollD/KopernicusExpansion-Continued/asset_match/ProceduralGasGiants",
+    "ksp_version":  "1.7",
     "license":      "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/119211-*"

--- a/NetKAN/KopernicusExpansionContinued-ReentryEffects.netkan
+++ b/NetKAN/KopernicusExpansionContinued-ReentryEffects.netkan
@@ -4,6 +4,7 @@
     "name":         "Kopernicus Expansion Continued - Reentry Effects",
     "author":       [ "MrHappyFace", "StollD" ],
     "$kref":        "#/ckan/github/StollD/KopernicusExpansion-Continued/asset_match/ReentryEffects",
+    "ksp_version":  "1.7",
     "license":      "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/119211-*"

--- a/NetKAN/KopernicusExpansionContinued-RegionalPQSMods.netkan
+++ b/NetKAN/KopernicusExpansionContinued-RegionalPQSMods.netkan
@@ -4,6 +4,7 @@
     "name":         "Kopernicus Expansion Continued - Regional PQSMods",
     "author":       [ "MrHappyFace", "StollD" ],
     "$kref":        "#/ckan/github/StollD/KopernicusExpansion-Continued/asset_match/RegionalPQSMods",
+    "ksp_version":  "1.7",
     "license":      "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/119211-*"

--- a/NetKAN/KopernicusExpansionContinued-VertexHeightDeformity.netkan
+++ b/NetKAN/KopernicusExpansionContinued-VertexHeightDeformity.netkan
@@ -4,6 +4,7 @@
     "name":         "Kopernicus Expansion Continued - Vertex Height Deformity",
     "author":       [ "MrHappyFace", "StollD" ],
     "$kref":        "#/ckan/github/StollD/KopernicusExpansion-Continued/asset_match/VertexHeightDeformity",
+    "ksp_version":  "1.7",
     "license":      "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/119211-*"

--- a/NetKAN/KopernicusExpansionContinued-VertexHeightMap.netkan
+++ b/NetKAN/KopernicusExpansionContinued-VertexHeightMap.netkan
@@ -4,6 +4,7 @@
     "name":         "Kopernicus Expansion Continued - Vertex Height Map",
     "author":       [ "MrHappyFace", "StollD" ],
     "$kref":        "#/ckan/github/StollD/KopernicusExpansion-Continued/asset_match/VertexHeightMap",
+    "ksp_version":  "1.7",
     "license":      "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/119211-*"

--- a/NetKAN/KopernicusExpansionContinued-Wormholes.netkan
+++ b/NetKAN/KopernicusExpansionContinued-Wormholes.netkan
@@ -4,6 +4,7 @@
     "name":         "Kopernicus Expansion Continued - Wormholes",
     "author":       [ "MrHappyFace", "StollD" ],
     "$kref":        "#/ckan/github/StollD/KopernicusExpansion-Continued/asset_match/Wormholes",
+    "ksp_version":  "1.7",
     "license":      "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/119211-*"


### PR DESCRIPTION
## Problem

#7247 indexed these modules with no compatibility set, even though they're almost all plugins. Now they don't work.

## Changes

Now they're set to KSP 1.7, based on the release numbering:

![image](https://user-images.githubusercontent.com/1559108/90684194-50920380-e257-11ea-81ff-947d463af0b2.png)
