### PR TITLE
Try switching EnduranceSpaceExplorationSystem kref to GitHub

### DIFF
--- a/NetKAN/EnduranceSpaceExplorationSystem.netkan
+++ b/NetKAN/EnduranceSpaceExplorationSystem.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier":   "EnduranceSpaceExplorationSystem",
-    "$kref":        "#/ckan/spacedock/357",
+    "$kref":        "#/ckan/github/JPLRepo/Endurance",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "CC-BY-NC-4.0",
     "tags": [


### PR DESCRIPTION
See JPLRepo/Endurance#37, the version file syntax error has been fixed on GitHub but not SpaceDock, due to replacing a release being more difficult on SpaceDock. This PR switches the kref so we can see how different the resulting metadata would be and whether it could work.