### PR TITLE
More craft file install fixes

### DIFF
--- a/NetKAN/AircraftCarrierAccessories.netkan
+++ b/NetKAN/AircraftCarrierAccessories.netkan
@@ -9,8 +9,12 @@
         "combat"
     ],
     "install": [ {
-        "find"       : "KFC",
-        "install_to" : "GameData"
+        "find":       "KFC",
+        "install_to": "GameData",
+        "filter":     [ "Ships" ]
+    }, {
+        "find":       "Ships/SPH",
+        "install_to": "Ships"
     } ],
     "recommends": [
         { "name": "BDArmoryContinued"  },

--- a/NetKAN/DunaDirect.netkan
+++ b/NetKAN/DunaDirect.netkan
@@ -9,7 +9,8 @@
     ],
     "install": [ {
         "find":       "GameData/MarsDirect",
-        "install_to": "GameData"
+        "install_to": "GameData",
+        "filter":     [ "Missions" ]
     }, {
         "find":       "Missions",
         "install_to": "Missions"


### PR DESCRIPTION
#8242 for the webhooks-only crowd.

![image](https://user-images.githubusercontent.com/1559108/100473736-a707ad00-30a4-11eb-880a-a3a1725f5d9f.png)

DunaDirect's craft file is in a Mission, which is not supposed to be under Ships, so that's another thing we can improve about this warning. Subassemblies can't be installed yet, see KSP-CKAN/CKAN#2804.