### PR TITLE
Fix KerbalTelemetry install

### DIFF
--- a/NetKAN/KerbalTelemetry.netkan
+++ b/NetKAN/KerbalTelemetry.netkan
@@ -1,5 +1,5 @@
 {
-    "spec_version": 1,
+    "spec_version": "v1.4",
     "identifier":   "KerbalTelemetry",
     "$kref":        "#/ckan/spacedock/2643",
     "license":      "MIT",
@@ -10,7 +10,10 @@
     ],
     "install": [
         {
-            "file": "GameData",
+            "find":       "Kerbal Telemetry",
+            "install_to": "GameData"
+        }, {
+            "find":       "Kerbal Telemetry.dll",
             "install_to": "GameData"
         }
     ]


### PR DESCRIPTION
This mod has changed its layout in the last release:

> New inflation error for KerbalTelemetry: No files found matching file="GameData" to install!

> * Kerbal Telemetry folder has been moved into the GameData folder to allow users to download mod from CurseForge without moving files and folders around.

The Python server part goes into GameData now as well, so we can install it too.
Why they haven't moved the `Kerbal Telemetry.dll` inside the `Kerbal Telemetry` folder, no idea.

The common top-level folder has a naming I'm not expecting to stay stable (`Kerbal-Telemetry-v2`) , so I'm picking the DLL and the folder out separately.
Let's see how long it takes for this stanza to fail.

The source code for reference:
https://github.com/yagiziskirik/Kerbal-Telemetry/blob/d9da45d6a46b3fbeda7948723a28a580400bdd02/Kerbal%20Telemetry/Class1.cs#L222
```
File.WriteAllText(@"GameData\Kerbal Telemetry\static\data.json", data);
```