### PR TITLE
Current B9-PWings depends on FAR

### DIFF
--- a/NetKAN/B9-PWings-Fork.netkan
+++ b/NetKAN/B9-PWings-Fork.netkan
@@ -18,7 +18,8 @@
         "parts"
     ],
     "depends": [
-        { "name": "ModuleManager" }
+        { "name": "ModuleManager" },
+        { "name": "FAR"           }
     ],
     "conflicts": [
         { "name": "B9AerospaceProceduralParts" }


### PR DESCRIPTION
#8144 had an undisclosed dependency:

- https://forum.kerbalspaceprogram.com/index.php?/topic/175197-13x14x15x16x17x18x19x-b9-procedural-wings-fork-go-big-or-go-home-update-40-larger-wings/&do=findComment&comment=3893680