### PR TITLE
Update StockWaterfallEffects compatibility for 0.5.2

### DIFF
--- a/NetKAN/StockWaterfallEffects.netkan
+++ b/NetKAN/StockWaterfallEffects.netkan
@@ -2,8 +2,8 @@
     "spec_version": "v1.4",
     "identifier":   "StockWaterfallEffects",
     "$kref":        "#/ckan/github/KnightofStJohn/StockWaterfallEffects",
-    "ksp_version_min": "1.8.1",
-    "ksp_version_max": "1.11",
+    "ksp_version_min": "1.11",
+    "ksp_version_max": "1.12.2",
     "license":      "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/200334-*"


### PR DESCRIPTION
This mod with hardcoded compatibility just had a new release, 0.5.2.
The author confirmed a compatibility range of KSP 1.11-1.12.2 on Discord:
![image](https://user-images.githubusercontent.com/28812678/131511330-9fe2de94-7d34-4695-ae17-6a14a901b956.png)
