### PR TITLE
Fix KerbinSideRemasteredTLA install location

### DIFF
--- a/NetKAN/KerbinSideRemasteredTLA.netkan
+++ b/NetKAN/KerbinSideRemasteredTLA.netkan
@@ -19,8 +19,4 @@ suggests:
   - name: KerbinSideRemasteredGAP
 install:
   - find: KerbinSideRemasteredTLA
-    install_to: GameData
-    filter: Ships
-  - find: Assets/Ships
-    install_to: Ships
-    as: SPH
+    install_to: GameData/ContractPacks


### PR DESCRIPTION
Fixup of #8636 
This mod belongs into `GameData/ContractPacks/`, as it is in the zip. Also the ships belong where they are in the zip, they are part of the contracts, _not_ user-playable ships: `craftURL = "ContractPacks/KerbinSideRemasteredTLA/Assets/Ships/" + @/wreckCraft`.

ckan compat add 1.8