### PR TITLE
Add StratPlusPlus

### DIFF
--- a/NetKAN/StratPlusPlus.netkan
+++ b/NetKAN/StratPlusPlus.netkan
@@ -1,0 +1,10 @@
+spec_version: v1.4
+identifier: StratPlusPlus
+$kref: '#/ckan/spacedock/2921'
+license: MIT
+tags:
+  - config
+  - career
+install:
+  - find: Kontracts
+    install_to: GameData


### PR DESCRIPTION
This was supposed to be an auto-generated PR from SD, but `requests` threw these while trying to download it:

```
OSError: [Errno 14] Bad address
urllib3.exceptions.ProtocolError: ("Connection broken: OSError(14, 'Bad address')", OSError(14, 'Bad address'))
requests.exceptions.ChunkedEncodingError: ("Connection broken: OSError(14, 'Bad address')", OSError(14, 'Bad address'))
```

It worked fine when I tried it locally, so chalking this up to a transient network problem for now.

https://spacedock.info/mod/2921/Strat%2B%2B
