### PR TITLE
Add mods from SpaceDock

### DIFF
--- a/NetKAN/BetterEarlyTree.netkan
+++ b/NetKAN/BetterEarlyTree.netkan
@@ -1,0 +1,37 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "BetterEarlyTree",
+    "$kref":        "#/ckan/spacedock/2629",
+    "license":      "MIT",
+    "tags": [
+        "config",
+        "tech-tree"
+    ],
+    "depends": [
+        { "name": "ModuleManager"     },
+        { "name": "CommunityTechTree" }
+    ],
+    "recommends": [
+        { "name": "MakingHistory-DLC"  },
+        { "name": "BreakingGround-DLC" },
+        { "name": "Restock"            },
+        { "name": "ReStockPlus"        }
+    ],
+    "suggests": [
+        { "name": "NearFutureElectrical"   },
+        { "name": "NearFuturePropulsion"   },
+        { "name": "NearFutureSolar"        },
+        { "name": "NearFutureAeronautics"  },
+        { "name": "NearFutureConstruction" },
+        { "name": "RationalResources"      },
+        { "name": "SpaceXLegs"             },
+        { "name": "SCANsat"                },
+        { "name": "DMagicOrbitalScience"   }
+    ],
+    "supports": [
+        { "name": "kOS"                                },
+        { "name": "NearFutureExploration"              },
+        { "name": "PEBKACIndustriesLaunchEscapeSystem" },
+        { "name": "UniversalStorage2"                  }
+    ]
+}

--- a/NetKAN/EnvironmentalVisualEnhancements.netkan
+++ b/NetKAN/EnvironmentalVisualEnhancements.netkan
@@ -1,14 +1,16 @@
 {
     "spec_version": 1,
     "identifier":   "EnvironmentalVisualEnhancements",
-    "name":         "Environmental Visual Enhancements",
-    "$kref":        "#/ckan/github/R-T-B/EnvironmentalVisualEnhancements/asset_match/EnvironmentalVisualEnhancements-[0-9]",
+    "author": [
+        "rbray89",
+        "WazWaz",
+        "R-T-B",
+        "blackrack"
+    ],
+    "$kref":        "#/ckan/spacedock/2631",
     "$vref":        "#/ckan/ksp-avc",
     "x_netkan_epoch": "2",
     "license":      "MIT",
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/196289-*"
-    },
     "tags": [
         "plugin",
         "graphics"


### PR DESCRIPTION
Another round of pull requests that never came in from SpaceDock.

- https://spacedock.info/mod/2631/Environmental%20Visual%20Enhancements%20Redux
  Previous maintainer intends to hand off to @blackrack, so we're updating the existing netkan
- https://spacedock.info/mod/2629/Better%20Early%20Tree


https://spacedock.info/mod/2630/KSPW00tNow will be done later/separately, because it uses the MPL-2.0 license which requires a spec update which requires us to release v1.30.0.