### PR TITLE
Install mods' TextureReplacer assets into own subdirectories

### DIFF
--- a/NetKAN/Astro-Cosmonauts.frozen
+++ b/NetKAN/Astro-Cosmonauts.frozen
@@ -9,7 +9,7 @@
     "install": [
         {
             "find":"TextureReplacer",
-            "install_to": "GameData"
+            "install_to": "GameData/Astro-Cosmonauts"
         }
     ]
 }

--- a/NetKAN/AustrianSpaceAgency.frozen
+++ b/NetKAN/AustrianSpaceAgency.frozen
@@ -21,8 +21,8 @@
         "install_to": "GameData"
     },
     {
-        "find":"Suits/AustrianSpaceAgency",
-        "install_to": "GameData/TextureReplacer/Suits"
+        "find":       "Suits/AustrianSpaceAgency",
+        "install_to": "GameData/AustrianSpaceAgency/TextureReplacer/Suits"
     }
     ]
 }

--- a/NetKAN/CustomDesignSpacesuits-Steampunk.frozen
+++ b/NetKAN/CustomDesignSpacesuits-Steampunk.frozen
@@ -1,5 +1,5 @@
 {
-  "spec_version": 1,
+  "spec_version": "v1.2",
   "identifier": "CustomDesignSpacesuits-Steampunk",
   "ksp_version": "0.90",
   "license": "CC-BY-NC-SA-4.0",
@@ -15,17 +15,10 @@
   "install": [
     {
       "file": "Steam-Punk-Pack-v0.38/Green Skull Inc/GameData/TextureReplacer",
-      "install_to": "GameData",
-	  "filter": [
-        "NegativeX.png",
-        "NegativeY.png",
-        "NegativeZ.png",
-        "PositiveX.png",
-        "PositiveY.png",
-        "PositiveZ.png",
-        "Visor.shader",
-        "TextureReplacer.dll",
-        "Readme.md"
+      "install_to": "GameData/CustomDesignSpacesuits-Steampunk",
+      "filter": [
+        "EnvMap",
+        "Plugins"
       ]
     }
   ],

--- a/NetKAN/DFBetweentheStarsSkybox.netkan
+++ b/NetKAN/DFBetweentheStarsSkybox.netkan
@@ -12,6 +12,6 @@
     ],
     "install": [ {
         "find":       "TextureReplacer",
-        "install_to": "GameData"
+        "install_to": "GameData/DFBetweentheStarsSkybox"
     } ]
 }

--- a/NetKAN/DFLargeMagellanicCloudSkybox.netkan
+++ b/NetKAN/DFLargeMagellanicCloudSkybox.netkan
@@ -12,6 +12,6 @@
     ],
     "install": [ {
         "find":       "TextureReplacer",
-        "install_to": "GameData"
+        "install_to": "GameData/DFLargeMagellanicCloudSkybox"
     } ]
 }

--- a/NetKAN/DFNGC3115Skybox.netkan
+++ b/NetKAN/DFNGC3115Skybox.netkan
@@ -12,6 +12,6 @@
     ],
     "install": [ {
         "find":       "TextureReplacer",
-        "install_to": "GameData"
+        "install_to": "GameData/DFNGC3115Skybox"
     } ]
 }

--- a/NetKAN/EpicSuits.frozen
+++ b/NetKAN/EpicSuits.frozen
@@ -10,63 +10,8 @@
     ],
     "install": [
         {
-            "file": "epic suits/the orginal suits /blue shirt and suit",
-            "install_to": "GameData/TextureReplacer/Suits",
-            "filter": ".DS_Store"
-        },
-        {
-            "file": "epic suits/the orginal suits /blue suit",
-            "install_to": "GameData/TextureReplacer/Suits",
-            "filter": ".DS_Store"
-        },
-        {
-            "file": "epic suits/the orginal suits /cyan suit",
-            "install_to": "GameData/TextureReplacer/Suits",
-            "filter": ".DS_Store"
-        },
-        {
-            "file": "epic suits/the orginal suits /orange shirt and suit",
-            "install_to": "GameData/TextureReplacer/Suits",
-            "filter": ".DS_Store"
-        },
-        {
-            "file": "epic suits/the orginal suits /orange suit",
-            "install_to": "GameData/TextureReplacer/Suits",
-            "filter": ".DS_Store"
-        },
-        {
-            "file": "epic suits/the orginal suits /purple suit",
-            "install_to": "GameData/TextureReplacer/Suits",
-            "filter": ".DS_Store"
-        },
-        {
-            "file": "epic suits/the orginal suits /Red shirt and suit",
-            "install_to": "GameData/TextureReplacer/Suits",
-            "filter": ".DS_Store"
-        },
-                {
-            "file": "epic suits/the orginal suits /red suit",
-            "install_to": "GameData/TextureReplacer/Suits",
-            "filter": ".DS_Store"
-        },
-                {
-            "file": "epic suits/the orginal suits /white shirt and suit",
-            "install_to": "GameData/TextureReplacer/Suits",
-            "filter": ".DS_Store"
-        },
-                {
-            "file": "epic suits/the orginal suits /white suit",
-            "install_to": "GameData/TextureReplacer/Suits",
-            "filter": ".DS_Store"
-        },
-                {
-            "file": "epic suits/the orginal suits /yellow shirt and suit",
-            "install_to": "GameData/TextureReplacer/Suits",
-            "filter": ".DS_Store"
-        },
-                {
-            "file": "epic suits/the orginal suits /yellow suit",
-            "install_to": "GameData/TextureReplacer/Suits",
+            "file": "epic suits/the orginal suits ",
+            "install_to": "GameData/EpicSuits/TextureReplacer/Suits",
             "filter": ".DS_Store"
         }
     ]

