### PR TITLE
Make Kerbalism-Config-RO conflict with life support mods

### DIFF
--- a/NetKAN/Kerbalism-Config-RO.netkan
+++ b/NetKAN/Kerbalism-Config-RO.netkan
@@ -15,7 +15,10 @@
         "Kerbalism-Config"
     ],
     "conflicts": [
-        { "name": "Kerbalism-Config" }
+        { "name": "Kerbalism-Config" },
+        { "name": "TACLS"            },
+        { "name": "Snacks"           },
+        { "name": "USI-LS"           }
     ],
     "depends": [
         { "name": "ModuleManager" },


### PR DESCRIPTION
Our friends at the KSP-RO Discord informed me that this mod provides its own life support, so it should conflict with TACLS, at least. Looking at the default Kerbalism config, there are already conflicts for several such mods:

https://github.com/KSP-CKAN/NetKAN/blob/908306929b12c8891046e6871545674086535787/NetKAN/Kerbalism-Config-Default.netkan#L23-L30

Now the ones that I was able to confirm are for life support are added here as well.

FYI to @siimav and @Standecco.