### PR TITLE
Make Scatterer-sunflare and Scatterer-config depend on Scatterer

### DIFF
--- a/NetKAN/Scatterer-config.netkan
+++ b/NetKAN/Scatterer-config.netkan
@@ -1,16 +1,19 @@
 {
-    "spec_version": "v1.4",
-    "identifier":   "Scatterer-config",
-    "name":         "Scatterer Default Config",
-    "abstract":     "The default configuration files for scatterer",
-    "$kref":        "#/ckan/spacedock/141",
+    "spec_version":     "v1.4",
+    "identifier":       "Scatterer-config",
+    "name":             "Scatterer Default Config",
+    "abstract":         "The default configuration files for scatterer",
+    "$kref":            "#/ckan/spacedock/141",
     "x_netkan_force_v": true,
-    "x_netkan_epoch": "2",
-    "release_status": "development",
-    "license":      "GPL-3.0",
+    "x_netkan_epoch":   "3",
+    "release_status":   "development",
+    "license":          "GPL-3.0",
     "tags": [
         "graphics",
         "config"
+    ],
+    "depends": [
+        { "name": "Scatterer" }
     ],
     "conflicts": [
         { "name": "Scatterer-config" }

--- a/NetKAN/Scatterer-sunflare.netkan
+++ b/NetKAN/Scatterer-sunflare.netkan
@@ -1,16 +1,19 @@
 {
-    "spec_version": "v1.4",
-    "identifier":   "Scatterer-sunflare",
-    "name":         "Scatterer Sunflare",
-    "abstract":     "The sunflare component of scatterer",
-    "$kref":        "#/ckan/spacedock/141",
+    "spec_version":     "v1.4",
+    "identifier":       "Scatterer-sunflare",
+    "name":             "Scatterer Sunflare",
+    "abstract":         "The sunflare component of scatterer",
+    "$kref":            "#/ckan/spacedock/141",
     "x_netkan_force_v": true,
-    "x_netkan_epoch": "2",
-    "release_status": "development",
-    "license":      "GPL-3.0",
+    "x_netkan_epoch":   "3",
+    "release_status":   "development",
+    "license":          "GPL-3.0",
     "tags": [
         "graphics",
         "config"
+    ],
+    "depends": [
+        { "name": "Scatterer" }
     ],
     "provides": [
         "Scatterer-sunflare-default"

--- a/NetKAN/Scatterer.netkan
+++ b/NetKAN/Scatterer.netkan
@@ -1,11 +1,11 @@
 {
-    "spec_version": "v1.4",
-    "identifier":   "Scatterer",
-    "$kref":        "#/ckan/spacedock/141",
+    "spec_version":     "v1.4",
+    "identifier":       "Scatterer",
+    "$kref":            "#/ckan/spacedock/141",
     "x_netkan_force_v": true,
-    "x_netkan_epoch": "2",
-    "release_status": "development",
-    "license":      "GPL-3.0",
+    "x_netkan_epoch":   "3",
+    "release_status":   "development",
+    "license":          "GPL-3.0",
     "tags": [
         "graphics",
         "plugin"


### PR DESCRIPTION
Noticed while working on #8474 

`Scatterer-sunflare` and `Scatterer-config` don't depend on core `Scatterer`.
To my knowledge they do nothing without it being installed as well.

In a case like #8474 where the sunflares are a recommendation, or if a user sees sunflares and wants to install them, they might only select "Scatterer Sunflare" and don't realize that they need Scatterer as well, then wondering why it doesn't work.

I haven't found a reason why they don't have the dependency yet, so I guess it is "because nobody noticed it yet".

So this PR adds `Scatterer` to the dependencies of `Scatterer-sunflare` and `Scatterer-config`.