### PR TITLE
Don't install Buffalo's Ships folder as part of Pathfinder

### DIFF
--- a/NetKAN/Pathfinder.netkan
+++ b/NetKAN/Pathfinder.netkan
@@ -38,9 +38,6 @@
         "install_to":    "GameData/WildBlueIndustries",
         "filter_regexp": [ ".*\\.pdb$" ]
     }, {
-        "find":       "SPH",
-        "install_to": "Ships"
-    }, {
         "file":        "GameData/WBIPlayMode.cfg",
         "install_to" : "GameData"
     } ]


### PR DESCRIPTION
## Problem

```
About to install:

 * Pathfinder v1.36.1 (cached)
 * Buffalo v2.9.0 (cached)
Module "Pathfinder" successfully installed
Oh no! We tried to overwrite a file owned by another mod!
Please try a `ckan update` and try again.

If this problem re-occurs, then it may be a packaging bug.
Please report it at:

https://github.com/KSP-CKAN/NetKAN/issues/new/choose

Please include the following information in your report:

File      : Ships/SPH/Guppy.craft
Installing Mod : Buffalo v2.9.0
Owning Mod: Pathfinder
CKAN Version   : v1.29.2
Your GameData has been returned to its original state.
Error during installation!
If the above message indicates a download error, please try again. Otherwise, please open an issue for us to investigate.
If you suspect a metadata problem: https://github.com/KSP-CKAN/NetKAN/issues/new/choose
If you suspect a bug in the client: https://github.com/KSP-CKAN/CKAN/issues/new/choose
```

## Cause

Pathfinder doesn't have its own Ships folder, but it bundles Buffalo, and as of b8c7a70a6b4bfee02b5104c5cc900eefcdacaaa1 from #7982, the netkan for Pathfinder installs the bundled Ships folder from Buffalo. This causes a collision with the real Buffalo.

## Changes

Now Pathfinder no longer installs Buffalo's Ships folder.

Will need a CKAN-meta PR to correct some historical versions.

Fixes #8253.