### PR TITLE
Pin min compat for PanoceanCanal

### DIFF
--- a/NetKAN/PanoceanCanal.netkan
+++ b/NetKAN/PanoceanCanal.netkan
@@ -11,3 +11,7 @@ depends:
   - name: KerbalKonstructs
   - name: KerbinSideCore
   - name: StockalikeStructures
+x_netkan_override:
+  - version: v1.0.0
+    override:
+      ksp_version_min: 1.11.2


### PR DESCRIPTION
Originally uploaded to SpaceDock for 1.11.2, just updated to 1.12.2. Let's see if I have the YAML right.

___

ckan compat add 1.5