### PR TITLE
Tags, vref, and license fix for BrickMod

### DIFF
--- a/NetKAN/BrickMod.netkan
+++ b/NetKAN/BrickMod.netkan
@@ -2,6 +2,6 @@ spec_version: v1.4
 identifier: BrickMod
 $kref: '#/ckan/spacedock/2905'
 $vref: '#/ckan/ksp-avc'
-license: CC-NC-SA-3.0
+license: CC-BY-NC-SA-3.0
 tags:
   - parts

--- a/NetKAN/BrickMod.netkan
+++ b/NetKAN/BrickMod.netkan
@@ -1,5 +1,7 @@
 spec_version: v1.4
 identifier: BrickMod
 $kref: '#/ckan/spacedock/2905'
-license: CC0
-x_via: Automated SpaceDock CKAN submission
+$vref: '#/ckan/ksp-avc'
+license: CC-NC-SA-3.0
+tags:
+  - parts


### PR DESCRIPTION
#8886 missed a few things.

![image](https://user-images.githubusercontent.com/1559108/144100740-c8c05550-34b0-4076-9e1c-6635c5b23e49.png)

There's a version file in the wrong folder in the ZIP, but Netkan can still read it.

Tags.