### PR TITLE
Add OreToParts

### DIFF
--- a/NetKAN/OreToParts.netkan
+++ b/NetKAN/OreToParts.netkan
@@ -1,0 +1,15 @@
+spec_version: 1
+identifier: OreToParts
+name: Ore To Parts
+abstract: >-
+  Transforms ore tanks into ore to part converters, part duplicators or ore to
+  EVA fuel converters.
+$kref: '#/ckan/github/Goufalite/OreToParts'
+ksp_version_min: 1.11.2
+license: CC-BY-SA-4.0
+resources:
+  manual: https://github.com/Goufalite/OreToParts/wiki
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/203705-*
+  x_screenshot: https://imgur.com/I5dEh7a.png
+depends:
+  - name: ModuleManager

--- a/NetKAN/OreToParts.netkan
+++ b/NetKAN/OreToParts.netkan
@@ -11,5 +11,8 @@ resources:
   manual: https://github.com/Goufalite/OreToParts/wiki
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/203705-*
   x_screenshot: https://imgur.com/I5dEh7a.png
+tags:
+  - plugin
+  - resources
 depends:
   - name: ModuleManager


### PR DESCRIPTION
https://github.com/Goufalite/OreToParts
https://forum.kerbalspaceprogram.com/index.php?/topic/203705-11121121ore

Fixes #8781.

- `version` removed because it will be pulled from each release
- `asset_match` removed because the releases have only one non-source asset
- `resources.license` removed because it's just a link to the standard definition of CC-BY-SA-4.0
- `author` removed because the same value will be pulled from the repo automatically