### PR TITLE
Switch UnKerballedStart to GitHub kref

### DIFF
--- a/NetKAN/UnKerballedStart.netkan
+++ b/NetKAN/UnKerballedStart.netkan
@@ -1,9 +1,16 @@
 spec_version: v1.4
 identifier: UnKerballedStart
-$kref: '#/ckan/spacedock/2074'
+author:
+  - SpinkAkron
+  - theonegalen
+$kref: '#/ckan/github/theonegalen/UnKerballedStart'
 $vref: '#/ckan/ksp-avc'
 x_netkan_allow_out_of_order: true
+x_netkan_version_edit: ^[vV]?(?<version>.+)$
 license: CC-BY-NC-SA-4.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/196589-*
+  spacedock: https://spacedock.info/mod/2074/UnKerballed%20Start
 tags:
   - config
   - tech-tree


### PR DESCRIPTION
While we were working on #8936, @theonegalen said:

![image](https://user-images.githubusercontent.com/1559108/147859493-a78ef639-60a1-485e-8375-97a59e7f670b.png)

This PR switches the kref from SpaceDock to GitHub.

- The authors are added to the netkan to avoid dropping one of them
- A `x_netkan_version_edit` is added to strip the `v` from the version so v1.3.0 will match 1.3.0
- `resources.homepage` and `resources.spacedock` are added to the netkan

This should allow the intended compatibility, 1.12.2 and later, to take effect.
