### PR TITLE
Fix spec versions of mods with filter_regexp

### DIFF
--- a/NetKAN/AirlineKuisine.netkan
+++ b/NetKAN/AirlineKuisine.netkan
@@ -1,38 +1,32 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "AirlineKuisine",
-    "$kref":        "#/ckan/spacedock/1252",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts",
-        "crewed"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "DeepSkyCore"   },
-        { "name": "B9PartSwitch"  }
-    ],
-    "suggests": [
-        { "name": "Mk2Expansion" },
-        { "name": "Mk3Expansion" }
-    ],
-    "supports": [
-        { "name": "ClassicStockResources" },
-        { "name": "CommunityResourcePack" },
-        { "name": "CommunityTechTree"     },
-        { "name": "ConnectedLivingSpace"  },
-        { "name": "Kerbalism"             },
-        { "name": "KIS"                   },
-        { "name": "Pathfinder"            },
-        { "name": "Snacks"                },
-        { "name": "TacLifeSupport"        },
-        { "name": "USI-LS"                },
-        { "name": "WildBlueTools"         }
-    ],
-    "install": [ {
-        "find":          "DeepSky",
-        "install_to":    "GameData",
-        "filter_regexp": [ ".*\\.pdb$" ]
-    } ]
-}
+spec_version: v1.10
+identifier: AirlineKuisine
+$kref: '#/ckan/spacedock/1252'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+  - crewed
+depends:
+  - name: ModuleManager
+  - name: DeepSkyCore
+  - name: B9PartSwitch
+suggests:
+  - name: Mk2Expansion
+  - name: Mk3Expansion
+supports:
+  - name: ClassicStockResources
+  - name: CommunityResourcePack
+  - name: CommunityTechTree
+  - name: ConnectedLivingSpace
+  - name: Kerbalism
+  - name: KIS
+  - name: Pathfinder
+  - name: Snacks
+  - name: TacLifeSupport
+  - name: USI-LS
+  - name: WildBlueTools
+install:
+  - find: DeepSky
+    install_to: GameData
+    filter_regexp:
+      - .*\.pdb$

--- a/NetKAN/BARIS.netkan
+++ b/NetKAN/BARIS.netkan
@@ -1,29 +1,23 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "BARIS",
-    "author":       "Angel125",
-    "$kref":        "#/ckan/github/Angel-125/BARIS",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/164448-*"
-    },
-    "tags": [
-        "plugin",
-        "career",
-        "crewed"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "BarisBridge"   }
-    ],
-    "recommends": [
-        { "name": "KerbalAlarmClock"       },
-        { "name": "KerbalConstructionTime" }
-    ],
-    "install": [ {
-        "find":          "000BARIS",
-        "install_to":    "GameData/WildBlueIndustries",
-        "filter_regexp": [ ".*\\.pdb$" ]
-    } ]
-}
+spec_version: v1.10
+identifier: BARIS
+author: Angel125
+$kref: '#/ckan/github/Angel-125/BARIS'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/164448-*
+tags:
+  - plugin
+  - career
+  - crewed
+depends:
+  - name: ModuleManager
+  - name: BarisBridge
+recommends:
+  - name: KerbalAlarmClock
+  - name: KerbalConstructionTime
+install:
+  - find: 000BARIS
+    install_to: GameData/WildBlueIndustries
+    filter_regexp:
+      - .*\.pdb$

--- a/NetKAN/BOMPs.netkan
+++ b/NetKAN/BOMPs.netkan
@@ -1,29 +1,23 @@
-{
-	"spec_version": "v1.4",
-	"identifier": "BOMPs",
-	"name": "BOMPs",
-	"abstract": "Bolt-On Mission Probe (BOMP)",
-	"author": "linuxgurugamer",
-	"license": "CC-BY-NC-SA-4.0",
-	"$kref": "#/ckan/github/linuxgurugamer/BOMPs",
-	"$vref": "#/ckan/ksp-avc",
-	"resources": {
-		"homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/160179-12-the-bolt-on-mission-probe-bomp-rerevival-thread/",
-		"spacedock": "https://spacedock.info/mod/1354/BOMPs",
-		"repository": "https://github.com/linuxgurugamer/BOMPs",
-		"x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/BOMPs/BOMPs-1493902399.1295142.png"
-	},
-	"tags": [
-		"parts",
-		"uncrewed"
-	],
-	"install": [
-		{
-			"filter_regexp": [
-				".*~$"
-			],
-			"find": "BOMPs",
-			"install_to": "GameData"
-		}
-	]
-}
+spec_version: v1.10
+identifier: BOMPs
+name: BOMPs
+abstract: Bolt-On Mission Probe (BOMP)
+author: linuxgurugamer
+license: CC-BY-NC-SA-4.0
+$kref: '#/ckan/github/linuxgurugamer/BOMPs'
+$vref: '#/ckan/ksp-avc'
+resources:
+  homepage: >-
+    http://forum.kerbalspaceprogram.com/index.php?/topic/160179-12-the-bolt-on-mission-probe-bomp-rerevival-thread/
+  spacedock: https://spacedock.info/mod/1354/BOMPs
+  repository: https://github.com/linuxgurugamer/BOMPs
+  x_screenshot: >-
+    https://spacedock.info/content/linuxgurugamer_179/BOMPs/BOMPs-1493902399.1295142.png
+tags:
+  - parts
+  - uncrewed
+install:
+  - filter_regexp:
+      - .*~$
+    find: BOMPs
+    install_to: GameData

--- a/NetKAN/CustomAsteroids-Pops-OPM-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-OPM-Outer.netkan
@@ -1,67 +1,47 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "CustomAsteroids-Pops-OPM-Outer",
-    "name":         "Custom Asteroids (Kuiper belt analog for OPM)",
-    "abstract":     "Adds Kentaurs and trans-Neidonian objects",
-    "$kref":        "#/ckan/github/Starstrider42/Custom-Asteroids-Extras",
-    "x_netkan_github": {
-        "use_source_archive": true
-    },
-    "ksp_version_min": "1.10.0",
-    "license": "MIT",
-    "resources": {
-        "bugtracker": "https://github.com/Starstrider42/Custom-Asteroids-Extras/issues",
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/72785-*"
-    },
-    "tags": [
-        "config",
-        "planet-pack"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "OuterPlanetsMod" },
-        {
-            "name": "CustomAsteroids",
-            "min_version": "v1.9.0",
-            "max_version": "v1.99.99",
-            "comment": "Requires comet support."
-        }
-    ],
-    "recommends": [
-        {
-            "name": "CustomAsteroids-Pops-Stock-Stockalike",
-            "min_version": "v1.9.0",
-            "max_version": "v1.99.99",
-            "comment": "Depends on Stockalike for standard comets."
-        }
-    ],
-    "provides": [ "CustomAsteroids-Pops" ],
-    "install": [
-        {
-            "find": "config",
-            "install_to": "GameData/CustomAsteroids",
-            "filter_regexp": "(?<!Trans-Neidon\\.cfg)$"
-        }
-    ],
-    "x_netkan_override" : [
-        {
-            "version" : "< v1.2.0",
-            "override" : {
-                "depends": [
-                    {
-                        "name": "OuterPlanetsMod"
-                    },
-                    {
-                        "name": "CustomAsteroids",
-                        "min_version": "v1.6.0",
-                        "max_version": "v1.99.99"
-                    }
-                ],
-                "comment": "Match to Custom Asteroids v1.9.0, see NetKAN#3841.",
-                "ksp_version_min": "1.4.0"
-            },
-            "delete" : [ "ksp_version", "recommends" ]
-        }
-    ],
-    "x_maintained_by": "Starstrider42"
-}
+spec_version: v1.10
+identifier: CustomAsteroids-Pops-OPM-Outer
+name: Custom Asteroids (Kuiper belt analog for OPM)
+abstract: Adds Kentaurs and trans-Neidonian objects
+$kref: '#/ckan/github/Starstrider42/Custom-Asteroids-Extras'
+x_netkan_github:
+  use_source_archive: true
+ksp_version_min: 1.10.0
+license: MIT
+resources:
+  bugtracker: https://github.com/Starstrider42/Custom-Asteroids-Extras/issues
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/72785-*
+tags:
+  - config
+  - planet-pack
+depends:
+  - name: ModuleManager
+  - name: OuterPlanetsMod
+  - name: CustomAsteroids
+    min_version: v1.9.0
+    max_version: v1.99.99
+    comment: Requires comet support.
+recommends:
+  - name: CustomAsteroids-Pops-Stock-Stockalike
+    min_version: v1.9.0
+    max_version: v1.99.99
+    comment: Depends on Stockalike for standard comets.
+provides:
+  - CustomAsteroids-Pops
+install:
+  - find: config
+    install_to: GameData/CustomAsteroids
+    filter_regexp: (?<!Trans-Neidon\.cfg)$
+x_netkan_override:
+  - version: < v1.2.0
+    override:
+      depends:
+        - name: OuterPlanetsMod
+        - name: CustomAsteroids
+          min_version: v1.6.0
+          max_version: v1.99.99
+      comment: Match to Custom Asteroids v1.9.0, see NetKAN#3841.
+      ksp_version_min: 1.4.0
+    delete:
+      - ksp_version
+      - recommends
+x_maintained_by: Starstrider42

