### PR TITLE
Add CRE

### DIFF
--- a/NetKAN/CRE.netkan
+++ b/NetKAN/CRE.netkan
@@ -1,0 +1,18 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "CRE",
+    "name":         "Commonwealth Rockets - Stockalike British Rocketry",
+    "abstract":     "Parts inspired by historical British rockets",
+    "author":       "Beale",
+    "$kref":        "#/ckan/github/Tantares/CRE",
+    "license":      "CC-BY-NC-SA-4.0",
+    "tags": [
+        "parts"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
+    "supports": [
+        { "name": "CommunityResourcePack" }
+    ]
+}

--- a/NetKAN/CRE.netkan
+++ b/NetKAN/CRE.netkan
@@ -5,6 +5,7 @@
     "abstract":     "Parts inspired by historical British rockets",
     "author":       "Beale",
     "$kref":        "#/ckan/github/Tantares/CRE",
+    "ksp_version":  "1.10",
     "license":      "CC-BY-NC-SA-4.0",
     "tags": [
         "parts"


### PR DESCRIPTION
Fixes #8117.

While I'm normally not a fan of acronyms, in this case the repo and the folder are both called CRE, and I could not figure out what the "E" stands for anyway, so it seems better not to fight it.