### PR TITLE
Mechjeb2 - add support for current KSP

### DIFF
--- a/NetKAN/MechJeb2.netkan
+++ b/NetKAN/MechJeb2.netkan
@@ -19,7 +19,8 @@
         "information",
         "control"
     ],
-    "ksp_version": "1.11",
+    "ksp_version_min": "1.8",
+    "ksp_version_max": "1.12.90",
     "install": [
         {
             "find": "MechJeb2",

--- a/NetKAN/MechJeb2.netkan
+++ b/NetKAN/MechJeb2.netkan
@@ -31,14 +31,14 @@
         { "name": "ModuleManager" }
     ],
     "x_netkan_override": [
-	    {
+        {
             "version": "2.9.2.0",
             "override": {
                 "ksp_version_min": "1.8.0",
                 "ksp_version_max": "1.9.90"
             }
         },
-	    {
+        {
             "version": "2.8.4.0",
             "override": {
                 "ksp_version_min": "1.7.0",


### PR DESCRIPTION
The new release of Mechjeb2 supports 1.8 to 1.12.
This should be the last required update of NetKAN for MJ. 