### PR TITLE
Fix Tantares mods

### DIFF
--- a/NetKAN/NewTantares.netkan
+++ b/NetKAN/NewTantares.netkan
@@ -1,18 +1,22 @@
 {
-    "spec_version" : 1,
-    "identifier"   : "NewTantares",
-    "name"         : "New Tantares",
-    "abstract"     : "Stockalike Soyuz, LK and more!",
-    "author"       : "Beale",
-    "$kref"        : "#/ckan/github/Tantares/Tantares",
-    "ksp_version"  : "1.11",
-    "license"      : "CC-BY-NC-SA-4.0",
+    "spec_version":    "v1.18",
+    "identifier":      "NewTantares",
+    "abstract":        "Stockalike Soviet Spacecraft",
+    "author":          "Beale",
+    "$kref":           "#/ckan/github/Tantares/Tantares",
+    "ksp_version_min": "1.10.1",
+    "ksp_version_max": "1.11",
+    "license":         "CC-BY-NC-SA-4.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/73686-*"
+        "homepage":  "https://forum.kerbalspaceprogram.com/index.php?/topic/73686-Tantares",
+        "spacedock": "https://spacedock.info/mod/174/Tantares"
     },
     "tags": [
         "parts",
         "crewed"
+    ],
+    "provides": [
+        "Tantares"
     ],
     "depends": [
         { "name": "ModuleManager" }
@@ -23,10 +27,12 @@
     "conflicts": [
         { "name": "Tantares" }
     ],
-    "install": [
-        {
-            "file"       : "GameData/Tantares",
-            "install_to" : "GameData"
-        }
-    ]
+    "install": [ {
+        "find":       "Tantares",
+        "install_to": "GameData"
+    }, {
+        "find":       "Crafts",
+        "install_to": "Ships",
+        "as":         "VAB"
+    } ]
 }

--- a/NetKAN/NewTantaresLV.netkan
+++ b/NetKAN/NewTantaresLV.netkan
@@ -1,17 +1,21 @@
 {
-    "spec_version" : "v1.4",
-    "identifier"   : "NewTantaresLV",
-    "name"         : "New TantaresLV",
-    "abstract"     : "Stockalike N1, Soyuz and more!",
-    "author"       : "Beale",
-    "$kref"        : "#/ckan/github/Tantares/TantaresLV",
-    "ksp_version"  : "1.11",
-    "license"      : "CC-BY-NC-SA-4.0",
+    "spec_version":    "v1.18",
+    "identifier":      "NewTantaresLV",
+    "abstract":        "Stockalike Soviet and European Launch Vehicles",
+    "author":          "Beale",
+    "$kref":           "#/ckan/github/Tantares/TantaresLV",
+    "ksp_version_min": "1.10.1",
+    "ksp_version_max": "1.11",
+    "license":         "CC-BY-NC-SA-4.0",
     "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/73686-Tantares"
+        "homepage":  "https://forum.kerbalspaceprogram.com/index.php?/topic/73686-Tantares",
+        "spacedock": "https://spacedock.info/mod/176/TantaresLV"
     },
     "tags": [
         "parts"
+    ],
+    "provides": [
+        "TantaresLV"
     ],
     "depends": [
         { "name": "ModuleManager" }
@@ -22,10 +26,12 @@
     "conflicts": [
         { "name": "TantaresLV" }
     ],
-    "install": [
-        {
-            "find"       : "TantaresLV",
-            "install_to" : "GameData"
-        }
-    ]
+    "install": [ {
+        "find":       "TantaresLV",
+        "install_to": "GameData"
+    }, {
+        "find":       "Crafts",
+        "install_to": "Ships",
+        "as":         "VAB"
+    } ]
 }

--- a/NetKAN/Tantares.frozen
+++ b/NetKAN/Tantares.frozen
@@ -19,5 +19,5 @@
             "install_to" : "GameData"
         }
     ],
-    "x_maintained_by": "eagleshift"
+    "replaced_by": "NewTantares"
 }

--- a/NetKAN/TantaresLV.frozen
+++ b/NetKAN/TantaresLV.frozen
@@ -20,6 +20,7 @@
     "install_to" : "GameData"
     }
   ],
