### PR TITLE
Cache permissions workaround

### DIFF
--- a/.github/workflows/inflate.yml
+++ b/.github/workflows/inflate.yml
@@ -39,3 +39,5 @@ jobs:
                   source: commits
                   diff meta root: .CKAN-meta
                   pull request body: ${{ github.event.pull_request.body }}
+            - name: Chmod cached files so actions/cache can read them
+              run: sudo chmod -R a+r .cache


### PR DESCRIPTION
## Problem

![screenshot](https://cdn.discordapp.com/attachments/601455398553387008/803054485467299920/unknown.png)

## Cause

`ckan.exe`'s cache entries are only readable by the user that creates them (whereas `netkan.exe`'s are readable by everyone, due to differences in how these files are created):

```
$ ll -n downloads-ckan/ downloads-netkan/ 
downloads-ckan/:
insgesamt 64K
-rw------- 1 1000 1000 62K Jan 25 01:14 E9582E0A-ModuleManager-4.1.4.zip

downloads-netkan/:
insgesamt 72K
-rw-rw-r-- 1 1000 1000 62K Jan 25 01:15 E9582E0A-netkan-ModuleManager.zip
-rw-rw-r-- 1 1000 1000  40 Jan 25 01:15 E9582E0A-netkan-ModuleManager.zip.sha1
-rw-rw-r-- 1 1000 1000  64 Jan 25 01:15 E9582E0A-netkan-ModuleManager.zip.sha256
```

GitHub's cache action somehow doesn't run with sufficient permissions to access all files (!), even though it runs in a nice safe sandbox, see actions/cache#133. (And the exact requirements and best practices for how to make it work heretofore seem to be completely undocumented, see actions/cache#512.) So it fails if we have to download any dependencies.

## Changes

Now we make everything in the cache readable to everyone in a new step at the end of the job.

I don't know for sure whether this will work (again because `actions/cache`'s requirements are not documented, but also because I don't know whether a `run` step is executed as root, because _that_ isn't documented), but it might, and if it doesn't, it should give us more clues toward a proper fix.