### PR TITLE
Pin min compat of NorthKerbinDynamicRenewed

### DIFF
--- a/NetKAN/NorthKerbinDynamicRenewed.netkan
+++ b/NetKAN/NorthKerbinDynamicRenewed.netkan
@@ -23,5 +23,11 @@
     }, {
         "find":       "Craft/VAB",
         "install_to": "Ships"
+    } ],
+    "x_netkan_override": [ {
+        "version": "0.0.16",
+        "override": {
+            "ksp_version_min": "1.9.1"
+        }
     } ]
 }


### PR DESCRIPTION
This release was originally set as compatible with 1.9.1 on SpaceDock.