### PR TITLE
Add Conformal Decals and Shabby

### DIFF
--- a/NetKAN/ConformalDecals.netkan
+++ b/NetKAN/ConformalDecals.netkan
@@ -3,6 +3,8 @@ identifier: ConformalDecals
 $kref: '#/ckan/spacedock/2451'
 $vref: '#/ckan/ksp-avc'
 license: GPL-3.0
+resources:
+  manual: https://github.com/drewcassidy/KSP-Conformal-Decals/wiki
 tags:
   - plugin
   - parts

--- a/NetKAN/ConformalDecals.netkan
+++ b/NetKAN/ConformalDecals.netkan
@@ -13,3 +13,6 @@ depends:
   - name: Shabby
 suggests:
   - name: WildBlueTools
+install:
+  - find: GameData/ConformalDecals
+    install-to: GameData

--- a/NetKAN/ConformalDecals.netkan
+++ b/NetKAN/ConformalDecals.netkan
@@ -15,4 +15,4 @@ suggests:
   - name: WildBlueTools
 install:
   - find: GameData/ConformalDecals
-    install-to: GameData
+    install_to: GameData

--- a/NetKAN/ConformalDecals.netkan
+++ b/NetKAN/ConformalDecals.netkan
@@ -1,0 +1,15 @@
+spec_version: v1.4
+identifier: ConformalDecals
+$kref: '#/ckan/spacedock/2451'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - parts
+depends:
+  - name: ModuleManager
+  - name: B9PartSwitch
+  - name: Harmony2
+  - name: Shabby
+suggests:
+  - name: WildBlueTools

--- a/NetKAN/ConformalDecals.netkan
+++ b/NetKAN/ConformalDecals.netkan
@@ -11,7 +11,6 @@ tags:
 depends:
   - name: ModuleManager
   - name: B9PartSwitch
-  - name: Harmony2
   - name: Shabby
 suggests:
   - name: WildBlueTools

--- a/NetKAN/Shabby.netkan
+++ b/NetKAN/Shabby.netkan
@@ -1,0 +1,18 @@
+spec_version: v1.10
+identifier: Shabby
+abstract: Shader asset bundle loader for KSP
+author: taniwha
+$kref: '#/ckan/ksp-avc/http://taniwha.org/~bill/Shabby.version'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+resources:
+  repository: https://github.com/taniwha/Shabby
+tags:
+  - library
+  - plugin
+depends:
+  - name: Harmony2
+install:
+  - find: Shabby
+    install_to: GameData
+    filter_regexp: .*Harmony.*.dll

--- a/NetKAN/Shabby.netkan
+++ b/NetKAN/Shabby.netkan
@@ -1,8 +1,10 @@
 spec_version: v1.10
 identifier: Shabby
 abstract: Shader asset bundle loader for KSP
-author: taniwha
-$kref: '#/ckan/ksp-avc/http://taniwha.org/~bill/Shabby.version'
+author:
+  - taniwha
+  - Andrew Cassidy
+$kref: '#/ckan/ksp-avc/https://pileof.rocks/KSP/Shabby.version'
 $vref: '#/ckan/ksp-avc'
 license: GPL-3.0
 resources:
@@ -12,7 +14,3 @@ tags:
   - plugin
 depends:
   - name: Harmony2
-install:
-  - find: Shabby
-    install_to: GameData
-    filter_regexp: .*Harmony.*.dll


### PR DESCRIPTION
https://spacedock.info/mod/2451/Conformal%20Decals
https://github.com/drewcassidy/KSP-Conformal-Decals
https://forum.kerbalspaceprogram.com/index.php?/topic/194802-18-111-conformal-decals-028-decals-done-the-right-way/

![image](https://user-images.githubusercontent.com/1559108/146687245-bcd45508-c6ba-4f30-874a-9b310322e32a.png)

http://taniwha.org/~bill/Shabby.version
https://github.com/taniwha/Shabby

~~We still need to check with @taniwha to see if adding Shabby to CKAN is OK before merging.~~ Submitting the PR just for metadata validation. Should merge KSP-CKAN/CKAN#3494 first to be safe, since the `filter_regexp` in Shabby is how I noticed that issue.