### PR TITLE
PhoenixIndustries no longer needs TextureReplacer

### DIFF
--- a/NetKAN/PhoenixIndustries.netkan
+++ b/NetKAN/PhoenixIndustries.netkan
@@ -8,17 +8,11 @@
         "graphics",
         "crewed"
     ],
-    "depends": [
-        { "name": "TextureReplacer" }
-    ],
     "recommends": [
         { "name": "KIS" }
     ],
     "install": [ {
         "find":       "PhoenixIndustries",
         "install_to": "GameData"
-    }, {
-        "find":       "TextureReplacer",
-        "install_to": "GameData/PhoenixIndustries"
     } ]
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/101400211-786dab80-38c8-11eb-9a86-ef86d706fe1a.png)

> CHANGELOG
> v1.6
> -Complete overhaul of EVA Suit textures - they now work with the stock suit switcher and do not require Texture Replacer.
