### PR TITLE
Upload .ckans instead of .repo/metadata.tar.gz as workflow artifact

### DIFF
--- a/.github/workflows/inflate.yml
+++ b/.github/workflows/inflate.yml
@@ -41,12 +41,12 @@ jobs:
                   diff meta root: .CKAN-meta
                   pull request url: ${{ github.event.pull_request.url }}
             - name: Chmod cached files so actions/cache and actions/upload-artifact can read them
-              run: sudo chmod -R a+r .cache .repo
+              run: sudo chmod -R a+r .cache
               if: ${{ always() }}
-            - name: Upload inflated repo metadata.tar.gz artifact
+            - name: Upload inflated ckans as metadata repository zip artifact
               if: ${{ always() && github.event_name == 'pull_request' }}
               uses: actions/upload-artifact@v2
               with:
-                  name: metadata.tar.gz
-                  path: .repo/metadata.tar.gz
+                  name: metadata-${{ github.event.pull_request.number }}
+                  path: .ckans
                   retention-days: 7


### PR DESCRIPTION
See https://github.com/KSP-CKAN/xKAN-meta_testing/pull/80 and https://github.com/KSP-CKAN/NetKAN/pull/8704#issuecomment-895115027, this uploads the `.ckans` directory instead of the `.repo/metadata.tar.gz` file, to avoid double compression. I hope the filename turns out the way I think it does.