### PR TITLE
De-meta GPP mods

### DIFF
--- a/NetKAN/GPP.netkan
+++ b/NetKAN/GPP.netkan
@@ -22,9 +22,9 @@ install:
     install_to: GameData
     comment: This correctly installs Final Frontier for GPP
 depends:
-  - name: ModuleManager
-  - name: Kopernicus
   - name: GPPTextures
+  - name: Kopernicus
+  - name: ModuleManager
 conflicts:
   - name: StockVisualEnhancements
 recommends:

--- a/NetKAN/GPP.netkan
+++ b/NetKAN/GPP.netkan
@@ -1,9 +1,115 @@
 {
     "spec_version": "v1.4",
-    "identifier":   "GPP",
+    "identifier": "GPP",
+    "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack/asset_match/Galileo.*?\\.zip",
+    "$vref": "#/ckan/ksp-avc",
     "x_netkan_epoch": 1,
-    "$kref":        "#/ckan/netkan/https://raw.githubusercontent.com/Galileo88/Galileos-Planet-Pack/master/CKAN/GPP.netkan",
-    "x_netkan_license_ok": true,
+    "name": "Galileo's Planet Pack",
+    "abstract": "Galileo's Planet Pack is an all new solar system. With high quality planets to explore, and more challeging gameplay than the stock game, GPP will give even the most accomplished KSPer hours of fun. GPP removes the stock planetary system and will corrupt stock system game saves.",
+    "author": "Galileo88",
+    "license": "CC-BY-NC-ND",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-galileos-planet-pack/"
+    },
+    "install": [
+        {
+            "find": "GPP",
+            "install_to": "GameData",
+            "filter": [ "Grannus" ],
+            "comment": "This is the main install for GPP"
+        },
+        {
+            "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
+            "install_to": "GameData",
+            "comment": "This correctly installs Final Frontier for GPP"
+        }
+    ],
+    "depends": [
+        {
+            "name": "ModuleManager"
+        },
+        {
+            "name": "Kopernicus"
+        },
+        {
+            "name": "GPPTextures"
+        }
+    ],
+    "conflicts": [
+        {
+            "name": "StockVisualEnhancements"
+        }
+    ],
+    "recommends": [
+        {
+            "name": "Strategia"
+        },
+        {
+            "name": "FinalFrontier"
+        },
+        {
+            "name": "OPM-Galileo"
+        },
+        {
+            "name": "KerbalKonstructs"
+        },
+        {
+            "name": "SigmaReplacements-Descriptions"
+        },
+        {
+            "name": "SigmaReplacements-Heads"
+        },
+        {
+            "name": "SigmaReplacements-Suits"
+        },
+        {
+            "name": "SigmaReplacements-SkyBox"
+        },
+        {
+            "name": "SigmaReplacements-Navigation"
+        },
+        {
+            "name": "SigmaReplacements-MenuScenes"
+        },
+        {
+            "name": "Grannus-RibbonPack"
+        }
+    ],
+    "suggests": [
+        {
+            "name": "SigmaBinary-core"
+        },
+        {
+            "name": "GPPCloudsHighRes"
+        },
+        {
+            "name": "GPPCloudsLowRes"
+        },
+        {
+            "name": "Rescale-25"
+        },
+        {
+            "name": "Rescale-32"
+        },
+        {
+            "name": "Rescale-64"
+        },
+        {
+            "name": "Rescale-10"
+        },
+        {
+            "name": "Rescale-10625"
+        },
+        {
+            "name": "BetterLookingOceans-HighRes"
+        },
+        {
+            "name": "BetterLookingOceans-MedRes"
+        },
+        {
+            "name": "BetterLookingOceans-LowRes"
+        }
+    ],
     "tags": [
         "config",
         "planet-pack"

--- a/NetKAN/GPP.netkan
+++ b/NetKAN/GPP.netkan
@@ -1,117 +1,56 @@
-{
-    "spec_version": "v1.4",
-    "identifier": "GPP",
-    "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack/asset_match/Galileo.*?\\.zip",
-    "$vref": "#/ckan/ksp-avc",
-    "x_netkan_epoch": 1,
-    "name": "Galileo's Planet Pack",
-    "abstract": "Galileo's Planet Pack is an all new solar system. With high quality planets to explore, and more challeging gameplay than the stock game, GPP will give even the most accomplished KSPer hours of fun. GPP removes the stock planetary system and will corrupt stock system game saves.",
-    "author": "Galileo88",
-    "license": "CC-BY-NC-ND",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-galileos-planet-pack/"
-    },
-    "install": [
-        {
-            "find": "GPP",
-            "install_to": "GameData",
-            "filter": [ "Grannus" ],
-            "comment": "This is the main install for GPP"
-        },
-        {
-            "find": "Optional Mods/GPP_FinalFrontier/GameData/Nereid",
-            "install_to": "GameData",
-            "comment": "This correctly installs Final Frontier for GPP"
-        }
-    ],
-    "depends": [
-        {
-            "name": "ModuleManager"
-        },
-        {
-            "name": "Kopernicus"
-        },
-        {
-            "name": "GPPTextures"
-        }
-    ],
-    "conflicts": [
-        {
-            "name": "StockVisualEnhancements"
-        }
-    ],
-    "recommends": [
-        {
-            "name": "Strategia"
-        },
-        {
-            "name": "FinalFrontier"
-        },
-        {
-            "name": "OPM-Galileo"
-        },
-        {
-            "name": "KerbalKonstructs"
-        },
-        {
-            "name": "SigmaReplacements-Descriptions"
-        },
-        {
-            "name": "SigmaReplacements-Heads"
-        },
-        {
-            "name": "SigmaReplacements-Suits"
-        },
-        {
-            "name": "SigmaReplacements-SkyBox"
-        },
-        {
-            "name": "SigmaReplacements-Navigation"
-        },
-        {
-            "name": "SigmaReplacements-MenuScenes"
-        },
-        {
-            "name": "Grannus-RibbonPack"
-        }
-    ],
-    "suggests": [
-        {
-            "name": "SigmaBinary-core"
-        },
-        {
-            "name": "GPPCloudsHighRes"
-        },
-        {
-            "name": "GPPCloudsLowRes"
-        },
-        {
-            "name": "Rescale-25"
-        },
-        {
-            "name": "Rescale-32"
-        },
-        {
-            "name": "Rescale-64"
-        },
-        {
-            "name": "Rescale-10"
-        },
-        {
-            "name": "Rescale-10625"
-        },
-        {
-            "name": "BetterLookingOceans-HighRes"
-        },
-        {
-            "name": "BetterLookingOceans-MedRes"
-        },
-        {
-            "name": "BetterLookingOceans-LowRes"
-        }
-    ],
-    "tags": [
-        "config",
-        "planet-pack"
-    ]
-}
+spec_version: v1.4
+identifier: GPP
+$kref: '#/ckan/github/Galileo88/Galileos-Planet-Pack/asset_match/Galileo.*?\.zip'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: 1
+name: Galileo's Planet Pack
+abstract: Galileo's Planet Pack is an all new solar system. With high quality planets
+  to explore, and more challeging gameplay than the stock game, GPP will give even
+  the most accomplished KSPer hours of fun. GPP removes the stock planetary system
+  and will corrupt stock system game saves.
+author: Galileo88
+license: CC-BY-NC-ND
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/152136-galileos-planet-pack/
+install:
+  - find: GPP
+    install_to: GameData
+    filter:
+      - Grannus
+    comment: This is the main install for GPP
+  - find: Optional Mods/GPP_FinalFrontier/GameData/Nereid
+    install_to: GameData
+    comment: This correctly installs Final Frontier for GPP
+depends:
+  - name: ModuleManager
+  - name: Kopernicus
+  - name: GPPTextures
+conflicts:
+  - name: StockVisualEnhancements
+recommends:
+  - name: Strategia
+  - name: FinalFrontier
+  - name: OPM-Galileo
+  - name: KerbalKonstructs
+  - name: SigmaReplacements-Descriptions
+  - name: SigmaReplacements-Heads
+  - name: SigmaReplacements-Suits
+  - name: SigmaReplacements-SkyBox
+  - name: SigmaReplacements-Navigation
+  - name: SigmaReplacements-MenuScenes
+  - name: Grannus-RibbonPack
+suggests:
+  - name: SigmaBinary-core
+  - name: GPPCloudsHighRes
+  - name: GPPCloudsLowRes
+  - name: Rescale-25
+  - name: Rescale-32
+  - name: Rescale-64
+  - name: Rescale-10
+  - name: Rescale-10625
+  - name: BetterLookingOceans-HighRes
+  - name: BetterLookingOceans-MedRes
+  - name: BetterLookingOceans-LowRes
+tags:
+  - config
+  - planet-pack

