### PR TITLE
Update KSCExtended relationships after adoption

### DIFF
--- a/NetKAN/KSCExtended.netkan
+++ b/NetKAN/KSCExtended.netkan
@@ -12,16 +12,16 @@
         { "name": "KerbalKonstructs"     },
         { "name": "TundraSpaceCenter"    },
         { "name": "StockalikeStructures" },
-        { "name": "KerbinSideRemastered" },
         { "name": "ModuleManager"        }
     ],
+    "conflicts": [
+        { "name": "GPP" }
+    ],
     "recommends": [
-        { "name": "KSCHarbor"                             },
         { "name": "TundraExploration"                     },
-        { "name": "Scatterer"                             },
-        { "name": "StockVisualEnhancements"               },
         { "name": "BluedogDB"                             },
         { "name": "ShuttleLiftingBodyCormorantAeronology" },
-        { "name": "ModularLaunchPads"                     }
+        { "name": "ModularLaunchPads"                     },
+        { "name": "KerbinSideRemastered"                  }
     ]
 }


### PR DESCRIPTION
This mod has been adopted by JadeOfMaar, and some of the relationships have changed.
- KerbinSideRemastered is no longer considered a dependency, but only a recommendation ([it fills in an empty space left by KSCExtended](https://forum.kerbalspaceprogram.com/index.php?/topic/203623-111-ksc-extended-30/&do=findComment&comment=4000171)).
- Scatterer and SVE have been removed from the recommendations
- reDirect is also a recommendation, but not indexed on CKAN
- It currently conflicts with GPP, which may change soon.

![image](https://user-images.githubusercontent.com/28812678/124507127-6c4dbc00-ddcd-11eb-8a6e-d71b2b6a5ed5.png)


The author is notified about the incorrect version file `URL`.

ckan compat add 1.8