### PR TITLE
Fix TweakScale install stanzas

### DIFF
--- a/NetKAN/TweakScale.netkan
+++ b/NetKAN/TweakScale.netkan
@@ -18,10 +18,10 @@
         "convenience"
     ],
     "install" : [ {
-        "file" : "GameData/999_Scale_Redist.dll",
+        "file" : "999_Scale_Redist.dll",
         "install_to" : "GameData"
     }, {
-        "file" : "GameData/TweakScale",
+        "file" : "TweakScale",
         "install_to" : "GameData"
     } ],
     "depends" : [


### PR DESCRIPTION
Version 2.4.5.1of this mods has been reuploaded, but with a different zip layout.

The `Extras` folder is gone, and the contents of the `GameData` directory are now at the root of the zip.

![image](https://user-images.githubusercontent.com/28812678/123548357-c662d780-d764-11eb-909f-45136db583e2.png)

Fixes #8598 