### PR TITLE
Install craft files to Ships folder

### DIFF
--- a/NetKAN/BDArmoryContinued.netkan
+++ b/NetKAN/BDArmoryContinued.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.18",
     "identifier":   "BDArmoryContinued",
     "name":         "BD Armory Continued",
     "abstract":     "The original Weapons mod by BahamutoD, continued!",

--- a/NetKAN/BDArmoryContinued.netkan
+++ b/NetKAN/BDArmoryContinued.netkan
@@ -34,7 +34,12 @@
     ],
     "install": [ {
         "find":       "BDArmory",
-        "install_to": "GameData"
+        "install_to": "GameData",
+        "filter":     [ "craft" ]
+    }, {
+        "find":       "craft",
+        "install_to": "Ships",
+        "as":         "SPH"
     } ],
     "x_netkan_override": [
         {

--- a/NetKAN/Buffalo.netkan
+++ b/NetKAN/Buffalo.netkan
@@ -37,6 +37,10 @@
     ],
     "install": [ {
         "find":       "Buffalo",
-        "install_to": "GameData/WildBlueIndustries"
+        "install_to": "GameData/WildBlueIndustries",
+        "filter":     [ "Ships" ]
+    }, {
+        "find":       "Ships/SPH",
+        "install_to": "Ships"
     } ]
 }

--- a/NetKAN/FlatBtmShtlSys.netkan
+++ b/NetKAN/FlatBtmShtlSys.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": "v1.4",
+    "spec_version": "v1.12",
     "identifier":   "FlatBtmShtlSys",
     "$kref":        "#/ckan/spacedock/2059",
     "$vref":        "#/ckan/ksp-avc",

--- a/NetKAN/FlatBtmShtlSys.netkan
+++ b/NetKAN/FlatBtmShtlSys.netkan
@@ -13,7 +13,11 @@
         { "name": "RasterPropMonitor" }
     ],
     "install": [ {
-        "find":       "TriCrossSection",
-        "install_to": "GameData"
+        "find":          "TriCrossSection",
+        "install_to":    "GameData",
+        "filter_regexp": [ "\\.craft$" ]
+    }, {
+        "find_regexp": "\\.craft$",
+        "install_to":  "Ships/SPH"
     } ]
 }

--- a/NetKAN/FuelTanksPlus.netkan
+++ b/NetKAN/FuelTanksPlus.netkan
@@ -11,26 +11,28 @@
         { "name": "ModuleManager" }
     ],
     "suggests": [
-        { "name": "ColorCodedCans" },
-        { "name": "InterstellarFuelSwitch-Core"}
+        { "name": "ColorCodedCans"              },
+        { "name": "InterstellarFuelSwitch-Core" }
     ],
     "supports": [
-        { "name": "ModularRocketSystem" },
-        { "name": "ModularRocketSystemsLITE" },
-        { "name": "ColorCodedCans" },
-        { "name": "ColorfulFuelLines" },
+        { "name": "ModularRocketSystem"               },
+        { "name": "ModularRocketSystemsLITE"          },
+        { "name": "ColorCodedCans"                    },
+        { "name": "ColorfulFuelLines"                 },
         { "name": "LithobrakeExplorationTechnologies" },
-        { "name": "TweakScale" },
-        { "name": "FerramAerospaceResearch" },
-        { "name": "KSP-AVC" },
-        { "name": "DeadlyReentry" },
-        { "name": "ModularFuelTanks" },
-        { "name": "InterstellarFuelSwitch" }
+        { "name": "TweakScale"                        },
+        { "name": "FerramAerospaceResearch"           },
+        { "name": "KSP-AVC"                           },
+        { "name": "DeadlyReentry"                     },
+        { "name": "ModularFuelTanks"                  },
+        { "name": "InterstellarFuelSwitch"            }
     ],
-    "install": [
-        {
-            "file": "FuelTanksPlus",
-            "install_to": "GameData"
-        }
-    ]
+    "install": [ {
+        "file":       "FuelTanksPlus",
+        "install_to": "GameData",
+        "filter":     [ "Ships" ]
+    }, {
+        "find":       "Ships/VAB",
+        "install_to": "Ships"
+    } ]
 }

--- a/NetKAN/FuelTanksPlus.netkan
+++ b/NetKAN/FuelTanksPlus.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier":   "FuelTanksPlus",
     "$kref":        "#/ckan/spacedock/92",
     "$vref":        "#/ckan/ksp-avc",

--- a/NetKAN/MS-SRBs.netkan
+++ b/NetKAN/MS-SRBs.netkan
@@ -1,30 +1,27 @@
 {
-  "license": "CC-BY-NC-SA-4.0",
-  "identifier": "MS-SRBs",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "$kref": "#/ckan/spacedock/2297",
-  "$vref": "#/ckan/ksp-avc",
-  "resources": {
-    "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/188482-*",
-    "repository": "https://github.com/linuxgurugamer/ModularSegmentedSRBs"
-  },
-  "tags": [
+    "spec_version": "v1.4",
+    "identifier":   "MS-SRBs",
+    "$kref":        "#/ckan/spacedock/2297",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "CC-BY-NC-SA-4.0",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/188482-*",
+        "repository": "https://github.com/linuxgurugamer/ModularSegmentedSRBs"
+    },
+    "tags": [
         "parts",
         "plugin"
-  ],
-  "depends": [
-    { "name": "ModuleManager" },
-    { "name": "SpaceTuxLibrary" }
-  ],
-  "install": [
-    {
-      "find": "ModularSegmentedSRBs",
-      "install_to": "GameData"
-    },
-    {
-      "find": "VAB",
-      "install_to": "Ships"
-    }
-  ],
-  "spec_version": "v1.4"
+    ],
+    "depends": [
+        { "name": "ModuleManager"   },
+        { "name": "SpaceTuxLibrary" }
+    ],
+    "install": [ {
+        "find":       "ModularSegmentedSRBs",
+        "install_to": "GameData",
+        "filter":     [ "Ships" ]
+    }, {
+        "find":       "VAB",
+        "install_to": "Ships"
+    } ]
 }

