### PR TITLE
Make RSS recommend RSSVE-Textures

### DIFF
--- a/NetKAN/RealSolarSystem.netkan
+++ b/NetKAN/RealSolarSystem.netkan
@@ -1,38 +1,38 @@
-{
-    "spec_version"    : "v1.12",
-    "identifier"      : "RealSolarSystem",
-    "name"            : "Real Solar System",
-    "abstract"        : "Resizes and rearranges the Kerbal system to more closely resemble the Solar System",
-    "author"          : [ "NathanKell", "eggrobin", "raidernick", "PhineasFreak" ],
-    "$kref"           : "#/ckan/github/KSP-RO/RealSolarSystem",
-    "$vref"           : "#/ckan/ksp-avc",
-    "x_netkan_force_v": true,
-    "license"         : "CC-BY-NC-SA",
-    "release_status"  : "stable",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177216-*"
-    },
-    "tags": [
-        "planet-pack",
-        "config",
-        "plugin",
-        "resources"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "Kopernicus", "min_version": "2:release-1.3.1-7" },
-        { "name": "RSSTextures" }
-    ],
-    "provides": [ "CustomAsteroids-Pops" ],
-    "recommends": [
-        { "name": "RealismOverhaul" },
-        { "name": "KSCSwitcher" },
-        { "name": "RSSDateTimeFormatter" }
-    ],
-    "install": [
-        {
-            "find"      : "RealSolarSystem",
-            "install_to": "GameData"
-        }
-    ]
-}
+spec_version: v1.12
+identifier: RealSolarSystem
+name: Real Solar System
+abstract: >-
+  Resizes and rearranges the Kerbal system to more closely resemble the Solar
+  System
+author:
+  - NathanKell
+  - eggrobin
+  - raidernick
+  - PhineasFreak
+$kref: '#/ckan/github/KSP-RO/RealSolarSystem'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+license: CC-BY-NC-SA
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/177216-*
+tags:
+  - planet-pack
+  - config
+  - plugin
+  - resources
+depends:
+  - name: ModuleManager
+  - name: Kopernicus
+    min_version: 2:release-1.3.1-7
+  - name: RSSTextures
+provides:
+  - CustomAsteroids-Pops
+recommends:
+  - name: RealismOverhaul
+  - name: KSCSwitcher
+  - name: RSSDateTimeFormatter
+  - name: RSSVE-Textures
+install:
+  - find: RealSolarSystem
+    install_to: GameData


### PR DESCRIPTION
Small fix we noticed in the course of #8688.

https://github.com/KSP-CKAN/NetKAN/issues/8688#issuecomment-890592737

> What can we do to make as many of the visual enhancements, that I do think most players install, easiest to get?

https://github.com/KSP-CKAN/NetKAN/issues/8688#issuecomment-890598647

> Should they be recommended or suggested?

https://github.com/KSP-CKAN/NetKAN/issues/8688#issuecomment-890606367

> RSS should rec RSSVE, yes. (And thus by the non-transitive property of recs, RO/RP-1 should too :D ).

https://github.com/KSP-CKAN/NetKAN/issues/8688#issuecomment-890634780

> That may be something easy we can fix in the short term, then; RSS currently only recommends RO, KSCSwitcher, and RSSDateTimeFormatter. Do you want to switch this to a metanetkan hosted on your repo for easier updates?
> 
> https://github.com/KSP-CKAN/NetKAN/blob/master/NetKAN/RealSolarSystem.netkan

https://github.com/KSP-CKAN/NetKAN/issues/8688#issuecomment-890636971

> Yeah think that probably makes sense, I've just held off touching the RSS metadata pending getting Kerbal Konstructs on 1.10 so I can do everything all at once (I.e. rec RSSVE, RSS-CanaveralHD, and CanaveralPads).

Now `RealSolarSystem` recommends `RSSVE-Textures`, which `RSSVE-LR` and `RSSVE-HR` provide (see #8595 for when we unfroze those modules).