### PR TITLE
Update SDHI-StrobeOMatic compatibility

### DIFF
--- a/NetKAN/SDHI-StrobeOMatic.netkan
+++ b/NetKAN/SDHI-StrobeOMatic.netkan
@@ -6,7 +6,7 @@
     "$kref"        : "#/ckan/github/sumghai/SDHI_StrobeOMatic",
     "x_netkan_force_v": true,
     "ksp_version_min": "1.4",
-    "ksp_version_max": "1.8",
+    "ksp_version_max": "1.11",
     "license"      : "CC-BY-SA-4.0",
     "resources"    : {
         "homepage"   : "http://forum.kerbalspaceprogram.com/index.php?/topic/137804-*",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/119754226-c883fe80-be65-11eb-8c9d-656aaa2881d9.png)

The current version of KSP on January 12, 2021 was 1.11.0.

Noticed while investigating for #8546.