### PR TITLE
Make RSSTextures16K compatible with 1.8+

### DIFF
--- a/NetKAN/RSSTextures16K.netkan
+++ b/NetKAN/RSSTextures16K.netkan
@@ -4,7 +4,7 @@
     "name":         "Real Solar System Textures - 16384 x 8192",
     "abstract":     "Textures for Real Solar Systems",
     "$kref":        "#/ckan/github/KSP-RO/RSS-Textures/asset_match/16384",
-    "ksp_version":  "1.8",
+    "ksp_version_min": "1.8",
     "license":      "CC-BY-NC-SA-4.0",
     "tags": [
         "config",


### PR DESCRIPTION
Adding a new author caused KSP-CKAN/CKAN-meta#2342 to be submitted, because the 16K textures are only marked as compatible with 1.8.

The other texture packs use 1.8 as a minimum:

https://github.com/KSP-CKAN/NetKAN/blob/b2dd4e2432d407cf3e64b6db4a08121d39c3caf7/NetKAN/RSSTextures8192.netkan#L9

https://github.com/KSP-CKAN/NetKAN/blob/b2dd4e2432d407cf3e64b6db4a08121d39c3caf7/NetKAN/RSSTextures4096.netkan#L9

https://github.com/KSP-CKAN/NetKAN/blob/b2dd4e2432d407cf3e64b6db4a08121d39c3caf7/NetKAN/RSSTextures2048.netkan#L9

So now this one will, too.