### PR TITLE
Add TUFX to CKAN

### DIFF
--- a/NetKAN/TUFX.netkan
+++ b/NetKAN/TUFX.netkan
@@ -10,3 +10,5 @@ resources:
 tags:
   - plugin
   - graphics
+depends:
+  - name: ModuleManager

--- a/NetKAN/TUFX.netkan
+++ b/NetKAN/TUFX.netkan
@@ -1,0 +1,20 @@
+{
+    "spec_version": "v1.16",
+    "identifier":   "TUFX",
+    "name":         "TUFX",
+    "abstract":     "Post-processing FX for KSP",
+    "$kref":        "#/ckan/github/shadowmage45/TUFX",
+    "$vref":        "#/ckan/ksp-avc",
+    "license":      "GPL-3.0",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/192212-*"
+    },
+    "tags": [
+        "plugin",
+        "graphics"
+    ],
+    "install": [ {
+        "find":       "TUFX",
+        "install_to": "GameData"
+    } ]
+}

--- a/NetKAN/TUFX.netkan
+++ b/NetKAN/TUFX.netkan
@@ -1,20 +1,12 @@
-{
-    "spec_version": "v1.16",
-    "identifier":   "TUFX",
-    "name":         "TUFX",
-    "abstract":     "Post-processing FX for KSP",
-    "$kref":        "#/ckan/github/shadowmage45/TUFX",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/192212-*"
-    },
-    "tags": [
-        "plugin",
-        "graphics"
-    ],
-    "install": [ {
-        "find":       "TUFX",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.16
+identifier: TUFX
+name: TUFX
+abstract: Post-processing FX for KSP
+$kref: '#/ckan/github/shadowmage45/TUFX'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/192212-*
+tags:
+  - plugin
+  - graphics


### PR DESCRIPTION
I believe I have done this correctly; it's been a while. In particular, this needs to use a remote version file as hosted on github here ( https://github.com/shadowmage45/TUFX/blob/master/GameData/TUFX/TexturesUnlimitedFX.version ) -- I copied the vref and kref lines from the Ven Stock Revamp core netkan which @HebaruSan pointed out has a remote version link so hopefully that is correct. (The .version in the archive specifies a URL, so I think that will work? The point is that the remote file is good for KSP 1.12 while the release one is older).

(PR'd by permission of @shadowmage45 )

https://github.com/shadowmage45/TUFX
https://forum.kerbalspaceprogram.com/index.php?/topic/192212-19x-tufx-post-processing/