### PR TITLE
Add KSP-Data-Export

### DIFF
--- a/NetKAN/KSP-Data-Export.netkan
+++ b/NetKAN/KSP-Data-Export.netkan
@@ -1,0 +1,15 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "KSP-Data-Export",
+    "$kref":        "#/ckan/spacedock/2711",
+    "license":      "MIT",
+    "tags": [
+        "plugin",
+        "app",
+        "information"
+    ],
+    "install": [ {
+        "find":       "DataExport",
+        "install_to": "GameData"
+    } ]
+}


### PR DESCRIPTION
A mod that exports flight data to CSV files. It has the CKAN badge on SpaceDock, but the automated PR did not generate.

https://spacedock.info/mod/2711/KSP%20Data%20Export

https://forum.kerbalspaceprogram.com/index.php?/topic/201967-111x-export-flight-data-to-a-csv-file-mod/

Hi @kna27, this is the pull request to add your mod to CKAN. The metadata validation process will be visible under the "Checks" tab once it begins.