### PR TITLE
Convert PlanningNode netkan to YAML

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 *.ckan linguist-language=JSON linguist-detectable=true
-*.netkan linguist-language=JSON linguist-detectable=true
+*.netkan linguist-language=YAML linguist-detectable=true
 *.frozen linguist-language=JSON linguist-detectable=true

--- a/NetKAN/PlanningNode.netkan
+++ b/NetKAN/PlanningNode.netkan
@@ -1,10 +1,7 @@
-{
-    "spec_version": 1,
-    "identifier":   "PlanningNode",
-    "$kref":        "#/ckan/github/HebaruSan/PlanningNode",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "information"
-    ]
-}
+spec_version: 1
+identifier:   PlanningNode
+"$kref":      "#/ckan/github/HebaruSan/PlanningNode"
+license:      GPL-3.0
+tags:
+  - plugin
+  - information


### PR DESCRIPTION
As of KSP-CKAN/CKAN#3367, netkans are allowed to use YAML format, however so far none do.
Now PlanningNode uses YAML format. This will give us a test case for YAML to make sure it works.
Also the git attributes are updated to count .netkan files as YAML instead of JSON.