### PR TITLE
Force v for BDArmoryForRunwayProject

### DIFF
--- a/NetKAN/BDArmoryForRunwayProject.netkan
+++ b/NetKAN/BDArmoryForRunwayProject.netkan
@@ -1,10 +1,11 @@
 {
-    "spec_version": "v1.18",
-    "identifier":   "BDArmoryForRunwayProject",
-    "author":       [ "BahamutoD", "Papa_Joe", "jrodrigv", "ouloul", "Scott Manley", "JR", "DocNappers", "Cl0by", "josue", "aubranium", "benbenwilde", "TheKurgan" ],
-    "$kref":        "#/ckan/spacedock/2487",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-SA-2.0",
+    "spec_version":     "v1.18",
+    "identifier":       "BDArmoryForRunwayProject",
+    "author":           [ "BahamutoD", "Papa_Joe", "jrodrigv", "ouloul", "Scott Manley", "JR", "DocNappers", "Cl0by", "josue", "aubranium", "benbenwilde", "TheKurgan" ],
+    "$kref":            "#/ckan/spacedock/2487",
+    "$vref":            "#/ckan/ksp-avc",
+    "x_netkan_force_v": true,
+    "license":          "CC-BY-SA-2.0",
     "tags": [
         "plugin",
         "parts",


### PR DESCRIPTION
This mod keeps changing between a 'v' prefix and no prefix:
* https://github.com/KSP-CKAN/CKAN-meta/pull/2292
* https://github.com/KSP-CKAN/CKAN-meta/pull/2318
* https://github.com/KSP-CKAN/CKAN-meta/pull/2333

https://spacedock.info/mod/2487/BDArmory%20for%20Runway%20Project

Let's put an end to this and force a `v`, then the author can do whatever they want and we don't have to merge an epoch bump PR every other week.

Closes https://github.com/KSP-CKAN/CKAN-meta/pull/2333