### PR TITLE
Share EPL core with SC

### DIFF
--- a/NetKAN/ExtraPlanetaryLaunchpads-Core.netkan
+++ b/NetKAN/ExtraPlanetaryLaunchpads-Core.netkan
@@ -1,0 +1,18 @@
+spec_version: v1.2
+identifier: ExtraPlanetaryLaunchpads-Core
+name: Extraplanetary Launchpads Core
+abstract: Plugin for ExtraPlanetaryLaunchpads
+author: taniwha
+$kref: '#/ckan/ksp-avc/http://taniwha.org/~bill/EL.version'
+$vref: >-
+  #/ckan/ksp-avc/ExtraplanetaryLaunchpads/Plugins/ExtraplanetaryLaunchpads.version
+license: GPL-3.0
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/54284-*
+  repository: https://github.com/taniwha-qf/Extraplanetary-Launchpads
+tags:
+  - plugin
+install:
+  - file: ExtraplanetaryLaunchpads/Plugins
+    install_to: GameData/ExtraplanetaryLaunchpads

--- a/NetKAN/ExtraPlanetaryLaunchpads.netkan
+++ b/NetKAN/ExtraPlanetaryLaunchpads.netkan
@@ -1,46 +1,36 @@
-{
-    "spec_version"   : 1,
-    "identifier"     : "ExtraPlanetaryLaunchpads",
-    "name"           : "Extraplanetary Launchpads",
-    "abstract"       : "Adds the ability to build crafts in flight mode to your game.",
-    "author"         : "taniwha",
-    "$kref"          : "#/ckan/ksp-avc/http://taniwha.org/~bill/EL.version",
-    "$vref"          : "#/ckan/ksp-avc/ExtraplanetaryLaunchpads/Plugins/ExtraplanetaryLaunchpads.version",
-    "license"        : "GPL-3.0",
-    "release_status" : "stable",
-    "resources"      : {
-        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/54284-*",
-        "repository" : "https://github.com/taniwha-qf/Extraplanetary-Launchpads"
-    },
-    "tags"           : [
-        "plugin",
-        "parts",
-        "crewed"
-    ],
-    "depends"        : [
-        { "name" : "ModuleManager" }
-    ],
-    "recommends"     : [
-        { "name" : "KIS"              },
-        { "name" : "KAS"              },
-        { "name" : "InfernalRobotics" },
-        { "name" : "KerbalStats"      },
-        { "name" : "Kethane"          },
-        { "name" : "Toolbar"          }
-    ],
-    "install"        : [
-        {
-            "file"       : "ExtraplanetaryLaunchpads",
-            "install_to" : "GameData",
-            "filter"     : "Ships"
-        },
-        {
-            "file"       : "ExtraplanetaryLaunchpads/Ships/SPH",
-            "install_to" : "Ships"
-        },
-        {
-            "file"       : "ExtraplanetaryLaunchpads/Ships/VAB",
-            "install_to" : "Ships"
-        }
-    ]
-}
+spec_version: 1
+identifier: ExtraPlanetaryLaunchpads
+name: Extraplanetary Launchpads
+abstract: Build crafts in flight mode
+author: taniwha
+$kref: '#/ckan/ksp-avc/http://taniwha.org/~bill/EL.version'
+$vref: >-
+  #/ckan/ksp-avc/ExtraplanetaryLaunchpads/Plugins/ExtraplanetaryLaunchpads.version
+license: GPL-3.0
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/54284-*
+  repository: https://github.com/taniwha-qf/Extraplanetary-Launchpads
+tags:
+  - parts
+  - crewed
+depends:
+  - name: ModuleManager
+  - name: ExtraPlanetaryLaunchpads-Core
+recommends:
+  - name: KIS
+  - name: KAS
+  - name: InfernalRobotics
+  - name: KerbalStats
+  - name: Kethane
+  - name: Toolbar
+install:
+  - file: ExtraplanetaryLaunchpads
+    install_to: GameData
+    filter:
+      - Ships
+      - Plugins
+  - file: ExtraplanetaryLaunchpads/Ships/SPH
+    install_to: Ships
+  - file: ExtraplanetaryLaunchpads/Ships/VAB
+    install_to: Ships

--- a/NetKAN/SimpleConstruction.netkan
+++ b/NetKAN/SimpleConstruction.netkan
@@ -16,6 +16,7 @@ tags:
   - config
 depends:
   - name: ModuleManager
+  - name: ExtraPlanetaryLaunchpads-Core
   - name: CommunityResourcePack
 recommends:
   - name: KerbalStats
@@ -39,5 +40,4 @@ provides:
 install:
   - find: SimpleConstruction
     install_to: GameData
-  - find: ExtraplanetaryLaunchpads
-    install_to: GameData
+    filter: Plugins


### PR DESCRIPTION
## Background

- https://spacedock.info/mod/59/SimpleConstruction
- https://github.com/zer0Kerbal/SimpleConstruction

## Motivation

![image](https://user-images.githubusercontent.com/1559108/114786843-57353400-9d6e-11eb-95d5-7e260d5d5db1.png)

##  Changes

- EPL's DLL is split out into `ExtraplanetaryLaunchpads-Core`
- EPL now depends on core
- SimpleConstruction now depends on EPL core and no longer installs its own EPL DLL or provides EPL