### PR TITLE
 Revert DeadlyReentry source back to Starwaster's fork 

### DIFF
--- a/NetKAN/DeadlyReentry.netkan
+++ b/NetKAN/DeadlyReentry.netkan
@@ -3,12 +3,11 @@
     "identifier"     : "DeadlyReentry",
     "name"           : "Deadly Reentry Continued",
     "abstract"       : "Makes re-entry much more dangerous",
-    "$kref"          : "#/ckan/github/KSP-RO/DeadlyReentry",
+    "$kref"          : "#/ckan/github/Starwaster/DeadlyReentry",
     "$vref"          : "#/ckan/ksp-avc",
     "license"        : "CC-BY-SA",
     "resources"      : {
-        "homepage"   : "https://forum.kerbalspaceprogram.com/index.php?/topic/204209-*",
-        "repository" : "https://github.com/KSP-RO/DeadlyReentry"
+        "homepage"   : "https://forum.kerbalspaceprogram.com/index.php?/topic/50296-*",
     },
     "tags"           : [
         "plugin",
@@ -17,7 +16,7 @@
         "sound"
     ],
     "depends"        : [
-        { "name": "ModuleManager", "min_version" : "2.6.5" }
+        { "name": "ModuleManager" }
     ],
     "install"        : [
         {
@@ -25,5 +24,6 @@
             "install_to": "GameData"
         }
     ],
-    "x_netkan_force_v": true
+    "x_netkan_force_v": true,
+    "x_netkan_epoch": 1
 }

--- a/NetKAN/DeadlyReentry.netkan
+++ b/NetKAN/DeadlyReentry.netkan
@@ -17,5 +17,6 @@ depends:
 install:
   - find: DeadlyReentry
     install_to: GameData
+    filter: .git
 x_netkan_force_v: true
 x_netkan_epoch: 1

--- a/NetKAN/DeadlyReentry.netkan
+++ b/NetKAN/DeadlyReentry.netkan
@@ -1,29 +1,21 @@
-{
-    "spec_version"   : "v1.4",
-    "identifier"     : "DeadlyReentry",
-    "name"           : "Deadly Reentry Continued",
-    "abstract"       : "Makes re-entry much more dangerous",
-    "$kref"          : "#/ckan/github/Starwaster/DeadlyReentry",
-    "$vref"          : "#/ckan/ksp-avc",
-    "license"        : "CC-BY-SA",
-    "resources"      : {
-        "homepage"   : "https://forum.kerbalspaceprogram.com/index.php?/topic/50296-*",
-    },
-    "tags"           : [
-        "plugin",
-        "parts",
-        "physics",
-        "sound"
-    ],
-    "depends"        : [
-        { "name": "ModuleManager" }
-    ],
-    "install"        : [
-        {
-            "find": "DeadlyReentry",
-            "install_to": "GameData"
-        }
-    ],
-    "x_netkan_force_v": true,
-    "x_netkan_epoch": 1
-}
+spec_version: v1.4
+identifier: DeadlyReentry
+name: Deadly Reentry Continued
+abstract: Makes re-entry much more dangerous
+$kref: '#/ckan/github/Starwaster/DeadlyReentry'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-SA
+resources:
+  homepage: 'https://forum.kerbalspaceprogram.com/index.php?/topic/50296-*'
+tags:
+  - plugin
+  - parts
+  - physics
+  - sound
+depends:
+  - name: ModuleManager
+install:
+  - find: DeadlyReentry
+    install_to: GameData
+x_netkan_force_v: true
+x_netkan_epoch: 1


### PR DESCRIPTION
This effectively reverts #8596 and #8696 to point the netkan back to https://github.com/Starwaster/DeadlyReentry, after @Starwaster became active again and created a new release.

As the new release has a lower version number than NathanKell's releases, the epoch is incremented to prompt users to "upgrade" to the new release.

A pull request in CKAN-meta will freeze the releases from the KSP-RO repository. Depending on the plans of @NathanKell, they can be moved to a new identifier after the corresponding netkan has been created,.