### PR TITLE
SmokeScreen for KSP 1.12

### DIFF
--- a/NetKAN/SmokeScreen.netkan
+++ b/NetKAN/SmokeScreen.netkan
@@ -10,7 +10,7 @@
     },
     "x_netkan_version_edit": "^SmokeScreen-(?<version>\\d+\\.\\d+\\.\\d+\\.\\d+)\\.zip$",
     "ksp_version_min": "1.8.0",
-    "ksp_version_max": "1.10.90",
+    "ksp_version_max": "1.12.90",
     "license": "BSD-2-clause",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/64987-*",

--- a/NetKAN/SmokeScreen.netkan
+++ b/NetKAN/SmokeScreen.netkan
@@ -34,7 +34,7 @@
                 "ksp_version_max": "1.7.90"
             }
         },
-		{
+        {
             "version": "2.8.0.0",
             "override": {
                 "ksp_version_min": "1.4.0",


### PR DESCRIPTION
Mark the current SmokeScreen as 1.8 to 1.12 compatible.

___

Fixes #8618.