--- a/NetKAN/GPPCloudsHighRes.netkan
+++ b/NetKAN/GPPCloudsHighRes.netkan
@@ -12,6 +12,7 @@ provides:
 depends:
   - name: EnvironmentalVisualEnhancements
   - name: GPP
+  - name: ModuleManager
 conflicts:
   - name: GPPCloudsLowRes
 install:

--- a/NetKAN/GPPCloudsHighRes.netkan
+++ b/NetKAN/GPPCloudsHighRes.netkan
@@ -1,35 +1,23 @@
-{
-    "spec_version": "v1.4",
-    "identifier": "GPPCloudsHighRes",
-    "name": "GPP HighRes clouds",
-    "abstract": "High resolution clouds for GPP",
-    "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack",
-    "$vref": "#/ckan/ksp-avc",
-    "license": "CC-BY-NC-ND",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-galileos-planet-pack/"
-    },
-    "provides": [
-        "EnvironmentalVisualEnhancements-Config"
-    ],
-    "depends": [
-        { "name": "EnvironmentalVisualEnhancements" },
-        { "name": "GPP"                             }
-    ],
-    "conflicts": [
-        {
-            "name": "GPPCloudsLowRes"
-        }
-    ],
-    "install": [
-        {
-            "find": "Optional Mods/GPP_Clouds/High-res Clouds_GameData inside/GameData/GPP",
-            "install_to": "GameData",
-            "comment": "This installs the high resolution clouds configs for GPP"
-        }
-    ],
-    "tags": [
-        "config",
-        "graphics"
-    ]
-}
+spec_version: v1.4
+identifier: GPPCloudsHighRes
+name: GPP HighRes clouds
+abstract: High resolution clouds for GPP
+$kref: '#/ckan/github/Galileo88/Galileos-Planet-Pack'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-ND
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/152136-galileos-planet-pack/
+provides:
+  - EnvironmentalVisualEnhancements-Config
+depends:
+  - name: EnvironmentalVisualEnhancements
+  - name: GPP
+conflicts:
+  - name: GPPCloudsLowRes
+install:
+  - find: Optional Mods/GPP_Clouds/High-res Clouds_GameData inside/GameData/GPP
+    install_to: GameData
+    comment: This installs the high resolution clouds configs for GPP
+tags:
+  - config
+  - graphics

