### PR TITLE
Update Kerbulator compatibility to 1.10

### DIFF
--- a/NetKAN/Kerbulator.netkan
+++ b/NetKAN/Kerbulator.netkan
@@ -4,7 +4,7 @@
     "name"         : "Kerbulator",
     "abstract"     : "Calculator plugin for Kerbal Space Program",
     "$kref"        : "#/ckan/github/wmvanvliet/Kerbulator",
-    "ksp_version"  : "1.9",
+    "ksp_version"  : "1.10",
     "license"      : "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/62988-*"


### PR DESCRIPTION
See https://github.com/KSP-CKAN/CKAN-meta/pull/2174 and https://github.com/KSP-CKAN/CKAN-meta/pull/2175

This PR updates the compatibility of Kerbulator, epoch should be taken care of automatically.

![Kerbulator compatibility](https://user-images.githubusercontent.com/28812678/98959983-22455c80-2504-11eb-8f3d-41dcec18e184.png)

Closes https://github.com/KSP-CKAN/CKAN-meta/pull/2174