### PR TITLE
Add RO/RP-1 express install netkans

### DIFF
--- a/NetKAN/RP-1-ExpressInstall-Graphics-High.netkan
+++ b/NetKAN/RP-1-ExpressInstall-Graphics-High.netkan
@@ -1,0 +1,9 @@
+spec_version: v1.12
+identifier: RP-1-ExpressInstall-Graphics-High
+$kref: '#/ckan/netkan/https://github.com/KSP-RO/RP-1-ExpressInstall-Graphics/raw/main/RP-1-ExpressInstall-Graphics-High.netkan'
+x_netkan_license_ok: true
+tags:
+  - config
+  - planet-pack
+  - resources
+  - graphics

--- a/NetKAN/RP-1-ExpressInstall-Graphics-Low.netkan
+++ b/NetKAN/RP-1-ExpressInstall-Graphics-Low.netkan
@@ -1,0 +1,9 @@
+spec_version: v1.12
+identifier: RP-1-ExpressInstall-Graphics-Low
+$kref: '#/ckan/netkan/https://github.com/KSP-RO/RP-1-ExpressInstall-Graphics/raw/main/RP-1-ExpressInstall-Graphics-Low.netkan'
+x_netkan_license_ok: true
+tags:
+  - config
+  - planet-pack
+  - resources
+  - graphics

--- a/NetKAN/RP-1-ExpressInstall-Graphics-Medium.netkan
+++ b/NetKAN/RP-1-ExpressInstall-Graphics-Medium.netkan
@@ -1,0 +1,9 @@
+spec_version: v1.12
+identifier: RP-1-ExpressInstall-Graphics-Medium
+$kref: '#/ckan/netkan/https://github.com/KSP-RO/RP-1-ExpressInstall-Graphics/raw/main/RP-1-ExpressInstall-Graphics-Medium.netkan'
+x_netkan_license_ok: true
+tags:
+  - config
+  - planet-pack
+  - resources
+  - graphics

--- a/NetKAN/RP-1-ExpressInstall.netkan
+++ b/NetKAN/RP-1-ExpressInstall.netkan
@@ -1,0 +1,13 @@
+spec_version: v1.12
+identifier: RP-1-ExpressInstall
+$kref: '#/ckan/netkan/https://github.com/KSP-RO/RP-1-ExpressInstall/raw/main/RP-1-ExpressInstall.netkan'
+x_netkan_license_ok: true
+tags:
+  - plugin
+  - config
+  - parts
+  - career
+  - science
+  - planet-pack
+  - resources
+  - graphics


### PR DESCRIPTION
## Purpose
This adds "express install" packages (a main package and three choices for graphics level) to allow express installation of RO/RP-1/RSS/etc.

## Motivations
RO/RP-1 users often ask for a simple gamedata zip, or "what mods should I install", or the like--to the point of asking which recommended or suggested mods to install, which graphics mods, etc.

## Changes
This adds a single express install netkan that depends on the core mods for an RP-1 install, and then depends on an RSSGraphics package. That package is provided by three express packages, each reporting only as a detail level, which depend the various RSS-Textures packages, visual enhancements, and Canaveral terrain/pads necessary for a complete experience.

Metanetkans for easy reference:

- https://raw.githubusercontent.com/KSP-RO/RP-1-ExpressInstall/main/RP-1-ExpressInstall.netkan
- https://raw.githubusercontent.com/KSP-RO/RP-1-ExpressInstall-Graphics/main/RP-1-ExpressInstall-Graphics-High.netkan
- https://raw.githubusercontent.com/KSP-RO/RP-1-ExpressInstall-Graphics/main/RP-1-ExpressInstall-Graphics-Medium.netkan
- https://raw.githubusercontent.com/KSP-RO/RP-1-ExpressInstall-Graphics/main/RP-1-ExpressInstall-Graphics-Low.netkan

## Issue ref: #8688

Once https://github.com/KSP-CKAN/CKAN/pull/3426 is merged, I will update the local netkans with comments on the graphics choice.