### PR TITLE
Move 'Grannus' filter to correct install stanza

### DIFF
--- a/NetKAN/GPP.netkan
+++ b/NetKAN/GPP.netkan
@@ -15,11 +15,11 @@ resources:
 install:
   - find: GPP
     install_to: GameData
-    filter:
-      - Grannus
     comment: This is the main install for GPP
   - find: Optional Mods/GPP_FinalFrontier/GameData/Nereid
     install_to: GameData
+    filter:
+      - Grannus
     comment: This correctly installs Final Frontier for GPP
 depends:
   - name: GPPTextures


### PR DESCRIPTION
Small fixup of #8644, I've accidentally put the `Grannus` filter for the Grannus Ribbon Pack on the wrong install stanza.
See
- https://github.com/Galileo88/Galileos-Planet-Pack/pull/64/files#diff-d9450be21cc6728de2fae4bd2b2976d5ad9504f3e9cee4fac255d80ca21e4c7c
- https://github.com/KSP-CKAN/NetKAN/pull/8024/files#diff-bef12baee87f4df2076d36570c2f62aa003bb27ba62601dbf0186e741864bf70

for reference