--- a/NetKAN/CustomAsteroids-Pops-OPM-Reconfig.netkan
+++ b/NetKAN/CustomAsteroids-Pops-OPM-Reconfig.netkan
@@ -1,44 +1,32 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "CustomAsteroids-Pops-OPM-Reconfig",
-    "name":         "Custom Asteroids (alternative OPM config)",
-    "abstract":     "Replaces default OPM asteroid config with one that uses Custom Asteroids",
-    "$kref":        "#/ckan/github/Starstrider42/Custom-Asteroids-Extras",
-    "x_netkan_github": {
-        "use_source_archive": true
-    },
-    "ksp_version_min": "1.4.0",
-    "license": "MIT",
-    "resources": {
-        "bugtracker": "https://github.com/Starstrider42/Custom-Asteroids-Extras/issues",
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/72785-*"
-    },
-    "tags": [
-        "config",
-        "planet-pack"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        {
-            "name": "OuterPlanetsMod",
-            "min_version": "2:2.2.2",
-            "max_version": "2:2.99.99",
-            "comment": "Version where OPM switched to Kopernicus asteroids."
-        },
-        {
-            "name": "CustomAsteroids",
-            "min_version": "v1.6.0",
-            "max_version": "v1.99.99",
-            "comment": "Requires localization support."
-        }
-    ],
-    "provides": [ "CustomAsteroids-Pops" ],
-    "install": [
-        {
-            "find": "config",
-            "install_to": "GameData/CustomAsteroids",
-            "filter_regexp": "(?<!OPM-Reconfig\\.cfg)$"
-        }
-    ],
-    "x_maintained_by": "HSJasperism"
-}
+spec_version: v1.10
+identifier: CustomAsteroids-Pops-OPM-Reconfig
+name: Custom Asteroids (alternative OPM config)
+abstract: Replaces default OPM asteroid config with one that uses Custom Asteroids
+$kref: '#/ckan/github/Starstrider42/Custom-Asteroids-Extras'
+x_netkan_github:
+  use_source_archive: true
+ksp_version_min: 1.4.0
+license: MIT
+resources:
+  bugtracker: https://github.com/Starstrider42/Custom-Asteroids-Extras/issues
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/72785-*
+tags:
+  - config
+  - planet-pack
+depends:
+  - name: ModuleManager
+  - name: OuterPlanetsMod
+    min_version: 2:2.2.2
+    max_version: 2:2.99.99
+    comment: Version where OPM switched to Kopernicus asteroids.
+  - name: CustomAsteroids
+    min_version: v1.6.0
+    max_version: v1.99.99
+    comment: Requires localization support.
+provides:
+  - CustomAsteroids-Pops
+install:
+  - find: config
+    install_to: GameData/CustomAsteroids
+    filter_regexp: (?<!OPM-Reconfig\.cfg)$
+x_maintained_by: HSJasperism

--- a/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Inner.netkan
@@ -1,105 +1,101 @@
-{
-    "spec_version": "v1.2",
-    "identifier":   "CustomAsteroids-Pops-Stock-Inner",
-    "name":         "Custom Asteroids (inner stock system data)",
-    "abstract":     "Adds asteroids inside orbit of Jool",
-    "$kref":        "#/ckan/spacedock/210",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "config",
-        "planet-pack"
-    ],
-    "depends": [
-        {
-            "name": "CustomAsteroids",
-            "min_version": "v1.9.0",
-            "max_version": "v1.99.99",
-            "comment": "Requires comet support."
-        }
-    ],
-    "provides": [ "CustomAsteroids-Pops" ],
-    "conflicts": [
-        { "name": "AlienSpaceProgram", "comment": "No Kerbin." },
-        { "name": "AlternisKerbolRekerjiggered", "comment": "Completely different system." },
-        { "name": "AlternisRealSolarSystem", "comment": "Completely different system."},
-        { "name": "BorisSystem", "comment": "Terrestrial planet in asteroid belt." },
-        { "name": "ChaniPlanetPack", "comment": "Giant planet in asteroid belt." },
-        { "name": "HarderSolarSystem", "comment": "Stock orbits not inclined." },
-        { "name": "Kronkus", "comment": "Giant planet in asteroid belt." },
-        { "name": "Ktolemy", "comment": "Completely different system." },
-        { "name": "LittleGreenMenFromMars", "comment": "Completely different system." },
-        { "name": "NewHorizons", "comment": "Completely different system." },
-        { "name": "RealSolarSystem", "comment": "Completely different system."},
-        { "name": "RhatssPlanetpack", "comment": "Giant planet in asteroid belt."},
-        { "name": "sidosUraniaSystem", "comment": "Giant planet in asteroid belt." },
-        { "name": "SmallSolarSystem", "comment": "Completely different system."},
-        { "name": "StockAlikeSolarSystem", "comment": "Completely different system."},
-        { "name": "TerrestrialPlanetPack", "comment": "Giant planet in asteroid belt." },
-        { "name": "UnchartedLands", "comment": "Completely different system."}
-    ],
-    "install": [
-        {
-            "file": "Standard Setup/config",
-            "install_to": "GameData/CustomAsteroids",
-            "filter_regexp": "(?<!Basic Asteroids\\.cfg)$"
-        }
-    ],
-    "x_netkan_override" : [
-        {
-            "version" : [ ">= v1.9.0", "< v2.0.0" ],
-            "override" : {
-                "comment": "Match to Custom Asteroids v1.9.0, see NetKAN#3841.",
-                "ksp_version_min": "1.10.0"
-            },
-            "delete" : [ "ksp_version" ]
-        },
-        {
-            "version" : [ ">= v1.6.0", "< v1.9.0" ],
-            "override" : {
-                "depends": [
-                    {
-                        "name": "CustomAsteroids",
-                        "min_version": "v1.6.0",
-                        "max_version": "v1.99.99"
-                    }
-                ],
-                "comment": "Match to Custom Asteroids v1.6.0, see NetKAN#3841.",
-                "ksp_version_min": "1.4.0"
-            },
-            "delete" : [ "ksp_version" ]
-        },
-        {
-            "version" : [ ">= v1.3.0", "< v1.6.0" ],
-            "override" : {
-                "comment": "Match to Custom Asteroids v1.3.0, see NetKAN#3841.",
-                "ksp_version_min": "1.1.0"
-            },
-            "delete" : [ "ksp_version" ]
-        },
-        {
-            "version" : "< v1.3.0",
-            "override" : {
-                "depends": [
-                    {
-                        "name": "CustomAsteroids",
-                        "min_version": "v1.0.0",
-                        "max_version": "v1.99.99",
-                        "comment": "Version at which config format stabilized."
-                    }
-                ],
-                "install": [
-                    {
-                        "file": "GameData/CustomAsteroids",
-                        "install_to": "GameData",
-                        "filter_regexp": "(?<!Basic Asteroids\\.cfg)$"
-                    }
-                ],
-                "comment": "Match to Custom Asteroids v1.0.0, see NetKAN#3841.",
-                "ksp_version_min": "1.0.0"
-            },
-            "delete" : [ "ksp_version" ]
-        }
-    ],
-    "x_maintained_by": "Starstrider42"
-}
+spec_version: v1.10
+identifier: CustomAsteroids-Pops-Stock-Inner
+name: Custom Asteroids (inner stock system data)
+abstract: Adds asteroids inside orbit of Jool
+$kref: '#/ckan/spacedock/210'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - config
+  - planet-pack
+depends:
+  - name: CustomAsteroids
+    min_version: v1.9.0
+    max_version: v1.99.99
+    comment: Requires comet support.
+provides:
+  - CustomAsteroids-Pops
+conflicts:
+  - name: AlienSpaceProgram
+    comment: No Kerbin.
+  - name: AlternisKerbolRekerjiggered
+    comment: Completely different system.
+  - name: AlternisRealSolarSystem
+    comment: Completely different system.
+  - name: BorisSystem
+    comment: Terrestrial planet in asteroid belt.
+  - name: ChaniPlanetPack
+    comment: Giant planet in asteroid belt.
+  - name: HarderSolarSystem
+    comment: Stock orbits not inclined.
+  - name: Kronkus
+    comment: Giant planet in asteroid belt.
+  - name: Ktolemy
+    comment: Completely different system.
+  - name: LittleGreenMenFromMars
+    comment: Completely different system.
+  - name: NewHorizons
+    comment: Completely different system.
+  - name: RealSolarSystem
+    comment: Completely different system.
+  - name: RhatssPlanetpack
+    comment: Giant planet in asteroid belt.
+  - name: sidosUraniaSystem
+    comment: Giant planet in asteroid belt.
+  - name: SmallSolarSystem
+    comment: Completely different system.
+  - name: StockAlikeSolarSystem
+    comment: Completely different system.
+  - name: TerrestrialPlanetPack
+    comment: Giant planet in asteroid belt.
+  - name: UnchartedLands
+    comment: Completely different system.
+install:
+  - file: Standard Setup/config
+    install_to: GameData/CustomAsteroids
+    filter_regexp: (?<!Basic Asteroids\.cfg)$
+x_netkan_override:
+  - version:
+      - '>= v1.9.0'
+      - < v2.0.0
+    override:
+      comment: Match to Custom Asteroids v1.9.0, see NetKAN#3841.
+      ksp_version_min: 1.10.0
+    delete:
+      - ksp_version
+  - version:
+      - '>= v1.6.0'
+      - < v1.9.0
+    override:
+      depends:
+        - name: CustomAsteroids
+          min_version: v1.6.0
+          max_version: v1.99.99
+      comment: Match to Custom Asteroids v1.6.0, see NetKAN#3841.
+      ksp_version_min: 1.4.0
+    delete:
+      - ksp_version
+  - version:
+      - '>= v1.3.0'
+      - < v1.6.0
+    override:
+      comment: Match to Custom Asteroids v1.3.0, see NetKAN#3841.
+      ksp_version_min: 1.1.0
+    delete:
+      - ksp_version
+  - version: < v1.3.0
+    override:
+      depends:
+        - name: CustomAsteroids
+          min_version: v1.0.0
+          max_version: v1.99.99
+          comment: Version at which config format stabilized.
+      install:
+        - file: GameData/CustomAsteroids
+          install_to: GameData
+          filter_regexp: (?<!Basic Asteroids\.cfg)$
+      comment: Match to Custom Asteroids v1.0.0, see NetKAN#3841.
+      ksp_version_min: 1.0.0
+    delete:
+      - ksp_version
+x_maintained_by: Starstrider42

