### PR TITLE
Update Snark compat overrides

### DIFF
--- a/NetKAN/DefaultActionGroups.netkan
+++ b/NetKAN/DefaultActionGroups.netkan
@@ -1,26 +1,21 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "DefaultActionGroups",
-    "$kref":        "#/ckan/spacedock/24",
-    "license":      "CC-BY-NC-ND-4.0",
-    "tags": [
-        "plugin",
-        "convenience"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "install": [ {
-        "file"       : "GameData/DefaultActionGroups",
-        "install_to" : "GameData"
-    }, {
-        "file"       : "Optional/GameData/DefaultActionGroups",
-        "install_to" : "GameData"
-    } ],
-    "x_netkan_override": [ {
-        "version": "1.3",
-        "override": {
-            "ksp_version_min": "1.8"
-        }
-    } ]
-}
+spec_version: v1.4
+identifier: DefaultActionGroups
+$kref: '#/ckan/spacedock/24'
+license: CC-BY-NC-ND-4.0
+tags:
+  - plugin
+  - convenience
+depends:
+  - name: ModuleManager
+install:
+  - file: GameData/DefaultActionGroups
+    install_to: GameData
+  - file: Optional/GameData/DefaultActionGroups
+    install_to: GameData
+x_netkan_override:
+  - version: '1.4'
+    override:
+      ksp_version_min: '1.12'
+  - version: '1.3'
+    override:
+      ksp_version_min: '1.8'

--- a/NetKAN/IndicatorLights.netkan
+++ b/NetKAN/IndicatorLights.netkan
@@ -1,19 +1,16 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "IndicatorLights",
-    "$kref":        "#/ckan/spacedock/566",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "x_netkan_override": [ {
-        "version": "1.7",
-        "override": {
-            "ksp_version_min": "1.10"
-        }
-    } ]
-}
+spec_version: v1.4
+identifier: IndicatorLights
+$kref: '#/ckan/spacedock/566'
+license: CC-BY-NC-SA-4.0
+tags:
+  - plugin
+  - information
+depends:
+  - name: ModuleManager
+x_netkan_override:
+  - version: 1.8.1
+    override:
+      ksp_version_min: '1.12'
+  - version: '1.7'
+    override:
+      ksp_version_min: '1.10'

--- a/NetKAN/MissingHistory.netkan
+++ b/NetKAN/MissingHistory.netkan
@@ -1,18 +1,15 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "MissingHistory",
-    "$kref":        "#/ckan/spacedock/1743",
-    "license":      "CC-BY-NC-SA",
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "x_netkan_override": [ {
-        "version": "1.9.1",
-        "override": {
-            "ksp_version_min": "1.11"
-        }
-    } ]
-}
+spec_version: v1.4
+identifier: MissingHistory
+$kref: '#/ckan/spacedock/1743'
+license: CC-BY-NC-SA
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+x_netkan_override:
+  - version: 1.9.3
+    override:
+      ksp_version_min: '1.12'
+  - version: 1.9.1
+    override:
+      ksp_version_min: '1.11'


### PR DESCRIPTION
#8309 added overrides to pin the minimum compatibility of these mods to their original values. Since then, they have had new releases without overrides, and the latest wave of updates lost the original compatibility:

https://github.com/KSP-CKAN/CKAN-meta/compare/982c540e68...73a534f848

Now these versions have pinned min compat as well.