### PR TITLE
Override max compat for ProceduralFairings-ForEverything

### DIFF
--- a/NetKAN/ProceduralFairings-ForEverything.netkan
+++ b/NetKAN/ProceduralFairings-ForEverything.netkan
@@ -1,9 +1,15 @@
 {
     "spec_version": "v1.4",
-    "identifier": "ProceduralFairings-ForEverything",
-    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/KSP-RO/ProceduralFairings-ForEverything/master/ProceduralFairings-ForEverything.netkan",
-    "x_netkan_license_ok": true,
+    "identifier":   "ProceduralFairings-ForEverything",
+    "$kref":        "#/ckan/netkan/https://raw.githubusercontent.com/KSP-RO/ProceduralFairings-ForEverything/master/ProceduralFairings-ForEverything.netkan",
+    "license":      "CC-BY-SA",
     "tags": [
         "parts"
-    ]
+    ],
+    "x_netkan_override": [ {
+        "version": "v0.3.0",
+        "override": {
+            "ksp_version_max": "1.11"
+        }
+    } ]
 }


### PR DESCRIPTION
## Problem

This video gives a newbie-friendly introduction to installing RSS/RO/RP-1 on KSP 1.8 (since followed up with another video on how to install on KSP 1.11 which doesn't get into this mod):

https://www.youtube.com/watch?v=6glycvICehU

It mostly uses CKAN, but it says you have to manually install `ProceduralFairings-ForEverything`. This is because its `ksp_version_max` is only 1.7 so it doesn't show up as installable with the settings in the video. The remote version file specifies 1.11:

https://github.com/KSP-RO/ProceduralFairings-ForEverything/blob/master/GameData/ProceduralFairings-ForEverything/ProceduralFairings-ForEverything.version

However, the internal version file's URL property is wrong in the latest release, see KSP-RO/ProceduralFairings-ForEverything#12, so that change can't be picked up.

## Changes

Now the max game version for this release is overridden to 1.11. Hopefully the above linked fix PR will be merged before the next release so this can all work more smoothly in the future.