### PR TITLE
Mark DerivativeTextures compatible with any version

### DIFF
--- a/NetKAN/DerivativeTextures.netkan
+++ b/NetKAN/DerivativeTextures.netkan
@@ -2,6 +2,7 @@
     "spec_version": "v1.4",
     "identifier":   "DerivativeTextures",
     "$kref":        "#/ckan/spacedock/1971",
+    "ksp_version":  "any",
     "license":      "CC-BY-NC-SA-4.0",
     "tags": [
         "config",


### PR DESCRIPTION
Note the sentence at the bottom:

![image](https://user-images.githubusercontent.com/1559108/124052744-a80b0f00-d9e4-11eb-83f6-6817a6d2deb4.png)
