### PR TITLE
Override compat of StrangeNewWorlds v0.1.2

### DIFF
--- a/NetKAN/StrangeNewWorlds.netkan
+++ b/NetKAN/StrangeNewWorlds.netkan
@@ -27,3 +27,8 @@ install:
     install_to: GameData
     filter:
       - .DS_Store
+x_netkan_override:
+  - version: v0.1.2
+    override:
+      ksp_version_min: 1.8
+      ksp_version_max: 1.12

--- a/NetKAN/StrangeNewWorlds.netkan
+++ b/NetKAN/StrangeNewWorlds.netkan
@@ -1,36 +1,29 @@
-{
-    "spec_version": "v1.26",
-    "identifier":   "StrangeNewWorlds",
-    "$kref":        "#/ckan/spacedock/2777",
-    "license":      "CC-BY-NC-ND",
-    "tags": [
-        "config",
-        "planet-pack"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "Kopernicus"    }
-    ],
-    "recommends": [
-        { "name": "EnvironmentalVisualEnhancements"              },
-        { "name": "EnvironmentalVisualEnhancements-Config-stock" },
-        { "name": "Scatterer"                                    },
-        { "name": "TiltUnlocker"                                 },
-        { "any_of": [
-            { "name": "KopernicusExpansionContinued-Wormholes" },
-            { "name": "Blueshift"                              },
-            { "name": "KSPInterstellarExtended"                },
-            { "name": "FarFutureTechnologies"                  }
-        ] },
-        { "name": "BetterTimeWarpCont" }
-    ],
-    "suggests": [
-        { "name": "BeyondHome"                          },
-        { "name": "ExtrasolarPlanetsBeyondKerbol-stock" }
-    ],
-    "install": [ {
-        "find":       "GameData/StrangeNewWorlds",
-        "install_to": "GameData",
-        "filter":     [ ".DS_Store" ]
-    } ]
-}
+spec_version: v1.26
+identifier: StrangeNewWorlds
+$kref: '#/ckan/spacedock/2777'
+license: CC-BY-NC-ND
+tags:
+  - config
+  - planet-pack
+depends:
+  - name: ModuleManager
+  - name: Kopernicus
+recommends:
+  - name: EnvironmentalVisualEnhancements
+  - name: EnvironmentalVisualEnhancements-Config-stock
+  - name: Scatterer
+  - name: TiltUnlocker
+  - any_of:
+      - name: KopernicusExpansionContinued-Wormholes
+      - name: Blueshift
+      - name: KSPInterstellarExtended
+      - name: FarFutureTechnologies
+  - name: BetterTimeWarpCont
+suggests:
+  - name: BeyondHome
+  - name: ExtrasolarPlanetsBeyondKerbol-stock
+install:
+  - find: GameData/StrangeNewWorlds
+    install_to: GameData
+    filter:
+      - .DS_Store


### PR DESCRIPTION
The author has let me know that the current release of this mod works in the range of KSP 1.8 to KSP 1.12.
![discord conversation](https://user-images.githubusercontent.com/28812678/139597685-ea1ff339-3226-4e7f-8656-379c51863750.png)

This also matches their comments on the forum thread:
https://forum.kerbalspaceprogram.com/index.php?/topic/202909-18-111-strange-new-worlds-a-new-high-quality-star-system-to-explore/&do=findComment&comment=4001617

They don't want to update the SpaceDock page or forum thread title until the next update though.