### PR TITLE
Continue unfreezing MiniSampleReturnCapsule

### DIFF
--- a/NetKAN/MiniSampleReturnCapsule.netkan
+++ b/NetKAN/MiniSampleReturnCapsule.netkan
@@ -3,3 +3,7 @@ spec_version: v1.4
 $kref: '#/ckan/spacedock/831'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+depends:
+  - name: ModuleManager


### PR DESCRIPTION
I meant to start a pull request with https://github.com/KSP-CKAN/NetKAN/commit/c2155c7ec9ca187623e8f7dec699c78aab6f1c78 but accidentally committed it to master instead. The bot reported these warnings:

![image](https://user-images.githubusercontent.com/1559108/128401425-f153f7e9-f5fd-4c52-ba64-819d763f3c0c.png)

So far these changes are not available to users yet due to auto-epoching, see KSP-CKAN/CKAN-meta#2426.

Now it has tags and an MM dep.

Replaces KSP-CKAN/CKAN-meta#2425.