### PR TITLE
Split out KerbalKomets play modes

### DIFF
--- a/NetKAN/KerbalKomets-PlayMode-CRP.netkan
+++ b/NetKAN/KerbalKomets-PlayMode-CRP.netkan
@@ -1,0 +1,26 @@
+spec_version: v1.18
+identifier: KerbalKomets-PlayMode-CRP
+name: KerbalKomets CRP Play Mode
+$kref: '#/ckan/spacedock/1249'
+$vref: '#/ckan/ksp-avc'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: GPL-3.0
+tags:
+  - config
+provides:
+  - KerbalKomets-PlayMode
+conflicts:
+  - name: KerbalKomets-PlayMode
+depends:
+  - name: KerbalKomets
+  - name: WildBlue-PlayMode-CRP
+  - name: ModuleManager
+install:
+  - find: WildBlueIndustries/KerbalKomets/Templates/CRP/MM_PotatoRoid.txt
+    install_to: GameData/WildBlueIndustries/KerbalKomets/Templates
+    as: MM_PotatoRoid.cfg
+    find_matches_files: true
+  - find: WildBlueIndustries/KerbalKomets/Templates/CRP.cfg
+    install_to: GameData/WildBlueIndustries/KerbalKomets/Templates
+    find_matches_files: true

--- a/NetKAN/KerbalKomets-PlayMode-ClassicStock.netkan
+++ b/NetKAN/KerbalKomets-PlayMode-ClassicStock.netkan
@@ -1,0 +1,24 @@
+spec_version: v1.16
+identifier: KerbalKomets-PlayMode-ClassicStock
+name: KerbalKomets Classic Stock Play Mode
+$kref: '#/ckan/spacedock/1249'
+$vref: '#/ckan/ksp-avc'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: GPL-3.0
+tags:
+  - config
+provides:
+  - KerbalKomets-PlayMode
+conflicts:
+  - name: KerbalKomets-PlayMode
+depends:
+  - name: KerbalKomets
+  - name: WildBlue-PlayMode-ClassicStock
+  - name: ModuleManager
+install:
+  - find: WildBlueIndustries/KerbalKomets/Templates/ClassicStock
+    install_to: GameData/WildBlueIndustries/KerbalKomets/Templates
+  - find: WildBlueIndustries/KerbalKomets/Templates/ClassicStock.cfg
+    install_to: GameData/WildBlueIndustries/KerbalKomets/Templates
+    find_matches_files: true

--- a/NetKAN/KerbalKomets.netkan
+++ b/NetKAN/KerbalKomets.netkan
@@ -8,8 +8,10 @@ tags:
   - planet-pack
 depends:
   - name: ModuleManager
+  - name: KerbalKomets-PlayMode
 install:
   - find: WildBlueIndustries
     install_to: GameData
     filter_regexp:
       - .*\.pdb$
+      - Templates

--- a/NetKAN/WildBlue-PlayMode-Pristine.netkan
+++ b/NetKAN/WildBlue-PlayMode-Pristine.netkan
@@ -1,36 +1,31 @@
-{
-    "spec_version": "v1.18",
-    "identifier":   "WildBlue-PlayMode-Pristine",
-    "name":         "WildBlueIndustries Pristine Play Mode",
-    "abstract":     "Pristine Mode removes all templates and converters. You'll have a number of nice looking parts for decorative base building.",
-    "author":       "Angel-125",
-    "$kref":        "#/ckan/github/Angel-125/WildBlueTools",
-    "$vref":        "#/ckan/ksp-avc/WildBlueTools.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "GPL-3.0",
-    "tags": [
-        "config"
-    ],
-    "depends": [
-        { "name": "WildBlueTools" },
-        { "name": "ModuleManager" }
-    ],
-    "provides": [
-        "WildBlue-PlayMode",
-        "Buffalo-PlayMode"
-    ],
-    "conflicts": [
-        { "name": "WildBlue-PlayMode" }
-    ],
-    "install": [ {
-        "find":       "000WildBlueTools/Templates/Pristine/MM_Pristine.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/Pristine",
-        "as":         "MM_Pristine.cfg",
-        "find_matches_files": true
-    }, {
-        "find":       "000WildBlueTools/Templates/Pristine.cfg",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates",
-        "find_matches_files": true
-    } ]
-}
+spec_version: v1.18
+identifier: WildBlue-PlayMode-Pristine
+name: WildBlueIndustries Pristine Play Mode
+abstract: >-
+  Pristine Mode removes all templates and converters. You'll have a number of
+  nice looking parts for decorative base building.
+author: Angel-125
+$kref: '#/ckan/github/Angel-125/WildBlueTools'
+$vref: '#/ckan/ksp-avc/WildBlueTools.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: GPL-3.0
+tags:
+  - config
+depends:
+  - name: WildBlueTools
+  - name: ModuleManager
+provides:
+  - WildBlue-PlayMode
+  - Buffalo-PlayMode
+  - KerbalKomets-PlayMode
+conflicts:
+  - name: WildBlue-PlayMode
+install:
+  - find: 000WildBlueTools/Templates/Pristine/MM_Pristine.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/Pristine
+    as: MM_Pristine.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/Pristine.cfg
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates
+    find_matches_files: true

