### PR TITLE
Add MissingRobotics

### DIFF
--- a/NetKAN/MissingRobotics.netkan
+++ b/NetKAN/MissingRobotics.netkan
@@ -1,0 +1,16 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "MissingRobotics",
+    "$kref":        "#/ckan/spacedock/2557",
+    "license":      "MIT",
+    "tags": [
+        "parts"
+    ],
+    "depends": [
+        { "name": "BreakingGround-DLC" }
+    ],
+    "install": [ {
+        "find":       "Missing_robotics",
+        "install_to": "GameData"
+    } ]
+}


### PR DESCRIPTION
@linuxgurugamer notified me that this mod had been marked with the CKAN badge on SpaceDock, but we never got a PR for it.

- https://spacedock.info/mod/2557/Missing%20Robotics
- https://forum.kerbalspaceprogram.com/index.php?/topic/197841-missing-robotics/