### PR TITLE
Conflicts between MinorPlanetsExpansionRevived and MinorPlanetsExpansion

### DIFF
--- a/NetKAN/MinorPlanetsExpansionRevived.netkan
+++ b/NetKAN/MinorPlanetsExpansionRevived.netkan
@@ -5,6 +5,8 @@ license: MIT
 tags:
   - config
   - planet-pack
+conflicts:
+  - name: MinorPlanetsExpansion
 depends:
   - name: ModuleManager
   - name: Kopernicus


### PR DESCRIPTION
While reviewing #8859 I realized that these two mods probably functionally conflict as they add many of the same planets.
Now the conflict is in the metadata.

___

ckan compat add 1.11