### PR TITLE
Extend current Scatterer compatibility back to KSP 1.9

### DIFF
--- a/NetKAN/Scatterer-config.netkan
+++ b/NetKAN/Scatterer-config.netkan
@@ -22,24 +22,25 @@
             "filter"     : "Sunflares"
         }
     ],
-    "x_netkan_override": [
-        {
-            "version": "2:v0.0256",
-            "override": {
-                "ksp_version" : "1.2"
-            }
-        },
-        {
-            "version": "2:v0.0320b",
-            "override": {
-                "ksp_version" : "1.3"
-            }
-        },
-        {
-            "version": "2:v0.0329_for_1.4.2",
-            "override": {
-                "ksp_version" : "1.4.2"
-            }
+    "x_netkan_override": [ {
+        "version": "3:v0.0723",
+        "override": {
+            "ksp_version_min": "1.9"
         }
-    ]
+    }, {
+        "version": "2:v0.0256",
+        "override": {
+            "ksp_version": "1.2"
+        }
+    }, {
+        "version": "2:v0.0320b",
+        "override": {
+            "ksp_version": "1.3"
+        }
+    }, {
+        "version": "2:v0.0329_for_1.4.2",
+        "override": {
+            "ksp_version": "1.4.2"
+        }
+    } ]
 }

--- a/NetKAN/Scatterer-sunflare.netkan
+++ b/NetKAN/Scatterer-sunflare.netkan
@@ -23,19 +23,24 @@
         "install_to": "GameData/scatterer/config"
     } ],
     "x_netkan_override": [ {
+        "version": "3:v0.0723",
+        "override": {
+            "ksp_version_min": "1.9"
+        }
+    }, {
         "version": "2:v0.0256",
         "override": {
-            "ksp_version" : "1.2"
+            "ksp_version": "1.2"
         }
     }, {
         "version": "2:v0.0320b",
         "override": {
-            "ksp_version" : "1.3"
+            "ksp_version": "1.3"
         }
     }, {
         "version": "2:v0.0329_for_1.4.2",
         "override": {
-            "ksp_version" : "1.4.2"
+            "ksp_version": "1.4.2"
         }
     } ]
 }

--- a/NetKAN/Scatterer.netkan
+++ b/NetKAN/Scatterer.netkan
@@ -24,24 +24,25 @@
             "filter_regexp" : "config\\/.*"
         }
     ],
-    "x_netkan_override": [
-        {
-            "version": "2:v0.0256",
-            "override": {
-                "ksp_version" : "1.2"
-            }
-        },
-        {
-            "version": "2:v0.0320b",
-            "override": {
-                "ksp_version" : "1.3"
-            }
-        },
-        {
-            "version": "2:v0.0329_for_1.4.2",
-            "override": {
-                "ksp_version" : "1.4.2"
-            }
+    "x_netkan_override": [ {
+        "version": "3:v0.0723",
+        "override": {
+            "ksp_version_min": "1.9"
         }
-    ]
+    }, {
+        "version": "2:v0.0256",
+        "override": {
+            "ksp_version": "1.2"
+        }
+    }, {
+        "version": "2:v0.0320b",
+        "override": {
+            "ksp_version": "1.3"
+        }
+    }, {
+        "version": "2:v0.0329_for_1.4.2",
+        "override": {
+            "ksp_version": "1.4.2"
+        }
+    } ]
 }


### PR DESCRIPTION
This mod from SpaceDock lacks a version file but has broader compatibility than SpaceDock can represent:

![image](https://user-images.githubusercontent.com/1559108/104797029-be981380-5780-11eb-9635-5047d3a3884c.png)

As of KSP-CKAN/CKAN#3265, we can handle this with overrides.