### PR TITLE
 hard code minimum KSP version Interstellar Redistributable

### DIFF
--- a/NetKAN/InterstellarRedistributable.netkan
+++ b/NetKAN/InterstellarRedistributable.netkan
@@ -8,3 +8,4 @@ tags:
 install:
  - file: Interstellar_Redist.dll
    install_to: GameData
+ksp_version_min: 1.8.1


### PR DESCRIPTION
It should be available for install from any KSP version starting from KSP 1.8.1

Closes https://github.com/KSP-CKAN/CKAN-meta/pull/2386