### PR TITLE
Force Parallax 1.0.1 for BeyondHome

### DIFF
--- a/NetKAN/BeyondHome.netkan
+++ b/NetKAN/BeyondHome.netkan
@@ -17,10 +17,10 @@
         "graphics"
     ],
     "depends": [
-        { "name": "ModuleManager"              },
-        { "name": "Kopernicus"                 },
-        { "name": "Scatterer-sunflare-default" },
-        { "name": "Parallax"                   }
+        { "name": "ModuleManager"                },
+        { "name": "Kopernicus"                   },
+        { "name": "Scatterer-sunflare-default"   },
+        { "name": "Parallax", "version": "1.0.1" }
     ],
     "conflicts": [
         { "name": "GPP"                     },


### PR DESCRIPTION
Forum thread says this:
![image](https://user-images.githubusercontent.com/28812678/109366674-60d50c00-7894-11eb-9ce9-67fd6ea6b0af.png)

According to comments from the author the restriction should go away with the next release of BeyondHome. But we'll get a staging PR for it anyways, since it has hardcoded KSP compatibility with a max of 1.10.

There's a small bug in the client, it installs the correct version of Parallax but then offers to upgrade it. The upgrade will abort due to the unsatisfied dependency though.