--- a/NetKAN/FwiffoRaredenSkybox.netkan
+++ b/NetKAN/FwiffoRaredenSkybox.netkan
@@ -22,6 +22,6 @@
     ],
     "install"            : [ {
         "find"           : "TextureReplacer",
-        "install_to"     : "GameData"
+        "install_to"     : "GameData/FwiffoRaredenSkybox"
     } ]
 }

--- a/NetKAN/GreenSkullRevived.netkan
+++ b/NetKAN/GreenSkullRevived.netkan
@@ -14,6 +14,6 @@
     ],
     "install": [ {
         "find":       "TextureReplacer",
-        "install_to": "GameData"
+        "install_to": "GameData/GreenSkullRevived"
     } ]
 }

--- a/NetKAN/GregroxMultiColorSuitsPack.netkan
+++ b/NetKAN/GregroxMultiColorSuitsPack.netkan
@@ -13,9 +13,9 @@
     ],
     "install": [ {
         "find":       "GameData/TextureReplacer",
-        "install_to": "GameData"
+        "install_to": "GameData/GregroxMultiColorSuitsPack"
     }, {
         "find":       "Extras/TextureReplacer",
-        "install_to": "GameData"
+        "install_to": "GameData/GregroxMultiColorSuitsPack"
     } ]
 }

--- a/NetKAN/GregroxsColoredEVAIVASuits.frozen
+++ b/NetKAN/GregroxsColoredEVAIVASuits.frozen
@@ -10,7 +10,7 @@
     "install": [
         {
             "find"       : "TextureReplacer",
-            "install_to" : "GameData"
+            "install_to" : "GameData/GregroxsColoredEVAIVASuits"
         }
     ]
 }

--- a/NetKAN/HumanColoredFaces.frozen
+++ b/NetKAN/HumanColoredFaces.frozen
@@ -11,7 +11,7 @@
     "install": [
         {
             "find": "TextureReplacer",
-            "install_to": "GameData"
+            "install_to": "GameData/HumanColoredFaces"
         }
     ]
 }

--- a/NetKAN/HumanStuff.netkan
+++ b/NetKAN/HumanStuff.netkan
@@ -23,6 +23,6 @@
         "install_to": "GameData"
     }, {
         "find":       "GameData/TextureReplacer",
-        "install_to": "GameData"
+        "install_to": "GameData/HumanStuff"
     } ]
 }

