### PR TITLE
Make TETRIXTechTree version_edit regex typo-safe

### DIFF
--- a/NetKAN/TETRIXTechTree.netkan
+++ b/NetKAN/TETRIXTechTree.netkan
@@ -4,7 +4,7 @@
     "$kref":        "#/ckan/spacedock/2299",
     "license":      "CC-BY-NC-SA",
     "x_netkan_version_edit": {
-        "find": "^(?<version>.+)\\.(?<date>[0-9]{4,8})$",
+        "find": "^(?<version>.+)\\.(?<date>[0-9]{4,8}.*)$",
         "replace": "${version}",
         "strict": true
     },


### PR DESCRIPTION
The latest release of TETRIXTechTree has a typo in the version number, as confirmed by the author:

- https://spacedock.info/mod/2299/TETRIX%20TechTree#changelog (`2.13.202109.2` should be `2.13.20210902`)
- https://forum.kerbalspaceprogram.com/index.php?/topic/174731-1122-tetrix-techtree-213-and-simplex-techtree-121/&do=findComment&comment=4027073

Due to the regex added in #8646, the inflation fails.

The author offered us to completely drop the date parts of the version number in future releases, so we could get rid of the regexs completely.
However as we don't know when new releases will drop, for now I'm editing the regex to cope with the typo and get the release indexed.
This makes the regex more ambiguous, now we only rely on the date part beginning with at least 4 digits, and take everything i front as the actual version number, and everything afterwards as appendix/typo of the date.

Normally I would've edited all of theJesuit's mods to keep the regexes in the netkans in sync, but as we will likely no longer need the soon, I saved myself the effort.