### PR TITLE
Add missing RealisticPowerDraw depends

### DIFF
--- a/NetKAN/RealisticPowerDraw.netkan
+++ b/NetKAN/RealisticPowerDraw.netkan
@@ -1,27 +1,15 @@
 {
-  "license": "GPL-2.0",
-  "identifier": "RealisticPowerDraw",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "$kref": "#/ckan/spacedock/2565",
-  "$vref": "#/ckan/ksp-avc",
-  "resources": {
-    "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/198035-18x-19x-110x-realistic-power-draw/",
-    "repository": "https://github.com/linuxgurugamer/RealisticPowerDraw"
-  },
-  "depends": [
-    {
-      "name": "ModuleManager"
-    }
-  ],
-  "tags": [
-    "config",
-    "resources"
-  ],
-  "install": [
-    {
-      "find": "RealisticPowerDraw",
-      "install_to": "GameData"
-    }
-  ],
-  "spec_version": "v1.4"
+    "spec_version": "v1.4",
+    "identifier":   "RealisticPowerDraw",
+    "$kref":        "#/ckan/spacedock/2565",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "GPL-2.0",
+    "depends": [
+        { "name": "ModuleManager"                  },
+        { "name": "ModuleAnimGenericResourceUsage" }
+    ],
+    "tags": [
+        "config",
+        "resources"
+    ]
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/121037244-e8c09100-c774-11eb-9b55-f5aff94a8bd8.png)

Confirmed on the thread.

![image](https://user-images.githubusercontent.com/1559108/121037297-f4ac5300-c774-11eb-8d6a-a64bd37a0475.png)

Also confirmed it was not added in #8222.