### PR TITLE
Min version overrides for SpaceDock mods

### DIFF
--- a/NetKAN/JX2Antenna.netkan
+++ b/NetKAN/JX2Antenna.netkan
@@ -17,5 +17,11 @@
         { "name": "GPP"                  },
         { "name": "GrannusExpansionPack" },
         { "name": "RemoteTech"           }
-    ]
+    ],
+    "x_netkan_override": [ {
+        "version": "2.0.5",
+        "override": {
+            "ksp_version_min": "1.4.3"
+        }
+    } ]
 }

--- a/NetKAN/ManhattanAirport.netkan
+++ b/NetKAN/ManhattanAirport.netkan
@@ -16,5 +16,11 @@
     "install": [ {
         "find":       "Manhattan_Airport",
         "install_to": "GameData"
+    } ],
+    "x_netkan_override": [ {
+        "version": "V0.3",
+        "override": {
+            "ksp_version_min": "1.10.1"
+        }
     } ]
 }

--- a/NetKAN/ModularLaunchPads.netkan
+++ b/NetKAN/ModularLaunchPads.netkan
@@ -21,5 +21,11 @@
     }, {
         "find":       "Ships/VAB",
         "install_to": "Ships"
+    } ],
+    "x_netkan_override": [ {
+        "version": "2.1.2",
+        "override": {
+            "ksp_version_min": "1.10.1"
+        }
     } ]
 }

--- a/NetKAN/SteeringTweaker.netkan
+++ b/NetKAN/SteeringTweaker.netkan
@@ -9,5 +9,11 @@
     ],
     "depends": [
         { "name": "ModuleManager" }
-    ]
+    ],
+    "x_netkan_override": [ {
+        "version": "1.1",
+        "override": {
+            "ksp_version_min": "1.11.0"
+        }
+    } ]
 }


### PR DESCRIPTION
Follow-up to #8309, apparently my search skipped mods with co-authors.

___

ckan compat add 1.8