--- a/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Outer.netkan
@@ -1,107 +1,105 @@
-{
-    "spec_version": "v1.2",
-    "identifier":   "CustomAsteroids-Pops-Stock-Outer",
-    "name":         "Custom Asteroids (outer stock system data)",
-    "abstract":     "Adds comets outside orbit of Jool",
-    "$kref":        "#/ckan/spacedock/210",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "config",
-        "planet-pack"
-    ],
-    "depends": [
-        {
-            "name": "CustomAsteroids",
-            "min_version": "v1.9.0",
-            "max_version": "v1.99.99",
-            "comment": "Requires comet support."
-        }
-    ],
-    "provides": [ "CustomAsteroids-Pops" ],
-    "conflicts": [
-        { "name": "AlternisKerbolRekerjiggered", "comment": "Completely different system." },
-        { "name": "AlternisRealSolarSystem", "comment": "Completely different system."},
-        { "name": "BorisSystem", "comment": "Giant planet in Kuper belt." },
-        { "name": "FarloPlanetaryPack", "comment": "Giant planet in scattered disk." },
-        { "name": "HarderSolarSystem", "comment": "Stock orbits not inclined." },
-        { "name": "JungisPlanetPack", "comment": "Giant planet in Kuper belt." },
-        { "name": "KerbolOrigins", "comment": "Giant planet in scattered disk." },
-        { "name": "KPlus", "comment": "Giant planet in scattered disk." },
-        { "name": "Ktolemy", "comment": "Completely different system." },
-        { "name": "LittleGreenMenFromMars", "comment": "Completely different system." },
-        { "name": "NewHorizons", "comment": "Completely different system." },
-        { "name": "OuterPlanetsMod", "comment": "Giant planets in Kuper belt and scattered disk." },
-        { "name": "RealSolarSystem", "comment": "Completely different system."},
-        { "name": "SaruPlanetPack", "comment": "Giant planet in Kuper belt." },
-        { "name": "SentarExpansion", "comment": "Giant planet in scattered disk." },
-        { "name": "SmallSolarSystem", "comment": "Completely different system."},
-        { "name": "StockAlikeSolarSystem", "comment": "Completely different system."},
-        { "name": "TerrestrialPlanetPack", "comment": "Terrestrial planets in Kuper belt and scattered disk." },
-        { "name": "UnchartedLands", "comment": "Completely different system."}
-    ],
-    "install": [
-        {
-            "file": "Standard Setup/config",
-            "install_to": "GameData/CustomAsteroids",
-            "filter_regexp": "(?<!Trans-Jool\\.cfg)$"
-        }
-    ],
-    "x_netkan_override" : [
-        {
-            "version" : [ ">= v1.9.0", "< v2.0.0" ],
-            "override" : {
-                "comment": "Match to Custom Asteroids v1.9.0, see NetKAN#3841.",
-                "ksp_version_min": "1.10.0"
-            },
-            "delete" : [ "ksp_version" ]
-        },
-        {
-            "version" : [ ">= v1.6.0", "< v1.9.0" ],
-            "override" : {
-                "depends": [
-                    {
-                        "name": "CustomAsteroids",
-                        "min_version": "v1.6.0",
-                        "max_version": "v1.99.99"
-                    }
-                ],
-                "comment": "Match to Custom Asteroids v1.6.0, see NetKAN#3841.",
-                "ksp_version_min": "1.4.0"
-            },
-            "delete" : [ "ksp_version" ]
-        },
-        {
-            "version" : [ ">= v1.3.0", "< v1.6.0" ],
-            "override" : {
-                "comment": "Match to Custom Asteroids v1.3.0, see NetKAN#3841.",
-                "ksp_version_min": "1.1.0"
-            },
-            "delete" : [ "ksp_version" ]
-        },
-        {
-            "version" : "< v1.3.0",
-            "override" : {
-                "depends": [
-                    {
-                        "name": "CustomAsteroids",
-                        "min_version": "v1.0.0",
-                        "max_version": "v1.99.99",
-                        "comment": "Version at which config format stabilized."
-                    }
-                ],
-                "install": [
-                    {
-                        "file": "GameData/CustomAsteroids",
-                        "install_to": "GameData",
-                        "filter_regexp": "(?<!Trans-Jool\\.cfg)$"
-                    }
-                ],
-                "comment": "Match to Custom Asteroids v1.0.0, see NetKAN#3841.",
-                "ksp_version_min": "1.0.0"
-            },
-            "delete" : [ "ksp_version" ]
-        }
-    ],
-    "x_maintained_by": "Starstrider42"
-}
+spec_version: v1.10
+identifier: CustomAsteroids-Pops-Stock-Outer
+name: Custom Asteroids (outer stock system data)
+abstract: Adds comets outside orbit of Jool
+$kref: '#/ckan/spacedock/210'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - config
+  - planet-pack
+depends:
+  - name: CustomAsteroids
+    min_version: v1.9.0
+    max_version: v1.99.99
+    comment: Requires comet support.
+provides:
+  - CustomAsteroids-Pops
+conflicts:
+  - name: AlternisKerbolRekerjiggered
+    comment: Completely different system.
+  - name: AlternisRealSolarSystem
+    comment: Completely different system.
+  - name: BorisSystem
+    comment: Giant planet in Kuper belt.
+  - name: FarloPlanetaryPack
+    comment: Giant planet in scattered disk.
+  - name: HarderSolarSystem
+    comment: Stock orbits not inclined.
+  - name: JungisPlanetPack
+    comment: Giant planet in Kuper belt.
+  - name: KerbolOrigins
+    comment: Giant planet in scattered disk.
+  - name: KPlus
+    comment: Giant planet in scattered disk.
+  - name: Ktolemy
+    comment: Completely different system.
+  - name: LittleGreenMenFromMars
+    comment: Completely different system.
+  - name: NewHorizons
+    comment: Completely different system.
+  - name: OuterPlanetsMod
+    comment: Giant planets in Kuper belt and scattered disk.
+  - name: RealSolarSystem
+    comment: Completely different system.
+  - name: SaruPlanetPack
+    comment: Giant planet in Kuper belt.
+  - name: SentarExpansion
+    comment: Giant planet in scattered disk.
+  - name: SmallSolarSystem
+    comment: Completely different system.
+  - name: StockAlikeSolarSystem
+    comment: Completely different system.
+  - name: TerrestrialPlanetPack
+    comment: Terrestrial planets in Kuper belt and scattered disk.
+  - name: UnchartedLands
+    comment: Completely different system.
+install:
+  - file: Standard Setup/config
+    install_to: GameData/CustomAsteroids
+    filter_regexp: (?<!Trans-Jool\.cfg)$
+x_netkan_override:
+  - version:
+      - '>= v1.9.0'
+      - < v2.0.0
+    override:
+      comment: Match to Custom Asteroids v1.9.0, see NetKAN#3841.
+      ksp_version_min: 1.10.0
+    delete:
+      - ksp_version
+  - version:
+      - '>= v1.6.0'
+      - < v1.9.0
+    override:
+      depends:
+        - name: CustomAsteroids
+          min_version: v1.6.0
+          max_version: v1.99.99
+      comment: Match to Custom Asteroids v1.6.0, see NetKAN#3841.
+      ksp_version_min: 1.4.0
+    delete:
+      - ksp_version
+  - version:
+      - '>= v1.3.0'
+      - < v1.6.0
+    override:
+      comment: Match to Custom Asteroids v1.3.0, see NetKAN#3841.
+      ksp_version_min: 1.1.0
+    delete:
+      - ksp_version
+  - version: < v1.3.0
+    override:
+      depends:
+        - name: CustomAsteroids
+          min_version: v1.0.0
+          max_version: v1.99.99
+          comment: Version at which config format stabilized.
+      install:
+        - file: GameData/CustomAsteroids
+          install_to: GameData
+          filter_regexp: (?<!Trans-Jool\.cfg)$
+      comment: Match to Custom Asteroids v1.0.0, see NetKAN#3841.
+      ksp_version_min: 1.0.0
+    delete:
+      - ksp_version
+x_maintained_by: Starstrider42

