### PR TITLE
Update ModuleManager compatibility to 1.12

### DIFF
--- a/NetKAN/ModuleManager.netkan
+++ b/NetKAN/ModuleManager.netkan
@@ -28,7 +28,7 @@
         }
     ],
     "x_netkan_override": [
-		{
+        {
             "version": "4.0.3",
             "override": {
                 "ksp_version_min": "1.4.0",

--- a/NetKAN/ModuleManager.netkan
+++ b/NetKAN/ModuleManager.netkan
@@ -9,8 +9,8 @@
         "use_filename_version": true
     },
     "x_netkan_version_edit": "^ModuleManager-(?<version>\\d+\\.\\d+\\.\\d+)\\.zip$",
-    "ksp_version_min": "1.8.0",
-    "ksp_version_max": "1.11",
+    "ksp_version_min": "1.8",
+    "ksp_version_max": "1.12",
     "license": "CC-BY-SA",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/50533-*",


### PR DESCRIPTION
As per https://github.com/KSP-CKAN/NetKAN/issues/8618#issuecomment-873410486:

> @sarbian is the latest ModuleManager release okay to be marked as compatible with KSP 1.12?
We got a bunch of 1.12 mods depending on ModuleManager already, would be nice to have them all show up on KSP 1.12 installations.

> It is but I am unable to do the change for a few more days. Feel free to do it,

Closes #8618