### PR TITLE
Update relationships for RoutineMissionManager and RecycledParts

### DIFF
--- a/NetKAN/RecycledParts.netkan
+++ b/NetKAN/RecycledParts.netkan
@@ -20,9 +20,7 @@
         { "name": "KSPWheel" },
         { "name": "PatchManager" },
         { "name": "ModuleManager" },
-        { "name": "BDAnimationModules" },
-        { "name": "ASETProps" },
-        { "name": "RasterPropMonitor-Core" }
+        { "name": "BDAnimationModules" }
     ],
     "recommends": [
         { "name": "CommunityTechTree" }

--- a/NetKAN/RecycledPartsMk2Lightning.netkan
+++ b/NetKAN/RecycledPartsMk2Lightning.netkan
@@ -13,15 +13,12 @@
         "install_to": "GameData/SpaceTuxIndustries/RecycledParts"
     } ],
     "depends": [
-        { "name": "ModuleManager" },
-        { "name": "ASETProps" },
-        { "name": "RasterPropMonitor-Core" }
+        { "name": "ModuleManager" }
     ],
     "suggests": [
         { "name": "JanitorsCloset" }
     ],
     "conflicts": [
-        { "name" : "RecycledPartsMk2Lightning" },
-        { "name" : "BDynamicsMk22Cockpits" }
+        { "name" : "RecycledPartsMk2Lightning" }
     ]
 }

--- a/NetKAN/RoutineMissionManager.netkan
+++ b/NetKAN/RoutineMissionManager.netkan
@@ -20,5 +20,5 @@
         { "name": "ClickThroughBlocker" },
         { "name": "SpaceTuxLibrary" }
     ],
-	"x_netkan_epoch": "1"
+    "x_netkan_epoch": "1"
 }

--- a/NetKAN/RoutineMissionManager.netkan
+++ b/NetKAN/RoutineMissionManager.netkan
@@ -17,7 +17,8 @@
     "depends" : [
         { "name": "ModuleManager" },
         { "name": "ToolbarController" },
-        { "name": "ClickThroughBlocker" }
+        { "name": "ClickThroughBlocker" },
+        { "name": "SpaceTuxLibrary" }
     ],
 	"x_netkan_epoch": "1"
 }


### PR DESCRIPTION
RoutineMissionManager now depends on SpaceTuxLibrary. @linuxgurugamer didn't tell me the reason for this change.

RecyledParts no longer depends on ASETProps or RasterPropMonitor-Core. @linuxgurugamer didn't tell me the reason for this change.

RecycledPartsMk2Lightning no longer depends on ASETProps or RasterPropMonitor-Core. @linuxgurugamer didn't tell me the reason for this change.

RecycledPartsMk2Lightning no longer conflicts with BDynamicsMk22Cockpits. @linuxgurugamer didn't tell me the reason for this change, but I did notice that the latest release of the main RecycledParts module now has a new plugin with a suspiciously similar name: 
![image](https://user-images.githubusercontent.com/1559108/126907169-57d9e68c-1bd1-431e-998b-de565010defe.png)
This makes me suspect that RecycledPartsMk2Lightning should include the same plugin, but it doesn't. Maybe that's coming in a future update?