--- a/NetKAN/CustomAsteroids-Pops-Stock-Stockalike.netkan
+++ b/NetKAN/CustomAsteroids-Pops-Stock-Stockalike.netkan
@@ -1,73 +1,72 @@
-{
-    "spec_version": 1,
-    "identifier":   "CustomAsteroids-Pops-Stock-Stockalike",
-    "name":         "Custom Asteroids (stockalike config)",
-    "abstract":     "Emulates stock asteroids with Custom Asteroids groups.",
-    "$kref":        "#/ckan/spacedock/210",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "config",
-        "planet-pack"
-    ],
-    "depends": [
-        {
-            "name": "CustomAsteroids",
-            "min_version": "v1.9.0",
-            "max_version": "v1.99.99",
-            "comment": "Requires comet support."
-        }
-    ],
-    "provides": [ "CustomAsteroids-Pops" ],
-    "conflicts": [
-        { "name": "AlienSpaceProgram", "comment": "No Kerbin." },
-        { "name": "AlternisKerbolRekerjiggered", "comment": "Completely different system." },
-        { "name": "AlternisRealSolarSystem", "comment": "Completely different system."},
-        { "name": "Ktolemy", "comment": "Completely different system." },
-        { "name": "LittleGreenMenFromMars", "comment": "Completely different system." },
-        { "name": "NewHorizons", "comment": "Completely different system." },
-        { "name": "RealSolarSystem", "comment": "Completely different system."},
-        { "name": "SmallSolarSystem", "comment": "Completely different system."},
-        { "name": "StockAlikeSolarSystem", "comment": "Completely different system."},
-        { "name": "UnchartedLands", "comment": "Completely different system."}
-    ],
-    "install": [ {
-        "file": "GameData/CustomAsteroids",
-        "install_to": "GameData",
-        "filter_regexp": "(?<!Stockalike\\.cfg)$"
-    } ],
-    "x_netkan_override" : [
-        {
-            "version" : [ ">= v1.9.0", "< v2.0.0" ],
-            "override" : {
-                "comment": "Match to Custom Asteroids v1.9.0, see NetKAN#3841.",
-                "ksp_version_min": "1.10.0"
-            },
-            "delete" : [ "ksp_version" ]
-        },
-        {
-            "version" : [ ">= v1.6.0", "< v1.9.0" ],
-            "override" : {
-                "depends": [
-                    {
-                        "name": "CustomAsteroids",
-                        "min_version": "v1.6.0",
-                        "max_version": "v1.99.99"
-                    }
-                ],
-                "comment": "Match to Custom Asteroids v1.6.0, see NetKAN#3841.",
-                "ksp_version_min": "1.4.0"
-            },
-            "delete" : [ "ksp_version" ]
-        },
-        {
-            "version" : [ ">= v1.0.0", "< v1.6.0" ],
-            "override" : {
-                "comment": "Match to Custom Asteroids v1.3.0, see NetKAN#3841.",
-                "ksp_version_min": "1.1.0"
-            },
-            "delete" : [ "ksp_version" ]
-        }
-    ],
-    "x_maintained_by": "Starstrider42"
-}
+spec_version: v1.10
+identifier: CustomAsteroids-Pops-Stock-Stockalike
+name: Custom Asteroids (stockalike config)
+abstract: Emulates stock asteroids with Custom Asteroids groups.
+$kref: '#/ckan/spacedock/210'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - config
+  - planet-pack
+depends:
+  - name: CustomAsteroids
+    min_version: v1.9.0
+    max_version: v1.99.99
+    comment: Requires comet support.
+provides:
+  - CustomAsteroids-Pops
+conflicts:
+  - name: AlienSpaceProgram
+    comment: No Kerbin.
+  - name: AlternisKerbolRekerjiggered
+    comment: Completely different system.
+  - name: AlternisRealSolarSystem
+    comment: Completely different system.
+  - name: Ktolemy
+    comment: Completely different system.
+  - name: LittleGreenMenFromMars
+    comment: Completely different system.
+  - name: NewHorizons
+    comment: Completely different system.
+  - name: RealSolarSystem
+    comment: Completely different system.
+  - name: SmallSolarSystem
+    comment: Completely different system.
+  - name: StockAlikeSolarSystem
+    comment: Completely different system.
+  - name: UnchartedLands
+    comment: Completely different system.
+install:
+  - file: GameData/CustomAsteroids
+    install_to: GameData
+    filter_regexp: (?<!Stockalike\.cfg)$
+x_netkan_override:
+  - version:
+      - '>= v1.9.0'
+      - < v2.0.0
+    override:
+      comment: Match to Custom Asteroids v1.9.0, see NetKAN#3841.
+      ksp_version_min: 1.10.0
+    delete:
+      - ksp_version
+  - version:
+      - '>= v1.6.0'
+      - < v1.9.0
+    override:
+      depends:
+        - name: CustomAsteroids
+          min_version: v1.6.0
+          max_version: v1.99.99
+      comment: Match to Custom Asteroids v1.6.0, see NetKAN#3841.
+      ksp_version_min: 1.4.0
+    delete:
+      - ksp_version
+  - version:
+      - '>= v1.0.0'
+      - < v1.6.0
+    override:
+      comment: Match to Custom Asteroids v1.3.0, see NetKAN#3841.
+      ksp_version_min: 1.1.0
+    delete:
+      - ksp_version
+x_maintained_by: Starstrider42

