### PR TITLE
Fix CommunityPartsTitlesExtrasNoCCKDup install

### DIFF
--- a/NetKAN/CommunityPartsTitlesExtrasCategory.netkan
+++ b/NetKAN/CommunityPartsTitlesExtrasCategory.netkan
@@ -26,8 +26,8 @@
         {
             "file"       : "002_CommunityPartsTitles/Extras",
             "install_to" : "GameData/002_CommunityPartsTitles",
-            "filter"     : "category_hide_cck.cfg",
-            "comment"    : "Extras folder without the category_hide_cck.cfg. There is CommunityPartsTitlesExtrasNoDup for it"
+            "filter"     : "category_hide_cck_parts.cfg",
+            "comment"    : "Extras folder without the category_hide_cck_parts.cfg. There is CommunityPartsTitlesExtrasNoDup for it"
         }
     ]
 }

--- a/NetKAN/CommunityPartsTitlesExtrasNoCCKDup.netkan
+++ b/NetKAN/CommunityPartsTitlesExtrasNoCCKDup.netkan
@@ -24,9 +24,9 @@
     ],
     "install" : [
         {
-            "file"       : "002_CommunityPartsTitles/Extras/category_hide_cck.cfg",
+            "file"       : "002_CommunityPartsTitles/Extras/category_hide_cck_parts.cfg",
             "install_to" : "GameData/002_CommunityPartsTitles/Extras",
-            "comment"    : "Install category_hide_cck.cfg into Extras/ folder. So it is kind of Extra for Extra."
+            "comment"    : "Install category_hide_cck_parts.cfg into Extras/ folder. So it is kind of Extra for Extra."
         }
     ]
 }


### PR DESCRIPTION
The file has been renamed from `category_hide_cck.cfg` to `category_hide_cck_parts.cfg`.

The filter for CommunityPartsTitlesExtrasCategory needed to be adjusted as well.