### PR TITLE
Update RealAntennas.netkan

### DIFF
--- a/NetKAN/RealAntennas.netkan
+++ b/NetKAN/RealAntennas.netkan
@@ -14,7 +14,8 @@
         "plugin"
     ],
     "depends": [
-        { "name": "ModuleManager" }
+        { "name": "ModuleManager" },
+        { "name": "KSPBurst" }
     ],
     "conflicts" : [
         { "name" : "RemoteTech" },


### PR DESCRIPTION
Prep for releasing <https://github.com/DRVeyl/RealAntennas/releases/tag/v2.0>
In pre-release on 16 MAY 2021.  New release will require KSPBurst.  Edited by hand, wanted to make sure this is ready to go for when I officially release 2.0 (expect 17 MAY) and it indexes.

I can update a comment here when that happens.  I'll mark the PR as draft until then.