### PR TITLE
Pin min compat of OldPartsRedux

### DIFF
--- a/NetKAN/OldPartsRedux.netkan
+++ b/NetKAN/OldPartsRedux.netkan
@@ -6,5 +6,11 @@
     "license":      "MIT",
     "tags": [
         "parts"
-    ]
+    ],
+    "x_netkan_override": [ {
+        "version": "1:0.10.0",
+        "override": {
+            "ksp_version_min": "1.8.1"
+        }
+    } ]
 }


### PR DESCRIPTION
This SpaceDock mod was originally uploaded for KSP 1.8.1. It has a version file, but there's a syntax error, so we just use the SD data. The repo wasn't linked on SpaceDock or I would have submitted TriggeredSnake/OldPartsRedux#1 sooner.