### PR TITLE
Update ModuleManager compatibility to 1.11

### DIFF
--- a/NetKAN/ModuleManager.netkan
+++ b/NetKAN/ModuleManager.netkan
@@ -10,7 +10,7 @@
     },
     "x_netkan_version_edit": "^ModuleManager-(?<version>\\d+\\.\\d+\\.\\d+)\\.zip$",
     "ksp_version_min": "1.8.0",
-    "ksp_version_max": "1.10.90",
+    "ksp_version_max": "1.11",
     "license": "CC-BY-SA",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/50533-*",


### PR DESCRIPTION
Sarbian confirms 1.11 compatibility:

https://github.com/KSP-CKAN/NetKAN/pull/8279#issuecomment-751136250

> @HebaruSan Yes it is ok. I will be able to do it sometime tomorrow but feel free to do it before if you have the time.