--- a/NetKAN/JupiteryJoolRecolor-TextureReplacer.frozen
+++ b/NetKAN/JupiteryJoolRecolor-TextureReplacer.frozen
@@ -1,6 +1,6 @@
 {
     "$kref": "#/ckan/spacedock/775",
-    "spec_version": 1,
+    "spec_version": "v1.2",
     "name": "GregroxMun's Jupitery Jool Recolor for TextureReplacer",
     "identifier": "JupiteryJoolRecolor-TextureReplacer",
     "license": "restricted",
@@ -12,7 +12,7 @@
     "install": [
         {
             "file":"Jool Recolor For Texture Replacer/GameData/TextureReplacer",
-            "install_to": "GameData"
+            "install_to": "GameData/JupiteryJoolRecolor"
         }
     ],
     "x_netkan_override": [

--- a/NetKAN/MilitarySuitTextures.frozen
+++ b/NetKAN/MilitarySuitTextures.frozen
@@ -9,119 +9,119 @@
     "install": [
         {
             "find":"Arctic",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"BDU",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"BritishArmy",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"Desert",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"DEUFlecktarn",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"eastgermany",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"Fallschirmjager",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"Forrest",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"General",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"Ghillie",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"HAZMATsuit",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"KING",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"Knight",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"Multicam",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"NavalWorkingUniform",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"Navy",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"Ninja",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"NWU",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"Olive",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"Samurai",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"SAR",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"SARBlue",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"SPecOps",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"Suit2",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"UKSR_EAST",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"UKSR_SPECOPS",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"UKSR_WEST",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"UNPeacekeeper",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         },
         {
             "find":"Woodland",
-            "install_to": "GameData/TextureReplacer/Suits/Military"
+            "install_to": "GameData/MilitarySuitTextures/TextureReplacer/Suits/Military"
         }
     ]
 }

--- a/NetKAN/MilkyWay-Skybox.netkan
+++ b/NetKAN/MilkyWay-Skybox.netkan
@@ -12,6 +12,6 @@
     ],
     "install": [ {
         "find":       "Default",
-        "install_to": "GameData/TextureReplacer"
+        "install_to": "GameData/Milky Way Galaxy Skybox/TextureReplacer"
     } ]
 }

--- a/NetKAN/Milkyway-Skybox-SpaceEngine.netkan
+++ b/NetKAN/Milkyway-Skybox-SpaceEngine.netkan
@@ -10,7 +10,7 @@
     ],
     "install": [ {
         "find":       "TextureReplacer",
-        "install_to": "GameData"
+        "install_to": "GameData/Milkyway-Skybox-SpaceEngine"
     } ],
     "depends": [
         { "name": "TextureReplacer" }

--- a/NetKAN/NGC3371-Skybox.netkan
+++ b/NetKAN/NGC3371-Skybox.netkan
@@ -10,7 +10,7 @@
     ],
     "install": [ {
         "find":       "TextureReplacer",
-        "install_to": "GameData"
+        "install_to": "GameData/NGC3371-Skybox"
     } ],
     "depends": [
         { "name": "TextureReplacer" }

--- a/NetKAN/OinkersSkybox.frozen
+++ b/NetKAN/OinkersSkybox.frozen
@@ -15,11 +15,11 @@
     "install": [
         {
             "find":"Default",
-            "install_to": "GameData/TextureReplacer"
+            "install_to": "GameData/OinkersSkybox/TextureReplacer"
         },
         {
             "find":"EnvMap",
-            "install_to": "GameData/TextureReplacer"
+            "install_to": "GameData/OinkersSkybox/TextureReplacer"
         }
     ]
 }

--- a/NetKAN/OutOfGalaxySkybox.netkan
+++ b/NetKAN/OutOfGalaxySkybox.netkan
@@ -8,28 +8,8 @@
         "graphics"
     ],
     "install": [ {
-        "find_regexp":        "GalaxyTex_PositiveX.png",
-        "install_to":         "GameData/TextureReplacer/Default",
-        "find_matches_files": true
-    }, {
-        "find_regexp":        "GalaxyTex_PositiveY.png",
-        "install_to":         "GameData/TextureReplacer/Default",
-        "find_matches_files": true
-    }, {
-        "find_regexp":        "GalaxyTex_PositiveZ.png",
-        "install_to":         "GameData/TextureReplacer/Default",
-        "find_matches_files": true
-    }, {
-        "find_regexp":        "GalaxyTex_NegativeX.png",
-        "install_to":         "GameData/TextureReplacer/Default",
-        "find_matches_files": true
-    }, {
-        "find_regexp":        "GalaxyTex_NegativeY.png",
-        "install_to":         "GameData/TextureReplacer/Default",
-        "find_matches_files": true
-    }, {
-        "find_regexp":        "GalaxyTex_NegativeZ.png",
-        "install_to":         "GameData/TextureReplacer/Default",
+        "find_regexp":        ".*\\.png",
+        "install_to":         "GameData/OutOfGalaxySkybox/TextureReplacer/Default",
         "find_matches_files": true
     } ],
     "depends": [

--- a/NetKAN/PhoenixIndustries.netkan
+++ b/NetKAN/PhoenixIndustries.netkan
@@ -19,6 +19,6 @@
         "install_to": "GameData"
     }, {
         "find":       "TextureReplacer",
-        "install_to": "GameData"
+        "install_to": "GameData/PhoenixIndustries"
     } ]
 }

