### PR TITLE
Add Harmony2 dependency to LMP, update compatibility

### DIFF
--- a/NetKAN/LunaMultiplayer.netkan
+++ b/NetKAN/LunaMultiplayer.netkan
@@ -15,4 +15,4 @@ depends:
 install:
   - find:       LunaMultiplayer
     install_to: GameData
-    filter:     0Harmony.dll 
+    filter:     0Harmony.dll

--- a/NetKAN/LunaMultiplayer.netkan
+++ b/NetKAN/LunaMultiplayer.netkan
@@ -1,21 +1,18 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "LunaMultiplayer",
-    "name":         "Luna Multiplayer Client",
-    "$kref":        "#/ckan/github/LunaMultiplayer/LunaMultiplayer/asset_match/^LunaMultiplayer-Release\\.zip$",
-    "comment":      "Version file is outdated",
-    "ksp_version":  "1.11",
-    "license":      "MIT",
-    "tags": [
-        "plugin"
-    ],
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Bundles Harmony. Please check the DLL's version, and if it's 2 or later, remove the provides and add a depends on Harmony2.",
-    "provides": [
-        "Harmony1"
-    ],
-    "resources": {
-        "homepage": "https://lunamultiplayer.com/",
-        "manual":   "https://github.com/LunaMultiplayer/LunaMultiplayer/wiki"
-    }
-}
+spec_version: v1.4
+identifier:   LunaMultiplayer
+name:         Luna Multiplayer Client
+$kref:        '#/ckan/github/LunaMultiplayer/LunaMultiplayer/asset_match/^LunaMultiplayer-Client-Release\.zip$'
+comment:      Version file is outdated
+ksp_version:  '1.12'
+license:      MIT
+resources:
+  homepage: 'https://lunamultiplayer.com/'
+  manual:   'https://github.com/LunaMultiplayer/LunaMultiplayer/wiki'
+tags:
+  - plugin
+depends:
+  - name: Harmony2
+install:
+  - find:       LunaMultiplayer
+    install_to: GameData
+    filter:     0Harmony.dll

--- a/NetKAN/LunaMultiplayer.netkan
+++ b/NetKAN/LunaMultiplayer.netkan
@@ -15,4 +15,4 @@ depends:
 install:
   - find:       LunaMultiplayer
     install_to: GameData
-    filter:     0Harmony.dll
+    filter:     0Harmony.dll 


### PR DESCRIPTION
The new release 0.28.0 now bundles Harmony2 (updated from Harmony1).
It is also released for KSP 1.12.

After talking to the author, we've decided to filter the Harmony DLL, and replace it with a dependency on our indexed `Harmony2` module (the [HarmonyKSP](https://github.com/KSPModdingLibs/HarmonyKSP) "mod").

They author might switch over to bundling HarmonyKSP themself, which would allow us to get rid of the filter, and make sure that both CKAN users and manual installers would have the same distributions of Harmony installed.
Since this wouldn't need a change in our metadata (besides removing the filter stance), I'm going to go ahead with this change already.

Also see https://github.com/LunaMultiplayer/LunaMultiplayer/issues/415

ckan compat add 1.11