### PR TITLE
Add B9PartSwitch dependency to StockWaterfallEffects

### DIFF
--- a/NetKAN/StockWaterfallEffects.netkan
+++ b/NetKAN/StockWaterfallEffects.netkan
@@ -13,6 +13,7 @@
         "graphics"
     ],
     "depends": [
+        { "name": "B9PartSwitch"  },
         { "name": "ModuleManager" },
         { "name": "Waterfall"     }
     ]


### PR DESCRIPTION
The author of StockWaterfallEffects kindly left us a a note on Discord that the [latest release](https://github.com/KnightofStJohn/StockWaterfallEffects/releases/tag/0.6.0) has a new dependency, B9PartSwitch:
![image](https://user-images.githubusercontent.com/28812678/145400298-13182b58-a7f8-4727-8279-617b8c3ce7b2.png)