### PR TITLE
Update Parallax compatibility for new release

### DIFF
--- a/NetKAN/Parallax.netkan
+++ b/NetKAN/Parallax.netkan
@@ -5,7 +5,7 @@
     "abstract":     "A PBR tessellation shader for planetary textures",
     "author":       "Linx",
     "$kref":        "#/ckan/github/Gameslinx/Tessellation/asset_match/^Parallax-[0-9.]+\\.zip$",
-    "ksp_version":  "1.11",
+    "ksp_version":  "1.12",
     "license":      "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/197024-*"


### PR DESCRIPTION
Parallax 1.3.0 released, with compatibility for KSP 1.12 only (as far as the forum thread title tells).
- https://github.com/Gameslinx/Tessellation/releases/tag/1.3.0
- https://forum.kerbalspaceprogram.com/index.php?/topic/197024-112x-parallax-a-pbr-terrain-shader-130/&do=findComment&comment=4000968

![image](https://user-images.githubusercontent.com/28812678/124777513-8cea5300-df40-11eb-8a22-9efda54a6d5f.png)

Closes https://github.com/KSP-CKAN/CKAN-meta/pull/2380

ckan compat add 1.11
(for ModularFlightIntegrator)