### PR TITLE
Force 'v' for Kronometer

### DIFF
--- a/NetKAN/Kronometer.netkan
+++ b/NetKAN/Kronometer.netkan
@@ -1,21 +1,20 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "Kronometer",
-    "name":         "Kronometer",
-    "abstract":     "A mod to manipulate the clock for Kerbal Space Program",
-    "author":       [ "Thomas P.", "Sigma88", "linuxgurugamer" ],
-    "$kref":        "#/ckan/github/linuxgurugamer/Kronometer",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/161218-*"
-    },
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "install": [ {
-        "find":       "Kronometer",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.4
+identifier: Kronometer
+name: Kronometer
+abstract: A mod to manipulate the clock for Kerbal Space Program
+author:
+  - Thomas P.
+  - Sigma88
+  - linuxgurugamer
+$kref: '#/ckan/github/linuxgurugamer/Kronometer'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+license: MIT
+resources:
+  homepage: http://forum.kerbalspaceprogram.com/index.php?/topic/161218-*
+tags:
+  - plugin
+  - information
+install:
+  - find: Kronometer
+    install_to: GameData


### PR DESCRIPTION
The bot submitted KSP-CKAN/CKAN-meta#2439 because the 'v' was dropped.
Now `x_netkan_force_v` is set to avoid this.