--- a/NetKAN/PhoenixIndustriesEVASuit.frozen
+++ b/NetKAN/PhoenixIndustriesEVASuit.frozen
@@ -14,7 +14,7 @@
     "install": [
         {
             "find": "Phoenix_Industries_EVA",
-            "install_to": "GameData/TextureReplacer/Suits",
+            "install_to": "GameData/Phoenix_Industries_EVA/TextureReplacer/Suits",
             "filter": [ "Poster.jpg", "screenshot0.png" ]
         }
     ],

--- a/NetKAN/PoliticalMap4kTexture.frozen
+++ b/NetKAN/PoliticalMap4kTexture.frozen
@@ -13,11 +13,11 @@
     "install": [
         {
             "file": "KerbinScaledSpace300.png",
-            "install_to": "GameData/TextureReplacer/Default"
+            "install_to": "GameData/PoliticalMap4kTexture/TextureReplacer/Default"
         },
         {
             "file": "KerbinScaledSpace401.png",
-            "install_to": "GameData/TextureReplacer/Default"
+            "install_to": "GameData/PoliticalMap4kTexture/TextureReplacer/Default"
         }
     ]
 }

--- a/NetKAN/PoliticalMap8kTexture.frozen
+++ b/NetKAN/PoliticalMap8kTexture.frozen
@@ -13,11 +13,11 @@
     "install": [
         {
             "file": "KerbinScaledSpace300.png",
-            "install_to": "GameData/TextureReplacer/Default"
+            "install_to": "GameData/PoliticalMap8kTexture/TextureReplacer/Default"
         },
         {
             "file": "KerbinScaledSpace401.png",
-            "install_to": "GameData/TextureReplacer/Default"
+            "install_to": "GameData/PoliticalMap8kTexture/TextureReplacer/Default"
         }
     ]
 }

--- a/NetKAN/PoliticalMapMilitaryTexture.frozen
+++ b/NetKAN/PoliticalMapMilitaryTexture.frozen
@@ -14,7 +14,7 @@
     "install": [
         {
             "file": "Kerbin_color.dds",
-            "install_to": "GameData/TextureReplacer/Default"
+            "install_to": "GameData/PoliticalMapMilitaryTexture/TextureReplacer/Default"
         }
     ]
 }

--- a/NetKAN/RN8474-8300-Skybox.netkan
+++ b/NetKAN/RN8474-8300-Skybox.netkan
@@ -9,7 +9,7 @@
     ],
     "install": [ {
         "find":       "TextureReplacer",
-        "install_to": "GameData"
+        "install_to": "GameData/RN8474-8300-Skybox"
     } ],
     "depends": [
         { "name": "TextureReplacer" }

--- a/NetKAN/RedSpiderSkybox.netkan
+++ b/NetKAN/RedSpiderSkybox.netkan
@@ -9,7 +9,7 @@
     ],
     "install": [ {
         "find":       "TextureReplacer",
-        "install_to": "GameData"
+        "install_to": "GameData/RedSpiderSkybox"
     } ],
     "depends": [
         { "name": "TextureReplacer" }

--- a/NetKAN/SN1006-Dark-Skybox.netkan
+++ b/NetKAN/SN1006-Dark-Skybox.netkan
@@ -12,6 +12,6 @@
     ],
     "install": [ {
         "find":       "TextureReplacer",
-        "install_to": "GameData"
+        "install_to": "GameData/SN1006-Dark-Skybox"
     } ]
 }

--- a/NetKAN/SN1006-Light-Skybox.netkan
+++ b/NetKAN/SN1006-Light-Skybox.netkan
@@ -12,6 +12,6 @@
     ],
     "install": [ {
         "find":       "TextureReplacer",
-        "install_to": "GameData"
+        "install_to": "GameData/SN1006-Light-Skybox"
     } ]
 }

--- a/NetKAN/SN1006-Unedited-Skybox.netkan
+++ b/NetKAN/SN1006-Unedited-Skybox.netkan
@@ -12,6 +12,6 @@
     ],
     "install": [ {
         "find":       "TextureReplacer",
-        "install_to": "GameData"
+        "install_to": "GameData/SN1006-Unedited-Skybox"
     } ]
 }

--- a/NetKAN/ShuttleEVASuit.netkan
+++ b/NetKAN/ShuttleEVASuit.netkan
@@ -13,6 +13,6 @@
     ],
     "install": [ {
         "find":       "Suits",
-        "install_to": "GameData/TextureReplacer"
+        "install_to": "GameData/EarthEVASuit/TextureReplacer"
     } ]
 }

