### PR TITLE
Move BiomaticForAll from Biomatic recommends to suggests

### DIFF
--- a/NetKAN/Biomatic.netkan
+++ b/NetKAN/Biomatic.netkan
@@ -6,10 +6,10 @@ license: GPL-3.0
 depends:
   - name: ModuleManager # Contains optional patch with .cfg.OFF extension
 recommends:
-  - name: BiomaticForAll
   - name: ToolbarController
   - name: ClickThroughBlocker
 suggests:
+  - name: BiomaticForAll
   - name: Toolbar
   - name: ODFC-Refueled
   - name: FieldTrainingFacility


### PR DESCRIPTION
Follow-up to #8674, see https://github.com/KSP-CKAN/NetKAN/pull/8674#issuecomment-887033388

The BiomaticForAll patch isn't fully stable, so now we move it to suggests so it's "disabled" by default.