--- a/NetKAN/DSEV.netkan
+++ b/NetKAN/DSEV.netkan
@@ -1,48 +1,40 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "DSEV",
-    "$kref":        "#/ckan/github/Angel-125/DSEV",
-    "$vref":        "#/ckan/ksp-avc/GameData/WildBlueIndustries/DSEV/DSEV.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that no new play modes were added to the Templates folder",
-    "license":      "restricted",
-    "resources": {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/122162-*",
-        "repository": "https://github.com/Angel-125/DSEV"
-    },
-    "tags": [
-        "parts",
-        "plugin",
-        "crewed"
-    ],
-    "depends": [
-        { "name": "DSEV-PlayMode"   },
-        { "name": "ModuleManager"   },
-        { "name": "WildBlueTools"   },
-        { "name": "NearFutureProps" },
-        { "name": "KerbalActuators" },
-        { "name": "BarisBridge"     }
-    ],
-    "recommends": [
-        { "name": "RasterPropMonitor-Core" },
-        { "name": "ASETProps"              },
-        { "name": "InfernalRobotics"       }
-    ],
-    "suggests": [
-        { "name": "ASET" }
-    ],
-    "install": [ {
-        "find":          "WildBlueIndustries/DSEV",
-        "install_to":    "GameData/WildBlueIndustries",
-        "filter_regexp": [ ".*\\.pdb$", "ReferenceDesigns", "Templates" ]
-    }, {
-        "find":       "DSEV/Templates/Common",
-        "install_to": "GameData/WildBlueIndustries/DSEV/Templates"
-    }, {
-        "find":       "VAB",
-        "install_to": "Ships"
-    }, {
-        "find":       "SPH",
-        "install_to": "Ships"
-    } ]
-}
+spec_version: v1.10
+identifier: DSEV
+$kref: '#/ckan/github/Angel-125/DSEV'
+$vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/DSEV/DSEV.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that no new play modes were added to the Templates folder
+license: restricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/122162-*
+  repository: https://github.com/Angel-125/DSEV
+tags:
+  - parts
+  - plugin
+  - crewed
+depends:
+  - name: DSEV-PlayMode
+  - name: ModuleManager
+  - name: WildBlueTools
+  - name: NearFutureProps
+  - name: KerbalActuators
+  - name: BarisBridge
+recommends:
+  - name: RasterPropMonitor-Core
+  - name: ASETProps
+  - name: InfernalRobotics
+suggests:
+  - name: ASET
+install:
+  - find: WildBlueIndustries/DSEV
+    install_to: GameData/WildBlueIndustries
+    filter_regexp:
+      - .*\.pdb$
+      - ReferenceDesigns
+      - Templates
+  - find: DSEV/Templates/Common
+    install_to: GameData/WildBlueIndustries/DSEV/Templates
+  - find: VAB
+    install_to: Ships
+  - find: SPH
+    install_to: Ships

--- a/NetKAN/DavonSupplyMod.netkan
+++ b/NetKAN/DavonSupplyMod.netkan
@@ -1,8 +1,8 @@
-spec_version: 1
-x_netkan_epoch: '1'
+spec_version: v1.10
 identifier: DavonSupplyMod
 $kref: '#/ckan/spacedock/364'
 $vref: '#/ckan/ksp-avc'
+x_netkan_epoch: '1'
 license: GPL-2.0
 tags:
   - plugin

--- a/NetKAN/EVAHandrailsPackContinued.netkan
+++ b/NetKAN/EVAHandrailsPackContinued.netkan
@@ -1,37 +1,27 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "EVAHandrailsPackContinued",
-    "$kref":        "#/ckan/spacedock/49",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-SA-3.0",
-    "tags": [
-        "parts"
-    ],
-    "conflicts": [
-        { "name": "NebulaEVAHandrails" }
-    ],
-    "provides": [ "NebulaEVAHandrails" ],
-    "depends" : [
-        { "name": "ModuleManager", "min_version": "2.6.5" }
-    ],
-    "suggests": [
-        { "name": "EvaHandrailsKISCompatibility" }
-    ],
-    "install": [
-        {
-            "find": "NEBULA",
-            "install_to": "GameData",
-            "filter_regexp": "ModuleManager.+\\.dll"
-        }
-    ],
-    "x_netkan_override" : [
-        {
-            "version" : "0.2.0",
-            "delete" : [ "ksp_version" ],
-            "override" : {
-                "ksp_version_min" : "1.0.2",
-                "ksp_version_max" : "1.0.4"
-            }
-        }
-    ]
-}
+spec_version: v1.10
+identifier: EVAHandrailsPackContinued
+$kref: '#/ckan/spacedock/49'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-SA-3.0
+tags:
+  - parts
+conflicts:
+  - name: NebulaEVAHandrails
+provides:
+  - NebulaEVAHandrails
+depends:
+  - name: ModuleManager
+    min_version: 2.6.5
+suggests:
+  - name: EvaHandrailsKISCompatibility
+install:
+  - find: NEBULA
+    install_to: GameData
+    filter_regexp: ModuleManager.+\.dll
+x_netkan_override:
+  - version: 0.2.0
+    delete:
+      - ksp_version
+    override:
+      ksp_version_min: 1.0.2
+      ksp_version_max: 1.0.4

--- a/NetKAN/Heisenberg.netkan
+++ b/NetKAN/Heisenberg.netkan
@@ -1,53 +1,45 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "Heisenberg",
-    "$kref":        "#/ckan/github/Angel-125/Airships",
-    "$vref":        "#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that no new play modes were added to the Templates folder",
-    "license":      "restricted",
-    "resources": {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*",
-        "repository": "https://github.com/Angel-125/Airships"
-    },
-    "tags": [
-        "parts",
-        "plugin",
-        "crewed"
-    ],
-    "depends": [
-        { "name": "Heisenberg-PlayMode"  },
-        { "name": "ModuleManager"        },
-        { "name": "WildBlueTools"        },
-        { "name": "HooliganLabsAirships" },
-        { "name": "KerbalActuators"      },
-        { "name": "BarisBridge"          }
-    ],
-    "recommends": [
-        { "name": "AirParkContinued"           },
-        { "name": "ASETProps"                  },
-        { "name": "AircraftCarrierAccessories" }
-    ],
-    "suggests": [
-        { "name": "Pathfinder" },
-        { "name": "KIS"        },
-        { "name": "KAS"        },
-        { "name": "kOS"        },
-        { "name": "Snacks"     },
-        { "name": "TACLS"      }
-    ],
-    "install": [ {
-        "find":          "WildBlueIndustries/Heisenberg",
-        "install_to":    "GameData/WildBlueIndustries",
-        "filter_regexp": [ ".*\\.pdb$", "SampleCraft", "Templates" ]
-    }, {
-        "find":       "WildBlueIndustries/Heisenberg/Templates/Common",
-        "install_to": "GameData/WildBlueIndustries/Templates"
-    }, {
-        "find":       "VAB",
-        "install_to": "Ships"
-    }, {
-        "find":       "SPH",
-        "install_to": "Ships"
-    } ]
-}
+spec_version: v1.10
+identifier: Heisenberg
+$kref: '#/ckan/github/Angel-125/Airships'
+$vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that no new play modes were added to the Templates folder
+license: restricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*
+  repository: https://github.com/Angel-125/Airships
+tags:
+  - parts
+  - plugin
+  - crewed
+depends:
+  - name: Heisenberg-PlayMode
+  - name: ModuleManager
+  - name: WildBlueTools
+  - name: HooliganLabsAirships
+  - name: KerbalActuators
+  - name: BarisBridge
+recommends:
+  - name: AirParkContinued
+  - name: ASETProps
+  - name: AircraftCarrierAccessories
+suggests:
+  - name: Pathfinder
+  - name: KIS
+  - name: KAS
+  - name: kOS
+  - name: Snacks
+  - name: TACLS
+install:
+  - find: WildBlueIndustries/Heisenberg
+    install_to: GameData/WildBlueIndustries
+    filter_regexp:
+      - .*\.pdb$
+      - SampleCraft
+      - Templates
+  - find: WildBlueIndustries/Heisenberg/Templates/Common
+    install_to: GameData/WildBlueIndustries/Templates
+  - find: VAB
+    install_to: Ships
+  - find: SPH
+    install_to: Ships

--- a/NetKAN/JDiminishingRTG.netkan
+++ b/NetKAN/JDiminishingRTG.netkan
@@ -1,20 +1,18 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "JDiminishingRTG",
-    "$kref":        "#/ckan/spacedock/2096",
-    "$vref":        "#/ckan/ksp-avc",
-    "author":       [ "KwirkyJ", "linuxgurugamer" ],
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "physics"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "install": [ {
-        "find": "JDiminishingRTG",
-        "install_to": "GameData",
-        "filter_regexp": [ "ModuleManager.*" ]
-    } ]
-}
+spec_version: v1.10
+identifier: JDiminishingRTG
+$kref: '#/ckan/spacedock/2096'
+$vref: '#/ckan/ksp-avc'
+author:
+  - KwirkyJ
+  - linuxgurugamer
+license: GPL-3.0
+tags:
+  - plugin
+  - physics
+depends:
+  - name: ModuleManager
+install:
+  - find: JDiminishingRTG
+    install_to: GameData
+    filter_regexp:
+      - ModuleManager.*

--- a/NetKAN/KSP-PartVolume.netkan
+++ b/NetKAN/KSP-PartVolume.netkan
@@ -1,21 +1,18 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "KSP-PartVolume",
-    "$kref":        "#/ckan/spacedock/2672",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "depends": [
-        { "name": "ModuleManager"       },
-        { "name": "ClickThroughBlocker" },
-        { "name": "SpaceTuxLibrary"     }
-    ],
-    "tags": [
-        "plugin",
-        "physics"
-    ],
-    "install": [ {
-        "find":          "KSP_PartVolume",
-        "install_to":    "GameData",
-        "filter_regexp": [ ".*~$", ".*\\.pdb$" ]
-    } ]
-}
+spec_version: v1.10
+identifier: KSP-PartVolume
+$kref: '#/ckan/spacedock/2672'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+depends:
+  - name: ModuleManager
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+tags:
+  - plugin
+  - physics
+install:
+  - find: KSP_PartVolume
+    install_to: GameData
+    filter_regexp:
+      - .*~$
+      - .*\.pdb$

