### PR TITLE
Provide unique identifier for the full KSPBurst module

### DIFF
--- a/NetKAN/KSPBurst.netkan
+++ b/NetKAN/KSPBurst.netkan
@@ -4,15 +4,16 @@ name: KSPBurst
 abstract: >-
   Better multithreaded performance for mods that use it.
   Requires Mono on Linux and macOS (you have it if you're running CKAN).
+author: dkavolis
 $kref: '#/ckan/github/KSPModdingLibs/KSPBurst/asset_match/^KSPBurst_[0-9.]+\.zip$'
 $vref: '#/ckan/ksp-avc'
-author: dkavolis
 license: unknown
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/201112-*
-  repository: https://github.com/KSPModdingLibs/KSPBurst
 tags:
   - library
+provides:
+  - KSPBurst-Full
 install:
   - find: 000_KSPBurst
     install_to: GameData


### PR DESCRIPTION
## Background

#8419 added KSPBurst and KSPBurst-Lite, which provides KSPBurst.

## Problem

In #8701 we would like to be able to depend on the "full" KSPBurst module without prompting the user to choose between them, but currently this isn't possible.

## Changes

Now KSPBurst provides KSPBurst-Full, so modules can depend on it if they know they want the full featured module.