### PR TITLE
Less confusing names for Tantares mods

### DIFF
--- a/NetKAN/NewTantares.netkan
+++ b/NetKAN/NewTantares.netkan
@@ -1,6 +1,7 @@
 {
     "spec_version":    "v1.18",
     "identifier":      "NewTantares",
+    "name":            "Tantares - Soviet Spacecraft",
     "abstract":        "Stockalike Soviet Spacecraft",
     "author":          "Beale",
     "$kref":           "#/ckan/github/Tantares/Tantares",

--- a/NetKAN/NewTantaresLV.netkan
+++ b/NetKAN/NewTantaresLV.netkan
@@ -1,6 +1,7 @@
 {
     "spec_version":    "v1.18",
     "identifier":      "NewTantaresLV",
+    "name":            "Tantares LV - Soviet Rockets",
     "abstract":        "Stockalike Soviet and European Launch Vehicles",
     "author":          "Beale",
     "$kref":           "#/ckan/github/Tantares/TantaresLV",

--- a/NetKAN/TantaresSP.netkan
+++ b/NetKAN/TantaresSP.netkan
@@ -1,6 +1,7 @@
 {
     "spec_version":    "v1.18",
     "identifier":      "TantaresSP",
+    "name":            "Tantares SP - Soviet Space Probes",
     "abstract":        "Soviet Space Probes and Interplanetary Spacecraft",
     "author":          "Beale",
     "$kref":           "#/ckan/github/Tantares/TantaresSP",


### PR DESCRIPTION
Got a request from Beale to give the Tantares mods more explanatory names, since people seem to get confused about which one is which:
![request](https://user-images.githubusercontent.com/28812678/110977324-56217900-8362-11eb-8fc9-9dfd3a56a85a.png)

I've pointed to the abstract which already contains the keywords to help distinguish them, but they still think a more detailed mod name should help, so why not.