### PR TITLE
Enable multi-asset indexing for Kopernicus

### DIFF
--- a/NetKAN/Kopernicus.netkan
+++ b/NetKAN/Kopernicus.netkan
@@ -3,7 +3,7 @@
     "identifier"    : "Kopernicus",
     "name"          : "Kopernicus Planetary System Modifier",
     "abstract"      : "Allows users to replace the planetary system used by the game.",
-    "$kref"         : "#/ckan/github/Kopernicus/Kopernicus/version_from_asset/^Kopernicus-(?<version>.+).zip$",
+    "$kref"         : "#/ckan/github/Kopernicus/Kopernicus/version_from_asset/^Kopernicus-(?<version>.+)\\.zip$",
     "$vref"         : "#/ckan/ksp-avc/GameData/Kopernicus/Plugins/Kopernicus.version",
     "x_netkan_epoch": "2",
     "x_netkan_version_edit": {

--- a/NetKAN/Kopernicus.netkan
+++ b/NetKAN/Kopernicus.netkan
@@ -3,9 +3,13 @@
     "identifier"    : "Kopernicus",
     "name"          : "Kopernicus Planetary System Modifier",
     "abstract"      : "Allows users to replace the planetary system used by the game.",
-    "$kref"         : "#/ckan/github/Kopernicus/Kopernicus",
+    "$kref"         : "#/ckan/github/Kopernicus/Kopernicus/version_from_asset/^Kopernicus-(?<version>.+).zip$",
     "$vref"         : "#/ckan/ksp-avc/GameData/Kopernicus/Plugins/Kopernicus.version",
     "x_netkan_epoch": "2",
+    "x_netkan_version_edit": {
+        "find": "^(?<version>.+)$",
+        "replace": "release-${version}"
+    },
     "release_status": "development",
     "license"       : "LGPL-3.0",
     "author": [


### PR DESCRIPTION
With https://github.com/KSP-CKAN/CKAN/pull/3279 we got the possibility to index multiple release assets from GitHub, taking the version number out of the file name.
@R-T-B planned to upload one Kopernicus release with multiple assets for different KSP versions  (like he already does for his [bleeeding edge repo](https://github.com/R-T-B/Kopernicus/releases)).
In fact, he already did so once, but reverted so CKAN can index it (see https://github.com/KSP-CKAN/CKAN-meta/pull/2248).

This PR adds the new `version_from_asset`, with a regex matching the current zip naming scheme. Judging from https://github.com/KSP-CKAN/CKAN-meta/pull/2248, it should stay the same when he switches to multiple assets again.

A `x_netkan_version_edit` prepends `release-` to match the current versioning.

Inflating the netkan with the master netkan.exe results in a .ckan file which exactly matches the currently indexed one for `release-1.9.1-24`.
So we should be fine merging this PR already, then we can tell @R-T-B (if he didn't already get the notification), and he can do a new release with multiple assets whenever he is ready to do so, without the need to coordinate with us. At least as long as the file names stay in the same format.