### PR TITLE
Manually triggerable inflate Action

### DIFF
--- a/.github/workflows/manual_inflate.yml
+++ b/.github/workflows/manual_inflate.yml
@@ -1,0 +1,28 @@
+name: Inflate a chosen module
+on:
+    workflow_dispatch:
+        inputs:
+            identifier:
+                description: Identifier of module to inflate
+                required: true
+jobs:
+    Inflate_module:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Get NetKAN repo
+              uses: actions/checkout@v2
+              with:
+                  path: NetKAN
+            - name: Get CKAN-meta repo
+              uses: actions/checkout@v2
+              with:
+                  repository: KSP-CKAN/CKAN-meta
+                  path: CKAN-meta
+            - name: Manual inflate
+              uses: HebaruSan/inflate-netkan@master
+              env:
+                  AWS_ACCESS_KEY_ID:     ${{ secrets.AWS_ACCESS_KEY_ID     }}
+                  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  AWS_DEFAULT_REGION:    ${{ secrets.AWS_DEFAULT_REGION    }}
+              with:
+                  identifier: ${{ github.event.inputs.identifier }}


### PR DESCRIPTION
## Motivation

Currently the Inflator is driven by the Scheduler and Webhooks. Sometimes it would be nice to have the option to trigger it manually, for example if a mod author wishes to upload several consecutive releases to GitHub in a short period.

## Background

I have created a simple new GitHub Action based on xKAN-meta_testing. It uses parts of NetKAN-Infra to submit one identifier for inflation:

- https://github.com/HebaruSan/inflate-netkan

## Changes

Now a new option "Inflate a chosen module" appears in the Actions list of the NetKAN repo:

![image](https://user-images.githubusercontent.com/1559108/102417648-b56d2880-3fc1-11eb-8abc-31dd5e51e5d7.png)

If you click it, a "Run workflow" dropdown is available:

![image](https://user-images.githubusercontent.com/1559108/102417698-cf0e7000-3fc1-11eb-82f8-16c294196a4e.png)

If you click that, you can type an identifier and click Run workflow:

![image](https://user-images.githubusercontent.com/1559108/102417720-da619b80-3fc1-11eb-8ea8-9ebdcaace6fc.png) ![image](https://user-images.githubusercontent.com/1559108/102417753-eb121180-3fc1-11eb-916c-ef9e555de567.png)

This will trigger the action, which checks out the NetKAN and CKAN-meta repos and uses them to submit a request to the queue for the Inflator to process normally.

Note that the AWS secrets must be added to the KSP-CKAN/NetKAN repo for the Action to work. I do not have them so I cannot do this or fully test it.

Fixes KSP-CKAN/NetKAN-Infra#110.