### PR TITLE
Add ContractConfigurator-PlanesWithPurposes

### DIFF
--- a/NetKAN/ContractConfigurator-PlanesWithPurposes.netkan
+++ b/NetKAN/ContractConfigurator-PlanesWithPurposes.netkan
@@ -1,0 +1,26 @@
+{
+    "spec_version": "v1.18",
+    "identifier":   "ContractConfigurator-PlanesWithPurposes",
+    "$kref":        "#/ckan/spacedock/2601",
+    "license":      "MIT",
+    "tags": [
+        "config",
+        "career"
+    ],
+    "depends": [
+        { "name": "ContractConfigurator" },
+        { "name": "ModuleManager"        }
+    ],
+    "recommends": [
+        { "name": "AirplanePlus"            },
+        { "name": "KerbalAircraftExpansion" }
+    ],
+    "install": [
+        {
+            "find":       "ContractPacks",
+            "install_to": "GameData/ContractPacks",
+            "as":         "PlanesWithPurposes",
+            "filter":     [ ".gitignore", "MiniAVC.dll" ]
+        }
+    ]
+}


### PR DESCRIPTION
Another mod that didn't get caught by the webhook, but noticed via a Reddit post about it.

* [SpaceDock](https://spacedock.info/mod/2601/Planes%20With%20Purposes)
* [Forum thread](https://forum.kerbalspaceprogram.com/index.php?/topic/199185-111x-planes-with-purposes-pwp/)
* [GitHub repo](https://github.com/TudorAerospace/PWP) (if I find some time I might try to explain to the author how to use Git)

Abstract:
>  The purpose of this mod is to encourage people to use planes more, as they are quite useless when not built as SSTOs. 

Description:
> Hello! This is my first mod. The purpose of this mod is to make Aircraft useful.
It adds a couple of contracts that will ,well, make aircraft useful.
The mod is by no means finished or bug free, so please report any bugs encountered on the mod's forum page or on my discord( Tudor#8762 )
Also the donation link is my YouTube channel lol

I filtered the `MiniAVC.dll` since there's not even a version file included.
I also used an `as` in the install stanza so it gets installed like the other contract packs.