### PR TITLE
Add mods from SpaceDock

### DIFF
--- a/NetKAN/Heracleitus.netkan
+++ b/NetKAN/Heracleitus.netkan
@@ -1,0 +1,15 @@
+{
+    "spec_version": 1,
+    "identifier":   "Heracleitus",
+    "name":         "Heracleitus",
+    "$kref":        "#/ckan/spacedock/2644",
+    "license":      "MIT",
+    "tags": [
+        "config",
+        "planet-pack"
+    ],
+    "depends": [
+        { "name": "Kopernicus" },
+        { "name": "ModuleManager"}
+    ]
+}

--- a/NetKAN/KerbalTelemetry.netkan
+++ b/NetKAN/KerbalTelemetry.netkan
@@ -1,0 +1,17 @@
+{
+    "spec_version": 1,
+    "identifier":   "KerbalTelemetry",
+    "$kref":        "#/ckan/spacedock/2643",
+    "license":      "MIT",
+    "tags": [
+        "plugin",
+        "app",
+        "information"
+    ],
+    "install": [
+        {
+            "file": "GameData",
+            "install_to": "GameData"
+        }
+    ]
+}


### PR DESCRIPTION
Some more mods that we didn't get a PR for.

* https://spacedock.info/mod/2644/heracleitus
* https://spacedock.info/mod/2643/Kerbal%20Telemetry

KerbalTelemetry also comes with a Python Flask application that serves as the frontend to the telemetry. The DLL expects it to be installed in GameRoot, since it writes its data exports into `<KSP>/Kerbal Telemetry/static` (yeah, I know...).

CKAN doesn't allow creating new folders in GameRoot, so we can't install that part. This isn't that much of a problem, since you need to install Python and Flask anyway to run it.

The DLL gets installed directly into GameData without a subfolder, I think this is fine since it's only a single DLL, and I don't want to mess with it too much in case they decide to switchover to relative paths or whatever in the future.