--- a/NetKAN/KaptainsLog.netkan
+++ b/NetKAN/KaptainsLog.netkan
@@ -1,21 +1,17 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "KaptainsLog",
-    "$kref":        "#/ckan/spacedock/1523",
-    "$vref":        "#/ckan/ksp-avc/GameData/KaptainsLog/KaptainsLog.version",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "install": [ {
-        "filter_regexp": [ ".*~$" ],
-        "find": "KaptainsLog",
-        "install_to": "GameData"
-    } ],
-    "depends" : [
-        { "name" : "ProgressParser" },
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ]
-}
+spec_version: v1.10
+identifier: KaptainsLog
+$kref: '#/ckan/spacedock/1523'
+$vref: '#/ckan/ksp-avc/GameData/KaptainsLog/KaptainsLog.version'
+license: GPL-3.0
+tags:
+  - plugin
+  - information
+install:
+  - filter_regexp:
+      - .*~$
+    find: KaptainsLog
+    install_to: GameData
+depends:
+  - name: ProgressParser
+  - name: ToolbarController
+  - name: ClickThroughBlocker

--- a/NetKAN/KerbalKomets.netkan
+++ b/NetKAN/KerbalKomets.netkan
@@ -1,19 +1,15 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "KerbalKomets",
-    "$kref":        "#/ckan/spacedock/1249",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "planet-pack"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "install": [ {
-        "find":          "WildBlueIndustries",
-        "install_to":    "GameData",
-        "filter_regexp": [ ".*\\.pdb$" ]
-    } ]
-}
+spec_version: v1.10
+identifier: KerbalKomets
+$kref: '#/ckan/spacedock/1249'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - planet-pack
+depends:
+  - name: ModuleManager
+install:
+  - find: WildBlueIndustries
+    install_to: GameData
+    filter_regexp:
+      - .*\.pdb$

--- a/NetKAN/MOLE.netkan
+++ b/NetKAN/MOLE.netkan
@@ -1,52 +1,45 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "MOLE",
-    "$kref":        "#/ckan/github/Angel-125/MOLE",
-    "$vref":        "#/ckan/ksp-avc/GameData/WildBlueIndustries/MOLE/MOLE.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that no new play modes were added to the Templates folder",
-    "license":      "restricted",
-    "resources": {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/154893-*",
-        "repository": "https://github.com/Angel-125/MOLE"
-    },
-    "tags": [
-        "parts",
-        "plugin",
-        "crewed"
-    ],
-    "depends": [
-        { "name": "MOLE-PlayMode"   },
-        { "name": "ModuleManager"   },
-        { "name": "WildBlueTools"   },
-        { "name": "KerbalActuators" },
-        { "name": "BarisBridge"     }
-    ],
-    "recommends": [
-        { "name": "ASETProps"                },
-        { "name": "ExtraPlanetaryLaunchpads" }
-    ],
-    "suggests": [
-        { "name": "Pathfinder"             },
-        { "name": "RealChute"              },
-        { "name": "KIS"                    },
-        { "name": "KAS"                    },
-        { "name": "kOS"                    },
-        { "name": "RasterPropMonitor-Core" },
-        { "name": "CactEyeCommunity"       },
-        { "name": "Snacks"                 },
-        { "name": "TACLS"                  },
-        { "name": "Kerbalism"              }
-    ],
-    "install": [ {
-        "find":          "WildBlueIndustries/MOLE",
-        "install_to":    "GameData/WildBlueIndustries",
-        "filter_regexp": [ ".*\\.pdb$", "SampleCraft", "Templates" ]
-    }, {
-        "find":       "MOLE/Templates/Common",
-        "install_to": "GameData/WildBlueIndustries/MOLE/Templates"
-    }, {
-        "find":       "VAB",
-        "install_to": "Ships"
-    } ]
-}
+spec_version: v1.10
+identifier: MOLE
+$kref: '#/ckan/github/Angel-125/MOLE'
+$vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/MOLE/MOLE.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that no new play modes were added to the Templates folder
+license: restricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/154893-*
+  repository: https://github.com/Angel-125/MOLE
+tags:
+  - parts
+  - plugin
+  - crewed
+depends:
+  - name: MOLE-PlayMode
+  - name: ModuleManager
+  - name: WildBlueTools
+  - name: KerbalActuators
+  - name: BarisBridge
+recommends:
+  - name: ASETProps
+  - name: ExtraPlanetaryLaunchpads
+suggests:
+  - name: Pathfinder
+  - name: RealChute
+  - name: KIS
+  - name: KAS
+  - name: kOS
+  - name: RasterPropMonitor-Core
+  - name: CactEyeCommunity
+  - name: Snacks
+  - name: TACLS
+  - name: Kerbalism
+install:
+  - find: WildBlueIndustries/MOLE
+    install_to: GameData/WildBlueIndustries
+    filter_regexp:
+      - .*\.pdb$
+      - SampleCraft
+      - Templates
+  - find: MOLE/Templates/Common
+    install_to: GameData/WildBlueIndustries/MOLE/Templates
+  - find: VAB
+    install_to: Ships

--- a/NetKAN/Mk-33.netkan
+++ b/NetKAN/Mk-33.netkan
@@ -1,44 +1,36 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "Mk-33",
-    "$kref":        "#/ckan/github/Angel-125/Mk-33",
-    "$vref":        "#/ckan/ksp-avc/GameData/WildBlueIndustries/Mk-33/Mk33.version",
-    "license":      "restricted",
-    "resources": {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/194713-*",
-        "repository": "https://github.com/Angel-125/Mk-33"
-    },
-    "tags": [
-        "parts",
-        "plugin",
-        "crewed"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "KerbalKonstructs" },
-        { "name": "DockRotate" }
-    ],
-    "suggests": [
-        { "name": "KIS" },
-        { "name": "KAS" },
-        { "name": "kOS" },
-        { "name": "CactEyeCommunity" },
-        { "name": "Snacks" },
-        { "name": "TACLS" },
-        { "name": "WildBlueTools" },
-        { "name": "Kerbalism" }
-    ],
-    "install": [ {
-        "find":          "WildBlueIndustries/Mk-33",
-        "install_to":    "GameData/WildBlueIndustries",
-        "filter_regexp": [ ".*\\.pdb$", "SampleCraft" ]
-    }, {
-        "find":       "VAB",
-        "install_to": "Ships"
-    }, {
-        "find":       "SPH",
-        "install_to": "Ships"
-    } ]
-}
+spec_version: v1.10
+identifier: Mk-33
+$kref: '#/ckan/github/Angel-125/Mk-33'
+$vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Mk-33/Mk33.version'
+license: restricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/194713-*
+  repository: https://github.com/Angel-125/Mk-33
+tags:
+  - parts
+  - plugin
+  - crewed
+depends:
+  - name: ModuleManager
+recommends:
+  - name: KerbalKonstructs
+  - name: DockRotate
+suggests:
+  - name: KIS
+  - name: KAS
+  - name: kOS
+  - name: CactEyeCommunity
+  - name: Snacks
+  - name: TACLS
+  - name: WildBlueTools
+  - name: Kerbalism
+install:
+  - find: WildBlueIndustries/Mk-33
+    install_to: GameData/WildBlueIndustries
+    filter_regexp:
+      - .*\.pdb$
+      - SampleCraft
+  - find: VAB
+    install_to: Ships
+  - find: SPH
+    install_to: Ships

--- a/NetKAN/NavBallTextureChangerUpdated.netkan
+++ b/NetKAN/NavBallTextureChangerUpdated.netkan
@@ -1,34 +1,20 @@
-{
-  "license": "MIT",
-  "author": "linuxgurugamer",
-  "identifier": "NavBallTextureChangerUpdated",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "$kref": "#/ckan/spacedock/2654",
-  "$vref": "#/ckan/ksp-avc",
-  "depends": [
-    {
-      "name": "ToolbarController"
-    },
-    {
-      "name": "ClickThroughBlocker"
-    },
-    {
-      "name": "SpaceTuxLibrary"
-    }
-  ],
-  "conflicts": [ { "name": "NavBallTextureExport" } ],
-  "tags": [
-    "plugin",
-    "graphics"
-  ],
-  "install": [
-    {
-      "find": "NavBallTextureChanger",
-      "install_to": "GameData",
-      "filter_regexp": [
-        ".*\\.pdb$"
-      ]
-    }
-  ],
-  "spec_version": "v1.4"
-}
+spec_version: v1.10
+identifier: NavBallTextureChangerUpdated
+$kref: '#/ckan/spacedock/2654'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+author: linuxgurugamer
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+conflicts:
+  - name: NavBallTextureExport
+tags:
+  - plugin
+  - graphics
+install:
+  - find: NavBallTextureChanger
+    install_to: GameData
+    filter_regexp:
+      - .*\.pdb$

