### PR TITLE
Try to rename ShipManifest's CLSInterfaces.dll

### DIFF
--- a/NetKAN/ShipManifest.netkan
+++ b/NetKAN/ShipManifest.netkan
@@ -32,4 +32,4 @@ install:
   - find: CLSInterfaces.dll
     find_matches_files: true
     install_to: GameData/ShipManifest/Plugins
-    as: SM_CLSInterfaces.dll
+    as: SM_CLSInterface.dll

--- a/NetKAN/ShipManifest.netkan
+++ b/NetKAN/ShipManifest.netkan
@@ -1,4 +1,4 @@
-spec_version: v1.4
+spec_version: v1.18
 identifier: ShipManifest
 name: Ship Manifest
 abstract: Manages Crew, Science, & Resources on a given vessel
@@ -24,3 +24,12 @@ suggests:
   - name: DeepFreeze
   - name: RemoteTech
   - name: ModuleManager
+install:
+  - find: ShipManifest
+    install_to: GameData
+    filter:
+      - CLSInterfaces.dll
+  - find: CLSInterfaces.dll
+    find_matches_files: true
+    install_to: GameData/ShipManifest/Plugins
+    as: SM_CLSInterfaces.dll


### PR DESCRIPTION
## Problem

KSP 1.12 can crash if it finds two DLLs with the same name.
Currently `ConnectedLivingSpace` ships a `CLSInterfaces.dll` file that is _intended_ to be used that way. `ShipManifest` bundles this DLL, so if both mods are installed, the game can crash.

The author is planning to rename this file to eliminate the conflict:

https://forum.kerbalspaceprogram.com/index.php?/topic/109972-111x-connected-living-space-v2006-29-dec-2020/&do=findComment&comment=4058927

## Changes

Now CKAN will install the `CLSInterfaces.dll` from the current release of `ShipManifest` as `SM_CLSInterfaces.dll`. This should fix the problem without breaking anything else.

At the moment I just want to submit this to make sure it works as expected in the validation scripts. If so, it may be suitable to merge, but I want to confirm with the mod author first.

Fixes #8874.