--- a/NetKAN/GPPCloudsHighRes.netkan
+++ b/NetKAN/GPPCloudsHighRes.netkan
@@ -1,8 +1,33 @@
 {
     "spec_version": "v1.4",
-    "identifier":   "GPPCloudsHighRes",
-    "$kref":        "#/ckan/netkan/https://raw.githubusercontent.com/Galileo88/Galileos-Planet-Pack/master/CKAN/GPPCloudsHighRes.netkan",
-    "x_netkan_license_ok": true,
+    "identifier": "GPPCloudsHighRes",
+    "name": "GPP HighRes clouds",
+    "abstract": "High resolution clouds for GPP",
+    "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack",
+    "$vref": "#/ckan/ksp-avc",
+    "license": "CC-BY-NC-ND",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-galileos-planet-pack/"
+    },
+    "provides": [
+        "EnvironmentalVisualEnhancements-Config"
+    ],
+    "depends": [
+        { "name": "EnvironmentalVisualEnhancements" },
+        { "name": "GPP"                             }
+    ],
+    "conflicts": [
+        {
+            "name": "GPPCloudsLowRes"
+        }
+    ],
+    "install": [
+        {
+            "find": "Optional Mods/GPP_Clouds/High-res Clouds_GameData inside/GameData/GPP",
+            "install_to": "GameData",
+            "comment": "This installs the high resolution clouds configs for GPP"
+        }
+    ],
     "tags": [
         "config",
         "graphics"

--- a/NetKAN/GPPCloudsLowRes.netkan
+++ b/NetKAN/GPPCloudsLowRes.netkan
@@ -12,6 +12,7 @@ provides:
 depends:
   - name: EnvironmentalVisualEnhancements
   - name: GPP
+  - name: ModuleManager
 conflicts:
   - name: GPPCloudsHighRes
 install:

--- a/NetKAN/GPPCloudsLowRes.netkan
+++ b/NetKAN/GPPCloudsLowRes.netkan
@@ -1,35 +1,23 @@
-{
-    "spec_version": "v1.4",
-    "identifier": "GPPCloudsLowRes",
-    "name": "GPP LowRes clouds",
-    "abstract": "Low resolution clouds for GPP",
-    "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack",
-    "$vref": "#/ckan/ksp-avc",
-    "license": "CC-BY-NC-ND",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-galileos-planet-pack/"
-    },
-    "provides": [
-        "EnvironmentalVisualEnhancements-Config"
-    ],
-    "depends": [
-        { "name": "EnvironmentalVisualEnhancements" },
-        { "name": "GPP"                             }
-    ],
-    "conflicts": [
-        {
-            "name": "GPPCloudsHighRes"
-        }
-    ],
-    "install": [
-        {
-            "find": "Optional Mods/GPP_Clouds/Low-res Clouds_GameData inside/GameData/GPP",
-            "install_to": "GameData",
-            "comment": "This installs the low resolution clouds configs for GPP"
-        }
-    ],
-    "tags": [
-        "config",
-        "graphics"
-    ]
-}
+spec_version: v1.4
+identifier: GPPCloudsLowRes
+name: GPP LowRes clouds
+abstract: Low resolution clouds for GPP
+$kref: '#/ckan/github/Galileo88/Galileos-Planet-Pack'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-ND
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/152136-galileos-planet-pack/
+provides:
+  - EnvironmentalVisualEnhancements-Config
+depends:
+  - name: EnvironmentalVisualEnhancements
+  - name: GPP
+conflicts:
+  - name: GPPCloudsHighRes
+install:
+  - find: Optional Mods/GPP_Clouds/Low-res Clouds_GameData inside/GameData/GPP
+    install_to: GameData
+    comment: This installs the low resolution clouds configs for GPP
+tags:
+  - config
+  - graphics

