### PR TITLE
Revert Scatterer-sunflare and Scatterer-config dependency on Scatterer

### DIFF
--- a/NetKAN/Scatterer-config.netkan
+++ b/NetKAN/Scatterer-config.netkan
@@ -12,9 +12,7 @@
         "graphics",
         "config"
     ],
-    "depends": [
-        { "name": "Scatterer" }
-    ],
+    "comment": "Does not depend on Scatterer to match Scatterer-sunflare",
     "conflicts": [
         { "name": "Scatterer-config" }
     ],

--- a/NetKAN/Scatterer-sunflare.netkan
+++ b/NetKAN/Scatterer-sunflare.netkan
@@ -12,9 +12,7 @@
         "graphics",
         "config"
     ],
-    "depends": [
-        { "name": "Scatterer" }
-    ],
+    "comment": "Does not depend on Scatterer to avoid planet packs forcing installation of Scatterer",
     "provides": [
         "Scatterer-sunflare-default"
     ],


### PR DESCRIPTION
## Problem
In #7794, #7800, #7870, https://github.com/Galileo88/JNSQ/pull/27 we made a bunch of planet packs depend on Scatterer-sunflare-default, to force them to install the default sunflare, as they would conflict with third-party sunflares.
This was done under the then correct assumption that Scatterer-sunflare does not depend on Scatterer, so that the sunflare would only have an effect if the user chooses core Scatterer additionally themself.

In #8475, we made Scatterer-sunflare and Scatterer-config depend on Scatterer, as by itself it would make more sense, but forgetting about the planet pack situation.

## Changes
Effectively revert #8475
Now Scatterer-sunflare no longer depends on Scatterer, to right the above assumption again.
Scatterer-config is changed the same way, to keep both modules in sync, as they are very similar in their setup. Keeping the dependency for the configs could lead to more confusion due to different behaviour.

At their place is now a comment, so future us does not do the same mistake again. (And there's this PR explaining the situation)

Ideally we find a solution that doesn't require the dependency on Scatterer-sunflare-default for planet packs some day. But right now this is the easiest and quickest fix to the problem.