### PR TITLE
Make SpaceLink compatible with its full game version ramge

### DIFF
--- a/NetKAN/SpaceLink.netkan
+++ b/NetKAN/SpaceLink.netkan
@@ -10,5 +10,11 @@
     "install": [ {
         "file": "SpaceLink.dll",
         "install_to": "GameData"
+    } ],
+    "x_netkan_override": [ {
+        "version": "1.0",
+        "override": {
+            "ksp_version_min": "1.2.2"
+        }
     } ]
 }


### PR DESCRIPTION
SpaceLink 1.0 has been updating its compatibility for every release since KSP 1.2.2, which has meant that while it works on all of those versions, we only have it as working with the latest game version at any given time.
Now the min game version is pinned to 1.2.2.