### PR TITLE
Upload repo artifacts for pull requests

### DIFF
--- a/.github/workflows/inflate.yml
+++ b/.github/workflows/inflate.yml
@@ -40,5 +40,12 @@ jobs:
                   source: commits
                   diff meta root: .CKAN-meta
                   pull request url: ${{ github.event.pull_request.url }}
+            - name: Upload inflated repo metadata.tar.gz artifact
+              if: ${{ github.event_name == 'pull_request' }}
+              uses: actions/upload-artifact@v2
+              with:
+                  name: metadata.tar.gz
+                  path: /repo/metadata.tar.gz
+                  retention-days: 7
             - name: Chmod cached files so actions/cache can read them
               run: sudo chmod -R a+r .cache


### PR DESCRIPTION
## Motivation

In #8701 we are trying to test GUI work flows for some metadata changes, which requires copying each .ckan file manually from the validation output to local files, then creating a tar.gz file for CKAN to use. But the metadata tester already has such a file created for its own use.

## Changes

Now `/repo/metadata.tar.gz` is uploaded as an artifact for pull requests, so we can download it and use it with CKAN directly.