### PR TITLE
Remove vref from Kerbalism-Config-RO

### DIFF
--- a/NetKAN/Kerbalism-Config-RO.netkan
+++ b/NetKAN/Kerbalism-Config-RO.netkan
@@ -3,7 +3,6 @@
     "identifier":   "Kerbalism-Config-RO",
     "name":         "Kerbalism - RealismOverhaul Config",
     "$kref":        "#/ckan/github/KSP-RO/ROKerbalism",
-    "$vref":        "#/ckan/ksp-avc/Kerbalism/Kerbalism.version",
     "license":      "Unlicense",
     "tags": [
         "config",


### PR DESCRIPTION
See #8602, this config pack no longer bundles the core Kerbalism, and thus no longer contains its version file to get compatibility data from.
> New inflation warnings for Kerbalism-Config-RO: $vref present, version file missing

Instead, we've decided to go with no KSP version restriction (i.e. `any`), and let the core Kerbalism dictate compatibility.
So let's remove the vref, to keep everything tidy.