### PR TITLE
Fix PlanesWithPurposes install stanza

### DIFF
--- a/NetKAN/ContractConfigurator-PlanesWithPurposes.netkan
+++ b/NetKAN/ContractConfigurator-PlanesWithPurposes.netkan
@@ -17,10 +17,8 @@
     ],
     "install": [
         {
-            "find":       "ContractPacks",
-            "install_to": "GameData/ContractPacks",
-            "as":         "PlanesWithPurposes",
-            "filter":     [ ".gitignore", "MiniAVC.dll" ]
+            "find":       "PWP",
+            "install_to": "GameData/ContractPacks"
         }
     ]
 }


### PR DESCRIPTION
Since version 1.3 this mod comes with its ContractConfigurator files in a `ContractPacks/PWP` folder instead of `ContractPacks/` directly.

Its config files also depend on being installed at this path (yes, even the older versions with the incorrectly packaged zip). I'm going to copy the change like this to 1.3, and adjust the `as` in 1.2.