### PR TITLE
Restore EnduranceSpaceExplorationSystem homepage

### DIFF
--- a/NetKAN/EnduranceSpaceExplorationSystem.netkan
+++ b/NetKAN/EnduranceSpaceExplorationSystem.netkan
@@ -5,7 +5,7 @@
     "$vref":        "#/ckan/ksp-avc",
     "license":      "CC-BY-NC-4.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/133590-*",
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/133590-*"
     },
     "tags": [
         "plugin",

--- a/NetKAN/EnduranceSpaceExplorationSystem.netkan
+++ b/NetKAN/EnduranceSpaceExplorationSystem.netkan
@@ -4,6 +4,9 @@
     "$kref":        "#/ckan/github/JPLRepo/Endurance",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "CC-BY-NC-4.0",
+    "resources": {
+        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/133590-*",
+    },
     "tags": [
         "plugin",
         "parts",


### PR DESCRIPTION
This got lost in #8134 because it was pulled from SD. Now it's in the netkan.