### PR TITLE
Fix CommunityPartsTitles install

### DIFF
--- a/NetKAN/CommunityPartsTitles.netkan
+++ b/NetKAN/CommunityPartsTitles.netkan
@@ -88,7 +88,7 @@
     ],
     "install" : [
         {
-            "file"       : "GameData/002_CommunityPartsTitles",
+            "file"       : "002_CommunityPartsTitles",
             "install_to" : "GameData",
             "filter"     : "Extras",
             "comment"    : "Exclude Extras/ folder. There are CommunityPartsTitlesExtrasCategory and CommunityPartsTitlesExtrasNoCCKDup for it"

--- a/NetKAN/CommunityPartsTitlesExtrasCategory.netkan
+++ b/NetKAN/CommunityPartsTitlesExtrasCategory.netkan
@@ -24,7 +24,7 @@
     ],
     "install" : [
         {
-            "file"       : "GameData/002_CommunityPartsTitles/Extras",
+            "file"       : "002_CommunityPartsTitles/Extras",
             "install_to" : "GameData/002_CommunityPartsTitles",
             "filter"     : "category_hide_cck.cfg",
             "comment"    : "Extras folder without the category_hide_cck.cfg. There is CommunityPartsTitlesExtrasNoDup for it"

--- a/NetKAN/CommunityPartsTitlesExtrasNoCCKDup.netkan
+++ b/NetKAN/CommunityPartsTitlesExtrasNoCCKDup.netkan
@@ -24,7 +24,7 @@
     ],
     "install" : [
         {
-            "file"       : "GameData/002_CommunityPartsTitles/Extras/category_hide_cck.cfg",
+            "file"       : "002_CommunityPartsTitles/Extras/category_hide_cck.cfg",
             "install_to" : "GameData/002_CommunityPartsTitles/Extras",
             "comment"    : "Install category_hide_cck.cfg into Extras/ folder. So it is kind of Extra for Extra."
         }


### PR DESCRIPTION
The latest release of the CommunityPartsTitles set of mods removed the `GameData` folder of the zip and put `002_CommunityPartsTitles` at the root.

