### PR TITLE
Allow DeepFreeze without BackgroundResources

### DIFF
--- a/NetKAN/DeepFreeze.netkan
+++ b/NetKAN/DeepFreeze.netkan
@@ -9,29 +9,28 @@
         "plugin",
         "crewed"
     ],
-    "depends" : [
-        { "name" : "ModuleManager", "min_version" : "2.3.5" },
-        { "name" : "REPOSoftTech-Agencies" },
-        { "name" : "CommunityResourcePack" },
-        { "name" : "BackgroundResources" }
+    "depends": [
+        { "name": "ModuleManager",
+          "min_version": "2.3.5"          },
+        { "name": "REPOSoftTech-Agencies" },
+        { "name": "CommunityResourcePack" }
     ],
-    "recommends" : [
-        { "name" : "Toolbar" },
-        { "name" : "RasterPropMonitor" },
-        { "name" : "BackgroundProcessing" },
-        { "name" : "ShipManifest" },
-        { "name" : "ConnectedLivingSpace" },
-        { "name" : "AmpYearPowerManager"}
+    "recommends": [
+        { "name": "Toolbar"              },
+        { "name": "RasterPropMonitor"    },
+        { "name": "BackgroundProcessing" },
+        { "name": "ShipManifest"         },
+        { "name": "ConnectedLivingSpace" },
+        { "name": "AmpYearPowerManager"  },
+        { "name": "BackgroundResources"  }
     ],
     "suggests": [
-        { "name" : "USI-LS" },
-        { "name" : "TACLS"  },
-        { "name" : "Snacks" }
+        { "name": "USI-LS" },
+        { "name": "TACLS"  },
+        { "name": "Snacks" }
     ],
-    "install": [
-        {
-            "find":       "REPOSoftTech/DeepFreeze",
-            "install_to": "GameData/REPOSoftTech"
-        }
-    ]
+    "install": [ {
+        "find":       "REPOSoftTech/DeepFreeze",
+        "install_to": "GameData/REPOSoftTech"
+    } ]
 }


### PR DESCRIPTION
According to a comment by the author in JPLRepo/DeepFreeze#96, this mod bundles a DLL it doesn't need (BackgroundResources). We have this as a dependency as of #7277 because it's bundled.

Now BackgroundResources is recommended instead of required.

Fixes #8271.