### PR TITLE
Override min game version for WarpEverywhere

### DIFF
--- a/NetKAN/WarpEverywhere.netkan
+++ b/NetKAN/WarpEverywhere.netkan
@@ -10,5 +10,11 @@
     "install": [ {
         "find":       "WarpEverywhere",
         "install_to": "GameData"
+    } ],
+    "x_netkan_override": [ {
+        "version": "1.0",
+        "override": {
+            "ksp_version_min": "1.4"
+        }
     } ]
 }


### PR DESCRIPTION
This is a very broadly compatible mod, apparently from 1.4.3 to the present. The SD entry has been updated to be compatible with 1.11.0.

Closes KSP-CKAN/CKAN-meta#2237.