### PR TITLE
Update Custom Asteroids dependencies for data configs.

### DIFF
--- a/NetKAN/CustomAsteroids-Pops-OPM-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-OPM-Outer.netkan
@@ -55,7 +55,7 @@
                     {
                         "name": "CustomAsteroids",
                         "min_version": "v1.6.0",
-                        "max_version": "v1.99.99",
+                        "max_version": "v1.99.99"
                     }
                 ],
                 "comment": "Match to Custom Asteroids v1.9.0, see NetKAN#3841.",

--- a/NetKAN/CustomAsteroids-Pops-OPM-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-OPM-Outer.netkan
@@ -7,7 +7,7 @@
     "x_netkan_github": {
         "use_source_archive": true
     },
-    "ksp_version_min": "1.4.0",
+    "ksp_version_min": "1.10.0",
     "license": "MIT",
     "resources": {
         "bugtracker": "https://github.com/Starstrider42/Custom-Asteroids-Extras/issues",
@@ -23,9 +23,17 @@
         },
         {
             "name": "CustomAsteroids",
-            "min_version": "v1.6.0",
+            "min_version": "v1.9.0",
             "max_version": "v1.99.99",
-            "comment": "Requires localization support."
+            "comment": "Requires comet support."
+        }
+    ],
+    "recommends": [
+        {
+            "name": "CustomAsteroids-Pops-Stock-Stockalike",
+            "min_version": "v1.9.0",
+            "max_version": "v1.99.99",
+            "comment": "Depends on Stockalike for standard comets."
         }
     ],
     "provides": [ "CustomAsteroids-Pops" ],
@@ -34,6 +42,26 @@
             "find": "config",
             "install_to": "GameData/CustomAsteroids",
             "filter_regexp": "(?<!Trans-Neidon\\.cfg)$"
+        }
+    ],
+    "x_netkan_override" : [
+        {
+            "version" : "< v1.2.0",
+            "override" : {
+                "depends": [
+                    {
+                        "name": "OuterPlanetsMod"
+                    },
+                    {
+                        "name": "CustomAsteroids",
+                        "min_version": "v1.6.0",
+                        "max_version": "v1.99.99",
+                    }
+                ],
+                "comment": "Match to Custom Asteroids v1.9.0, see NetKAN#3841.",
+                "ksp_version_min": "1.4.0"
+            },
+            "delete" : [ "ksp_version", "recommends" ]
         }
     ],
     "x_maintained_by": "Starstrider42"

--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -13,9 +13,9 @@
     "depends": [
         {
             "name": "CustomAsteroids",
-            "min_version": "v1.6.0",
+            "min_version": "v1.9.0",
             "max_version": "v1.99.99",
-            "comment": "Requires localization support."
+            "comment": "Requires comet support."
         }
     ],
     "provides": [ "CustomAsteroids-Pops" ],
@@ -47,8 +47,23 @@
     ],
     "x_netkan_override" : [
         {
-            "version" : [ ">= v1.6.0", "< v2.0.0" ],
+            "version" : [ ">= v1.9.0", "< v2.0.0" ],
             "override" : {
+                "comment": "Match to Custom Asteroids v1.9.0, see NetKAN#3841.",
+                "ksp_version_min": "1.10.0"
+            },
+            "delete" : [ "ksp_version" ]
+        },
+        {
+            "version" : [ ">= v1.6.0", "< v1.9.0" ],
+            "override" : {
+                "depends": [
+                    {
+                        "name": "CustomAsteroids",
+                        "min_version": "v1.6.0",
+                        "max_version": "v1.99.99",
+                    }
+                ],
                 "comment": "Match to Custom Asteroids v1.6.0, see NetKAN#3841.",
                 "ksp_version_min": "1.4.0"
             },

--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -61,7 +61,7 @@
                     {
                         "name": "CustomAsteroids",
                         "min_version": "v1.6.0",
-                        "max_version": "v1.99.99",
+                        "max_version": "v1.99.99"
                     }
                 ],
                 "comment": "Match to Custom Asteroids v1.6.0, see NetKAN#3841.",

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -63,7 +63,7 @@
                     {
                         "name": "CustomAsteroids",
                         "min_version": "v1.6.0",
-                        "max_version": "v1.99.99",
+                        "max_version": "v1.99.99"
                     }
                 ],
                 "comment": "Match to Custom Asteroids v1.6.0, see NetKAN#3841.",

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -13,9 +13,9 @@
     "depends": [
         {
             "name": "CustomAsteroids",
-            "min_version": "v1.6.0",
+            "min_version": "v1.9.0",
             "max_version": "v1.99.99",
-            "comment": "Requires localization support."
+            "comment": "Requires comet support."
         }
     ],
     "provides": [ "CustomAsteroids-Pops" ],
