### PR TITLE
Update install for KerbinPlacePack

### DIFF
--- a/NetKAN/KerbinPlacePack.netkan
+++ b/NetKAN/KerbinPlacePack.netkan
@@ -20,7 +20,7 @@
         { "name": "DodoLabsStockalikeElectron" }
     ],
     "install": [ {
-        "find":       "KerbinExpanisonPack",
+        "find":       "KerbinExpansionPack",
         "install_to": "GameData"
     } ]
 }


### PR DESCRIPTION
A new release is out which no longer uses the old misspelled path.
___

ckan compat add 1.8