### PR TITLE
Fix AECS-Motion-Suppressor abstract

### DIFF
--- a/NetKAN/AECS-Motion-Suppressor.netkan
+++ b/NetKAN/AECS-Motion-Suppressor.netkan
@@ -1,38 +1,38 @@
 {
-	"spec_version": "v1.4",
-	"identifier": "AECS-Motion-Suppressor",
-	"name": "AECS_Motion_Suppressor (air brake, engine, & control surface)",
-	"abstract": "This﻿ ﻿mod disables and ﻿﻿﻿re﻿-enables﻿ your control surfaces on atmosphere exit/ entry to stop your SSTOs pointlessly flapping their wings in space. ﻿Also disables engine gimbaling when not running",
-	"author": "linuxgurugamer",
-	"license": "MIT",
-	"$kref": "#/ckan/github/linuxgurugamer/AECS_Motion_Suppressor",
-	"$vref": "#/ckan/ksp-avc",
-	"resources": {
-		"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/182622-*",
-		"spacedock": "https://spacedock.info/mod/2095/AECS_Motion_Suppressor%20(air%20brake,%20engine,%20&%20control%20surface)",
-		"repository": "https://github.com/linuxgurugamer/AECS_Motion_Suppressor"
-	},
-	"tags": [
-		"plugin",
-		"control"
-	],
-	"depends": [
-		{
-			"name": "ModuleManager"
-		}
-	],
-	"conflicts": [
-		{
-			"name": "ControlSurfaceToggle"
-		},
-		{
-			"name": "SmartActuation"
-		}
-	],
-	"install": [
-		{
-			"find": "AECS_Motion_Suppressor",
-			"install_to": "GameData"
-		}
-	]
+    "spec_version": "v1.4",
+    "identifier": "AECS-Motion-Suppressor",
+    "name": "AECS_Motion_Suppressor (air brake, engine, & control surface)",
+    "abstract": "This mod disables and re-enables your control surfaces on atmosphere exit/ entry to stop your SSTOs pointlessly flapping their wings in space. Also disables engine gimbaling when not running",
+    "author": "linuxgurugamer",
+    "license": "MIT",
+    "$kref": "#/ckan/github/linuxgurugamer/AECS_Motion_Suppressor",
+    "$vref": "#/ckan/ksp-avc",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/182622-*",
+        "spacedock": "https://spacedock.info/mod/2095/AECS_Motion_Suppressor%20(air%20brake,%20engine,%20&%20control%20surface)",
+        "repository": "https://github.com/linuxgurugamer/AECS_Motion_Suppressor"
+    },
+    "tags": [
+        "plugin",
+        "control"
+    ],
+    "depends": [
+        {
+            "name": "ModuleManager"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "ControlSurfaceToggle"
+        },
+        {
+            "name": "SmartActuation"
+        }
+    ],
+    "install": [
+        {
+            "find": "AECS_Motion_Suppressor",
+            "install_to": "GameData"
+        }
+    ]
 }


### PR DESCRIPTION
This mod's abstract has a bunch of ZERO WIDTH NO-BREAK SPACE characters in it:

![screenshot](https://i.ibb.co/r4WsmQK/CKAN-v1-28-0-KSP-1-10-1-2939-D-Kerbal-Space-Program-1-10-1-2020-10-08-17-08-31.png)

![screenshot](https://i.imgur.com/o9Sm23i.png)

Now they're removed.