### PR TITLE
Try to clarify KSPBurst abstracts

### DIFF
--- a/NetKAN/KSPBurst-Lite.netkan
+++ b/NetKAN/KSPBurst-Lite.netkan
@@ -1,23 +1,22 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "KSPBurst-Lite",
-    "name":         "KSPBurst Lite",
-    "abstract":     "A stand-in for KSPBurst that satisfies all dependendent mods but doesn't install and run the compiler",
-    "$kref":        "#/ckan/github/KSPModdingLibs/KSPBurst/asset_match/^KSPBurst_[0-9.]+_plugins_only\\.zip$",
-    "$vref":        "#/ckan/ksp-avc",
-    "author":       "dkavolis",
-    "license":      "unknown",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/201112-*",
-        "repository": "https://github.com/KSPModdingLibs/KSPBurst"
-    },
-    "tags":      [ "library" ],
-    "provides":  [ "KSPBurst" ],
-    "conflicts": [ { "name": "KSPBurst" } ],
-    "install": [
-        {
-            "find"       : "000_KSPBurst",
-            "install_to" : "GameData"
-        }
-    ]
-}
+spec_version: v1.4
+identifier: KSPBurst-Lite
+name: KSPBurst Lite
+abstract: >-
+  Run KSPBurst-dependent mods without the compiler, more slowly but with a smaller download
+$kref: >-
+  #/ckan/github/KSPModdingLibs/KSPBurst/asset_match/^KSPBurst_[0-9.]+_plugins_only\.zip$
+$vref: '#/ckan/ksp-avc'
+author: dkavolis
+license: unknown
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/201112-*
+  repository: https://github.com/KSPModdingLibs/KSPBurst
+tags:
+  - library
+provides:
+  - KSPBurst
+conflicts:
+  - name: KSPBurst
+install:
+  - find: 000_KSPBurst
+    install_to: GameData

--- a/NetKAN/KSPBurst.netkan
+++ b/NetKAN/KSPBurst.netkan
@@ -1,21 +1,18 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "KSPBurst",
-    "name":         "KSPBurst",
-    "abstract":     "Burst compiler for Kerbal Space Program. Needs Mono installed on Linux and macOS.",
-    "$kref":        "#/ckan/github/KSPModdingLibs/KSPBurst/asset_match/^KSPBurst_[0-9.]+\\.zip$",
-    "$vref":        "#/ckan/ksp-avc",
-    "author":       "dkavolis",
-    "license":      "unknown",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/201112-*",
-        "repository": "https://github.com/KSPModdingLibs/KSPBurst"
-    },
-    "tags": [ "library" ],
-    "install": [
-        {
-            "find"       : "000_KSPBurst",
-            "install_to" : "GameData"
-        }
-    ]
-}
+spec_version: v1.4
+identifier: KSPBurst
+name: KSPBurst
+abstract: >-
+  Better multithreaded performance for mods that use it.
+  Requires Mono on Linux and macOS (you have it if you're running CKAN).
+$kref: '#/ckan/github/KSPModdingLibs/KSPBurst/asset_match/^KSPBurst_[0-9.]+\.zip$'
+$vref: '#/ckan/ksp-avc'
+author: dkavolis
+license: unknown
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/201112-*
+  repository: https://github.com/KSPModdingLibs/KSPBurst
+tags:
+  - library
+install:
+  - find: 000_KSPBurst
+    install_to: GameData


### PR DESCRIPTION
## Problems

During investigation of #8688, this prompt threw me for a loop:

![image](https://user-images.githubusercontent.com/1559108/127786240-b57106b1-c7d6-4e6f-8729-4865e760d950.png)

I just want a working install. Will the "Lite" version work, or is it some kind of cheaty bypass? What does any of this even do?

## Changes

I've tried to rewrite the abstracts of those modules to clarify what they're about. The main KSPBurst module now explains that it's about boosting multithreaded performance, and the Lite module says it can do the same job but more slowly. Users should feel more confident choosing between them now.