### PR TITLE
Update NeptuneCamera compat to 1.11

### DIFF
--- a/NetKAN/NeptuneCamera.netkan
+++ b/NetKAN/NeptuneCamera.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "NeptuneCamera",
     "$kref":        "#/ckan/github/Tantares/NeptuneCamera",
-    "ksp_version":  "1.10",
+    "ksp_version":  "1.11",
     "license":      "MIT",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/196339-*"


### PR DESCRIPTION
Hardcoded compatibility, v3.0 is compatible with KSP 1.11
![image](https://user-images.githubusercontent.com/28812678/107151048-df5b1f80-6960-11eb-9dfc-c6cbeed89ef8.png)
![image](https://user-images.githubusercontent.com/28812678/107151065-ef72ff00-6960-11eb-8684-b6a0978054fa.png)

Closes https://github.com/KSP-CKAN/CKAN-meta/pull/2258