### PR TITLE
Remove TestFlight's asset_match

### DIFF
--- a/NetKAN/TestFlight.netkan
+++ b/NetKAN/TestFlight.netkan
@@ -1,40 +1,33 @@
 {
     "spec_version": "v1.2",
     "identifier":   "TestFlight",
-    "name":         "TestFlight",
-    "abstract":     "Flight Testing of your space hardware in KSP!  Fly your parts to gain flight data and make them more reliable and less likely to fail.  THIS IS THE PLUGIN ONLY.  You will need a TestFlight Config pack in order for any parts to actually be controlled by TestFlight.",
-    "$kref":        "#/ckan/github/KSP-RO/TestFlight/asset_match/TestFlightCore*",
+    "name":         "Test Flight",
+    "abstract":     "Flight Testing of your space hardware in KSP! Fly your parts to gain flight data and make them more reliable and less likely to fail.  THIS IS THE PLUGIN ONLY.  You will need a TestFlight Config pack in order for any parts to actually be controlled by TestFlight.",
+    "$kref":        "#/ckan/github/KSP-RO/TestFlight",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "CC-BY-NC-SA-4.0",
     "author":       [ "Agathorn", "KSP-RO Group" ],
     "release_status": "stable",
     "resources": {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/99043-*",
-        "repository": "https://github.com/KSP-RO/TestFlight",
-        "bugtracker": "https://github.com/KSP-RO/TestFlight/issues"
+        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/99043-*"
     },
     "tags": [
         "plugin"
     ],
-    "install": [
-        {
-            "file":       "GameData/TestFlight",
-            "install_to": "GameData",
-            "filter":     [ "Config" ]
-        }
-    ],
+    "install": [ {
+        "file":       "GameData/TestFlight",
+        "install_to": "GameData"
+    } ],
     "depends": [
-        { "name" : "TestFlightConfig" },
+        { "name" : "TestFlightConfig"     },
         { "name" : "ContractConfigurator" }
     ],
-    "x_netkan_override": [
-        {
-            "version": "1.3.1.1",
-            "delete":  [ "ksp_version" ],
-            "override": {
-                "ksp_version_min": "1.0.2",
-                "ksp_version_max": "1.0.4"
-            }
+    "x_netkan_override": [ {
+        "version": "1.3.1.1",
+        "delete":  [ "ksp_version" ],
+        "override": {
+            "ksp_version_min": "1.0.2",
+            "ksp_version_max": "1.0.4"
         }
-    ]
+    } ]
 }


### PR DESCRIPTION
This mod's releases aren't being indexed because of a mismatched asset_match:

https://github.com/KSP-RO/TestFlight/releases

Now this is removed.

Brought to my attention by @DRVeyl on Discord.