### PR TITLE
Vref for RadioFreeKerbin

### DIFF
--- a/NetKAN/RadioFreeKerbin.netkan
+++ b/NetKAN/RadioFreeKerbin.netkan
@@ -2,6 +2,7 @@ spec_version: v1.2
 identifier: RadioFreeKerbin
 $kref: '#/ckan/github/benjwgarner/RadioFreeKerbin'
 x_netkan_version_edit: ^[vV]?(?<version>.+)$
+$vref: '#/ckan/ksp-avc'
 license: MIT
 tags:
   - config


### PR DESCRIPTION
I removed the vref in #8642 to see if it would help with a validation error. It didn't, and I forgot to add it back in.
This data is probably redundant with the internal ckan, but the possibility of updating the remote version file slightly tips the balance in favor.