### PR TITLE
Add MM dep for mods with MM syntax

### DIFF
--- a/NetKAN/CapsuleCorpKerbalKolonizationProgram.netkan
+++ b/NetKAN/CapsuleCorpKerbalKolonizationProgram.netkan
@@ -1,16 +1,18 @@
 {
     "spec_version": "v1.4",
-    "identifier": "CapsuleCorpKerbalKolonizationProgram",
-    "$kref": "#/ckan/spacedock/2558",
-    "license": "MIT",
-      "install": [ {
-        "find":"CapsuleCorp",
-        "install_to": "GameData"
-    } ],
+    "identifier":   "CapsuleCorpKerbalKolonizationProgram",
+    "$kref":        "#/ckan/spacedock/2558",
+    "license":      "MIT",
     "tags": [
         "config",
         "parts",
         "crewed"
     ],
-    "x_via": "Automated SpaceDock CKAN submission"
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
+    "install": [ {
+        "find":       "CapsuleCorp",
+        "install_to": "GameData"
+    } ]
 }

--- a/NetKAN/JamesWebbForKerbal.netkan
+++ b/NetKAN/JamesWebbForKerbal.netkan
@@ -8,6 +8,7 @@
         "science"
     ],
     "depends": [
+        { "name": "ModuleManager" },
         { "name": "TarsierSpaceTechnologyWithGalaxies" },
         { "name": "TexturesUnlimited" }
     ],

--- a/NetKAN/LosslessISRU.netkan
+++ b/NetKAN/LosslessISRU.netkan
@@ -6,5 +6,8 @@
     "tags": [
         "config",
         "resources"
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
     ]
 }


### PR DESCRIPTION
27 mods have the "ModuleManager syntax used without ModuleManager dependency" warning.
22 of these have metanetkans and so would have to be fixed by their authors.
ScienceRolesFinalFrontierRibbonPack and STMsFFRibbonPackExpeditionRibbons are false positives; they use a purely custom syntax in files with the .cfg extension.

The remaining 3 are fixed here.