### PR TITLE
Move KIS back to Extraplanetary Launchpads's recommends list

### DIFF
--- a/NetKAN/ExtraPlanetaryLaunchpads.netkan
+++ b/NetKAN/ExtraPlanetaryLaunchpads.netkan
@@ -18,10 +18,10 @@
         "crewed"
     ],
     "depends"        : [
-        { "name" : "ModuleManager" },
-        { "name" : "KIS"           }
+        { "name" : "ModuleManager" }
     ],
     "recommends"     : [
+        { "name" : "KIS"              },
         { "name" : "KAS"              },
         { "name" : "InfernalRobotics" },
         { "name" : "KerbalStats"      },


### PR DESCRIPTION
[This mod] lists an optional mod in its "required" list:

![image](https://user-images.githubusercontent.com/1559108/104765138-093c7000-572e-11eb-94e3-af0c93304bc0.png)

[This mod]: https://forum.kerbalspaceprogram.com/index.php?/topic/54284-18-110-extraplanetary-launchpads-v683/

But apparently it's **really** optional:

![image](https://user-images.githubusercontent.com/1559108/104765303-4acd1b00-572e-11eb-9c70-fc740c0c2852.png)

Originally switched the other way in #4883 "as per forum thread", presumably referring to the above "required" list; I could find no specific discussion of it on [the EL thread in the days leading up to Nov 4, 2016]. There's a gap in the record of forum posts on the CKAN threads; [pjf's thread] ends in July 2016, and [politas's thread] starts in January 2017, so if it was mentioned there, it's gone now.

[the EL thread in the days leading up to Nov 4, 2016]: https://forum.kerbalspaceprogram.com/index.php?/topic/54284-18-110-extraplanetary-launchpads-v683/page/170/
[pjf's thread]: https://forum.kerbalspaceprogram.com/index.php?/topic/90246-the-comprehensive-kerbal-archive-network-ckan-package-manager-v1180-19-june-2016/page/134/
[politas's thread]: https://forum.kerbalspaceprogram.com/index.php?/topic/154922-ckan-the-comprehensive-kerbal-archive-network-v1280-dyson/

Now KIS is recommended again.