### PR TITLE
Change Parallax min KSP version to 1.11

### DIFF
--- a/NetKAN/Parallax.netkan
+++ b/NetKAN/Parallax.netkan
@@ -5,8 +5,9 @@
     "abstract":     "A PBR tessellation shader for planetary textures",
     "author":       "Linx",
     "$kref":        "#/ckan/github/Gameslinx/Tessellation/asset_match/^Parallax-[0-9.]+\\.zip$",
-    "ksp_version":  "1.12",
-    "license":      "CC-BY-NC-ND-4.0",
+    "ksp_version_min":  "1.11",
+    "ksp_version_max":  "1.12",
+    "license":          "CC-BY-NC-ND-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/197024-*"
     },


### PR DESCRIPTION
Per a random Discord conversation with Gameslinx:
![image](https://user-images.githubusercontent.com/28812678/124823215-3b0df100-df71-11eb-9e86-dfe8b2d7b507.png)

This PR marks the latest release, 1.3.0, as compatible with KSP 1.11 - 1.12.
A CKAN-meta PR will also adjust the metadata of the previous 1.2.3 release to have the same range, maybe there's someone who wants to stick to the older release for now, bugs, performance or whatever.