### PR TITLE
Override TundraSpaceCenter 2.0.1 max KSP version

### DIFF
--- a/NetKAN/TundraSpaceCenter.netkan
+++ b/NetKAN/TundraSpaceCenter.netkan
@@ -8,6 +8,14 @@
         "config",
         "buildings"
     ],
+    "x_netkan_override" : [
+        {
+            "version" : ">=2.0.1",
+            "override" : {
+                "ksp_version_max" : "1.12.99"
+            }
+        }
+    ],
     "depends": [
         { "name": "ModuleManager"    },
         { "name": "KerbalKonstructs" }


### PR DESCRIPTION
I asked damonvv's permission to override the CKAN versioning of TSC and was kindly granted permission. The thread title has "KSP 1.8+" and the mod is just assets and KK statics so it is not version-locked in and of itself, but I wanted to wait until I had a chance to check with damonvv regardless. Having now received the OK, here's the PR.