### PR TITLE
Try to enforce Scatterer compatibility for GPP and GEP

### DIFF
--- a/NetKAN/GPP.netkan
+++ b/NetKAN/GPP.netkan
@@ -27,6 +27,8 @@ depends:
   - name: ModuleManager
 conflicts:
   - name: StockVisualEnhancements
+  - name: Scatterer
+    version_min: '3:v0.0825b'
 recommends:
   - name: Strategia
   - name: FinalFrontier

--- a/NetKAN/GPPSecondary.netkan
+++ b/NetKAN/GPPSecondary.netkan
@@ -22,6 +22,8 @@ install:
 conflicts:
   - name: GPP
   - name: StockVisualEnhancements
+  - name: Scatterer
+    version_min: '3:v0.0825b'
 depends:
   - name: ModuleManager
   - name: Kopernicus

--- a/NetKAN/GrannusExpansionPack.netkan
+++ b/NetKAN/GrannusExpansionPack.netkan
@@ -1,41 +1,36 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "GrannusExpansionPack",
-    "$kref":        "#/ckan/github/OhioBob/Grannus-Expansion-Pack",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-ND",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/169664-*"
-    },
-    "tags": [
-        "config",
-        "planet-pack"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "Kopernicus"    }
-    ],
-    "recommends": [
-        { "name": "EnvironmentalVisualEnhancements" },
-        { "name": "Scatterer"                       },
-        { "name": "DistantObject"                   },
-        { "name": "ResearchBodies"                  },
-        { "name": "FinalFrontier"                   },
-        { "name": "KerbalHealth"                    },
-        { "name": "Grannus-RibbonPack"              }
-    ],
-    "suggests": [
-        { "name": "GPP"                          },
-        { "name": "GrannusExpansionPack-Primary" },
-        { "name": "GrannusExpansionPack-Rescale" },
-        { "name": "GrannusExpansionPack-CommNet" }
-    ],
-    "install": [ {
-        "file":       "GameData/GEP",
-        "install_to": "GameData"
-    }, {
-        "find":       "GameData/Nereid",
-        "install_to": "GameData",
-        "filter":     [ "Grannus" ]
-    } ]
-}
+spec_version: v1.4
+identifier: GrannusExpansionPack
+$kref: '#/ckan/github/OhioBob/Grannus-Expansion-Pack'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-ND
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/169664-*
+tags:
+  - config
+  - planet-pack
+conflicts:
+  - name: Scatterer
+    version_min: '3:v0.0825b'
+depends:
+  - name: ModuleManager
+  - name: Kopernicus
+recommends:
+  - name: EnvironmentalVisualEnhancements
+  - name: Scatterer
+  - name: DistantObject
+  - name: ResearchBodies
+  - name: FinalFrontier
+  - name: KerbalHealth
+  - name: Grannus-RibbonPack
+suggests:
+  - name: GPP
+  - name: GrannusExpansionPack-Primary
+  - name: GrannusExpansionPack-Rescale
+  - name: GrannusExpansionPack-CommNet
+install:
+  - file: GameData/GEP
+    install_to: GameData
+  - find: GameData/Nereid
+    install_to: GameData
+    filter:
+      - Grannus


### PR DESCRIPTION
## Motivation

The latest release announcements for GPP, GEP, and JNSQ all say:

![image](https://user-images.githubusercontent.com/1559108/143488517-19a6e32f-770d-4e0f-8cb8-88532bba9aad.png)

## Changes

Now GPP, GPPSecondary, and GEP conflict with Scatterer 3:0.0825b and later (on the assumption that the latest Scatterer changes will not be rolled back).

JNSQ has a metanetkan, so Team Galileo will have to handle that one themselves.

https://raw.githubusercontent.com/Galileo88/JNSQ/master/CKAN/JNSQ.netkan

We will probably have to add this conflict to all the historical versions as well to prevent them from being installed if the user installs Scatterer first.