### PR TITLE
Fix dbent metanetkan branches

### DIFF
--- a/NetKAN/HotSpot.netkan
+++ b/NetKAN/HotSpot.netkan
@@ -1,10 +1,8 @@
-{
-    "spec_version": 1,
-    "identifier": "HotSpot",
-    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Apokee/HotSpot/master/HotSpot.netkan",
-    "x_netkan_license_ok": true,
-    "tags": [
-        "plugin",
-        "information"
-    ]
-}
+spec_version: 1
+identifier: HotSpot
+$kref: >-
+  #/ckan/netkan/https://raw.githubusercontent.com/Apokee/HotSpot/develop/HotSpot.netkan
+license: MIT
+tags:
+  - plugin
+  - information

--- a/NetKAN/PlaneMode.netkan
+++ b/NetKAN/PlaneMode.netkan
@@ -1,10 +1,8 @@
-{
-    "spec_version": 1,
-    "identifier": "PlaneMode",
-    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/Apokee/PlaneMode/master/PlaneMode.netkan",
-    "x_netkan_license_ok": true,
-    "tags": [
-        "plugin",
-        "control"
-    ]
-}
+spec_version: 1
+identifier: PlaneMode
+$kref: >-
+  #/ckan/netkan/https://raw.githubusercontent.com/Apokee/PlaneMode/develop/PlaneMode.netkan
+license: MIT
+tags:
+  - plugin
+  - control


### PR DESCRIPTION
## Problem

These errors haven't gone away.

![image](https://user-images.githubusercontent.com/1559108/131266732-97ea88c9-1b2c-45e7-ac17-06c81f947f00.png)

## Cause

As of a few hours ago, these mods no longer have a `master` branch and appear to have a `develop` branch instead.

## Changes

Now we reference the metanetkans on the develop branches.