### PR TITLE
Fix TrekDrive install and depends

### DIFF
--- a/NetKAN/TrekDrive.netkan
+++ b/NetKAN/TrekDrive.netkan
@@ -9,8 +9,9 @@
         "crewed"
     ],
     "depends": [
-        { "name": "ModuleManager"         },
+        { "name": "B9PartSwitch"          },
         { "name": "CommunityResourcePack" },
+        { "name": "ModuleManager"         },
         { "name": "Waterfall"             }
     ],
     "install": [ {
@@ -18,8 +19,10 @@
         "install_to": "GameData",
         "filter":     [ ".DS_Store" ]
     }, {
-        "find":       "Craft",
-        "install_to": "Ships",
-        "as":         "VAB"
+        "find":       "Craft/VAB",
+        "install_to": "Ships"
+    }, {
+        "find":       "Craft/SPH",
+        "install_to": "Ships"
     } ]
 }


### PR DESCRIPTION
The latest release `0.99w` of this mod changed the folder structure for crafts, as it now also includes files for the SPH.
![](https://cdn.discordapp.com/attachments/132503638793912320/873162598827315221/unknown.png)

Additionally, release notes say it also depends on B9PS now:
https://forum.kerbalspaceprogram.com/index.php?/topic/199749-wip-191-112-trekdrive-a-star-trek-like-warp-drive-by-shadowworks-v099w-nx-class-05082021/&do=findComment&comment=4015214

ckan compat add 1.11