### PR TITLE
Update LessRealThanReal.netkan

### DIFF
--- a/NetKAN/LessRealThanReal.netkan
+++ b/NetKAN/LessRealThanReal.netkan
@@ -4,8 +4,7 @@
     "name":         "Less Real Than Real(ism)",
     "abstract":     "Real Progression One without RealismOverhaul",
     "$kref":        "#/ckan/github/pehvbot/LRTR",
-    "ksp_version_min": "1.8",
-    "ksp_version_max": "1.11",
+    "ksp_version_max": "1.12",
     "license":      "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/189978-*"
@@ -24,27 +23,23 @@
         "filter":     [ ".DS_Store" ]
     } ],
     "depends": [
-        { "name": "ModuleManager"          },
-        { "name": "RealSolarSystem"        },
-        { "name": "CustomBarnKit"          },
-        { "name": "RSSDateTimeFormatter"   },
-        { "name": "ContractConfigurator"   },
-        { "name": "DMagicScienceAnimate"   },
-        { "name": "KerbalConstructionTime" }
+        { "name": "ModuleManager"           },
+        { "name": "ClickThroughBlocker"     },
+        { "name": "CustomBarnKit"           },
+        { "name": "ContractConfigurator"    },
+        { "name": "DMagicScienceAnimate"    },
+        { "name": "MagiCore"                },
+        { "name": "ModularFlightIntegrator" }
     ],
     "recommends" : [
-        { "name": "ReStockPlus"            },
-        { "name": "KSCSwitcher"            },
-        { "name": "KerbalConstructionTime" },
-        { "name": "LessRealKerbalism"      }
+        { "name": "ReStockPlus"       },
+        { "name": "RealSolarSystem"   },
+        { "name": "LessRealKerbalism" }
     ],
     "suggests": [
-        { "name": "KerbalAlarmClock" },
-        { "name": "KRASH"            },
-        { "name": "ScrapYard"        },
-        { "name": "OhScrap"          }
     ],
     "conflicts": [
-        { "name": "RealismOverhaul" }
+        { "name": "KerbalConstructionTime" },
+        { "name": "RealismOverhaul"        }
     ]
 }

--- a/NetKAN/LessRealThanReal.netkan
+++ b/NetKAN/LessRealThanReal.netkan
@@ -1,45 +1,36 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "LessRealThanReal",
-    "name":         "Less Real Than Real(ism)",
-    "abstract":     "Real Progression One without RealismOverhaul",
-    "$kref":        "#/ckan/github/pehvbot/LRTR",
-    "ksp_version_max": "1.12",
-    "license":      "CC-BY-NC-SA-4.0",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/189978-*"
-    },
-    "tags": [
-        "plugin",
-        "config",
-        "parts",
-        "tech-tree",
-        "career",
-        "science"
-    ],
-    "install": [ {
-        "find":       "GameData/LRTR",
-        "install_to": "GameData",
-        "filter":     [ ".DS_Store" ]
-    } ],
-    "depends": [
-        { "name": "ModuleManager"           },
-        { "name": "ClickThroughBlocker"     },
-        { "name": "CustomBarnKit"           },
-        { "name": "ContractConfigurator"    },
-        { "name": "DMagicScienceAnimate"    },
-        { "name": "MagiCore"                },
-        { "name": "ModularFlightIntegrator" }
-    ],
-    "recommends" : [
-        { "name": "ReStockPlus"       },
-        { "name": "RealSolarSystem"   },
-        { "name": "LessRealKerbalism" }
-    ],
-    "suggests": [
-    ],
-    "conflicts": [
-        { "name": "KerbalConstructionTime" },
-        { "name": "RealismOverhaul"        }
-    ]
-}
+spec_version: v1.4
+identifier: LessRealThanReal
+name: Less Real Than Real(ism)
+abstract: Real Progression One without RealismOverhaul
+$kref: '#/ckan/github/pehvbot/LRTR'
+ksp_version_min: 1.12
+license: CC-BY-NC-SA-4.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/189978-*
+tags:
+  - plugin
+  - config
+  - parts
+  - tech-tree
+  - career
+  - science
+install:
+  - find: GameData/LRTR
+    install_to: GameData
+    filter:
+      - .DS_Store
+depends:
+  - name: ModuleManager
+  - name: ClickThroughBlocker
+  - name: CustomBarnKit
+  - name: ContractConfigurator
+  - name: DMagicScienceAnimate
+  - name: MagiCore
+  - name: ModularFlightIntegrator
+recommends:
+  - name: ReStockPlus
+  - name: RealSolarSystem
+  - name: LessRealKerbalism
+conflicts:
+  - name: KerbalConstructionTime
+  - name: RealismOverhaul


### PR DESCRIPTION
LRTR v2+ changes the dependency list and requires KSP version 1.12+.  It works with RSS and KSRSS (Kerbal Sized RSS which is not currently on CKAN) so I moved RSS to 'recommends' to allow a simpler install for any KSRSS users.  It now also conflicts with KerbalConstructionTime.

___

ckan compat add 1.10