### PR TITLE
Fix install_to capitalization of Scatterer config and sunflare

### DIFF
--- a/NetKAN/Scatterer-config.netkan
+++ b/NetKAN/Scatterer-config.netkan
@@ -14,8 +14,8 @@ comment: Does not depend on Scatterer to match Scatterer-sunflare
 conflicts:
   - name: Scatterer-config
 install:
-  - find: scatterer/config
-    install_to: GameData/scatterer
+  - find: Scatterer/config
+    install_to: GameData/Scatterer
     filter: Sunflares
 x_netkan_override:
   - version:

--- a/NetKAN/Scatterer-sunflare.netkan
+++ b/NetKAN/Scatterer-sunflare.netkan
@@ -19,7 +19,7 @@ conflicts:
   - name: Scatterer-sunflare
 install:
   - find: Sunflares
-    install_to: GameData/scatterer/config
+    install_to: GameData/Scatterer/config
 x_netkan_override:
   - version:
       - '>=3:v0.0723'

--- a/NetKAN/Scatterer.netkan
+++ b/NetKAN/Scatterer.netkan
@@ -14,7 +14,7 @@ depends:
 conflicts:
   - name: Scatterer
 install:
-  - find: scatterer
+  - find: Scatterer
     install_to: GameData
     filter_regexp: config\/.*
 x_netkan_override:


### PR DESCRIPTION
Latest Scatterer update (0.0825b) changed the capitalization of the directory name in GameData from `scatterer` to `Scatterer`.
This seems to cause some issues within CKAN, especially on systems with case-insensitive filesystems (-> Windows).

The `install_to` stanza of the config and sunflare modules still install it with a the lower-case directory name.
On Linux, this creates to separate directories, on Windows the one that gets installed first wins.

There might still be code fixes needed in the client, but at least the metadata is correct now.

Note that while the `find` properties where still lowercase too, the relevant parts within netkan and the client did match those case-insensitive, that's why we didn't get "No file found to install errors" after the update.