### PR TITLE
Correct minversion for Scatterer

### DIFF
--- a/NetKAN/Scatterer-config.netkan
+++ b/NetKAN/Scatterer-config.netkan
@@ -26,7 +26,7 @@
         }
     ],
     "x_netkan_override": [ {
-        "version": "3:v0.0723",
+        "version": ">=3:v0.0723",
         "override": {
             "ksp_version_min": "1.9"
         }

--- a/NetKAN/Scatterer-sunflare.netkan
+++ b/NetKAN/Scatterer-sunflare.netkan
@@ -26,7 +26,7 @@
         "install_to": "GameData/scatterer/config"
     } ],
     "x_netkan_override": [ {
-        "version": ">3:v0.0723",
+        "version": ">=3:v0.0723",
         "override": {
             "ksp_version_min": "1.9"
         }

--- a/NetKAN/Scatterer-sunflare.netkan
+++ b/NetKAN/Scatterer-sunflare.netkan
@@ -26,7 +26,7 @@
         "install_to": "GameData/scatterer/config"
     } ],
     "x_netkan_override": [ {
-        "version": "3:v0.0723",
+        "version": ">3:v0.0723",
         "override": {
             "ksp_version_min": "1.9"
         }

--- a/NetKAN/Scatterer.netkan
+++ b/NetKAN/Scatterer.netkan
@@ -25,7 +25,7 @@
         }
     ],
     "x_netkan_override": [ {
-        "version": "3:v0.0723",
+        "version": ">=3:v0.0723",
         "override": {
             "ksp_version_min": "1.9"
         }


### PR DESCRIPTION
There is a netkan version override specifically for 723, but since that was done @LGHassen has released new versions of Scatterer. I believe the correct solution here -- since the forum OP and docs make clear that all these versions are compatible with 1.9+ -- is to apply this override to all versions going forward, until such time as there is a version that is not backwards compatible with 1.9 etc. The issue here appears to be that versioning from Spacedock has only the active KSP version, not a min/max, or such was done when new Scatterers were released, despite other sources maintaining that they are backwards compatible.