### PR TITLE
Include Patches and Resources folders in Wanhu-Common

### DIFF
--- a/NetKAN/DongFangHongPlatformSeries.netkan
+++ b/NetKAN/DongFangHongPlatformSeries.netkan
@@ -13,7 +13,7 @@
         "find":       "DongFangHong Platform Series",
         "install_to": "GameData",
         "as":         "Wanhu",
-        "filter":     [ "Assets", "Flags", "FX", "Icons", "WanhuTools.dll", "WanhuCategory.cfg" ],
+        "filter":     [ "Assets", "Flags", "FX", "Icons", "Patches", "Resources", "WanhuTools.dll", "WanhuCategory.cfg" ],
         "filter_regexp": [ ".*\\.craft$" ]
     } ]
 }

--- a/NetKAN/LongMarch10CZ10.netkan
+++ b/NetKAN/LongMarch10CZ10.netkan
@@ -12,7 +12,7 @@
     "install": [ {
         "find":       "Wanhu",
         "install_to": "GameData",
-        "filter":     [ "Assets", "Flags", "FX", "Icons", "WanhuTools.dll", "WanhuCategory.cfg" ],
+        "filter":     [ "Assets", "Flags", "FX", "Icons", "Patches", "Resources", "WanhuTools.dll", "WanhuCategory.cfg" ],
         "filter_regexp": [ ".*\\.craft$" ]
     }, {
         "find":       "CZ-10M.craft",

--- a/NetKAN/LongMarch11CZ11.netkan
+++ b/NetKAN/LongMarch11CZ11.netkan
@@ -12,7 +12,7 @@
     "install": [ {
         "find":       "Wanhu",
         "install_to": "GameData",
-        "filter":     [ "Assets", "Flags", "FX", "Icons", "WanhuTools.dll", "WanhuCategory.cfg" ],
+        "filter":     [ "Assets", "Flags", "FX", "Icons", "Patches", "Resources", "WanhuTools.dll", "WanhuCategory.cfg" ],
         "filter_regexp": [ ".*\\.craft$" ]
     }, {
         "find":       "CZ-11.craft",

--- a/NetKAN/LongMarch5CZ5.netkan
+++ b/NetKAN/LongMarch5CZ5.netkan
@@ -12,6 +12,6 @@
     "install": [ {
         "find":       "Wanhu",
         "install_to": "GameData",
-        "filter":     [ "Assets", "Flags", "FX", "Icons", "WanhuTools.dll", "WanhuCategory.cfg" ]
+        "filter":     [ "Assets", "Flags", "FX", "Icons", "Patches", "Resources", "WanhuTools.dll", "WanhuCategory.cfg" ]
     } ]
 }

--- a/NetKAN/LongMarch9CZ9.netkan
+++ b/NetKAN/LongMarch9CZ9.netkan
@@ -12,7 +12,7 @@
     "install": [ {
         "find":       "Wanhu",
         "install_to": "GameData",
-        "filter":     [ "Assets", "Flags", "FX", "Icons", "WanhuTools.dll", "WanhuCategory.cfg" ],
+        "filter":     [ "Assets", "Flags", "FX", "Icons", "Patches", "Resources", "WanhuTools.dll", "WanhuCategory.cfg" ],
         "filter_regexp": [ ".*\\.craft$" ]
     }, {
         "find":       "CZ-09.craft",

--- a/NetKAN/Wanhu-Common.netkan
+++ b/NetKAN/Wanhu-Common.netkan
@@ -3,7 +3,7 @@
     "identifier":   "Wanhu-Common",
     "name":         "Wanhu Common",
     "abstract":     "Shared files for the Long March mods",
-    "$kref":        "#/ckan/spacedock/2362",
+    "$kref":        "#/ckan/spacedock/2507",
     "license":      "CC-BY-NC-ND-4.0",
     "tags": [
         "library",
@@ -20,6 +20,12 @@
         "install_to": "GameData/Wanhu/Wanhu_Parts"
     }, {
         "find":       "Wanhu/Wanhu_Parts/Icons",
+        "install_to": "GameData/Wanhu/Wanhu_Parts"
+    }, {
+        "find":       "Wanhu/Wanhu_Parts/Patches",
+        "install_to": "GameData/Wanhu/Wanhu_Parts"
+    }, {
+        "find":       "Wanhu/Wanhu_Parts/Resources",
         "install_to": "GameData/Wanhu/Wanhu_Parts"
     }, {
         "find":       "Wanhu/Wanhu_Parts/WanhuTools.dll",


### PR DESCRIPTION
These mods have a very problematic common structure. They include many of the same folders with the same files, which means they conflict in CKAN. So the Wanhu-Common module was created to install the common folders.

However, the latest mods include such common files in two _new_ folders that were empty before: Patches and Resources. Now these folders are filtered out of the installs and added to Wanhu-Common, which now pulls from a different `$kref` to get a ZIP that contains the files.

Note that the `Localization` folder will continue to be a problem because it represents a true conflict; the same `Wanhu_zh-cn.cfg` file contains mod-specific data in each module, so if you try to install multiple of these mods manually, there will be collisions. Something will have to change upstream in how these mods are packaged for this to be resolved.