### PR TITLE
Turn off auto-epoching for DiRT

### DIFF
--- a/NetKAN/DiRT.netkan
+++ b/NetKAN/DiRT.netkan
@@ -3,6 +3,7 @@
     "identifier":   "DiRT",
     "$kref":        "#/ckan/github/cydonian-monk/KSP-DiRT",
     "$vref":        "#/ckan/ksp-avc",
+    "x_netkan_allow_out_of_order": true,
     "license":      "MIT",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/172055-*"


### PR DESCRIPTION
The current release is a backport, so we've been getting a lot of auto-epoching pull requests. So far this mod has no real epochs.

- https://github.com/KSP-CKAN/CKAN-meta/pull/2180
- https://github.com/KSP-CKAN/CKAN-meta/pull/2183
- https://github.com/KSP-CKAN/CKAN-meta/pull/2186
- https://github.com/KSP-CKAN/CKAN-meta/pull/2188