### PR TITLE
Update KSP version to any

### DIFF
--- a/NetKAN/MechJebForAll.netkan
+++ b/NetKAN/MechJebForAll.netkan
@@ -4,6 +4,7 @@
     "name":         "MechJeb and Engineer for all!",
     "$kref":        "#/ckan/spacedock/1854",
     "$vref":        "#/ckan/ksp-avc",
+    "ksp_version":  "any",
     "license":      "GPL-3.0",
     "tags": [
         "config",


### PR DESCRIPTION
This mod is just a MM patch that should be fine with any version of KSP. Setting the version to any makes it easier to find in CKAN and to install without doing a compatibility override.

@linuxgurugamer What do you think? Would this be okay?