### PR TITLE
Mark ManeuverD as bundling Harmony1

### DIFF
--- a/NetKAN/ManeuverD.netkan
+++ b/NetKAN/ManeuverD.netkan
@@ -21,6 +21,8 @@
         "library"
     ],
     "provides": [ "Harmony1" ],
+    "x_netkan_staging": true,
+    "x_netkan_staging_reason": "Bundles Harmony. Please check the DLL's version, and if it's 2 or later, remove the provides and add a depends on Harmony2.",
     "install": [
         {
             "find": "ManeuverD",

--- a/NetKAN/ManeuverD.netkan
+++ b/NetKAN/ManeuverD.netkan
@@ -20,6 +20,7 @@
         "plugin",
         "library"
     ],
+    "provides": [ "Harmony1" ],
     "install": [
         {
             "find": "ManeuverD",


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/111556297-33bf9f00-8758-11eb-98b6-7507bf45c426.png)

(From KSP-CKAN/CKAN#3326.)

## Cause

This mod bundles Harmony, but we didn't know about it.
See KSP-CKAN/NetKAN#8288 for why that's bad.

## Changes

Now it's marked as providing Harmony1 and has staging enabled.
This way it won't be installed alongside Harmony2, and we'll get notifications if it's ever updated.