### PR TITLE
Remove vref from LessRealKerbalism

### DIFF
--- a/NetKAN/LessRealKerbalism.netkan
+++ b/NetKAN/LessRealKerbalism.netkan
@@ -1,32 +1,24 @@
-{
-    "spec_version": "v1.18",
-    "identifier":   "LessRealKerbalism",
-    "name":         "Kerbalism - LRTR Config",
-    "$kref":        "#/ckan/github/pehvbot/LRKerbalism",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/189978-*"
-    },
-    "tags": [
-        "config",
-        "crewed",
-        "science",
-        "parts"
-    ],
-    "provides": [ "Kerbalism-Config" ],
-    "conflicts": [
-        { "name": "Kerbalism-Config" }
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "Kerbalism"     }
-    ],
-    "recommends": [
-        { "name": "LessRealThanReal" }
-    ],
-    "install": [ {
-        "find":       "KerbalismConfig",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.18
+identifier: LessRealKerbalism
+name: Kerbalism - LRTR Config
+$kref: '#/ckan/github/pehvbot/LRKerbalism'
+license: CC-BY-NC-SA-4.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/189978-*
+tags:
+  - config
+  - crewed
+  - science
+  - parts
+provides:
+  - Kerbalism-Config
+conflicts:
+  - name: Kerbalism-Config
+depends:
+  - name: ModuleManager
+  - name: Kerbalism
+recommends:
+  - name: LessRealThanReal
+install:
+  - find: KerbalismConfig
+    install_to: GameData


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/138476173-da0353b9-e6c4-4085-955b-575dda1554ce.png)

See pehvbot/LRKerbalism#1, this mod formerly had the wrong version file in it. Now it has none, so a vref isn't needed.