### PR TITLE
Add mods from SpaceDock

### DIFF
--- a/NetKAN/BuranEnergia.netkan
+++ b/NetKAN/BuranEnergia.netkan
@@ -1,0 +1,23 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "BuranEnergia",
+    "$kref":        "#/ckan/spacedock/2623",
+    "license":      "GPL-3.0",
+    "tags": [
+        "parts"
+    ],
+    "depends": [
+        { "name": "KSPWheel"                 },
+        { "name": "KerbalJointReinforcement" }
+    ],
+    "install": [ {
+        "find":       "BURAN ENERGIA MOD/For Stock Game/GameData/DECQ_ENERGIA",
+        "install_to": "GameData"
+    },  {
+        "find":       "BURAN ENERGIA MOD/For Stock Game/GameData/Alcentar_Add-ons",
+        "install_to": "GameData"
+    }, {
+        "find":       "VAB",
+        "install_to": "Ships"
+    } ]
+}

--- a/NetKAN/KSPRescueContractFix.netkan
+++ b/NetKAN/KSPRescueContractFix.netkan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "KSPRescueContractFix",
+    "$kref":        "#/ckan/spacedock/2622",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "GPL-3.0",
+    "tags": [
+        "plugin",
+        "config",
+        "career"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ]
+}

--- a/NetKAN/PitchPerfect.netkan
+++ b/NetKAN/PitchPerfect.netkan
@@ -1,0 +1,13 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "PitchPerfect",
+    "$kref":        "#/ckan/spacedock/2616",
+    "license":      "MIT",
+    "tags": [
+        "plugin",
+        "control"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ]
+}


### PR DESCRIPTION
These mods have the CKAN badge but no auto PR:

- https://spacedock.info/mod/2623/%5B1.8-1.10%5D%20Buran%20Energia%20Mod%20%28Rebalanced%20and%20Fixed%29?ga=%3CGame+3102+%27Kerbal+Space+Program%27%3E
- https://spacedock.info/mod/2622/KSP%20Rescue%20Contract%20Fix
- https://spacedock.info/mod/2616/Pitch%20Perfect

RVE-Extended was examined and not indexed:
- It depends on Principia, which we can't index due to system dependencies
- Its installation instructions suggest that it overwrites files

___

ckan compat add 1.8