### PR TITLE
Revert "Fix TweakScale install stanzas (#8599)"

### DIFF
--- a/NetKAN/TweakScale.netkan
+++ b/NetKAN/TweakScale.netkan
@@ -18,10 +18,10 @@
         "convenience"
     ],
     "install" : [ {
-        "file" : "999_Scale_Redist.dll",
+        "file" : "GameData/999_Scale_Redist.dll",
         "install_to" : "GameData"
     }, {
-        "file" : "TweakScale",
+        "file" : "GameData/TweakScale",
         "install_to" : "GameData"
     } ],
     "depends" : [


### PR DESCRIPTION
Reverting #8599 

When I look at what I _think_ is the most recent reupload from TweakScale 2.4.5.1 (file size 288150, matches the one from [GitHub](https://github.com/net-lisias-ksp/TweakScale/releases/tag/RELEASE%2F2.4.5.1)), the layout is as it was in the very initial upload and all previous releases:
![image](https://user-images.githubusercontent.com/28812678/123554315-ae4c8180-d77f-11eb-9eee-fcf60308ba2a.png)

Inflation will probably succeed here, but fail for the bot because it has the outdated file in its cache (see [my comment here](https://github.com/KSP-CKAN/NetKAN/issues/8598#issuecomment-869200228)).
However with the failed inflation, it _might_ delete the zip from the cache and download the new one, with some luck.