### PR TITLE
Fix install stanza for Adiri's TUFX Profiles

### DIFF
--- a/NetKAN/C1ustasTUFXProfiles.netkan
+++ b/NetKAN/C1ustasTUFXProfiles.netkan
@@ -8,5 +8,5 @@ tags:
 depends:
   - name: TUFX
 install:
-  - find: C1usta TUFX
+  - find: Adiri's TUFX Profiles
     install_to: GameData


### PR DESCRIPTION
The author of this mod changed their username (on SpaceDock, the forum, Discord, and probably a lot of other places as well), and with the latest release the directory name in the ZIP has been adjusted accordingly:

> New inflation error for C1ustasTUFXProfiles: No files found matching find="C1usta TUFX" to install!