### PR TITLE
Minimum compatible version overrides for Snark's mods

### DIFF
--- a/NetKAN/AntennaSleep.netkan
+++ b/NetKAN/AntennaSleep.netkan
@@ -10,5 +10,11 @@
     ],
     "depends": [
         { "name": "ModuleManager" }
-    ]
+    ],
+    "x_netkan_override": [ {
+        "version": "1.1",
+        "override": {
+            "ksp_version_min": "1.8"
+        }
+    } ]
 }

--- a/NetKAN/AttitudeAdjuster.netkan
+++ b/NetKAN/AttitudeAdjuster.netkan
@@ -11,7 +11,13 @@
         { "name": "ModuleManager" }
     ],
     "install": [ {
-        "find": "AttitudeAdjuster",
+        "find":       "AttitudeAdjuster",
         "install_to": "GameData"
+    } ],
+    "x_netkan_override": [ {
+        "version": "1.2",
+        "override": {
+            "ksp_version_min": "1.8"
+        }
     } ]
 }

--- a/NetKAN/AutoAGL.netkan
+++ b/NetKAN/AutoAGL.netkan
@@ -6,5 +6,11 @@
     "tags": [
         "plugin",
         "convenience"
-    ]
+    ],
+    "x_netkan_override": [ {
+        "version": "1.2",
+        "override": {
+            "ksp_version_min": "1.8"
+        }
+    } ]
 }

--- a/NetKAN/BetterBurnTime.netkan
+++ b/NetKAN/BetterBurnTime.netkan
@@ -11,6 +11,11 @@
         { "name": "ModuleManager" }
     ],
     "x_netkan_override": [ {
+        "version": "1.10",
+        "override": {
+            "ksp_version_min": "1.8"
+        }
+    }, {
         "version":  "1.6.1",
         "delete":   [ "ksp_version" ],
         "override": {

--- a/NetKAN/BetterCrewAssignment.netkan
+++ b/NetKAN/BetterCrewAssignment.netkan
@@ -14,5 +14,11 @@
         "plugin",
         "convenience",
         "crewed"
-    ]
+    ],
+    "x_netkan_override": [ {
+        "version": "1.4",
+        "override": {
+            "ksp_version_min": "1.8"
+        }
+    } ]
 }

--- a/NetKAN/DefaultActionGroups.netkan
+++ b/NetKAN/DefaultActionGroups.netkan
@@ -10,14 +10,17 @@
     "depends": [
         { "name": "ModuleManager" }
     ],
-    "install": [
-        {
-            "file"       : "GameData/DefaultActionGroups",
-            "install_to" : "GameData"
-        },
-        {
-            "file"       : "Optional/GameData/DefaultActionGroups",
-            "install_to" : "GameData"
+    "install": [ {
+        "file"       : "GameData/DefaultActionGroups",
+        "install_to" : "GameData"
+    }, {
+        "file"       : "Optional/GameData/DefaultActionGroups",
+        "install_to" : "GameData"
+    } ],
+    "x_netkan_override": [ {
+        "version": "1.3",
+        "override": {
+            "ksp_version_min": "1.8"
         }
-    ]
+    } ]
 }

--- a/NetKAN/IndicatorLights.netkan
+++ b/NetKAN/IndicatorLights.netkan
@@ -9,5 +9,11 @@
     ],
     "depends": [
         { "name": "ModuleManager" }
-    ]
+    ],
+    "x_netkan_override": [ {
+        "version": "1.7",
+        "override": {
+            "ksp_version_min": "1.10"
+        }
+    } ]
 }

--- a/NetKAN/IndicatorLightsCommunityExtensions.netkan
+++ b/NetKAN/IndicatorLightsCommunityExtensions.netkan
@@ -15,5 +15,11 @@
         { "name": "Mk1CabinHatch"         },
         { "name": "PartOverhauls"         },
         { "name": "VenStockRevamp"        }
-    ]
+    ],
+    "x_netkan_override": [ {
+        "version": "1.6.2",
+        "override": {
+            "ksp_version_min": "1.10"
+        }
+    } ]
 }

--- a/NetKAN/MissingHistory.netkan
+++ b/NetKAN/MissingHistory.netkan
@@ -8,5 +8,11 @@
     ],
     "depends": [
         { "name": "ModuleManager" }
-    ]
+    ],
+    "x_netkan_override": [ {
+        "version": "1.9.1",
+        "override": {
+            "ksp_version_min": "1.11"
+        }
+    } ]
 }

--- a/NetKAN/SimpleFuelSwitch.netkan
+++ b/NetKAN/SimpleFuelSwitch.netkan
@@ -11,7 +11,13 @@
         { "name": "ModuleManager" }
     ],
     "install": [ {
-        "find": "SimpleFuelSwitch",
+        "find":       "SimpleFuelSwitch",
         "install_to": "GameData"
+    } ],
+    "x_netkan_override": [ {
+        "version": "1.4",
+        "override": {
+            "ksp_version_min": "1.8"
+        }
     } ]
 }

--- a/NetKAN/Snarkiverse.netkan
+++ b/NetKAN/Snarkiverse.netkan
@@ -13,5 +13,11 @@
     ],
     "supports": [
         { "name": "OuterPlanetsMod" }
-    ]
+    ],
+    "x_netkan_override": [ {
+        "version": "1.2",
+        "override": {
+            "ksp_version_min": "1.5.1"
+        }
+    } ]
 }

--- a/NetKAN/VABReorienter.netkan
+++ b/NetKAN/VABReorienter.netkan
@@ -9,5 +9,11 @@
     "tags": [
         "plugin",
         "convenience"
-    ]
+    ],
+    "x_netkan_override": [ {
+        "version": "1.2",
+        "override": {
+            "ksp_version_min": "1.8"
+        }
+    } ]
 }

--- a/NetKAN/VariantPersist.netkan
+++ b/NetKAN/VariantPersist.netkan
@@ -7,5 +7,11 @@
         "plugin",
         "editor",
         "convenience"
-    ]
+    ],
+    "x_netkan_override": [ {
+        "version": "1.1",
+        "override": {
+            "ksp_version_min": "1.8"
+        }
+    } ]
 }

--- a/NetKAN/VectorRepurposed.netkan
+++ b/NetKAN/VectorRepurposed.netkan
@@ -8,5 +8,11 @@
     ],
     "depends": [
         { "name" : "ModuleManager" }
-    ]
+    ],
+    "x_netkan_override": [ {
+        "version": "1.0",
+        "override": {
+            "ksp_version_min": "1.0.5"
+        }
+    } ]
 }


### PR DESCRIPTION
## Problem

Several mods on SpaceDock have quite broad actual/intended compatibility and narrow in-metadata compatibility, because the minimum compatible version is not stored anywhere, and SpaceDock provides only the current/latest game version.

## Changes

Before KSP-CKAN/CKAN#3265 is merged, this PR will fail to validate because these overrides won't work.

Once that PR is merged, this PR will set the minimum compatibility to the original compatibility of the current release of each of these mods, as determined programmatically during investigation of #8291.

Fixes #8291.