### PR TITLE
Add 'suits' tag to suit mods

### DIFF
--- a/NetKAN/Ceteras-Suit-Pack.frozen
+++ b/NetKAN/Ceteras-Suit-Pack.frozen
@@ -4,7 +4,7 @@
     "$kref"        : "#/ckan/spacedock/1595",
     "license"      : "CC-BY-NC-SA-4.0",
     "tags": [
-        "config",
+        "suits",
         "graphics",
         "crewed"
     ],

--- a/NetKAN/CustomDesignSpacesuits-Steampunk.frozen
+++ b/NetKAN/CustomDesignSpacesuits-Steampunk.frozen
@@ -3,6 +3,11 @@
   "identifier": "CustomDesignSpacesuits-Steampunk",
   "ksp_version": "0.90",
   "license": "CC-BY-NC-SA-4.0",
+  "tags": [
+    "suits",
+    "graphics",
+    "crewed"
+  ],
   "resources": {
     "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/142824-113-green-skull-inc-custom-design-spacesuits-v039-29th-june-16/"
   },

--- a/NetKAN/GregroxMultiColorSuitsPack.netkan
+++ b/NetKAN/GregroxMultiColorSuitsPack.netkan
@@ -4,7 +4,7 @@
     "$kref":        "#/ckan/spacedock/2030",
     "license":      "CC-BY-SA-4.0",
     "tags": [
-        "config",
+        "suits",
         "graphics",
         "crewed"
     ],

--- a/NetKAN/GregroxsColoredEVAIVASuits.frozen
+++ b/NetKAN/GregroxsColoredEVAIVASuits.frozen
@@ -4,6 +4,11 @@
     "identifier": "GregroxsColoredEVAIVASuits",
     "license": "MIT",
     "x_netkan_epoch": 1,
+    "tags": [
+        "suits",
+        "graphics",
+        "crewed"
+    ],
     "depends": [
         { "name": "TextureReplacer" }
     ],

--- a/NetKAN/KSPArtemisSuit.netkan
+++ b/NetKAN/KSPArtemisSuit.netkan
@@ -4,6 +4,7 @@
     "$kref":        "#/ckan/spacedock/2517",
     "license":      "GPL-3.0",
     "tags": [
+        "suits",
         "graphics",
         "crewed"
     ],

--- a/NetKAN/MilitarySuitTextures.frozen
+++ b/NetKAN/MilitarySuitTextures.frozen
@@ -3,6 +3,11 @@
     "$kref": "#/ckan/spacedock/884",
     "spec_version": "v1.4",
     "identifier": "MilitarySuitTextures",
+    "tags": [
+        "suits",
+        "graphics",
+        "crewed"
+    ],
     "depends": [
         { "name": "TextureReplacer" }
     ],

--- a/NetKAN/PartlyColoredSuits.netkan
+++ b/NetKAN/PartlyColoredSuits.netkan
@@ -4,7 +4,7 @@
     "$kref":        "#/ckan/spacedock/2606",
     "license":      "CC-BY-NC-4.0",
     "tags": [
-        "config",
+        "suits",
         "graphics",
         "crewed"
     ],

--- a/NetKAN/PhoenixIndustriesEVASuit.frozen
+++ b/NetKAN/PhoenixIndustriesEVASuit.frozen
@@ -4,7 +4,7 @@
     "$kref"        : "#/ckan/spacedock/659",
     "license"      : "CC-BY-NC-ND-4.0",
     "tags"         : [
-        "config",
+        "suits",
         "graphics",
         "crewed"
     ],

--- a/NetKAN/ShuttleEVASuit.netkan
+++ b/NetKAN/ShuttleEVASuit.netkan
@@ -4,7 +4,7 @@
     "$kref":        "#/ckan/spacedock/2514",
     "license":      "MIT",
     "tags": [
-        "config",
+        "suits",
         "graphics",
         "crewed"
     ],

--- a/NetKAN/SpaceXSuits.netkan
+++ b/NetKAN/SpaceXSuits.netkan
@@ -4,6 +4,7 @@
     "$kref":        "#/ckan/spacedock/2612",
     "license":      "MIT",
     "tags": [
+        "suits",
         "graphics",
         "crewed"
     ],

--- a/NetKAN/SteampunkColorCodedSpaceSuits.frozen
+++ b/NetKAN/SteampunkColorCodedSpaceSuits.frozen
@@ -3,6 +3,11 @@
     "license": "MIT",
     "$kref": "#/ckan/kerbalstuff/1025",
     "identifier": "SteampunkColorCodedSpaceSuits",
+    "tags": [
+        "suits",
+        "graphics",
+        "crewed"
+    ],
     "depends": [
         { "name" : "TextureReplacer" }
     ],

--- a/NetKAN/USIKolClassSuits.frozen
+++ b/NetKAN/USIKolClassSuits.frozen
@@ -4,6 +4,7 @@
     "$kref":        "#/ckan/spacedock/1175",
     "license":      "unrestricted",
     "tags": [
+        "suits",
         "graphics",
         "crewed"
     ],

--- a/NetKAN/USIKolClassSuitsRedux.netkan
+++ b/NetKAN/USIKolClassSuitsRedux.netkan
@@ -5,6 +5,7 @@
     "$kref":        "#/ckan/spacedock/2035",
     "license":      "CC-BY-SA-4.0",
     "tags": [
+        "suits",
         "graphics",
         "crewed"
     ],


### PR DESCRIPTION
There are a bunch of mods adding new suits to the game, previously using TextureReplacer ans since 1.10 (I think) the built-in feature.

They didn't really fit into any of the existing mod types, they aren't really parts, nor configs.
We've already got `parts` and `flags`, `suits` should complement the list nicely.

As discussed on Discord, we are tagging those mods with `[ "suits", "graphics", "crewed" ]` now, which should cover the categories users likely expect to find them under.