### PR TITLE
Add vrefs to mods with unused version files

### DIFF
--- a/NetKAN/BarisBridge.netkan
+++ b/NetKAN/BarisBridge.netkan
@@ -3,7 +3,7 @@
     "identifier":   "BarisBridge",
     "author":       "Angel125",
     "$kref":        "#/ckan/github/Angel-125/BARISBridge",
-    "ksp_version_min": "1.8",
+    "$vref":        "#/ckan/ksp-avc",
     "license":      "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/164448-*"

--- a/NetKAN/BarisBridge.netkan
+++ b/NetKAN/BarisBridge.netkan
@@ -3,7 +3,8 @@
     "identifier":   "BarisBridge",
     "author":       "Angel125",
     "$kref":        "#/ckan/github/Angel-125/BARISBridge",
-    "$vref":        "#/ckan/ksp-avc",
+    "comment":      "Version file has a syntax error",
+    "ksp_version_min": "1.8",
     "license":      "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/164448-*"

--- a/NetKAN/CST100Starliner.netkan
+++ b/NetKAN/CST100Starliner.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.18",
     "identifier":   "CST100Starliner",
     "$kref":        "#/ckan/spacedock/2405",
+    "$vref":        "#/ckan/ksp-avc",
     "license":      "CC-BY-NC-4.0",
     "tags": [
         "parts",

--- a/NetKAN/CST100Starliner.netkan
+++ b/NetKAN/CST100Starliner.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.18",
     "identifier":   "CST100Starliner",
     "$kref":        "#/ckan/spacedock/2405",
-    "$vref":        "#/ckan/ksp-avc",
+    "comment":      "Version file has a syntax error",
     "license":      "CC-BY-NC-4.0",
     "tags": [
         "parts",

--- a/NetKAN/FelineUtilityRovers.netkan
+++ b/NetKAN/FelineUtilityRovers.netkan
@@ -1,8 +1,9 @@
 {
-    "spec_version" : 1,
-    "identifier"   : "FelineUtilityRovers",
-    "$kref"        : "#/ckan/spacedock/1172",
-    "license"      : "CC-BY-NC",
+    "spec_version": 1,
+    "identifier":   "FelineUtilityRovers",
+    "$kref":        "#/ckan/spacedock/1172",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "CC-BY-NC",
     "tags": [
         "parts",
         "crewed"
@@ -11,7 +12,7 @@
         { "name": "ModuleManager" }
     ],
     "install": [ {
-        "file"       : "GameData/KerbetrotterLtd",
-        "install_to" : "GameData"
+        "file":       "GameData/KerbetrotterLtd",
+        "install_to": "GameData"
     } ]
 }

--- a/NetKAN/FelineUtilityRovers.netkan
+++ b/NetKAN/FelineUtilityRovers.netkan
@@ -2,7 +2,7 @@
     "spec_version": 1,
     "identifier":   "FelineUtilityRovers",
     "$kref":        "#/ckan/spacedock/1172",
-    "$vref":        "#/ckan/ksp-avc",
+    "comment":      "Version file has a syntax error",
     "license":      "CC-BY-NC",
     "tags": [
         "parts",

--- a/NetKAN/HullBreach.netkan
+++ b/NetKAN/HullBreach.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "HullBreach",
     "$kref":        "#/ckan/spacedock/935",
-    "$vref":        "#/ckan/ksp-avc",
+    "comment":      "Version file has a syntax error",
     "license":      "CC-BY-NC-SA",
     "resources": {
         "homepage":"http://forum.kerbalspaceprogram.com/index.php?/topic/133439-113-large-boat-parts-pack/&page=20#comment-2740885"

--- a/NetKAN/HullBreach.netkan
+++ b/NetKAN/HullBreach.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "HullBreach",
     "$kref":        "#/ckan/spacedock/935",
+    "$vref":        "#/ckan/ksp-avc",
     "license":      "CC-BY-NC-SA",
     "resources": {
         "homepage":"http://forum.kerbalspaceprogram.com/index.php?/topic/133439-113-large-boat-parts-pack/&page=20#comment-2740885"

--- a/NetKAN/JackOLantern.netkan
+++ b/NetKAN/JackOLantern.netkan
@@ -3,6 +3,7 @@
     "identifier":   "JackOLantern",
     "author":       [ "Porkjet", "zer0Kerbal" ],
     "$kref":        "#/ckan/spacedock/2261",
+    "$vref":        "#/ckan/ksp-avc",
     "license":      "CC-BY-NC-4.0",
     "tags": [
         "parts"

--- a/NetKAN/LunaMultiplayer.netkan
+++ b/NetKAN/LunaMultiplayer.netkan
@@ -3,7 +3,7 @@
     "identifier":   "LunaMultiplayer",
     "name":         "Luna Multiplayer Client",
     "$kref":        "#/ckan/github/LunaMultiplayer/LunaMultiplayer/asset_match/^LunaMultiplayer-Release\\.zip$",
-    "ksp_version":  "1.11",
+    "$vref":        "#/ckan/ksp-avc",
     "license":      "MIT",
     "tags": [
         "plugin"

--- a/NetKAN/LunaMultiplayer.netkan
+++ b/NetKAN/LunaMultiplayer.netkan
@@ -3,7 +3,8 @@
     "identifier":   "LunaMultiplayer",
     "name":         "Luna Multiplayer Client",
     "$kref":        "#/ckan/github/LunaMultiplayer/LunaMultiplayer/asset_match/^LunaMultiplayer-Release\\.zip$",
-    "$vref":        "#/ckan/ksp-avc",
+    "comment":      "Version file is outdated",
+    "ksp_version":  "1.11",
     "license":      "MIT",
     "tags": [
         "plugin"

--- a/NetKAN/ManhattanAirport.netkan
+++ b/NetKAN/ManhattanAirport.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "ManhattanAirport",
     "$kref":        "#/ckan/spacedock/2545",
-    "$vref":        "#/ckan/ksp-avc",
+    "comment":      "Version file has a syntax error",
     "license":      "CC-BY-NC-SA-4.0",
     "tags": [
         "config",

--- a/NetKAN/ManhattanAirport.netkan
+++ b/NetKAN/ManhattanAirport.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "ManhattanAirport",
     "$kref":        "#/ckan/spacedock/2545",
+    "$vref":        "#/ckan/ksp-avc",
     "license":      "CC-BY-NC-SA-4.0",
     "tags": [
         "config",

--- a/NetKAN/NoCrewRequirementContinued.netkan
+++ b/NetKAN/NoCrewRequirementContinued.netkan
@@ -3,7 +3,7 @@
     "identifier":   "NoCrewRequirementContinued",
     "author":       [ "RealGecko", "Orbinaut" ],
     "$kref":        "#/ckan/spacedock/715",
-    "ksp_version":  "any",
+    "$vref":        "#/ckan/ksp-avc",
     "license":      "GPL-3.0",
     "tags": [
         "config",

--- a/NetKAN/NoCrewRequirementContinued.netkan
+++ b/NetKAN/NoCrewRequirementContinued.netkan
@@ -3,7 +3,8 @@
     "identifier":   "NoCrewRequirementContinued",
     "author":       [ "RealGecko", "Orbinaut" ],
     "$kref":        "#/ckan/spacedock/715",
-    "$vref":        "#/ckan/ksp-avc",
+    "comment":      "Version file has no compat info, just a small MM patch",
+    "ksp_version":  "any",
     "license":      "GPL-3.0",
     "tags": [
         "config",

--- a/NetKAN/OldPartsRedux.netkan
+++ b/NetKAN/OldPartsRedux.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "OldPartsRedux",
     "$kref":        "#/ckan/spacedock/1744",
+    "$vref":        "#/ckan/ksp-avc",
     "license":      "MIT",
     "tags": [
         "parts"

--- a/NetKAN/OldPartsRedux.netkan
+++ b/NetKAN/OldPartsRedux.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "OldPartsRedux",
     "$kref":        "#/ckan/spacedock/1744",
-    "$vref":        "#/ckan/ksp-avc",
+    "comment":      "Version file has a syntax error",
     "license":      "MIT",
     "tags": [
         "parts"

--- a/NetKAN/RFStockalike.netkan
+++ b/NetKAN/RFStockalike.netkan
@@ -4,7 +4,7 @@
     "name":         "Real Fuels: Stockalike RF Configs",
     "abstract":     "Adds RealFuels configs to stock and many mods' engines, keeping engine role as designed to fit with stock and stock-aligned mods.",
     "$kref":        "#/ckan/github/Raptor831/RFStockalike",
-    "$vref":        "#/ckan/ksp-avc",
+    "comment":      "Version file has a syntax error",
     "license":      "CC-BY-SA",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/73410-*"

--- a/NetKAN/RFStockalike.netkan
+++ b/NetKAN/RFStockalike.netkan
@@ -1,36 +1,37 @@
 {
-    "spec_version" : "v1.4",
-    "identifier"   : "RFStockalike",
-    "name"         : "Real Fuels: Stockalike RF Configs",
-    "abstract"     : "Adds RealFuels configs to stock and many mods' engines, keeping engine role as designed to fit with stock and stock-aligned mods.",
-    "$kref"        : "#/ckan/github/Raptor831/RFStockalike",
-    "license"      : "CC-BY-SA",
-    "resources" : {
-        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/73410-*"
+    "spec_version": "v1.4",
+    "identifier":   "RFStockalike",
+    "name":         "Real Fuels: Stockalike RF Configs",
+    "abstract":     "Adds RealFuels configs to stock and many mods' engines, keeping engine role as designed to fit with stock and stock-aligned mods.",
+    "$kref":        "#/ckan/github/Raptor831/RFStockalike",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "CC-BY-SA",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/73410-*"
     },
     "tags": [
         "config"
     ],
-    "install" : [ {
-        "find"       : "GameData/RealFuels-Stockalike",
-        "install_to" : "GameData"
+    "install": [ {
+        "find":       "GameData/RealFuels-Stockalike",
+        "install_to": "GameData"
     }, {
-        "find"       : "GameData/RealPlume-RFStockalike",
-        "install_to" : "GameData"
+        "find":       "GameData/RealPlume-RFStockalike",
+        "install_to": "GameData"
     }, {
-        "find"       : "GameData/zzRFStockalike",
-        "install_to" : "GameData"
+        "find":       "GameData/zzRFStockalike",
+        "install_to": "GameData"
     } ],
-    "depends" : [
-        { "name" : "ModuleManager" },
-        { "name" : "RealFuels"     }
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "RealFuels"     }
     ],
-    "provides" : [
+    "provides": [
         "RealPlumeConfigs",
         "RealFuels-Engine-Configs"
     ],
-    "recommends" : [
-        { "name" : "RealPlume" }
+    "recommends": [
+        { "name": "RealPlume" }
     ],
-    "comment" : "Multiple configs can be installed; RO disables its engine configs if RFStockalike is detected. KSP-CKAN/NetKAN#55."
+    "comment": "Multiple configs can be installed; RO disables its engine configs if RFStockalike is detected. KSP-CKAN/NetKAN#55."
 }

--- a/NetKAN/RFStockalike.netkan
+++ b/NetKAN/RFStockalike.netkan
@@ -4,7 +4,7 @@
     "name":         "Real Fuels: Stockalike RF Configs",
     "abstract":     "Adds RealFuels configs to stock and many mods' engines, keeping engine role as designed to fit with stock and stock-aligned mods.",
     "$kref":        "#/ckan/github/Raptor831/RFStockalike",
-    "comment":      "Version file has a syntax error",
+    "comment":      "Version file has a syntax error.   Multiple configs can be installed; RO disables its engine configs if RFStockalike is detected. KSP-CKAN/NetKAN#55.",
     "license":      "CC-BY-SA",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/73410-*"
@@ -32,6 +32,5 @@
     ],
     "recommends": [
         { "name": "RealPlume" }
-    ],
-    "comment": "Multiple configs can be installed; RO disables its engine configs if RFStockalike is detected. KSP-CKAN/NetKAN#55."
+    ]
 }

--- a/NetKAN/ShowAllFuelsContinued.netkan
+++ b/NetKAN/ShowAllFuelsContinued.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "ShowAllFuelsContinued",
     "$kref":        "#/ckan/spacedock/1031",
+    "$vref":        "#/ckan/ksp-avc",
     "license":      "MIT",
     "tags": [
         "plugin",

--- a/NetKAN/ShowAllFuelsContinued.netkan
+++ b/NetKAN/ShowAllFuelsContinued.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "ShowAllFuelsContinued",
     "$kref":        "#/ckan/spacedock/1031",
-    "$vref":        "#/ckan/ksp-avc",
+    "comment":      "Version file has a syntax error",
     "license":      "MIT",
     "tags": [
         "plugin",

--- a/NetKAN/StreamlineEnginesRCSsandfueltanks.netkan
+++ b/NetKAN/StreamlineEnginesRCSsandfueltanks.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "StreamlineEnginesRCSsandfueltanks",
     "$kref":        "#/ckan/spacedock/1503",
+    "$vref":        "#/ckan/ksp-avc",
     "license":      "MIT",
     "tags": [
         "parts"

--- a/NetKAN/StreamlineEnginesRCSsandfueltanks.netkan
+++ b/NetKAN/StreamlineEnginesRCSsandfueltanks.netkan
@@ -2,7 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "StreamlineEnginesRCSsandfueltanks",
     "$kref":        "#/ckan/spacedock/1503",
-    "$vref":        "#/ckan/ksp-avc",
+    "comment":      "Version file has a syntax error",
     "license":      "MIT",
     "tags": [
         "parts"

--- a/NetKAN/UnKerballedStart.netkan
+++ b/NetKAN/UnKerballedStart.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "UnKerballedStart",
     "$kref":        "#/ckan/spacedock/2074",
+    "$vref":        "#/ckan/ksp-avc",
     "x_netkan_allow_out_of_order": true,
     "license":      "CC-BY-NC-SA-4.0",
     "tags": [


### PR DESCRIPTION
After KSP-CKAN/CKAN#3327 we now have a much more reasonable list of vref warnings:

![image](https://user-images.githubusercontent.com/1559108/111910388-0e34dd00-8a59-11eb-9710-d7f8de3101b2.png)

Now these mods have vrefs.

RadioFreeKerbin isn't updated because it has a metanetkan.

___

ckan compat add 1.8