### PR TITLE
Add vrefs for Tantares SP and Tantares LV

### DIFF
--- a/NetKAN/NewTantaresLV.netkan
+++ b/NetKAN/NewTantaresLV.netkan
@@ -5,8 +5,7 @@
     "abstract":        "Stockalike Soviet and European Launch Vehicles",
     "author":          "Beale",
     "$kref":           "#/ckan/github/Tantares/TantaresLV",
-    "ksp_version_min": "1.10.1",
-    "ksp_version_max": "1.11",
+    "$vref":           "#/ckan/ksp-avc",
     "license":         "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage":  "https://forum.kerbalspaceprogram.com/index.php?/topic/73686-Tantares",

--- a/NetKAN/TantaresSP.netkan
+++ b/NetKAN/TantaresSP.netkan
@@ -5,8 +5,7 @@
     "abstract":        "Soviet Space Probes and Interplanetary Spacecraft",
     "author":          "Beale",
     "$kref":           "#/ckan/github/Tantares/TantaresSP",
-    "ksp_version_min": "1.10.1",
-    "ksp_version_max": "1.11",
+    "$vref":           "#/ckan/ksp-avc",
     "license":         "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage":  "https://forum.kerbalspaceprogram.com/index.php?/topic/73686-Tantares",


### PR DESCRIPTION
Both mods now include version files (and even valid on first try! :tada:), so let's remove the hardcoded version range.

The third Tantares mod should follow soon.