--- a/NetKAN/WildBlue-PlayMode-Simplified.netkan
+++ b/NetKAN/WildBlue-PlayMode-Simplified.netkan
@@ -1,37 +1,33 @@
-{
-    "spec_version": "v1.18",
-    "identifier":   "WildBlue-PlayMode-Simplified",
-    "name":         "WildBlueIndustries Simplified Play Mode",
-    "abstract":     "Lite Blue reduces the number available templates and resources used. This is great for players new to Pathfinder and other WildBlue mods or for those that don't want a lot of complexity.",
-    "author":       "Angel-125",
-    "$kref":        "#/ckan/github/Angel-125/WildBlueTools",
-    "$vref":        "#/ckan/ksp-avc/WildBlueTools.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "GPL-3.0",
-    "tags": [
-        "config"
-    ],
-    "depends": [
-        { "name": "WildBlueTools" }
-    ],
-    "provides": [
-        "WildBlue-PlayMode",
-        "Buffalo-PlayMode",
-        "DSEV-PlayMode",
-        "MOLE-PlayMode"
-    ],
-    "conflicts": [
-        { "name": "WildBlue-PlayMode" }
-    ],
-    "install": [ {
-        "find":       "000WildBlueTools/Templates/Simplified/Storage/OmniStorage.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/Simplified/Storage",
-        "as":         "OmniStorage.cfg",
-        "find_matches_file": true
-    }, {
-        "find":       "000WildBlueTools/Templates/Simplified.cfg",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates",
-        "find_matches_files": true
-    } ]
-}
+spec_version: v1.18
+identifier: WildBlue-PlayMode-Simplified
+name: WildBlueIndustries Simplified Play Mode
+abstract: >-
+  Lite Blue reduces the number available templates and resources used. This is
+  great for players new to Pathfinder and other WildBlue mods or for those that
+  don't want a lot of complexity.
+author: Angel-125
+$kref: '#/ckan/github/Angel-125/WildBlueTools'
+$vref: '#/ckan/ksp-avc/WildBlueTools.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: GPL-3.0
+tags:
+  - config
+depends:
+  - name: WildBlueTools
+provides:
+  - WildBlue-PlayMode
+  - Buffalo-PlayMode
+  - DSEV-PlayMode
+  - MOLE-PlayMode
+  - KerbalKomets-PlayMode
+conflicts:
+  - name: WildBlue-PlayMode
+install:
+  - find: 000WildBlueTools/Templates/Simplified/Storage/OmniStorage.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/Simplified/Storage
+    as: OmniStorage.cfg
+    find_matches_file: true
+  - find: 000WildBlueTools/Templates/Simplified.cfg
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates
+    find_matches_files: true


### PR DESCRIPTION
This mod has play modes and should have been included in #8275, but I only found out about it while reviewing output from #8943.

Now two new play mode modules are created for CRP and ClassicStock, and the WildBlueTools play modes for Pristine and Simplified provide KerbalKomets play modes as well.