### PR TITLE
Fix UTechNuclearScienceInk install

### DIFF
--- a/NetKAN/UTechNuclearScienceInk.netkan
+++ b/NetKAN/UTechNuclearScienceInk.netkan
@@ -5,6 +5,6 @@ ksp_version: any
 license: MIT
 tags:
   - parts
-install
+install:
   - find: Utek NTS
     install_to: GameData


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/136705963-13845dfc-62f9-4f5c-b544-e4780a369c59.png)

Also see #8808, the same ZIP was uploaded to this mod and a new mod for unknown reasons. We'll keep the existing identifier.