### PR TITLE
Override compat of LMP 0.27.0 to KSP 1.11 and remove vref

### DIFF
--- a/NetKAN/LunaMultiplayer.netkan
+++ b/NetKAN/LunaMultiplayer.netkan
@@ -3,7 +3,6 @@
     "identifier":   "LunaMultiplayer",
     "name":         "Luna Multiplayer Client",
     "$kref":        "#/ckan/github/LunaMultiplayer/LunaMultiplayer/asset_match/^LunaMultiplayer-Release\\.zip$",
-    "$vref":        "#/ckan/ksp-avc",
     "license":      "MIT",
     "tags": [
         "plugin"
@@ -11,5 +10,9 @@
     "resources": {
         "homepage": "https://lunamultiplayer.com/",
         "manual":   "https://github.com/LunaMultiplayer/LunaMultiplayer/wiki"
-    }
+    },
+    "x_netkan_override": [ {
+        "version": "0.27.0",
+        "override": { "ksp_version": "1.11" }
+    } ]
 }

--- a/NetKAN/LunaMultiplayer.netkan
+++ b/NetKAN/LunaMultiplayer.netkan
@@ -3,6 +3,7 @@
     "identifier":   "LunaMultiplayer",
     "name":         "Luna Multiplayer Client",
     "$kref":        "#/ckan/github/LunaMultiplayer/LunaMultiplayer/asset_match/^LunaMultiplayer-Release\\.zip$",
+    "ksp_version":  "1.11",
     "license":      "MIT",
     "tags": [
         "plugin"
@@ -10,9 +11,5 @@
     "resources": {
         "homepage": "https://lunamultiplayer.com/",
         "manual":   "https://github.com/LunaMultiplayer/LunaMultiplayer/wiki"
-    },
-    "x_netkan_override": [ {
-        "version": "0.27.0",
-        "override": { "ksp_version": "1.11" }
-    } ]
+    }
 }


### PR DESCRIPTION
LunaMultiplayer got a new release for KSP 1.11 yesterday, however the version file hasn't been updated in time to reflect this. It has only been updated _after_ the release was already published.
So the included version file still says `VERSION: 0.26.0` and `KSP_VERSION: 1.10`, while the remote version file says `VERSION: 0.27.0` and `KSP_VERSION: 1.11`. Due to the version mismatch CKAN doesn't consider the remote version file for compatibility data now, and still has 1.10 in its metadata.

Additionally, LMP is version locked and not backwards compatible, so users installing the mod new or updating it will end up with a non-functional version on KSP 1.10.
Users on KSP 1.11 won't see any version as compatible at all.

So this PR overrides the `ksp_version` to `1.11` (which the updated [remote version file](https://github.com/LunaMultiplayer/LunaMultiplayer/blob/master/LunaMultiplayer.version) says by now) for the current release 0.27.0.

I also removed the vref, to keep the same from happening in the future again. Given the commit history of the version file before I added it back in, it's reasonable to say that it isn't very well-maintained. LMP doesn't have new releases often, mostly only for new major versions of KSP.
I think it's better to receive staging PRs and adjusting the netkan there, than maybe or maybe not finding out several days after the release that the compatibility information is wrong and potentially screwing some peoples' installs.