### PR TITLE
Specify name of ScrapYard version file

### DIFF
--- a/NetKAN/ScrapYard.netkan
+++ b/NetKAN/ScrapYard.netkan
@@ -7,4 +7,3 @@ tags:
   - plugin
 depends:
   - name: ModuleManager
-  - name: MagiCore

--- a/NetKAN/ScrapYard.netkan
+++ b/NetKAN/ScrapYard.netkan
@@ -1,14 +1,10 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "ScrapYard",
-    "$kref":        "#/ckan/spacedock/1746",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "MagiCore"      }
-    ]
-}
+spec_version: v1.4
+identifier: ScrapYard
+$kref: '#/ckan/spacedock/1746'
+$vref: '#/ckan/ksp-avc/ScrapYard.version'
+license: MIT
+tags:
+  - plugin
+depends:
+  - name: ModuleManager
+  - name: MagiCore


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/133868345-f0c3769f-d4a9-46dc-a412-05ab4394ffcd.png)

@zer0Kerbal has clarified that the original version file is still applicable, and that this mod isn't bundling ContractConfigurator. Now we tell Netkan which version file to use.

https://forum.kerbalspaceprogram.com/index.php?/topic/192456-112x-scrapyard-the-common-part-inventory-2200-prerelease-2021-jul-19/page/3/&tab=comments#comment-4033347