--- a/NetKAN/GPPCloudsLowRes.netkan
+++ b/NetKAN/GPPCloudsLowRes.netkan
@@ -1,8 +1,33 @@
 {
     "spec_version": "v1.4",
-    "identifier":   "GPPCloudsLowRes",
-    "$kref":        "#/ckan/netkan/https://raw.githubusercontent.com/Galileo88/Galileos-Planet-Pack/master/CKAN/GPPCloudsLowRes.netkan",
-    "x_netkan_license_ok": true,
+    "identifier": "GPPCloudsLowRes",
+    "name": "GPP LowRes clouds",
+    "abstract": "Low resolution clouds for GPP",
+    "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack",
+    "$vref": "#/ckan/ksp-avc",
+    "license": "CC-BY-NC-ND",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-galileos-planet-pack/"
+    },
+    "provides": [
+        "EnvironmentalVisualEnhancements-Config"
+    ],
+    "depends": [
+        { "name": "EnvironmentalVisualEnhancements" },
+        { "name": "GPP"                             }
+    ],
+    "conflicts": [
+        {
+            "name": "GPPCloudsHighRes"
+        }
+    ],
+    "install": [
+        {
+            "find": "Optional Mods/GPP_Clouds/Low-res Clouds_GameData inside/GameData/GPP",
+            "install_to": "GameData",
+            "comment": "This installs the low resolution clouds configs for GPP"
+        }
+    ],
     "tags": [
         "config",
         "graphics"

--- a/NetKAN/GPPSecondary.netkan
+++ b/NetKAN/GPPSecondary.netkan
@@ -12,8 +12,9 @@ install:
     install_to: GameData
     comment: This installs the GPP_Secondary configs for GPP
 depends:
-  - name: Kopernicus
   - name: GPP
+  - name: Kopernicus
+  - name: ModuleManager
 tags:
   - config
   - planet-pack

--- a/NetKAN/GPPSecondary.netkan
+++ b/NetKAN/GPPSecondary.netkan
@@ -1,8 +1,25 @@
 {
     "spec_version": "v1.4",
-    "identifier":   "GPPSecondary",
-    "$kref":        "#/ckan/netkan/https://raw.githubusercontent.com/Galileo88/Galileos-Planet-Pack/master/CKAN/GPPSecondary.netkan",
-    "x_netkan_license_ok": true,
+    "identifier": "GPPSecondary",
+    "name": "GPP Secondary",
+    "abstract": "GPP secondary puts Galileo's Planet Pack around the stock solar system.",
+    "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack",
+    "$vref": "#/ckan/ksp-avc",
+    "license": "CC-BY-NC-ND",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-galileos-planet-pack/"
+    },
+    "install": [
+        {
+            "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",
+            "install_to": "GameData",
+            "comment": "This installs the GPP_Secondary configs for GPP"
+        }
+    ],
+    "depends": [
+        { "name": "Kopernicus" },
+        { "name": "GPP"        }
+    ],
     "tags": [
         "config",
         "planet-pack"

--- a/NetKAN/GPPSecondary.netkan
+++ b/NetKAN/GPPSecondary.netkan
@@ -1,27 +1,19 @@
-{
-    "spec_version": "v1.4",
-    "identifier": "GPPSecondary",
-    "name": "GPP Secondary",
-    "abstract": "GPP secondary puts Galileo's Planet Pack around the stock solar system.",
-    "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack",
-    "$vref": "#/ckan/ksp-avc",
-    "license": "CC-BY-NC-ND",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-galileos-planet-pack/"
-    },
-    "install": [
-        {
-            "find": "Optional Mods/GPP_Secondary/GameData/GPP_Secondary",
-            "install_to": "GameData",
-            "comment": "This installs the GPP_Secondary configs for GPP"
-        }
-    ],
-    "depends": [
-        { "name": "Kopernicus" },
-        { "name": "GPP"        }
-    ],
-    "tags": [
-        "config",
-        "planet-pack"
-    ]
-}
+spec_version: v1.4
+identifier: GPPSecondary
+name: GPP Secondary
+abstract: GPP secondary puts Galileo's Planet Pack around the stock solar system.
+$kref: '#/ckan/github/Galileo88/Galileos-Planet-Pack'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-ND
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/152136-galileos-planet-pack/
+install:
+  - find: Optional Mods/GPP_Secondary/GameData/GPP_Secondary
+    install_to: GameData
+    comment: This installs the GPP_Secondary configs for GPP
+depends:
+  - name: Kopernicus
+  - name: GPP
+tags:
+  - config
+  - planet-pack

--- a/NetKAN/GPPTextures.netkan
+++ b/NetKAN/GPPTextures.netkan
@@ -1,8 +1,23 @@
 {
-	"spec_version": "v1.4",
-	"identifier": "GPPTextures",
-	"$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Galileo88/Galileos-Planet-Pack/master/CKAN/GPPTextures.netkan",
-	"x_netkan_license_ok": true,
+    "spec_version": "v1.4",
+    "identifier": "GPPTextures",
+    "name": "GPP Textures",
+    "abstract": "Textures for Galileo's Planet Pack.",
+    "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack/asset_match/GPP_Textures-.*\\.zip"
+    "license": "CC-BY-NC-ND",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-galileos-planet-pack/"
+    },
+    "depends": [
+        { "name": "GPP" }
+    ],
+    "install": [
+        {
+            "find": "GPP",
+            "install_to": "GameData",
+            "comment": "This correctly installs the textures for GPP"
+        }
+    ],
     "tags": [
         "config",
         "graphics"

--- a/NetKAN/GPPTextures.netkan
+++ b/NetKAN/GPPTextures.netkan
@@ -1,25 +1,17 @@
-{
-    "spec_version": "v1.4",
-    "identifier": "GPPTextures",
-    "name": "GPP Textures",
-    "abstract": "Textures for Galileo's Planet Pack.",
-    "$kref": "#/ckan/github/Galileo88/Galileos-Planet-Pack/asset_match/GPP_Textures-.*\\.zip"
-    "license": "CC-BY-NC-ND",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152136-galileos-planet-pack/"
-    },
-    "depends": [
-        { "name": "GPP" }
-    ],
-    "install": [
-        {
-            "find": "GPP",
-            "install_to": "GameData",
-            "comment": "This correctly installs the textures for GPP"
-        }
-    ],
-    "tags": [
-        "config",
-        "graphics"
-    ]
-}
+spec_version: v1.4
+identifier: GPPTextures
+name: GPP Textures
+abstract: Textures for Galileo's Planet Pack.
+$kref: '#/ckan/github/Galileo88/Galileos-Planet-Pack/asset_match/GPP_Textures-.*\.zip'
+license: CC-BY-NC-ND
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/152136-galileos-planet-pack/
+depends:
+  - name: GPP
+install:
+  - find: GPP
+    install_to: GameData
+    comment: This correctly installs the textures for GPP
+tags:
+  - config
+  - graphics


### PR DESCRIPTION
See https://github.com/Galileo88/Galileos-Planet-Pack/pull/69:
The compatibility data for GPP, GPPClouds*, GPPSecondary and GPPTextures are a mess:
![](https://cdn.discordapp.com/attachments/601455398553387008/818659559018856488/unknown.png)

This was due to hardcoded compatibility in the metanetkans.
I've had the PR open for several months, but got not a single person of the Galileo team to look at it, even after several pings on the PR itself, or the forum thread. Several team members have been active both on the GitHub repo and the forum thread in the meantime. Maybe they are purposefully ignoring us, I don't know.
In any case, since this is a live problem, with a worse impact than our average "forgot a comma in the version file" upstream issues and causes people to have broken installs, with several people messaging me about this in the last few months, I decided to de-meta these metanetkans and fix them here.

## Changes
The hardcoded compatibilities in all netkan files are removed. That's what the AVC .version file included in the download (and its online copy in the repo) is for, which CKAN will use as source of compatibility data from now on.

~~The .version file got a new `KSP_VERSION_MAX` to make sure the releases don't have unbounded future compatibility. This means a tiny bit of extra maintenance to update the maximum compatibility when new KSP versions drop, but gives an extra safeguard to avoid users installing it even if it is broken for the new release.~~
We can't de-meta version files. Since the version file itself looks good and the unbounded future compat being a minor issue (especially now after the final KSP release), I've decided to keep the vref instead of hardcoding it in our netkans. But I'm going to monitor it, as we can't rely on the GPP team not breaking it.

The zip for GPPTextures doesn't have a version file, so it's now unbounded, which shouldn't be much of a problem since it is dependent on GPP anyway.

To reflect this in CKAN, GPP is added to the dependencies of GPPTextures, as well as GPPCloudsHighRes, GPPCloudsLowRes and GPPSecondary.

The hardcoded `download` link of GPPTextures is replaced with a `kref`+`asset_match`.

Also includes https://github.com/Galileo88/Galileos-Planet-Pack/pull/64

CKAN-meta clean-up needed after merging this