### PR TITLE
Fix GrannusExpansionPack-Rescale install folder

### DIFF
--- a/NetKAN/GrannusExpansionPack-Rescale.netkan
+++ b/NetKAN/GrannusExpansionPack-Rescale.netkan
@@ -1,24 +1,18 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "GrannusExpansionPack-Rescale",
-    "name":         "Grannus Expansion Pack Rescale",
-    "abstract":     "Grannus Expansion Pack rescaled 2.5x",
-    "$kref":        "#/ckan/github/OhioBob/Grannus-Expansion-Pack",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-ND",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/169664-*"
-    },
-    "tags": [
-        "config",
-        "planet-pack"
-    ],
-    "depends": [
-        { "name": "ModuleManager"        },
-        { "name": "GrannusExpansionPack" }
-    ],
-    "install": [ {
-        "find":       "GEP_Rescale/Game Data/GEP_Rescale",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.4
+identifier: GrannusExpansionPack-Rescale
+name: Grannus Expansion Pack Rescale
+abstract: Grannus Expansion Pack rescaled 2.5x
+$kref: '#/ckan/github/OhioBob/Grannus-Expansion-Pack'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-ND
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/169664-*
+tags:
+  - config
+  - planet-pack
+depends:
+  - name: ModuleManager
+  - name: GrannusExpansionPack
+install:
+  - find: GEP_Rescale/Rescale_2.5X/Game Data/GEP_Rescale
+    install_to: GameData


### PR DESCRIPTION
The folder for this 2.X rescale patch has moved, because there's now also a new 10X rescale patch.
Probably won't inflate properly due to version file syntax errors, see OhioBob/Grannus-Expansion-Pack#7.