### PR TITLE
Fix CommunityPartTitles installs

### DIFF
--- a/NetKAN/CommunityPartsTitles.netkan
+++ b/NetKAN/CommunityPartsTitles.netkan
@@ -88,7 +88,7 @@
     ],
     "install" : [
         {
-            "file"       : "002_CommunityPartsTitles",
+            "file"       : "GameData/002_CommunityPartsTitles",
             "install_to" : "GameData",
             "filter"     : "Extras",
             "comment"    : "Exclude Extras/ folder. There are CommunityPartsTitlesExtrasCategory and CommunityPartsTitlesExtrasNoCCKDup for it"

--- a/NetKAN/CommunityPartsTitlesExtrasCategory.netkan
+++ b/NetKAN/CommunityPartsTitlesExtrasCategory.netkan
@@ -24,7 +24,7 @@
     ],
     "install" : [
         {
-            "file"       : "002_CommunityPartsTitles/Extras",
+            "file"       : "GameData/002_CommunityPartsTitles/Extras",
             "install_to" : "GameData/002_CommunityPartsTitles",
             "filter"     : "category_hide_cck_parts.cfg",
             "comment"    : "Extras folder without the category_hide_cck_parts.cfg. There is CommunityPartsTitlesExtrasNoDup for it"

--- a/NetKAN/CommunityPartsTitlesExtrasCategory.netkan
+++ b/NetKAN/CommunityPartsTitlesExtrasCategory.netkan
@@ -26,7 +26,7 @@
         {
             "file"       : "GameData/002_CommunityPartsTitles/Extras",
             "install_to" : "GameData/002_CommunityPartsTitles",
-            "filter"     : "category_hide_cck_parts.cfg",
+            "filter"     : "CPTE_category_hide_cck_parts.cfg",
             "comment"    : "Extras folder without the category_hide_cck_parts.cfg. There is CommunityPartsTitlesExtrasNoDup for it"
         }
     ]


### PR DESCRIPTION
In the course of #8394, the folder paths of CommunityPartTitles's ZIP were updated to include a `GameData/` prefix, but only one of its three netkans were updated.

Now the other two are updated.