### PR TITLE
HangarGrid fixes

### DIFF
--- a/NetKAN/HangarGrid.netkan
+++ b/NetKAN/HangarGrid.netkan
@@ -3,13 +3,10 @@ identifier: HangarGrid
 $kref: '#/ckan/spacedock/2872'
 $vref: '#/ckan/ksp-avc'
 license: GPL-3.0
-resources:
-  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/205069-112x-
-  repository: https://github.com/linuxgurugamer/HangarGrid
+tags:
+  - plugin
+  - editor
 depends:
   - name: ToolbarController
   - name: ClickThroughBlocker
   - name: SpaceTuxLibrary
-tags:
-  - plugin
-  - editor

--- a/NetKAN/HangarGrid.netkan
+++ b/NetKAN/HangarGrid.netkan
@@ -1,31 +1,15 @@
-{
-  "license": "GPL-3.0",
-  "identifier": "HangarGrid",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "$kref": "#/ckan/spacedock/2872",
-  "$vref": "#/ckan/ksp-avc",
-  "resources": {
-    "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/205069-112x-",
-    "repository": "https://github.com/linuxgurugamer/HangarGrid"
-  },
-  "depends": [
-    {
-      "name": "HangarGrid"
-    },
-    {
-      "name": "ToolbarController"
-    },
-    {
-      "name": "ClickThroughBlocker"
-    },
-    {
-      "name": "SpaceTuxLibrary"
-    }
-  ],
-  "tags": [
-    "plugin",
-    "editor"
-  ],
-  "install": [],
-  "spec_version": "v1.4"
-}
+spec_version: v1.4
+identifier: HangarGrid
+$kref: '#/ckan/spacedock/2872'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/205069-112x-
+  repository: https://github.com/linuxgurugamer/HangarGrid
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+tags:
+  - plugin
+  - editor


### PR DESCRIPTION
Some things were missed in KSP-CKAN/NetKAN#8796.

- Mod depends on itself unintentionally
- `resources.homepage` and `resources.repository` set unnecesarily
- Empty `install` list

These will be fixed here.