### PR TITLE
Add vref to NextStarIndustries

### DIFF
--- a/NetKAN/NextStarIndustries.netkan
+++ b/NetKAN/NextStarIndustries.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "NextStarIndustries",
     "$kref":        "#/ckan/spacedock/2506",
+    "$vref":        "#/ckan/ksp-avc",
     "license":      "CC-BY-SA-2.0",
     "tags": [
         "plugin",


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/28812678/94293298-5b2e6f80-ff5e-11ea-8745-5452f1a9db49.png)

NSI has a version file since a v2.3.0: https://github.com/NextStarIndustries/Next-Star-Industries/blob/master/GameData/NSI/NextStarIndustries.version

It is even a valid one without syntax errors or anything! Which you can't really say of the versioning system, expect yet another epoch soon...
![grafik](https://user-images.githubusercontent.com/28812678/94293260-51a50780-ff5e-11ea-84b1-3b6a475d4b23.png)
