### PR TITLE
Add ContractConfigurator dependency to TestFlight

### DIFF
--- a/NetKAN/TestFlight.netkan
+++ b/NetKAN/TestFlight.netkan
@@ -24,7 +24,8 @@
         }
     ],
     "depends": [
-        { "name" : "TestFlightConfig" }
+        { "name" : "TestFlightConfig" },
+        { "name" : "ContractConfigurator" }
     ],
     "x_netkan_override": [
         {


### PR DESCRIPTION
@JonnyOThan made me aware of another user having problems running KSP with RealismOverhaul and TestFlight installed. Apparently TestFlight includes a `TestFlightContracts.dll`, depending on `ContractConfigurator.dll`, since version 1.3 for KSP 0.90.

* https://github.com/KSP-RO/TestFlight/commit/639e90583e8ca3c4f79d8527566e3d8fc2c6ed1f#diff-4485773c9a03724d0df8939c3c71534d
* https://forum.kerbalspaceprogram.com/index.php?/topic/99043-122-testflight-v180-01-may-2017-bring-flight-testing-to-ksp/&do=findComment&comment=1934467

```
158 [WRN 14:18:14.760] AssemblyLoader: Assembly 'TestFlightContracts' has not met dependency 'ContractConfigurator' V1.0.0
```

I wonder why no one ever complained about that before, but I guess TestFlight usually gets installed with RO, and RP-1 (and maybe also other mods) which also often gets installed alongside RO, depends on ContractConfigurator, and thus can hide the missing dependency.