### PR TITLE
Add KSPW00tNow

### DIFF
--- a/NetKAN/KSPW00tNow.netkan
+++ b/NetKAN/KSPW00tNow.netkan
@@ -1,0 +1,10 @@
+{
+    "spec_version": "v1.30",
+    "identifier":   "KSPW00tNow",
+    "$kref":        "#/ckan/spacedock/2630",
+    "license":      "MPL-2.0",
+    "tags": [
+        "plugin",
+        "control"
+    ]
+}


### PR DESCRIPTION
This mod has the CKAN badge on SD but no PR.
https://spacedock.info/mod/2630/KSPW00tNow
It uses the MPL-2.0 license which the current client doesn't support, so it will need to wait till CKAN v1.30.0 is released.
https://github.com/KSP-CKAN/CKAN/commit/85ac317f9512a8e4706fb1ace06b5a8553a465b3

It also bundles Harmony and so may need to be considered for #8288.