### PR TITLE
Fix KerbalMiniShuttle install

### DIFF
--- a/NetKAN/KerbalMiniShuttle.netkan
+++ b/NetKAN/KerbalMiniShuttle.netkan
@@ -1,23 +1,15 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "KerbalMiniShuttle",
-    "$kref":        "#/ckan/spacedock/2678",
-    "license":      "GPL-2.0",
-    "tags": [
-        "parts",
-        "crewed"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "install": [ {
-        "find":       "GameData/BTS",
-        "install_to": "GameData"
-    }, {
-        "find":       "GameData/1MAIN",
-        "install_to": "GameData"
-    }, {
-        "find":       "Ships/VAB",
-        "install_to": "Ships"
-    } ]
-}
+spec_version: v1.4
+identifier: KerbalMiniShuttle
+$kref: '#/ckan/spacedock/2678'
+license: GPL-2.0
+tags:
+  - parts
+  - crewed
+depends:
+  - name: ModuleManager
+  - name: B9PartSwitch
+install:
+  - find: GameData/MKS
+    install_to: GameData
+  - find: Ships/VAB
+    install_to: Ships


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/127902460-bae86804-7566-44ce-8c8f-9507c3b13843.png)

Also B9PartSwitch is required now.

___

ckan compat add 1.11