### PR TITLE
Pin min compat of KSP-Data-Export

### DIFF
--- a/NetKAN/KSP-Data-Export.netkan
+++ b/NetKAN/KSP-Data-Export.netkan
@@ -11,5 +11,11 @@
     "install": [ {
         "find":       "DataExport",
         "install_to": "GameData"
+    } ],
+    "x_netkan_override": [ {
+        "version": "0.6",
+        "override": {
+            "ksp_version_min": "1.12.0"
+        }
     } ]
 }


### PR DESCRIPTION
This time it is my turn. KSP-Data-Export 0.6 has originally been released for KSP 1.12.0