### PR TITLE
Distant Object is under New Management.

### DIFF
--- a/NetKAN/DistantObject-default.netkan
+++ b/NetKAN/DistantObject-default.netkan
@@ -1,14 +1,14 @@
 {
     "spec_version": "v1.16",
     "identifier":   "DistantObject-default",
-    "name":         "Distant Object Enhancement Continued default config",
+    "name":         "Distant Object Enhancement /L default config",
     "abstract":     "Default planets colors",
-    "$kref":        "#/ckan/github/TheDarkBadger/DistantObject",
+    "$kref":        "#/ckan/github/net-lisias-ksp/DistantObject",
     "$vref":        "#/ckan/ksp-avc",
     "x_netkan_force_v": true,
     "license":      "CC-BY-4.0",
     "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/189759-*"
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/205063-*"
     },
     "tags": [
         "config",

--- a/NetKAN/DistantObject.netkan
+++ b/NetKAN/DistantObject.netkan
@@ -1,14 +1,14 @@
 {
     "spec_version": "v1.4",
     "identifier":   "DistantObject",
-    "name":         "Distant Object Enhancement Continued",
+    "name":         "Distant Object Enhancement /L",
     "abstract":     "Visual enhancement mod that makes objects realistically visible over large distances",
-    "$kref":        "#/ckan/github/TheDarkBadger/DistantObject",
+    "$kref":        "#/ckan/github/net-lisias-ksp/DistantObject",
     "$vref":        "#/ckan/ksp-avc",
     "x_netkan_force_v": true,
     "license":      "CC-BY-4.0",
-    "resources" : {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/189759-*"
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/205063-*"
     },
     "tags": [
         "plugin",


### PR DESCRIPTION
Hi!

Distant Object (Continued) is under New Management, and this pull request redirects the links reflecting the change.

In time… How this `DistantObject-config` stunt works? I found a frozen one for RRS, there's the "default" (aka Stock) one, and so goes on…

Cheers!

(I tried to ping TheDarkBadger here, but I'm unable)