--- a/NetKAN/Pathfinder.netkan
+++ b/NetKAN/Pathfinder.netkan
@@ -1,49 +1,41 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "Pathfinder",
-    "author":       "Angel-125",
-    "$kref":        "#/ckan/github/Angel-125/Pathfinder",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that no new play modes were added to the Templates folder",
-    "license":      "GPL-3.0",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/121397-*"
-    },
-    "tags": [
-        "parts",
-        "plugin",
-        "agency",
-        "resources",
-        "crewed"
-    ],
-    "depends": [
-        { "name": "Pathfinder-PlayMode"   },
-        { "name": "ModuleManager"         },
-        { "name": "KerbalActuators"       },
-        { "name": "BarisBridge"           },
-        { "name": "WildBlueTools"         },
-        { "name": "Buffalo"               }
-    ],
-    "recommends": [
-        { "name": "KAS" },
-        { "name": "KIS" }
-    ],
-    "supports": [
-        { "name": "ConnectedLivingSpace" },
-        { "name": "TACLS"                },
-        { "name": "USI-LS"               },
-        { "name": "Snacks"               }
-    ],
-    "install": [ {
-        "find":          "Pathfinder",
-        "install_to":    "GameData/WildBlueIndustries",
-        "filter_regexp": [ ".*\\.pdb$", "Templates" ]
-    }, {
-        "find":       "Pathfinder/Templates/Common",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates"
-    }, {
-        "file":        "GameData/WBIPlayMode.cfg",
-        "install_to" : "GameData"
-    } ]
-}
+spec_version: v1.10
+identifier: Pathfinder
+author: Angel-125
+$kref: '#/ckan/github/Angel-125/Pathfinder'
+$vref: '#/ckan/ksp-avc'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that no new play modes were added to the Templates folder
+license: GPL-3.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/121397-*
+tags:
+  - parts
+  - plugin
+  - agency
+  - resources
+  - crewed
+depends:
+  - name: Pathfinder-PlayMode
+  - name: ModuleManager
+  - name: KerbalActuators
+  - name: BarisBridge
+  - name: WildBlueTools
+  - name: Buffalo
+recommends:
+  - name: KAS
+  - name: KIS
+supports:
+  - name: ConnectedLivingSpace
+  - name: TACLS
+  - name: USI-LS
+  - name: Snacks
+install:
+  - find: Pathfinder
+    install_to: GameData/WildBlueIndustries
+    filter_regexp:
+      - .*\.pdb$
+      - Templates
+  - find: Pathfinder/Templates/Common
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates
+  - file: GameData/WBIPlayMode.cfg
+    install_to: GameData

--- a/NetKAN/RoutineMissionManager.netkan
+++ b/NetKAN/RoutineMissionManager.netkan
@@ -1,24 +1,19 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "RoutineMissionManager",
-    "$kref":        "#/ckan/spacedock/362",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "BSD-2-clause",
-    "tags": [
-        "plugin",
-        "career",
-        "convenience"
-    ],
-    "install": [ {
-        "file"          : "GameData/RoutineMissionManager",
-        "install_to"    : "GameData",
-        "filter_regexp" : "Licences and Source"
-    } ],
-    "depends" : [
-        { "name": "ModuleManager" },
-        { "name": "ToolbarController" },
-        { "name": "ClickThroughBlocker" },
-        { "name": "SpaceTuxLibrary" }
-    ],
-    "x_netkan_epoch": "1"
-}
+spec_version: v1.10
+identifier: RoutineMissionManager
+$kref: '#/ckan/spacedock/362'
+$vref: '#/ckan/ksp-avc'
+license: BSD-2-clause
+tags:
+  - plugin
+  - career
+  - convenience
+install:
+  - file: GameData/RoutineMissionManager
+    install_to: GameData
+    filter_regexp: Licences and Source
+depends:
+  - name: ModuleManager
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+x_netkan_epoch: '1'

--- a/NetKAN/ServoController.netkan
+++ b/NetKAN/ServoController.netkan
@@ -1,4 +1,4 @@
-spec_version: v1.4
+spec_version: v1.10
 identifier: ServoController
 $kref: '#/ckan/github/Angel-125/ServoController'
 $vref: '#/ckan/ksp-avc'

--- a/NetKAN/TestFlightConfig-KerbalAtomics.netkan
+++ b/NetKAN/TestFlightConfig-KerbalAtomics.netkan
@@ -1,34 +1,25 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "TestFlightConfig-KerbalAtomics",
-    "name":         "TestFlight Config for Kerbal Atomics",
-    "abstract":     "This config pack adds TestFlight support for Kerbal Atomics parts. It does not affect stock parts; install a stock TestFlight config if desired.",
-    "$kref":        "#/ckan/github/Starstrider42/TestFlight-Configs",
-    "release_status": "testing",
-    "license":      "MIT",
-    "resources": {
-        "bugtracker": "https://github.com/Starstrider42/TestFlight-Configs/issues"
-    },
-    "tags": [
-        "config"
-    ],
-    "provides": [
-        "TestFlightConfig"
-    ],
-    "depends": [
-        { "name": "TestFlightConfigLibrary" },
-        { "name": "ModuleManager" },
-        {
-            "name": "KerbalAtomics",
-            "min_version": "1:1.0"
-        }
-    ],
-    "install": [
-        {
-            "file": "GameData/TestFlight/Config",
-            "install_to": "GameData/TestFlight",
-            "filter_regexp": "(?<!KA_.+\\.cfg)$"
-        }
-    ],
-    "x_maintained_by": "Starstrider42"
-}
+spec_version: v1.10
+identifier: TestFlightConfig-KerbalAtomics
+name: TestFlight Config for Kerbal Atomics
+abstract: >-
+  This config pack adds TestFlight support for Kerbal Atomics parts. It does not
+  affect stock parts; install a stock TestFlight config if desired.
+$kref: '#/ckan/github/Starstrider42/TestFlight-Configs'
+release_status: testing
+license: MIT
+resources:
+  bugtracker: https://github.com/Starstrider42/TestFlight-Configs/issues
+tags:
+  - config
+provides:
+  - TestFlightConfig
+depends:
+  - name: TestFlightConfigLibrary
+  - name: ModuleManager
+  - name: KerbalAtomics
+    min_version: '1:1.0'
+install:
+  - file: GameData/TestFlight/Config
+    install_to: GameData/TestFlight
+    filter_regexp: (?<!KA_.+\.cfg)$
+x_maintained_by: Starstrider42

--- a/NetKAN/TestFlightConfig-NFPropulsion.netkan
+++ b/NetKAN/TestFlightConfig-NFPropulsion.netkan
@@ -1,34 +1,25 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "TestFlightConfig-NFPropulsion",
-    "name":         "TestFlight Config for Near Future Propulsion",
-    "abstract":     "This config pack adds TestFlight support for Near Future Propulsion parts. It does not affect stock parts; install a stock TestFlight config if desired.",
-    "$kref":        "#/ckan/github/Starstrider42/TestFlight-Configs",
-    "release_status": "testing",
-    "license":      "MIT",
-    "resources": {
-        "bugtracker": "https://github.com/Starstrider42/TestFlight-Configs/issues"
-    },
-    "tags": [
-        "config"
-    ],
-    "provides": [
-        "TestFlightConfig"
-    ],
-    "depends": [
-        { "name": "TestFlightConfigLibrary" },
-        { "name": "ModuleManager" },
-        {
-            "name": "NearFuturePropulsion",
-            "min_version": "1.0"
-        }
-    ],
-    "install": [
-        {
-            "file": "GameData/TestFlight/Config",
-            "install_to": "GameData/TestFlight",
-            "filter_regexp": "(?<!NFP_.+\\.cfg)$"
-        }
-    ],
-    "x_maintained_by": "Starstrider42"
-}
+spec_version: v1.10
+identifier: TestFlightConfig-NFPropulsion
+name: TestFlight Config for Near Future Propulsion
+abstract: >-
+  This config pack adds TestFlight support for Near Future Propulsion parts. It
+  does not affect stock parts; install a stock TestFlight config if desired.
+$kref: '#/ckan/github/Starstrider42/TestFlight-Configs'
+release_status: testing
+license: MIT
+resources:
+  bugtracker: https://github.com/Starstrider42/TestFlight-Configs/issues
+tags:
+  - config
+provides:
+  - TestFlightConfig
+depends:
+  - name: TestFlightConfigLibrary
+  - name: ModuleManager
+  - name: NearFuturePropulsion
+    min_version: '1.0'
+install:
+  - file: GameData/TestFlight/Config
+    install_to: GameData/TestFlight
+    filter_regexp: (?<!NFP_.+\.cfg)$
+x_maintained_by: Starstrider42

