### PR TITLE
Select the right asset

### DIFF
--- a/NetKAN/AdvancedFlyByWire-Linux.netkan
+++ b/NetKAN/AdvancedFlyByWire-Linux.netkan
@@ -1,51 +1,51 @@
 {
-	"spec_version": 1,
-	"identifier": "AdvancedFlyByWire-Linux",
-	"name": "Advanced Fly-By-Wire (Linux)",
-	"abstract": "AFBW is an input overhaul mod. It dramatically enhances the stock input system with a bunch of fixes and many new features.",
-	"author": "linuxgurugamer",
-	"license": "MIT",
-	"$kref": "#/ckan/github/linuxgurugamer/ksp-advanced-flybywire",
-	"$vref": "#/ckan/ksp-avc",
-	"release_status": "stable",
-	"resources": {
-		"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/175359-*",
-		"spacedock": "https://spacedock.info/mod/1870/AFBW%20Revived%20(Linux%20version)",
-		"repository": "https://github.com/linuxgurugamer/ksp-advanced-flybywire",
-		"x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/AFBW_Revived_Linux_version/AFBW_Revived_Linux_version-1527384062.2632098.png"
-	},
-	"tags": [
-		"plugin",
-		"control"
-	],
-	"provides": [
-		"AdvancedFlyByWireRevived"
-	],
-	"depends": [
-		{
-			"name": "ToolbarController"
-		},
-		{
-			"name": "ClickThroughBlocker"
-		}
-	],
-	"recommends": [
-		{
-			"name": "ToolbarController"
-		},
-		{
-			"name": "ClickThroughBlocker"
-		}
-	],
-	"conflicts": [
-		{
-			"name": "AdvancedFlyByWireRevived"
-		}
-	],
-	"install": [
-		{
-			"file": "GameData/ksp-advanced-flybywire",
-			"install_to": "GameData"
-		}
-	]
+    "spec_version": 1,
+    "identifier": "AdvancedFlyByWire-Linux",
+    "name": "Advanced Fly-By-Wire (Linux)",
+    "abstract": "AFBW is an input overhaul mod. It dramatically enhances the stock input system with a bunch of fixes and many new features.",
+    "author": "linuxgurugamer",
+    "license": "MIT",
+    "$kref": "#/ckan/github/linuxgurugamer/ksp-advanced-flybywire/asset_match/linux",
+    "$vref": "#/ckan/ksp-avc",
+    "release_status": "stable",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/175359-*",
+        "spacedock": "https://spacedock.info/mod/1870/AFBW%20Revived%20(Linux%20version)",
+        "repository": "https://github.com/linuxgurugamer/ksp-advanced-flybywire",
+        "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/AFBW_Revived_Linux_version/AFBW_Revived_Linux_version-1527384062.2632098.png"
+    },
+    "tags": [
+        "plugin",
+        "control"
+    ],
+    "provides": [
+        "AdvancedFlyByWireRevived"
+    ],
+    "depends": [
+        {
+            "name": "ToolbarController"
+        },
+        {
+            "name": "ClickThroughBlocker"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "ToolbarController"
+        },
+        {
+            "name": "ClickThroughBlocker"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "AdvancedFlyByWireRevived"
+        }
+    ],
+    "install": [
+        {
+            "file": "GameData/ksp-advanced-flybywire",
+            "install_to": "GameData"
+        }
+    ]
 }

--- a/NetKAN/AdvancedFlyByWire-OSX.netkan
+++ b/NetKAN/AdvancedFlyByWire-OSX.netkan
@@ -1,51 +1,51 @@
 {
-	"spec_version": 1,
-	"identifier": "AdvancedFlyByWire-OSX",
-	"name": "Advanced Fly-By-Wire (OSX)",
-	"abstract": "AFBW is an input overhaul mod. It dramatically enhances the stock input system with a bunch of fixes and many new features.",
-	"author": "linuxgurugamer",
-	"license": "MIT",
-	"$kref": "#/ckan/github/linuxgurugamer/ksp-advanced-flybywire",
-	"$vref": "#/ckan/ksp-avc",
-	"release_status": "stable",
-	"resources": {
-		"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/175359-*",
-		"spacedock": "https://spacedock.info/mod/1878/ABFW%20Revived%20(OSX%20version)",
-		"repository": "https://github.com/linuxgurugamer/ksp-advanced-flybywire",
-		"x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/ABFW_Revived_OSX_version/ABFW_Revived_OSX_version-1527782505.4308672.png"
-	},
-	"tags": [
-		"plugin",
-		"control"
-	],
-	"provides": [
-		"AdvancedFlyByWireRevived"
-	],
-	"depends": [
-		{
-			"name": "ToolbarController"
-		},
-		{
-			"name": "ClickThroughBlocker"
-		}
-	],
-	"recommends": [
-		{
-			"name": "ToolbarController"
-		},
-		{
-			"name": "ClickThroughBlocker"
-		}
-	],
-	"conflicts": [
-		{
-			"name": "AdvancedFlyByWireRevived"
-		}
-	],
-	"install": [
-		{
-			"file": "GameData/ksp-advanced-flybywire",
-			"install_to": "GameData"
-		}
-	]
+    "spec_version": 1,
+    "identifier": "AdvancedFlyByWire-OSX",
+    "name": "Advanced Fly-By-Wire (OSX)",
+    "abstract": "AFBW is an input overhaul mod. It dramatically enhances the stock input system with a bunch of fixes and many new features.",
+    "author": "linuxgurugamer",
+    "license": "MIT",
+    "$kref": "#/ckan/github/linuxgurugamer/ksp-advanced-flybywire/asset_match/osx",
+    "$vref": "#/ckan/ksp-avc",
+    "release_status": "stable",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/175359-*",
+        "spacedock": "https://spacedock.info/mod/1878/ABFW%20Revived%20(OSX%20version)",
+        "repository": "https://github.com/linuxgurugamer/ksp-advanced-flybywire",
+        "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/ABFW_Revived_OSX_version/ABFW_Revived_OSX_version-1527782505.4308672.png"
+    },
+    "tags": [
+        "plugin",
+        "control"
+    ],
+    "provides": [
+        "AdvancedFlyByWireRevived"
+    ],
+    "depends": [
+        {
+            "name": "ToolbarController"
+        },
+        {
+            "name": "ClickThroughBlocker"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "ToolbarController"
+        },
+        {
+            "name": "ClickThroughBlocker"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "AdvancedFlyByWireRevived"
+        }
+    ],
+    "install": [
+        {
+            "file": "GameData/ksp-advanced-flybywire",
+            "install_to": "GameData"
+        }
+    ]
 }

