### PR TITLE
Update NewTantaresLV compat to 1.11

### DIFF
--- a/NetKAN/NewTantaresLV.netkan
+++ b/NetKAN/NewTantaresLV.netkan
@@ -5,13 +5,16 @@
     "abstract"     : "Stockalike N1, Soyuz and more!",
     "author"       : "Beale",
     "$kref"        : "#/ckan/github/Tantares/TantaresLV",
-    "ksp_version"  : "1.10",
+    "ksp_version"  : "1.11",
     "license"      : "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/73686-Tantares"
     },
     "tags": [
         "parts"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ],
     "recommends": [
         { "name": "NewTantares" }


### PR DESCRIPTION
GitHub-hosted mod without version file - hardcoded game version.

![grafik](https://user-images.githubusercontent.com/28812678/102533976-6220d600-40a6-11eb-943e-60c520828196.png)

Closes https://github.com/KSP-CKAN/CKAN-meta/pull/2187

ckan compat add 1.10