--- a/NetKAN/TestFlightConfig-NFSpacecraft.netkan
+++ b/NetKAN/TestFlightConfig-NFSpacecraft.netkan
@@ -1,34 +1,25 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "TestFlightConfig-NFSpacecraft",
-    "name":         "TestFlight Config for Near Future Spacecraft",
-    "abstract":     "This config pack adds TestFlight support for Near Future Spacecraft parts. It does not affect stock parts; install a stock TestFlight config if desired.",
-    "$kref":        "#/ckan/github/Starstrider42/TestFlight-Configs",
-    "release_status": "testing",
-    "license": "MIT",
-    "resources": {
-        "bugtracker": "https://github.com/Starstrider42/TestFlight-Configs/issues"
-    },
-    "tags": [
-        "config"
-    ],
-    "provides": [
-        "TestFlightConfig"
-    ],
-    "depends": [
-        { "name": "TestFlightConfigLibrary" },
-        { "name": "ModuleManager" },
-        {
-            "name": "NearFutureSpacecraft",
-            "min_version": "1.2"
-        }
-    ],
-    "install": [
-        {
-            "file": "GameData/TestFlight/Config",
-            "install_to": "GameData/TestFlight",
-            "filter_regexp": "(?<!NFS_.+\\.cfg)$"
-        }
-    ],
-    "x_maintained_by": "Starstrider42"
-}
+spec_version: v1.10
+identifier: TestFlightConfig-NFSpacecraft
+name: TestFlight Config for Near Future Spacecraft
+abstract: >-
+  This config pack adds TestFlight support for Near Future Spacecraft parts. It
+  does not affect stock parts; install a stock TestFlight config if desired.
+$kref: '#/ckan/github/Starstrider42/TestFlight-Configs'
+release_status: testing
+license: MIT
+resources:
+  bugtracker: https://github.com/Starstrider42/TestFlight-Configs/issues
+tags:
+  - config
+provides:
+  - TestFlightConfig
+depends:
+  - name: TestFlightConfigLibrary
+  - name: ModuleManager
+  - name: NearFutureSpacecraft
+    min_version: '1.2'
+install:
+  - file: GameData/TestFlight/Config
+    install_to: GameData/TestFlight
+    filter_regexp: (?<!NFS_.+\.cfg)$
+x_maintained_by: Starstrider42

--- a/NetKAN/TestFlightConfig-Stock-S42.netkan
+++ b/NetKAN/TestFlightConfig-Stock-S42.netkan
@@ -1,37 +1,29 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "TestFlightConfig-Stock-S42",
-    "name":         "TestFlight Config for Stock (alternative config)",
-    "abstract":     "This config pack adds TestFlight support for Stock parts.",
-    "$kref":        "#/ckan/github/Starstrider42/TestFlight-Configs",
-    "ksp_version_min": "1.4",
-    "ksp_version_max": "1.9",
-    "comment": "ksp_version_max because each release adds TF-eligible parts",
-    "release_status": "testing",
-    "license": "MIT",
-    "resources": {
-        "bugtracker": "https://github.com/Starstrider42/TestFlight-Configs/issues"
-    },
-    "tags": [
-        "config"
-    ],
-    "depends": [
-        { "name": "TestFlightConfigLibrary" },
-        { "name": "ModuleManager" }
-    ],
-    "provides": [
-        "TestFlightConfig"
-    ],
-    "conflicts": [
-        { "name": "TestFlightConfigStock", "comment": "Modifies same parts" },
-        { "name": "RealismOverhaul",       "comment": "Removes stock parts" }
-    ],
-    "install": [
-        {
-            "file": "GameData/TestFlight/Config",
-            "install_to": "GameData/TestFlight",
-            "filter_regexp": "(?<!Stock_.+\\.cfg)$"
-        }
-    ],
-    "x_maintained_by": "Starstrider42"
-}
+spec_version: v1.10
+identifier: TestFlightConfig-Stock-S42
+name: TestFlight Config for Stock (alternative config)
+abstract: This config pack adds TestFlight support for Stock parts.
+$kref: '#/ckan/github/Starstrider42/TestFlight-Configs'
+ksp_version_min: '1.4'
+ksp_version_max: '1.9'
+comment: ksp_version_max because each release adds TF-eligible parts
+release_status: testing
+license: MIT
+resources:
+  bugtracker: https://github.com/Starstrider42/TestFlight-Configs/issues
+tags:
+  - config
+depends:
+  - name: TestFlightConfigLibrary
+  - name: ModuleManager
+provides:
+  - TestFlightConfig
+conflicts:
+  - name: TestFlightConfigStock
+    comment: Modifies same parts
+  - name: RealismOverhaul
+    comment: Removes stock parts
+install:
+  - file: GameData/TestFlight/Config
+    install_to: GameData/TestFlight
+    filter_regexp: (?<!Stock_.+\.cfg)$
+x_maintained_by: Starstrider42

--- a/NetKAN/TestFlightConfigLibrary.netkan
+++ b/NetKAN/TestFlightConfigLibrary.netkan
@@ -1,37 +1,26 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "TestFlightConfigLibrary",
-    "name":         "TestFlight Generic Config Library",
-    "abstract":     "ModuleManager scripts for simplifying and standardizing TestFlight configs. Do *not* provide TestFlight support by themselves.",
-    "$kref":        "#/ckan/github/Starstrider42/TestFlight-Configs",
-    "release_status": "testing",
-    "license":      "MIT",
-    "resources": {
-        "bugtracker": "https://github.com/Starstrider42/TestFlight-Configs/issues"
-    },
-    "tags": [
-        "config",
-        "library"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        {
-            "name": "TestFlight",
-            "min_version": "1.8.0"
-        }
-    ],
-    "conflicts": [
-        {
-            "name": "RealismOverhaul",
-            "comment": "RO uses similar scripts; they will likely interfere with each other."
-        }
-    ],
-    "install": [
-        {
-            "file": "GameData/TestFlight/Config",
-            "install_to": "GameData/TestFlight",
-            "filter_regexp": "(?<!Generic_.+\\.cfg)$"
-        }
-    ],
-    "x_maintained_by": "Starstrider42"
-}
+spec_version: v1.10
+identifier: TestFlightConfigLibrary
+name: TestFlight Generic Config Library
+abstract: >-
+  ModuleManager scripts for simplifying and standardizing TestFlight configs. Do
+  *not* provide TestFlight support by themselves.
+$kref: '#/ckan/github/Starstrider42/TestFlight-Configs'
+release_status: testing
+license: MIT
+resources:
+  bugtracker: https://github.com/Starstrider42/TestFlight-Configs/issues
+tags:
+  - config
+  - library
+depends:
+  - name: ModuleManager
+  - name: TestFlight
+    min_version: 1.8.0
+conflicts:
+  - name: RealismOverhaul
+    comment: RO uses similar scripts; they will likely interfere with each other.
+install:
+  - file: GameData/TestFlight/Config
+    install_to: GameData/TestFlight
+    filter_regexp: (?<!Generic_.+\.cfg)$
+x_maintained_by: Starstrider42

--- a/NetKAN/WernherCheckerContinued.netkan
+++ b/NetKAN/WernherCheckerContinued.netkan
@@ -1,22 +1,18 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "WernherCheckerContinued",
-    "$kref":        "#/ckan/spacedock/1237",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "editor",
-        "information"
-    ],
-    "install": [ {
-        "filter_regexp": [ ".*~$" ],
-        "find": "WernherChecker",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" },
-        { "name" : "SpaceTuxLibrary" }
-    ]
-}
+spec_version: v1.10
+identifier: WernherCheckerContinued
+$kref: '#/ckan/spacedock/1237'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - editor
+  - information
+install:
+  - filter_regexp:
+      - .*~$
+    find: WernherChecker
+    install_to: GameData
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/147945808-3ebef857-02ec-4157-9f45-3b47b08329f4.png)

These mods were violating the spec by using `filter_regexp` with a spec version older than v1.10, which has been caught now that KSP-CKAN/CKAN#3494 is merged. Now they're updated to v1.10 (and YAMLized).

___

ckan compat add 1.8 1.11 1.12