--- a/NetKAN/AirlockPlus.netkan
+++ b/NetKAN/AirlockPlus.netkan
@@ -1,12 +1,12 @@
 {
-    "spec_version" : "v1.16",
-    "identifier"   : "AirlockPlus",
-    "name"         : "AirlockPlus",
-    "abstract"     : "Allows the use of any airlock on a vessel in conjunction with any crew part on the vessel, without requiring manual crew transfer.",
-    "author"       : "cake-pie",
-    "license"      : "restricted",
-    "$kref"        : "#/ckan/github/cake-pie/AirlockPlus",
-    "$vref"        : "#/ckan/ksp-avc",
+    "spec_version": "v1.16",
+    "identifier":   "AirlockPlus",
+    "name":         "AirlockPlus",
+    "abstract":     "Allows the use of any airlock on a vessel in conjunction with any crew part on the vessel, without requiring manual crew transfer.",
+    "author":       "cake-pie",
+    "$kref":        "#/ckan/github/cake-pie/AirlockPlus/asset_match/^AirlockPlus\\.[.0-9]*\\.zip$",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "restricted",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?showtopic=160268"
     },
@@ -15,17 +15,14 @@
         "crewed",
         "convenience"
     ],
-    "install": [
-        {
-            "file": "GameData/AirlockPlus",
-            "install_to": "GameData"
-        },
-        {
-            "find_regexp": "0Harmony.*\\.dll$",
-            "find_matches_files": true,
-            "install_to": "GameData/AirlockPlus"
-        }
-    ],
+    "install": [ {
+        "file": "GameData/AirlockPlus",
+        "install_to": "GameData"
+    }, {
+        "find_regexp": "0Harmony.*\\.dll$",
+        "find_matches_files": true,
+        "install_to": "GameData/AirlockPlus"
+    } ],
     "x_netkan_override": [ {
         "version": "<=v0.0.10",
         "override": {

--- a/NetKAN/DockingCamKURS.netkan
+++ b/NetKAN/DockingCamKURS.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
     "identifier":   "DockingCamKURS",
-    "$kref":        "#/ckan/github/linuxgurugamer/DockingCam",
+    "$kref":        "#/ckan/github/linuxgurugamer/DockingCam/asset_match/DockingCamera",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "CC-BY-NC-SA-4.0",
     "resources": {

--- a/NetKAN/PicoPort4AllSizes.netkan
+++ b/NetKAN/PicoPort4AllSizes.netkan
@@ -3,7 +3,7 @@
     "identifier":   "PicoPort4AllSizes",
     "name":         "PicoPort for all sizes",
     "abstract":     "This is a patch which makes the PicoPort available in many sizes",
-    "$kref":        "#/ckan/github/linuxgurugamer/PicoPort4AllSizes",
+    "$kref":        "#/ckan/github/linuxgurugamer/PicoPort4AllSizes/asset_match/^PicoPort4AllSizes-[^-]*$",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "MIT",
     "resources": {
@@ -13,11 +13,11 @@
         "config"
     ],
     "install": [ {
-        "install_to": "GameData",
-        "find": "SHED"
+        "find":       "SHED",
+        "install_to": "GameData"
     } ],
-    "depends" : [
-        { "name" : "ModuleManager" },
-        { "name" : "PicoPort" }
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "PicoPort"      }
     ]
 }


### PR DESCRIPTION
KSP-CKAN/CKAN#3286 found five mods with multi-asset releases on GitHub:

![image](https://user-images.githubusercontent.com/1559108/106389796-f8852e80-63aa-11eb-9c23-971ff67293c3.png)

In most cases it's a harmless warning we can suppress by specifying `asset_match`.
For AFBW-OSX, the wrong file is being inflated since #7729, and clean-up will be required.