### PR TITLE
Strip date portion of SIMPLEX* and TETRIXTechTree versions

### DIFF
--- a/NetKAN/SIMPLEXKerbalism.netkan
+++ b/NetKAN/SIMPLEXKerbalism.netkan
@@ -8,6 +8,7 @@
         "replace": "${version}",
         "strict": true
     },
+    "x_netkan_epoch": 2,
     "tags": [
         "config",
         "parts",

--- a/NetKAN/SIMPLEXKerbalism.netkan
+++ b/NetKAN/SIMPLEXKerbalism.netkan
@@ -3,6 +3,11 @@
     "identifier":   "SIMPLEXKerbalism",
     "$kref":        "#/ckan/spacedock/2300",
     "license":      "Unlicense",
+    "x_netkan_version_edit": {
+        "find": "^(?<version>.+)\\.(?<date>[0-9]{4,8})$",
+        "replace": "${version}",
+        "strict": true
+    },
     "tags": [
         "config",
         "parts",

--- a/NetKAN/SimplexPropulsion.netkan
+++ b/NetKAN/SimplexPropulsion.netkan
@@ -3,6 +3,11 @@
     "identifier":   "SimplexPropulsion",
     "$kref":        "#/ckan/spacedock/2112",
     "license":      "CC-BY-NC-SA",
+    "x_netkan_version_edit": {
+        "find": "^(?<version>.+)\\.(?<date>[0-9]{4,8})$",
+        "replace": "${version}",
+        "strict": true
+    },
     "tags": [
         "config"
     ],

--- a/NetKAN/SimplexPropulsion.netkan
+++ b/NetKAN/SimplexPropulsion.netkan
@@ -8,6 +8,7 @@
         "replace": "${version}",
         "strict": true
     },
+    "x_netkan_epoch": 1,
     "tags": [
         "config"
     ],

--- a/NetKAN/SimplexTechTree.netkan
+++ b/NetKAN/SimplexTechTree.netkan
@@ -3,6 +3,11 @@
     "identifier":   "SimplexTechTree",
     "$kref":        "#/ckan/spacedock/1848",
     "license":      "CC-BY-NC-SA",
+    "x_netkan_version_edit": {
+        "find": "^(?<version>.+)\\.(?<date>[0-9]{4,8})$",
+        "replace": "${version}",
+        "strict": true
+    },
     "tags": [
         "config",
         "tech-tree"

--- a/NetKAN/SimplexTechTree.netkan
+++ b/NetKAN/SimplexTechTree.netkan
@@ -8,6 +8,7 @@
         "replace": "${version}",
         "strict": true
     },
+    "x_netkan_epoch": 3,
     "tags": [
         "config",
         "tech-tree"

--- a/NetKAN/TETRIXTechTree.netkan
+++ b/NetKAN/TETRIXTechTree.netkan
@@ -3,6 +3,11 @@
     "identifier":   "TETRIXTechTree",
     "$kref":        "#/ckan/spacedock/2299",
     "license":      "CC-BY-NC-SA",
+    "x_netkan_version_edit": {
+        "find": "^(?<version>.+)\\.(?<date>[0-9]{4,8})$",
+        "replace": "${version}",
+        "strict": true
+    },
     "tags": [
         "config",
         "tech-tree"

--- a/NetKAN/TETRIXTechTree.netkan
+++ b/NetKAN/TETRIXTechTree.netkan
@@ -8,6 +8,7 @@
         "replace": "${version}",
         "strict": true
     },
+    "x_netkan_epoch": 4,
     "tags": [
         "config",
         "tech-tree"


### PR DESCRIPTION
These mods have a versioning scheme that doesn't interact well with CKAN's sorting logic.
Basically it consists of a semver-like numbers separated by dots part, and a date part in at the end.
The first part alternates between two and three "subparts", so whenever a release with a third subpart comes out, it's compared against the date of the previous release, and is obviously less, so we get a epoch-bump staging PR.

TETRIXTechTree:
- https://github.com/KSP-CKAN/CKAN-meta/pull/1771
- https://github.com/KSP-CKAN/CKAN-meta/pull/1848
- https://github.com/KSP-CKAN/CKAN-meta/pull/1887
- https://github.com/KSP-CKAN/CKAN-meta/pull/2338

SIMPLEXTechTree:
- https://github.com/KSP-CKAN/CKAN-meta/pull/1847
- https://github.com/KSP-CKAN/CKAN-meta/pull/2339

SIMPLEXKerbalism:
- https://github.com/KSP-CKAN/CKAN-meta/pull/1737
- https://github.com/KSP-CKAN/CKAN-meta/pull/1744
- https://github.com/KSP-CKAN/CKAN-meta/pull/2390

(+ SIMPLEXPropulsion which only has one release so far)

This PR adds an `x_netkan_version_edit` that strips the date part of all version numbers.
As far as I can see, there has never been a release with the first part being the same and only the date bumped. It appears to only act as release date label for these mods – since CKAN already stores and shows them separately, it should be fine to remove them from the version numbers as is.

There was one release (`2.3.B.20200511`, TETRIXTechTree) with a letter instead of a digit as "patch" part of the version number, so I've decided to match all chars in the first part, instead of only digits and dots.
The initial release of SIMPLEXKerbalism also had dots in the date part, which this regex doesn't match. It never appeared again, so I think we are fine, if it _does_ happen again, inflation will fail and we need to revisit the regex.

Examples: https://regex101.com/r/G4U5W0/1

Closes https://github.com/KSP-CKAN/CKAN-meta/pull/2390

ckan compat add 1.11