### PR TITLE
Update VenStockRevamp mods' max KSP version to 1.10.1

### DIFF
--- a/NetKAN/VenStockRevamp-Core.netkan
+++ b/NetKAN/VenStockRevamp-Core.netkan
@@ -24,5 +24,11 @@
         "find"       : "VenStockRevamp",
         "install_to" : "GameData",
         "filter"     : [ "PathPatches", "Squad", "Part Bin" ]
+    } ],
+    "x_netkan_override": [ {
+        "version": "v1.15.1",
+        "override": {
+            "ksp_version_max": "1.10.1"
+        }
     } ]
 }

--- a/NetKAN/VenStockRevamp-NewParts.netkan
+++ b/NetKAN/VenStockRevamp-NewParts.netkan
@@ -25,5 +25,11 @@
     "install": [ {
         "find"       : "VenStockRevamp/Part Bin",
         "install_to" : "GameData/VenStockRevamp"
+    } ],
+    "x_netkan_override": [ {
+        "version": "v1.15.1",
+        "override": {
+            "ksp_version_max": "1.10.1"
+        }
     } ]
 }

--- a/NetKAN/VenStockRevamp.netkan
+++ b/NetKAN/VenStockRevamp.netkan
@@ -29,5 +29,11 @@
     }, {
         "find"       : "VenStockRevamp/Squad",
         "install_to" : "GameData/VenStockRevamp"
+    } ],
+    "x_netkan_override": [ {
+        "version": "v1.15.1",
+        "override": {
+            "ksp_version_max": "1.10.1"
+        }
     } ]
 }


### PR DESCRIPTION
These work fine on 1.10 as far as I can tell, and I've seen no reported issues from anyone on RO using them in the last long while that RO's been on 1.10. So I forum-PM'd @kerbas-ad-astra to ask it would be ok to override the max version to 1.10 and was given the OK.

So here we are! It's _probably_ safe to bump them up further, but I can't speak to versions after 1.10 and kerbas is planning to release a new version targeting 1.12 Soon (tm).