@@ -49,8 +49,23 @@
     ],
     "x_netkan_override" : [
         {
-            "version" : [ ">= v1.6.0", "< v2.0.0" ],
+            "version" : [ ">= v1.9.0", "< v2.0.0" ],
             "override" : {
+                "comment": "Match to Custom Asteroids v1.9.0, see NetKAN#3841.",
+                "ksp_version_min": "1.10.0"
+            },
+            "delete" : [ "ksp_version" ]
+        },
+        {
+            "version" : [ ">= v1.6.0", "< v1.9.0" ],
+            "override" : {
+                "depends": [
+                    {
+                        "name": "CustomAsteroids",
+                        "min_version": "v1.6.0",
+                        "max_version": "v1.99.99",
+                    }
+                ],
                 "comment": "Match to Custom Asteroids v1.6.0, see NetKAN#3841.",
                 "ksp_version_min": "1.4.0"
             },

--- a/NetKAN/CustomAsteroids-Pops-Stock-Stockalike.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Stockalike.netkan
@@ -13,9 +13,9 @@
     "depends": [
         {
             "name": "CustomAsteroids",
-            "min_version": "v1.6.0",
+            "min_version": "v1.9.0",
             "max_version": "v1.99.99",
-            "comment": "Requires localization support."
+            "comment": "Requires comet support."
         }
     ],
     "provides": [ "CustomAsteroids-Pops" ],
@@ -38,8 +38,23 @@
     } ],
     "x_netkan_override" : [
         {
-            "version" : [ ">= v1.6.0", "< v2.0.0" ],
+            "version" : [ ">= v1.9.0", "< v2.0.0" ],
             "override" : {
+                "comment": "Match to Custom Asteroids v1.9.0, see NetKAN#3841.",
+                "ksp_version_min": "1.10.0"
+            },
+            "delete" : [ "ksp_version" ]
+        },
+        {
+            "version" : [ ">= v1.6.0", "< v1.9.0" ],
+            "override" : {
+                "depends": [
+                    {
+                        "name": "CustomAsteroids",
+                        "min_version": "v1.6.0",
+                        "max_version": "v1.99.99",
+                    }
+                ],
                 "comment": "Match to Custom Asteroids v1.6.0, see NetKAN#3841.",
                 "ksp_version_min": "1.4.0"
             },

--- a/NetKAN/CustomAsteroids-Pops-Stock-Stockalike.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Stockalike.netkan
@@ -52,7 +52,7 @@
                     {
                         "name": "CustomAsteroids",
                         "min_version": "v1.6.0",
-                        "max_version": "v1.99.99",
+                        "max_version": "v1.99.99"
                     }
                 ],
                 "comment": "Match to Custom Asteroids v1.6.0, see NetKAN#3841.",


### PR DESCRIPTION
Old configs continue to work with CA 1.6+, while new configs (version 1.9+) require CA 1.9+ and KSP 1.10+. The `x_netkan_override` blocks ensure continuity in behavior until Custom Asteroids 1.9 and CA-OPM 1.2 are actually released (tested by running `netkan` locally).

`CustomAsteroids.netkan` itself requires no updates for the new release; its versioning will be handled through Spacedock/AVC metadata.