### PR TITLE
Add Parallax-StockTextures and create texture dependency system

### DIFF
--- a/NetKAN/Parallax-StockTextures.netkan
+++ b/NetKAN/Parallax-StockTextures.netkan
@@ -1,0 +1,25 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "Parallax-StockTextures",
+    "name": "Parallax - Stock Planet Textures",
+    "$kref": "#/ckan/spacedock/2539",
+    "license": "CC-BY-NC-ND-4.0",
+    "tags": [
+        "config",
+        "graphics"
+    ],
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "Parallax" }
+    ],
+    "provides": [
+        "Parallax-Textures"
+    ],
+    "conflicts": [
+        { "name": "Parallax-Textures" }
+    ],
+    "install": [{
+        "find":       "Parallax_StockTextures",
+        "install_to": "GameData"
+    }]
+}

--- a/NetKAN/Parallax.netkan
+++ b/NetKAN/Parallax.netkan
@@ -8,6 +8,10 @@
         "library",
         "graphics"
     ],
+    "depends": [
+        { "name": "Kopernicus" },
+        { "name": "Parallax-Textures" }
+    ],
     "recommends": [
         { "name": "Scatterer" }
     ],


### PR DESCRIPTION
Parallax 1.1.0(-PRE) just released and includes textures for stock planets now, while previously only BeyondHome had textures for Parallax.
https://spacedock.info/mod/2539/Parallax

Parallax now depends on the virtual module `Parallax-Textures`. A dependency on Kopernicus is also added to Parallax itself now, it was previously pulled in by BeyondHome:
![image](https://user-images.githubusercontent.com/28812678/98450650-92d42e00-213e-11eb-9d51-ed8be7f6363b.png)

A new module, `Parallax-StockTextures`, providing `Parallax-Textures`, is introduced. It installs the `Parallax_StockTextures` folder into GameData.
BeyondHome also provides `Parallax-Textures` (moved into separate branch to reduce disk usage).

___

ckan compat add 1.9