### PR TITLE
Update references to migrated repositories

### DIFF
--- a/NetKAN/CryoTanks-Core.netkan
+++ b/NetKAN/CryoTanks-Core.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version"   : "v1.4",
     "identifier"     : "CryoTanks-Core",
-    "$kref"         : "#/ckan/netkan/https://github.com/ChrisAdderley/CryoTanks/raw/master/CKAN/CryoTanks-Core.netkan",
+    "$kref"         : "#/ckan/netkan/https://github.com/post-kerbin-mining-corporation/CryoTanks/raw/master/CKAN/CryoTanks-Core.netkan",
     "tags": [
         "plugin"
     ]

--- a/NetKAN/CryoTanks.netkan
+++ b/NetKAN/CryoTanks.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version"   : "v1.4",
     "identifier"     : "CryoTanks",
-    "$kref"         : "#/ckan/netkan/https://github.com/ChrisAdderley/CryoTanks/raw/master/CKAN/CryoTanks.netkan",
+    "$kref"         : "#/ckan/netkan/https://github.com/post-kerbin-mining-corporation/CryoTanks/raw/master/CKAN/CryoTanks.netkan",
     "tags": [
         "parts"
     ]

--- a/NetKAN/DeployableEngines.netkan
+++ b/NetKAN/DeployableEngines.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version"   : "v1.4",
     "identifier"     : "DeployableEngines",
-    "$kref"         : "#/ckan/netkan/https://github.com/ChrisAdderley/DeployableEngines/raw/master/CKAN/DeployableEngines.netkan",
+    "$kref"         : "#/ckan/netkan/https://github.com/post-kerbin-mining-corporation/DeployableEngines/raw/master/CKAN/DeployableEngines.netkan",
     "tags": [
         "plugin",
         "library"

--- a/NetKAN/DynamicBatteryStorage.netkan
+++ b/NetKAN/DynamicBatteryStorage.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version"   : "v1.4",
     "identifier"     : "DynamicBatteryStorage",
-    "$kref"         : "#/ckan/netkan/https://github.com/ChrisAdderley/DynamicBatteryStorage/raw/master/CKAN/DynamicBatteryStorage.netkan",
+    "$kref"         : "#/ckan/netkan/https://github.com/post-kerbin-mining-corporation/DynamicBatteryStorage/raw/master/CKAN/DynamicBatteryStorage.netkan",
     "tags": [
         "plugin",
         "library"

--- a/NetKAN/Kronometer.netkan
+++ b/NetKAN/Kronometer.netkan
@@ -1,12 +1,12 @@
 {
-    "spec_version" : "v1.4",
-    "identifier"   : "Kronometer",
-    "name"         : "Kronometer",
-    "abstract"     : "A mod to manipulate the clock for Kerbal Space Program.",
-    "author"       : [ "Thomas P.", "Sigma88" ],
-    "$kref"        : "#/ckan/github/StollD/Kronometer",
-    "$vref"        : "#/ckan/ksp-avc",
-    "license"      : "MIT",
+    "spec_version": "v1.4",
+    "identifier":   "Kronometer",
+    "name":         "Kronometer",
+    "abstract":     "A mod to manipulate the clock for Kerbal Space Program",
+    "author":       [ "Thomas P.", "Sigma88" ],
+    "$kref":        "#/ckan/github/Kopernicus/Kronometer",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "MIT",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/161218-*"
     },
@@ -14,10 +14,8 @@
         "plugin",
         "information"
     ],
-    "install": [
-        {
-            "find": "Kronometer",
-            "install_to": "GameData"
-        }
-    ]
+    "install": [ {
+        "find":       "Kronometer",
+        "install_to": "GameData"
+    } ]
 }

--- a/NetKAN/NearFutureProps.netkan
+++ b/NetKAN/NearFutureProps.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier":   "NearFutureProps",
-    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/ChrisAdderley/NearFutureProps/master/CKAN/NearFutureProps.netkan",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/post-kerbin-mining-corporation/NearFutureProps/master/CKAN/NearFutureProps.netkan",
     "tags": [
         "config",
         "crewed",


### PR DESCRIPTION
A bunch of Nertea's mods have been moved to:

- https://github.com/post-kerbin-mining-corporation

And Kronometer is now under Kopernicus.

This is causing API rate limit errors in Discord.