### PR TITLE
Fix PlanetShine indentation

### DIFF
--- a/NetKAN/PlanetShine.netkan
+++ b/NetKAN/PlanetShine.netkan
@@ -5,7 +5,7 @@
     "abstract":     "Planets and moons reflects their light to your vessel + other ambient light improvements",
     "$kref":        "#/ckan/github/prestja/ksp-planetshine",
     "$vref":        "#/ckan/ksp-avc",
-	"license":      "Apache-2.0",
+    "license":      "Apache-2.0",
     "resources": {
         "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/189071-*",
         "repository": "https://github.com/prestja/ksp-planetshine"


### PR DESCRIPTION
One of the mods that caused https://github.com/KSP-CKAN/NetKAN-Infra/pull/220

GitHub highlights this syntax error nicely, now that all netkans are marked as YAML (https://github.com/KSP-CKAN/NetKAN/pull/8566), so I think it was a good thing to do in the end.

![image](https://user-images.githubusercontent.com/28812678/122736087-ef283000-d27f-11eb-8aea-99c855d7453b.png)


https://github.com/KSP-CKAN/NetKAN/blob/339d2f3dc336ec880be6b587a352d0e0d809d583/NetKAN/PlanetShine.netkan#L7-L9