### PR TITLE
Add IXSWarpship-Blueshift and FlyingSaucers

### DIFF
--- a/NetKAN/FlyingSaucers.netkan
+++ b/NetKAN/FlyingSaucers.netkan
@@ -1,0 +1,25 @@
+spec_version: v1.4
+identifier: FlyingSaucers
+$kref: '#/ckan/github/Angel-125/FlyingSaucers'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - parts
+  - plugin
+depends:
+  - name: ModuleManager
+  - name: NearFutureProps
+  - name: BarisBridge
+  - name: WildBlueTools
+  - name: KerbalActuators
+recommends:
+  - name: ClassicStockResources
+install:
+  - find: GameData/WildBlueIndustries/FlyingSaucers
+    install_to: GameData/WildBlueIndustries
+    filter:
+      - Ships
+  - find: Ships/SPH
+    install_to: Ships
+  - find: Ships/VAB
+    install_to: Ships

--- a/NetKAN/FlyingSaucers.netkan
+++ b/NetKAN/FlyingSaucers.netkan
@@ -2,10 +2,13 @@ spec_version: v1.4
 identifier: FlyingSaucers
 $kref: '#/ckan/github/Angel-125/FlyingSaucers'
 $vref: '#/ckan/ksp-avc'
-license: GPL-3.0
+license: restricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/173857-*
 tags:
   - parts
   - plugin
+  - crewed
 depends:
   - name: ModuleManager
   - name: NearFutureProps
@@ -13,13 +16,13 @@ depends:
   - name: WildBlueTools
   - name: KerbalActuators
 recommends:
-  - name: ClassicStockResources
+  - name: ExtraPlanetaryLaunchpads
+suggests:
+  - name: KIS
+  - name: KAS
+  - name: kOS
+  - name: Snacks
+  - name: TACLS
 install:
   - find: GameData/WildBlueIndustries/FlyingSaucers
     install_to: GameData/WildBlueIndustries
-    filter:
-      - Ships
-  - find: Ships/SPH
-    install_to: Ships
-  - find: Ships/VAB
-    install_to: Ships

--- a/NetKAN/IXSWarpship-Blueshift.netkan
+++ b/NetKAN/IXSWarpship-Blueshift.netkan
@@ -1,0 +1,25 @@
+spec_version: v1.4
+identifier: IXSWarpship-Blueshift
+$kref: '#/ckan/github/Araym-KSP/IXS-Warship-for-Blueshift'
+x_netkan_github:
+  use_source_archive: true
+license: GPL-3.0
+tags:
+  - config
+  - parts
+  - crewed
+depends:
+  - name: ModuleManager
+  - name: IXSWarpshipOS
+  - name: Blueshift
+  - name: FlyingSaucers
+  - name: Waterfall
+  - name: CommunityResourcePack
+suggests:
+  - name: SpaceDust
+  - name: CommunityTechTree
+  - name: FarFutureTechnologies
+  - name: OuterPlanetsMod
+install:
+  - find: IXSWarshipsBlueshift
+    install_to: GameData


### PR DESCRIPTION
I was lurking on this thread because IXS ships look neat, and the first question and answer was about CKAN:

- https://forum.kerbalspaceprogram.com/index.php?/topic/202697-111x-ixs-warpship-for-blueshift-warp-mod-v104/
- https://github.com/Araym-KSP/IXS-Warship-for-Blueshift

~~The author gave what I interpret as a "soft no," in that he isn't interested in spending extra time on figuring out CKAN procedures or metadata, but it's not clear how he would feel about it if all the work was done for him (hence this pull request, which is intended to do all the work for him).~~

It depends on Flying Saucers, ~~which Angel-125 says will be added to CKAN eventually, but not yet~~:

- https://forum.kerbalspaceprogram.com/index.php?/topic/173857-min-ksp-181-kerbal-flying-saucers-build-flying-saucers-in-ksp/page/37/&tab=comments#comment-3889809
- https://github.com/Angel-125/FlyingSaucers

~~So we can't merge this yet for multiple reasons. I just want to see whether these netkans pass validation.~~

UPDATE 2021-09-04:
@Angel-125 has submitted #8747, so FlyingSaucers is now ready to be indexed, and IXSWarpship-Blueshift's author has approved CKAN indexing on the forum. So we should be able to merge this. If we do, it also replaces #8747 because the only new mod in that PR is FlyingSaucers, Blueshift having been added in #8357.

Closes #8747.