### PR TITLE
CactEye fixes

### DIFF
--- a/NetKAN/CactEyeCommunityRefocused.netkan
+++ b/NetKAN/CactEyeCommunityRefocused.netkan
@@ -1,33 +1,18 @@
-{
-    "spec_version" : 1,
-    "identifier"   : "CactEyeCommunityRefocused",
-    "name"         : "CactEye Optics Community Refocused",
-    "$kref"        : "#/ckan/spacedock/2930",
-    "$vref"        : "#/ckan/ksp-avc",
-    "license"      : "CC-BY-4.0",
-    "resources"    : {
-        "homepage"   : "http://forum.kerbalspaceprogram.com/index.php?/topic/141280-*",
-        "bugtracker" : "https://github.com/linuxgurugamer/CactEye-2/issues",
-        "repository" : "https://github.com/linuxgurugamer/CactEye-2",
-        "spacedock"  : "https://spacedock.info/mod/2930/CactEye-2%20Orbital%20Telescope%20Refocused"
-    },
-    "tags": [
-        "parts"
-    ],
-    "install": [ {
-        "file"      : "GameData/CactEye",
-        "install_to": "GameData"
-    } ],
-    "conflicts": [
-        { "name": "CactEyeTelescopesContinued" },
-        { "name": "CactEyeTelescopesCommunity" },
-        { "name": "CactEye2" }
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "CactEyeCommunityDOEPatch" },
-        { "name": "DistantObject" }
-    ]
-}
+spec_version: 1
+identifier: CactEyeCommunityRefocused
+$kref: '#/ckan/spacedock/2930'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-4.0
+tags:
+  - parts
+conflicts:
+  - name: CactEye2
+  - name: CactEyeCommunity
+depends:
+  - name: ModuleManager
+recommends:
+  - name: CactEyeCommunityDOEPatch
+  - name: DistantObject
+install:
+  - file: GameData/CactEye
+    install_to: GameData


### PR DESCRIPTION
Fixes for #8923.

- `resources.homepage` was out of date and will now be retrieved from SpaceDock, which has the right URL
- `resources.repository` is now retrieved from SpaceDock
- `resources.bugtracker` is now retrieved from SpaceDock
- `resources.spacedock` is now retrieved from SpaceDock
- `name` is now retrieved from SpaceDock
- The conflict with `CactEyeTelescopesContinued` is removed because this was completely frozen in KSP-CKAN/CKAN-meta#1198 and is not in CKAN anymore
- YAMLized