### PR TITLE
Add conflicts between ContractConfigurator-HistoricMissions variants

### DIFF
--- a/NetKAN/ContractConfigurator-HistoricMissions.frozen
+++ b/NetKAN/ContractConfigurator-HistoricMissions.frozen
@@ -9,6 +9,9 @@
     "depends": [
         { "name": "ContractConfigurator", "min_version": "1.15.1" }
     ],
+    "conflicts": [
+        { "name": "ContractConfigurator-HistoricMissionsRSS" }
+    ],
     "install": [
         {
             "find"       : "RegularVersion/ContractPacks/HistoricMissions",

--- a/NetKAN/ContractConfigurator-HistoricMissionsRSS.frozen
+++ b/NetKAN/ContractConfigurator-HistoricMissionsRSS.frozen
@@ -11,6 +11,9 @@
         { "name": "ContractConfigurator", "min_version": "1.15.1" },
         { "name": "RealSolarSystem" }
     ],
+    "conflicts": [
+        { "name": "ContractConfigurator-HistoricMissions" }
+    ],
     "install": [
         {
             "find"       : "RSSVersion/ContractPacks/HistoricMissions",


### PR DESCRIPTION
There are two variants of HistoricMissions, one for RSS and one for "stock".
They are currently not marked as conflicts, which they should be as they try to write the same files.

Both modules are already frozen due to inactivity, a CKAN-meta PR will follow in a minute, this one is just for completeness.