### PR TITLE
Add KSPBurst

### DIFF
--- a/NetKAN/KSPBurst-Lite.netkan
+++ b/NetKAN/KSPBurst-Lite.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version": "v1.4",
-    "identifier":   "KSPBurst-NOOP",
-    "name":         "KSPBurst no-op version",
+    "identifier":   "KSPBurst-Lite",
+    "name":         "KSPBurst Lite",
     "abstract":     "A stand-in for KSPBurst that satisfies all dependendent mods but doesn't install and run the compiler",
     "$kref":        "#/ckan/github/KSPModdingLibs/KSPBurst/asset_match/^KSPBurst_[0-9.]+_plugins_only\\.zip$",
     "$vref":        "#/ckan/ksp-avc",

--- a/NetKAN/KSPBurst-Lite.netkan
+++ b/NetKAN/KSPBurst-Lite.netkan
@@ -6,7 +6,7 @@
     "$kref":        "#/ckan/github/KSPModdingLibs/KSPBurst/asset_match/^KSPBurst_[0-9.]+_plugins_only\\.zip$",
     "$vref":        "#/ckan/ksp-avc",
     "author":       "dkavolis",
-    "license":      "MIT",
+    "license":      "unknown",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/201112-*",
         "repository": "https://github.com/KSPModdingLibs/KSPBurst"

--- a/NetKAN/KSPBurst-NOOP.netkan
+++ b/NetKAN/KSPBurst-NOOP.netkan
@@ -1,9 +1,9 @@
 {
     "spec_version": "v1.4",
-    "identifier":   "KSPBurst",
-    "name":         "KSPBurst",
-    "abstract":     "Burst compiler for Kerbal Space Program. Needs Mono installed on Linux and macOS.",
-    "$kref":        "#/ckan/github/KSPModdingLibs/KSPBurst/asset_match/^KSPBurst_[0-9.]+\\.zip$",
+    "identifier":   "KSPBurst-NOOP",
+    "name":         "KSPBurst no-op version",
+    "abstract":     "A stand-in for KSPBurst that satisfies all dependendent mods but doesn't install and run the compiler",
+    "$kref":        "#/ckan/github/KSPModdingLibs/KSPBurst/asset_match/^KSPBurst_[0-9.]+_plugins_only\\.zip$",
     "$vref":        "#/ckan/ksp-avc",
     "author":       "dkavolis",
     "license":      "MIT",
@@ -12,6 +12,7 @@
         "repository": "https://github.com/KSPModdingLibs/KSPBurst"
     },
     "tags": [ "library" ],
+    "provides": [ "KSPBurst" ],
     "install": [
         {
             "find"       : "000_KSPBurst",

--- a/NetKAN/KSPBurst-NOOP.netkan
+++ b/NetKAN/KSPBurst-NOOP.netkan
@@ -11,8 +11,9 @@
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/201112-*",
         "repository": "https://github.com/KSPModdingLibs/KSPBurst"
     },
-    "tags": [ "library" ],
-    "provides": [ "KSPBurst" ],
+    "tags":      [ "library" ],
+    "provides":  [ "KSPBurst" ],
+    "conflicts": [ { "name": "KSPBurst" } ],
     "install": [
         {
             "find"       : "000_KSPBurst",

--- a/NetKAN/KSPBurst.netkan
+++ b/NetKAN/KSPBurst.netkan
@@ -1,0 +1,21 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "KSPBurst",
+    "name": "KSPBurst",
+    "abstract": "Burst compiler for Kerbal Space Program",
+    "$kref": "#/ckan/github/KSPModdingLibs/KSPBurst/version_from_asset/^KSPBurst_[vV]?(?<version>\\d+(?:\\.\\d+){0,3})\\.zip$",
+    "$vref": "#/ckan/ksp-avc",
+    "license": "MIT",
+    "resources" : {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/201112-*",
+        "repository": "https://github.com/KSPModdingLibs/KSPBurst"
+    },
+    "tags": [ "library" ],
+    "provides"  : [ "Burst" ],
+    "install" : [
+        {
+            "find"       : "000_KSPBurst",
+            "install_to" : "GameData"
+        }
+    ]
+}

--- a/NetKAN/KSPBurst.netkan
+++ b/NetKAN/KSPBurst.netkan
@@ -6,7 +6,7 @@
     "$kref":        "#/ckan/github/KSPModdingLibs/KSPBurst/asset_match/^KSPBurst_[0-9.]+\\.zip$",
     "$vref":        "#/ckan/ksp-avc",
     "author":       "dkavolis",
-    "license":      "MIT",
+    "license":      "unknown",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/201112-*",
         "repository": "https://github.com/KSPModdingLibs/KSPBurst"


### PR DESCRIPTION
Replaces #8418 due to some commit weirdness, and GitHub locking the PR closed and no abillity to force-push to the previous commit.

Quick links:
* https://github.com/KSPModdingLibs/KSPBurst
* https://forum.kerbalspaceprogram.com/index.php?/topic/201112-18-111-kspburst-burst-compiler-for-kerbal-space-program/

KSPBurst is a library providing the Burst compiler tool. Some mods plan to use it in the future to make use of [Unity Jobs](https://docs.unity3d.com/Manual/JobSystem.html), which requires all job code to be located in a single DLL, so this mod allows mods to dynamically register themselves and compiles all code into a single DLL. At least that's my understanding.

Maintained and submitted by @dkavolis 