--- a/NetKAN/ModularRocketSystem.netkan
+++ b/NetKAN/ModularRocketSystem.netkan
@@ -8,19 +8,19 @@
         "parts"
     ],
     "supports": [
-        { "name": "SpaceY-Lifters" },
-        { "name": "ColorCodedCans" },
-        { "name": "ColorfulFuelLines" },
-        { "name": "FuelTanksPlus" },
+        { "name": "SpaceY-Lifters"                    },
+        { "name": "ColorCodedCans"                    },
+        { "name": "ColorfulFuelLines"                 },
+        { "name": "FuelTanksPlus"                     },
         { "name": "LithobrakeExplorationTechnologies" },
-        { "name": "TweakScale" },
-        { "name": "FerramAerospaceResearch" },
-        { "name": "KSP-AVC" },
-        { "name": "RemoteTech" },
-        { "name": "EngineIgnitorReignited" },
-        { "name": "CommunityTechTree" },
-        { "name": "HotRockets" },
-        { "name": "ConnectedLivingSpace" }
+        { "name": "TweakScale"                        },
+        { "name": "FerramAerospaceResearch"           },
+        { "name": "KSP-AVC"                           },
+        { "name": "RemoteTech"                        },
+        { "name": "EngineIgnitorReignited"            },
+        { "name": "CommunityTechTree"                 },
+        { "name": "HotRockets"                        },
+        { "name": "ConnectedLivingSpace"              }
     ],
     "conflicts": [
         { "name": "ModularRocketSystemsLITE" }
@@ -30,6 +30,10 @@
     ],
     "install": [ {
         "file":       "ModRocketSys",
-        "install_to": "GameData"
+        "install_to": "GameData",
+        "filter_regexp": [ "\\.craft$" ]
+    }, {
+        "find_regexp": "\\.craft$",
+        "install_to":  "Ships/SPH"
     } ]
 }

--- a/NetKAN/ModularRocketSystem.netkan
+++ b/NetKAN/ModularRocketSystem.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.12",
     "identifier":   "ModularRocketSystem",
     "$kref":        "#/ckan/spacedock/86",
     "$vref":        "#/ckan/ksp-avc",

--- a/NetKAN/RetroFuture.netkan
+++ b/NetKAN/RetroFuture.netkan
@@ -1,33 +1,37 @@
 {
-    "spec_version"   : "v1.4",
-    "identifier"     : "RetroFuture",
-    "author"         : [ "LinuxGuruGamer", "NohArk", "amankduffers" ],
-    "$kref"          : "#/ckan/spacedock/2153",
-    "$vref"          : "#/ckan/ksp-avc",
-    "x_netkan_epoch" : "2",
-    "license"        : "CC-BY-NC-SA-4.0",
-    "tags"           : [
+    "spec_version": "v1.4",
+    "identifier":   "RetroFuture",
+    "author":       [ "LinuxGuruGamer", "NohArk", "amankduffers" ],
+    "$kref":        "#/ckan/spacedock/2153",
+    "$vref":        "#/ckan/ksp-avc",
+    "x_netkan_epoch": "2",
+    "license":      "CC-BY-NC-SA-4.0",
+    "tags": [
         "parts",
         "combat"
     ],
-    "depends" : [
-        { "name" : "FirespitterCore" },
-        { "name" : "ModuleManager" }
+    "depends": [
+        { "name": "FirespitterCore" },
+        { "name": "ModuleManager"   }
     ],
-    "recommends" : [
-        { "name" : "FerramAerospaceResearchContinued" },
-        { "name" : "RasterPropMonitor" },
-        { "name" : "PatchManager" }
+    "recommends": [
+        { "name": "FerramAerospaceResearchContinued" },
+        { "name": "RasterPropMonitor"                },
+        { "name": "PatchManager"                     }
     ],
-    "suggests" : [
-        { "name" : "SmokeScreen" },
-        { "name" : "TweakScale" }
+    "suggests": [
+        { "name": "SmokeScreen" },
+        { "name": "TweakScale"  }
     ],
-    "supports" : [
-        { "name" : "BDArmory" }
+    "supports": [
+        { "name": "BDArmory" }
     ],
-    "install" : [ {
-        "find"       : "RetroFuture",
-        "install_to" : "GameData"
+    "install": [ {
+        "find":       "RetroFuture",
+        "install_to": "GameData",
+        "filter":     [ "Ships" ]
+    }, {
+        "find":       "Ships/SPH",
+        "install_to": "Ships"
     } ]
 }


### PR DESCRIPTION
Follow-up after KSP-CKAN/CKAN#3207.

![image](https://user-images.githubusercontent.com/1559108/100386043-f341e700-2fe9-11eb-9753-10e3b10a40b8.png)

Oddiseo needs them where they are:

```
            craftURL = ContractPacks/Oddiseo/Vessels/Damaged Oddiseo tourist orbiter.craft
```

Same for ContractConfigurator-AnomalySurveyor:

```
            craftURL = ContractPacks/AnomalySurveyor/Monolith/Monolith.craft
```

Potentially a common pattern for contract packs, might want to account for that in future.