+  "replaced_by": "NewTantaresLV",
   "x_netkan_override" : [
     {
         "version" : "12.1",

--- a/NetKAN/TantaresSP.netkan
+++ b/NetKAN/TantaresSP.netkan
@@ -1,9 +1,16 @@
 {
-    "spec_version": "v1.18",
-    "identifier":   "TantaresSP",
-    "$kref":        "#/ckan/spacedock/2498",
-    "ksp_version":  "1.10",
-    "license":      "MIT",
+    "spec_version":    "v1.18",
+    "identifier":      "TantaresSP",
+    "abstract":        "Soviet Space Probes and Interplanetary Spacecraft",
+    "author":          "Beale",
+    "$kref":           "#/ckan/github/Tantares/TantaresSP",
+    "ksp_version_min": "1.10.1",
+    "ksp_version_max": "1.11",
+    "license":         "CC-BY-NC-SA-4.0",
+    "resources": {
+        "homepage":  "https://forum.kerbalspaceprogram.com/index.php?/topic/73686-Tantares",
+        "spacedock": "https://spacedock.info/mod/2498/TantaresSP"
+    },
     "tags": [
         "parts",
         "uncrewed"
@@ -21,5 +28,10 @@
         "find":       "Crafts",
         "install_to": "Ships",
         "as":         "VAB"
-    } ]
+    } ],
+    "x_netkan_version_edit": {
+        "find": "^[vV]?(?<version>.+)$",
+        "replace": "${version}",
+        "strict": true
+    }
 }


### PR DESCRIPTION
## Problem
See the conversation above and below [this comment](https://forum.kerbalspaceprogram.com/index.php?/topic/73686-111x-tantares-stockalike-soyuz-and-mir-2402122021/&do=findComment&comment=3937912) on the Tantares thread.

In early 2017, the SpaceDock entries for `Tantares` and `TantaresLV` stopped receiving updates, while releases were still published in the GitHub repo.
After [an issue](https://github.com/KSP-CKAN/NetKAN/issues/5295) from a user who seemed close to the project, [new netkans have been added](https://github.com/KSP-CKAN/NetKAN/pull/5317) for those two mods, with the identifiers `NewTantares` and `NewTantaresLV`. Ideally only the kref should've been changed instead of creating two completely new modules, but well.
Shortly after the original netkans have been frozen. Some time later the SpaceDock pages started to receive updates again.

Last year we indexed `TantaresSP` after getting an [automated SpaceDock PR](https://github.com/KSP-CKAN/NetKAN/pull/8091).

The "New" prefixes in the names (and identifiers) don't reflect the official mod names, and users got confused, especially after seeing three other mods without "New" prefix, where to of them are really outdated.

The craft files for `NewTantares` and `NewTantaresLV` don't get installed by CKAN, whereas those of `TantaresSP` do.

And the compatibility data isn't fully correct either:
![image](https://user-images.githubusercontent.com/28812678/110536327-a067e780-8121-11eb-9f0c-cdc1dbeed46c.png)


## Changes
The NetKAN files for `NewTantares` and `NewTantaresLV` are cleaned up. The `name` is now pulled form the GitHub repo, so we get rid of the "New" prefix. They'll show up as "Tantares" and "Tantares LV" in the GUI now.
The identifiers still have the "New" in them, but that's where all the releases of the mods are now. Instead they got a `"provides": "Tantares[LV]"`.

We are now also installing the crafts for `NewTantares` and `NewTantaresLV`.

The compatibility ranges have been updated to KSP 1.10.1 - 1.11 for all three mods.
Beale said that they plan to include .version files in the next release :crossed_fingers: 

`TantaresSP` has been switched over to GitHub as well, to match the other two mods. This simplifies future maintenance.

The license for `TantaresSP` has been changed to `CC-BY-NC-SA-4.0` (like both other mods), I also updated the SpaceDock page earlier, since the zip file states:
> TantaresSP is distributed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.

## Quick Links
* https://spacedock.info/mod/174/Tantares
* https://spacedock.info/mod/176/TantaresLV
* https://spacedock.info/mod/2498/TantaresSP
* https://github.com/Tantares/Tantares
* https://github.com/Tantares/TantaresLV
* https://github.com/Tantares/TantaresSP
* [Forum Thread](https://forum.kerbalspaceprogram.com/index.php?/topic/73686-Tantares)