### PR TITLE
Hard code IFS repo links

### DIFF
--- a/NetKAN/InterstellarFuelSwitch-Core.netkan
+++ b/NetKAN/InterstellarFuelSwitch-Core.netkan
@@ -1,29 +1,18 @@
 {
     "spec_version" : "v1.4",
-    "$kref"        : "#/ckan/spacedock/175",
-    "$vref"        : "#/ckan/ksp-avc/InterstellarFuelSwitch.version",
     "identifier"   : "InterstellarFuelSwitch-Core",
     "name"         : "Interstellar Fuel Switch Core",
     "abstract"     : "Core plugin for Interstellar Fuel Switch",
+    "$kref"        : "#/ckan/spacedock/175",
+    "$vref"        : "#/ckan/ksp-avc/InterstellarFuelSwitch.version",
     "license"      : "GPL-2.0",
+    "resources": {
+        "repository": "https://github.com/sswelm/KSP-Interstellar-Extended/tree/master/FuelSwitch"
+    },
     "tags": [
         "plugin",
         "resources",
         "library"
-    ],
-    "install": [
-        {
-            "find"       : "InterstellarFuelSwitch/Plugins",
-            "install_to" : "GameData/InterstellarFuelSwitch"
-        },
-        {
-            "find"       : "InterstellarFuelSwitch/Resources",
-            "install_to" : "GameData/InterstellarFuelSwitch"
-        },
-        {
-            "find"       : "InterstellarFuelSwitch/Localization",
-            "install_to" : "GameData/InterstellarFuelSwitch"
-        }
     ],
     "provides": [
         "DeadskinsTextureSwitch",
@@ -35,5 +24,15 @@
     ],
     "recommends": [
         { "name" : "CommunityResourcePack", "min_version" : "0.7.1" }
-    ]
+    ],
+    "install": [ {
+        "find":       "InterstellarFuelSwitch/Plugins",
+        "install_to": "GameData/InterstellarFuelSwitch"
+    }, {
+        "find":       "InterstellarFuelSwitch/Resources",
+        "install_to": "GameData/InterstellarFuelSwitch"
+    }, {
+        "find":       "InterstellarFuelSwitch/Localization",
+        "install_to": "GameData/InterstellarFuelSwitch"
+    } ]
 }

--- a/NetKAN/InterstellarFuelSwitch.netkan
+++ b/NetKAN/InterstellarFuelSwitch.netkan
@@ -1,29 +1,29 @@
 {
     "spec_version": "v1.4",
     "identifier":   "InterstellarFuelSwitch",
-    "abstract":     "Library that enables switching the contents, meshes, and textures of tanks.",
+    "abstract":     "Library that enables switching the contents, meshes, and textures of tanks",
     "$kref":        "#/ckan/spacedock/175",
     "$vref":        "#/ckan/ksp-avc/InterstellarFuelSwitch.version",
     "license":      "GPL-2.0",
     "resources": {
-        "bugtracker": "https://github.com/sswelm/KSP-Interstellar-Extended/issues"
+        "repository": "https://github.com/sswelm/KSP-Interstellar-Extended/tree/master/FuelSwitch"
     },
     "tags": [
         "crewed",
         "parts"
     ],
+    "depends": [
+        { "name": "ModuleManager"                                       },
+        { "name": "InterstellarFuelSwitch-Core", "min_version" : "1.28" },
+        { "name": "CommunityTechTree"                                   }
+    ],
+    "recommends": [
+        { "name": "KSPInterstellarExtended" },
+        { "name": "PatchManager"            }
+    ],
     "install": [ {
         "find":       "InterstellarFuelSwitch",
         "install_to": "GameData",
         "filter":     [ "Plugins", "Resources", "Localization" ]
-    } ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "InterstellarFuelSwitch-Core", "min_version" : "1.28" },
-        { "name": "CommunityTechTree" }
-    ],
-    "recommends": [
-        { "name": "KSPInterstellarExtended" },
-        { "name": "PatchManager" }
-    ]
+    } ]
 }


### PR DESCRIPTION
## Problem

See KSP-CKAN/CKAN#3390, I'd like to use the GitHub API to populate `resources.repository` for mods on SpaceDock, but InterstellarFuelSwitch uses a special link to a particular subdirectory of the main KSPInterstellarExtended repo, which we would like to preserve, and which would be truncated to the main repo with that change.

## Changes

Now IFS's `resources.respository` "deep links" are set in the netkans, so they will be set regardless of how we treat this property in the Inflator.