### PR TITLE
Vref for CarnationREDFlexibleParts

### DIFF
--- a/NetKAN/CarnationREDFlexibleParts.netkan
+++ b/NetKAN/CarnationREDFlexibleParts.netkan
@@ -1,17 +1,13 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "CarnationREDFlexibleParts",
-    "$kref":        "#/ckan/spacedock/2380",
-    "license":      "CC-BY-SA-4.0",
-    "tags": [
-        "plugin",
-        "parts"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "install": [ {
-        "find":       "CarnationREDFlexiblePart",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.4
+identifier: CarnationREDFlexibleParts
+$kref: '#/ckan/spacedock/2380'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-SA-4.0
+tags:
+  - plugin
+  - parts
+depends:
+  - name: ModuleManager
+install:
+  - find: CarnationREDFlexiblePart
+    install_to: GameData


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/139451245-a53d2c0c-0135-4bbc-9d0e-a062387bbadc.png)

Now a vref is added.

Also noticed that the new download is ~53x larger than the previous version, but that appears to be intentional because many more textures are included.