--- a/NetKAN/SimpleFemaleKerbals.frozen
+++ b/NetKAN/SimpleFemaleKerbals.frozen
@@ -9,7 +9,7 @@
     "install": [
         {
             "find"       : "TextureReplacer",
-            "install_to" : "GameData"
+            "install_to" : "GameData/SimpleFemaleKerbals"
         }
     ]
 }

--- a/NetKAN/StarTrekRebootUniformPack.frozen
+++ b/NetKAN/StarTrekRebootUniformPack.frozen
@@ -11,7 +11,7 @@
     "install": [
         {
             "find": "TextureReplacer",
-            "install_to": "GameData"
+            "install_to": "GameData/StarTrekRebootUniformPack"
         }
     ]
 }

--- a/NetKAN/StarTrekTOSTunics.frozen
+++ b/NetKAN/StarTrekTOSTunics.frozen
@@ -9,7 +9,7 @@
     "install": [
         {
             "file"       : "TextureReplacer",
-            "install_to" : "GameData",
+            "install_to" : "GameData/StarTrekTOSTunics",
             "filter"     : "Thumbs.db"
         }
     ]

--- a/NetKAN/SteampunkColorCodedSpaceSuits.frozen
+++ b/NetKAN/SteampunkColorCodedSpaceSuits.frozen
@@ -9,19 +9,19 @@
     "install": [
         {
             "file"       : "SteamSuitCommand",
-            "install_to" : "GameData/TextureReplacer/suits"
+            "install_to" : "GameData/SteampunkColorCodedSpaceSuits/TextureReplacer/Suits"
         },
         {
             "file"       : "SteamSuitEngineer",
-            "install_to" : "GameData/TextureReplacer/suits"
+            "install_to" : "GameData/SteampunkColorCodedSpaceSuits/TextureReplacer/Suits"
         },
         {
             "file"       : "SteamSuitScience",
-            "install_to" : "GameData/TextureReplacer/suits"
+            "install_to" : "GameData/SteampunkColorCodedSpaceSuits/TextureReplacer/Suits"
         },
         {
             "file"       : "SteampunkStarTrekSuits.cfg",
-            "install_to" : "GameData/TextureReplacer"
+            "install_to" : "GameData/SteampunkColorCodedSpaceSuits/TextureReplacer"
         }
     ]
 }

--- a/NetKAN/USIKolClassSuitsRedux.netkan
+++ b/NetKAN/USIKolClassSuitsRedux.netkan
@@ -12,6 +12,6 @@
     ],
     "install": [ {
         "find":       "TextureReplacer",
-        "install_to": "GameData"
+        "install_to": "GameData/USIKolClassSuitsRedux"
     } ]
 }

--- a/NetKAN/WindowShineTR.netkan
+++ b/NetKAN/WindowShineTR.netkan
@@ -14,7 +14,7 @@
         { "name": "TextureReplacer" }
     ],
     "install": [ {
-        "find":       "WindowShine",
-        "install_to": "GameData"
+        "find":       "Default",
+        "install_to": "GameData/WindowShine/TextureReplacer"
     } ]
 }

--- a/NetKAN/WinterKerbol.frozen
+++ b/NetKAN/WinterKerbol.frozen
@@ -23,6 +23,6 @@
         "install_to" : "GameData"
     }, {
         "find"       : "TextureReplacer",
-        "install_to" : "GameData"
+        "install_to" : "GameData/WinterKerbol"
     } ]
 }

--- a/NetKAN/halocharactercostumes.frozen
+++ b/NetKAN/halocharactercostumes.frozen
@@ -8,8 +8,8 @@
     ],
     "install": [
         {
-            "find"       : "Suits",
-            "install_to" : "GameData/TextureReplacer",
+            "find"       : "TextureReplacer",
+            "install_to" : "GameData/halocharactercostumes",
             "filter"     : ".DS_Store"
         }
     ]


### PR DESCRIPTION
## Problem
Almost all mods using TextureReplacer are trying to put their files into `GameData/TextureReplacer`. 
This leads to installation errors when trying to install mods that have some conflicting files ([which TR can handle](https://github.com/jrodrigv/TextureReplacer/blob/master/TextureReplacer/Replacer.cs#L382-L388)), even if the rest would work perfectly fine side by side (e.g. HumanStuff and Spectra pre #8016).

However the [README](https://github.com/jrodrigv/TextureReplacer#instructions) shows it's also possible to each mod's assets into its own subdirectory, like `GameData/HumanStuff/TextureReplacer`.

## Changes
I've gone through all mods that depend on TextureReplacer, and adjusted their install stanzas to install them into their own subdirectories, if needed.