### PR TITLE
Allow out of order releases for Kopernicus

### DIFF
--- a/NetKAN/Kopernicus.netkan
+++ b/NetKAN/Kopernicus.netkan
@@ -10,6 +10,7 @@
         "find": "^(?<version>.+)$",
         "replace": "release-${version}"
     },
+    "x_netkan_allow_out_of_order": true,
     "release_status": "development",
     "license"       : "LGPL-3.0",
     "author": [


### PR DESCRIPTION
See https://github.com/KSP-CKAN/CKAN-meta/pull/2251, follow-up to #8338 

Since in the current version format for Kopernicus the KSP version comes before the release counter, we will always get a out-of-order auto-epoch for the assets for older KSP versions.
And apparently also for every other asset in the same release, because they share the `TransformOptions`.

We don't want that, so let's enable `x_netkan_allow_out_of_order` here.

Alternative would be swapping the release counter and the KSP version part in the version, but I think in this case it's nicer to keep the current format, which also helps users identifying the zip belonging to the version on CKAN if they want to have a look or something.

Closes https://github.com/KSP-CKAN/CKAN-meta/pull/2251
Closes https://github.com/KSP-CKAN/CKAN-meta/pull/2252