### PR TITLE
Set Kerbal Flight Indicators repo back to DaMichel's

### DIFF
--- a/NetKAN/KerbalFlightIndicators.netkan
+++ b/NetKAN/KerbalFlightIndicators.netkan
@@ -3,7 +3,7 @@
     "identifier"   : "KerbalFlightIndicators",
     "name"         : "Kerbal Flight Indicators",
     "abstract"     : "Displays indicators for the flight vector and other things. Works like a HUD. In external view, too!",
-    "$kref"        : "#/ckan/github/PapaJoesSoup/KerbalFlightIndicators",
+    "$kref"        : "#/ckan/github/DaMichel/KerbalFlightIndicators",
     "$vref"        : "#/ckan/ksp-avc",
     "license"      : "CC-BY-NC-SA-3.0",
     "resources" : {


### PR DESCRIPTION
I updated the mod for ksp 1.11.x. Looks like PapaJoe is not active currenlty so I'm pointing the reference back to my repo.

https://github.com/DaMichel/KerbalFlightIndicators
Current thread by Papa Joe: https://forum.kerbalspaceprogram.com/index.php?/topic/172904-kfi
Previous thread by DaMichel: https://forum.kerbalspaceprogram.com/index.php?/topic/72595-kfi