### PR TITLE
Make Kronometer depend on Kopernicus

### DIFF
--- a/NetKAN/Kronometer.netkan
+++ b/NetKAN/Kronometer.netkan
@@ -15,6 +15,8 @@ resources:
 tags:
   - plugin
   - information
+depends:
+  - name: Kopernicus
 install:
   - find: Kronometer
     install_to: GameData


### PR DESCRIPTION
This mod had been bundling `Kopernicus.Parser.dll`, which caused crashes for users with Kopernicus installed on KSP 1.12.

@linuxgurugamer has released a version without that DLL. Now it depends on Kopernicus to make sure the real DLL is installed.

- ~~We need to do the same for JNSQ's bundled Kronometer DLL~~
  Will have to happen at the metanetkan:  https://github.com/Galileo88/JNSQ/blob/master/CKAN/JNSQ.netkan