### PR TITLE
Add resources.manual for ModuleManager

### DIFF
--- a/NetKAN/ModuleManager.netkan
+++ b/NetKAN/ModuleManager.netkan
@@ -1,46 +1,37 @@
-{
-    "spec_version": "v1.16",
-    "identifier": "ModuleManager",
-    "name": "Module Manager",
-    "abstract": "Modify KSP configs without conflict",
-    "author": [ "ialdabaoth", "Sarbian", "Blowfish" ],
-    "$kref": "#/ckan/jenkins/https://ksp.sarbian.com/jenkins/job/ModuleManager/",
-    "x_netkan_jenkins": {
-        "use_filename_version": true
-    },
-    "x_netkan_version_edit": "^ModuleManager-(?<version>\\d+\\.\\d+\\.\\d+)\\.zip$",
-    "ksp_version_min": "1.8",
-    "ksp_version_max": "1.12",
-    "license": "CC-BY-SA",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/50533-*",
-        "repository": "https://github.com/sarbian/ModuleManager"
-    },
-    "tags": [
-        "plugin",
-        "library"
-    ],
-    "install": [
-        {
-            "find_regexp": "ModuleManager.*\\.dll$",
-            "find_matches_files": true,
-            "install_to": "GameData"
-        }
-    ],
-    "x_netkan_override": [
-        {
-            "version": "4.0.3",
-            "override": {
-                "ksp_version_min": "1.4.0",
-                "ksp_version_max": "1.7.90"
-            }
-        },
-        {
-            "version": "3.0.4",
-            "delete": [ "ksp_version_min", "ksp_version_max" ],
-            "override": {
-                "ksp_version" : "1.3"
-            }
-        }
-    ]
-}
+spec_version: v1.16
+identifier: ModuleManager
+name: Module Manager
+abstract: Modify KSP configs without conflict
+author:
+  - ialdabaoth
+  - Sarbian
+  - Blowfish
+$kref: '#/ckan/jenkins/https://ksp.sarbian.com/jenkins/job/ModuleManager/'
+x_netkan_jenkins:
+  use_filename_version: true
+x_netkan_version_edit: ^ModuleManager-(?<version>\d+\.\d+\.\d+)\.zip$
+ksp_version_min: 1.8
+ksp_version_max: 1.12
+license: CC-BY-SA
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/50533-*
+  repository: https://github.com/sarbian/ModuleManager
+  manual: https://github.com/sarbian/ModuleManager/wiki/Module-Manager-Syntax
+tags:
+  - plugin
+  - library
+install:
+  - find_regexp: ModuleManager.*\.dll$
+    find_matches_files: true
+    install_to: GameData
+x_netkan_override:
+  - version: 4.0.3
+    override:
+      ksp_version_min: 1.4.0
+      ksp_version_max: 1.7.90
+  - version: 3.0.4
+    delete:
+      - ksp_version_min
+      - ksp_version_max
+    override:
+      ksp_version: '1.3'


### PR DESCRIPTION
ModuleManager has a pretty decent wiki describing the syntax, but it's not hugely discoverable.
Now it's added to `resources.manual` so I can easily click it from the Netkan status page.