### PR TITLE
Add KerbinSideRemastered to KSCExtended's dependencies

### DIFF
--- a/NetKAN/KSCExtended.netkan
+++ b/NetKAN/KSCExtended.netkan
@@ -9,12 +9,14 @@
         "buildings"
     ],
     "depends": [
-        { "name": "ModuleManager"        },
         { "name": "KerbalKonstructs"     },
         { "name": "TundraSpaceCenter"    },
-        { "name": "StockalikeStructures" }
+        { "name": "StockalikeStructures" },
+        { "name": "KerbinSideRemastered" },
+        { "name": "ModuleManager"        }
     ],
     "recommends": [
+        { "name": "KSCHarbor"                             },
         { "name": "TundraExploration"                     },
         { "name": "Scatterer"                             },
         { "name": "StockVisualEnhancements"               },


### PR DESCRIPTION
KSCExtended depends on KerbinSideRemastered since version 2.0:
![grafik](https://user-images.githubusercontent.com/28812678/104505026-9f17b400-55e3-11eb-84ab-76f859b5d613.png)

https://forum.kerbalspaceprogram.com/index.php?/topic/181556-18x-ksc-extended-v22-expanding-your-ksc-in-style/&do=findComment&comment=3718738

It also recommends KSCHarbor now.