### PR TITLE
Fix ULAVulcan install

### DIFF
--- a/NetKAN/ULAVulcan.netkan
+++ b/NetKAN/ULAVulcan.netkan
@@ -17,7 +17,7 @@
         { "name": "BluedogDB" }
     ],
     "install": [ {
-        "find":       "Hephaistos",
+        "find":       "GameData/Hephaistos",
         "install_to": "GameData"
     }, {
         "find":       "Ships",


### PR DESCRIPTION
The directory layout changed in the latest release of ULAVulcan:
```
New inflation error for ULAVulcan: GameData directory found within GameData:
```

ckan compat add 1.9