### PR TITLE
Remove EVE-Config provides from StrangeNewWorlds

### DIFF
--- a/NetKAN/AstronomersVisualPack.netkan
+++ b/NetKAN/AstronomersVisualPack.netkan
@@ -8,10 +8,14 @@
     "license"      : "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160878-*"
-	},
+    },
     "tags": [
         "config",
         "graphics"
+    ],
+    "provides": [
+        "EnvironmentalVisualEnhancements-Config",
+        "EnvironmentalVisualEnhancements-Config-stock"
     ],
     "conflicts": [
         { "name" : "EnvironmentalVisualEnhancements-Config" }
@@ -30,8 +34,5 @@
         { "name": "DistantObject" },
         { "name": "PlanetShine" },
         { "name": "Chatterer" }
-    ],
-    "provides" : [
-        "EnvironmentalVisualEnhancements-Config"
     ]
 }

--- a/NetKAN/EnvironmentalVisualEnhancements-LR.frozen
+++ b/NetKAN/EnvironmentalVisualEnhancements-LR.frozen
@@ -18,7 +18,8 @@
         }
     ],
     "provides": [
-        "EnvironmentalVisualEnhancements-Config"
+        "EnvironmentalVisualEnhancements-Config",
+        "EnvironmentalVisualEnhancements-Config-stock"
     ],
     "depends": [
         { "name" : "EnvironmentalVisualEnhancements" }

--- a/NetKAN/SciFiVisualEnhancements-WeimaranersTweaks.netkan
+++ b/NetKAN/SciFiVisualEnhancements-WeimaranersTweaks.netkan
@@ -9,6 +9,7 @@
     ],
     "provides":  [
         "EnvironmentalVisualEnhancements-Config",
+        "EnvironmentalVisualEnhancements-Config-stock",
         "SciFiVisualEnhancements"
     ],
     "conflicts": [

--- a/NetKAN/SciFiVisualEnhancements.netkan
+++ b/NetKAN/SciFiVisualEnhancements.netkan
@@ -15,7 +15,10 @@
         "config",
         "graphics"
     ],
-    "provides":  [ "EnvironmentalVisualEnhancements-Config" ],
+    "provides":  [
+        "EnvironmentalVisualEnhancements-Config",
+        "EnvironmentalVisualEnhancements-Config-stock"
+    ],
     "conflicts": [
         { "name" : "EnvironmentalVisualEnhancements-Config" }
     ],

--- a/NetKAN/Spectra.netkan
+++ b/NetKAN/Spectra.netkan
@@ -17,7 +17,8 @@
         "graphics"
     ],
     "provides": [
-        "EnvironmentalVisualEnhancements-Config"
+        "EnvironmentalVisualEnhancements-Config",
+        "EnvironmentalVisualEnhancements-Config-stock"
     ],
     "conflicts": [
         { "name": "EnvironmentalVisualEnhancements-Config" }

--- a/NetKAN/StockVisualEnhancements.netkan
+++ b/NetKAN/StockVisualEnhancements.netkan
@@ -18,7 +18,8 @@
         "graphics"
     ],
     "provides": [
-        "EnvironmentalVisualEnhancements-Config"
+        "EnvironmentalVisualEnhancements-Config",
+        "EnvironmentalVisualEnhancements-Config-stock"
     ],
     "conflicts": [
         { "name" : "EnvironmentalVisualEnhancements-Config" },

--- a/NetKAN/StrangeNewWorlds.netkan
+++ b/NetKAN/StrangeNewWorlds.netkan
@@ -7,17 +7,15 @@
         "config",
         "planet-pack"
     ],
-    "provides": [
-        "EnvironmentalVisualEnhancements-Config"
-    ],
     "depends": [
         { "name": "ModuleManager" },
         { "name": "Kopernicus"    }
     ],
     "recommends": [
-        { "name": "EnvironmentalVisualEnhancements"        },
-        { "name": "Scatterer"                              },
-        { "name": "TiltUnlocker"                           },
+        { "name": "EnvironmentalVisualEnhancements"              },
+        { "name": "EnvironmentalVisualEnhancements-Config-stock" },
+        { "name": "Scatterer"                                    },
+        { "name": "TiltUnlocker"                                 },
         { "any_of": [
             { "name": "KopernicusExpansionContinued-Wormholes" },
             { "name": "Blueshift"                              },


### PR DESCRIPTION
Just got pinged by the author on the Kopernicus Discord that this mod conflicts with AVP on CKAN, but it shouldn't.
This is due to the `EnvironmentalVisualEnhancements-Config` provides.

This mod only provides EVE configs for its own planets, but not the stock ones, and it doesn't remove the stock planets.
Thus it still needs another set of EVE configs installed alongside (default configs, AVP, ...) to make EVE work to its full extents,

Now the provides is removed, and instead the virtual module `EnvironmentalVisualEnhancements-Config-stock` is added to the recommendations, alongside `EnvironmentalVisualEnhancements`.

Several EVE config packs that provide configs for the stock planet now provide `EnvironmentalVisualEnhancements-Config-stock`.

---

I've also sent the author a notice about the huge `.git` folder in the zip that really doesn't need to be there;
```
$ du -chd2 SNW/ | sort -h
427K    SNW/__MACOSX
427K    SNW/__MACOSX/StrangeNewWorlds
755M    SNW/StrangeNewWorlds/GameData
778M    SNW/StrangeNewWorlds/.git
1.5G    SNW/StrangeNewWorlds
1.5G    SNW/
1.5G    total
```

It's outside the directory we're installing, so we don't need to filter it extra.