### PR TITLE
GPP/GEP: version_min → min_version

### DIFF
--- a/NetKAN/GPP.netkan
+++ b/NetKAN/GPP.netkan
@@ -28,7 +28,7 @@ depends:
 conflicts:
   - name: StockVisualEnhancements
   - name: Scatterer
-    version_min: '3:v0.0825b'
+    min_version: '3:v0.0825b'
 recommends:
   - name: Strategia
   - name: FinalFrontier

--- a/NetKAN/GPPSecondary.netkan
+++ b/NetKAN/GPPSecondary.netkan
@@ -23,7 +23,7 @@ conflicts:
   - name: GPP
   - name: StockVisualEnhancements
   - name: Scatterer
-    version_min: '3:v0.0825b'
+    min_version: '3:v0.0825b'
 depends:
   - name: ModuleManager
   - name: Kopernicus

--- a/NetKAN/GrannusExpansionPack.netkan
+++ b/NetKAN/GrannusExpansionPack.netkan
@@ -10,7 +10,7 @@ tags:
   - planet-pack
 conflicts:
   - name: Scatterer
-    version_min: '3:v0.0825b'
+    min_version: '3:v0.0825b'
 depends:
   - name: ModuleManager
   - name: Kopernicus


### PR DESCRIPTION
## Problem

Right now the latest versions of GPP, GPPSecondary, and GEP conflict with _all_ versions of Scatterer. That's very wrong.

## Cause

In #8880, I tried to add a version-specific conflict to these mods. However, since I very frequently use the `ksp_version_min` property and almost never the `min_version` property, I typed `version_min` instead, which is not a relationship property. The client interprets this as a conflict with no version limits.

## Changes

Now the `version_min` properties are changed to `min_version`.