### PR TITLE
De-meta RadioFreeKerbin metanetkan with hardcoded download

### DIFF
--- a/NetKAN/RadioFreeKerbin.netkan
+++ b/NetKAN/RadioFreeKerbin.netkan
@@ -1,6 +1,7 @@
 spec_version: v1.2
 identifier: RadioFreeKerbin
 $kref: '#/ckan/github/benjwgarner/RadioFreeKerbin'
+x_netkan_version_edit: ^[vV]?(?<version>.+)$
 license: MIT
 tags:
   - config

--- a/NetKAN/RadioFreeKerbin.netkan
+++ b/NetKAN/RadioFreeKerbin.netkan
@@ -6,7 +6,3 @@ license: MIT
 tags:
   - config
   - science
-depends:
-  - name: ModuleManager
-supports:
-  - name: KSP-AVC

--- a/NetKAN/RadioFreeKerbin.netkan
+++ b/NetKAN/RadioFreeKerbin.netkan
@@ -1,7 +1,6 @@
 spec_version: v1.2
 identifier: RadioFreeKerbin
 $kref: '#/ckan/spacedock/818'
-$vref: '#/ckan/ksp-avc'
 license: MIT
 tags:
   - config

--- a/NetKAN/RadioFreeKerbin.netkan
+++ b/NetKAN/RadioFreeKerbin.netkan
@@ -1,6 +1,6 @@
 spec_version: v1.2
 identifier: RadioFreeKerbin
-$kref: '#/ckan/spacedock/818'
+$kref: '#/ckan/github/benjwgarner/RadioFreeKerbin'
 license: MIT
 tags:
   - config

--- a/NetKAN/RadioFreeKerbin.netkan
+++ b/NetKAN/RadioFreeKerbin.netkan
@@ -1,9 +1,12 @@
-{
-    "spec_version"   : "v1.2",
-    "identifier"     : "RadioFreeKerbin",
-    "$kref"          : "#/ckan/netkan/https://raw.githubusercontent.com/benjwgarner/RadioFreeKerbin/master/RadioFreeKerbin.ckan",
-    "tags": [
-        "config",
-        "science"
-    ]
-}
+spec_version: v1.2
+identifier: RadioFreeKerbin
+$kref: '#/ckan/spacedock/818'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - config
+  - science
+depends:
+  - name: ModuleManager
+supports:
+  - name: KSP-AVC


### PR DESCRIPTION
See #8641, a metanetkan with hard-coded `download` property has downsides and isn't necessary when the mod is hosted on GitHub or SpaceDock (or both!). This one even has a version file.