### PR TITLE
Fix KerbalKomets dependencies and paths

### DIFF
--- a/NetKAN/KerbalKomets-PlayMode-CRP.netkan
+++ b/NetKAN/KerbalKomets-PlayMode-CRP.netkan
@@ -18,7 +18,7 @@ depends:
   - name: ModuleManager
 install:
   - find: WildBlueIndustries/KerbalKomets/Templates/CRP/MM_PotatoRoid.txt
-    install_to: GameData/WildBlueIndustries/KerbalKomets/Templates
+    install_to: GameData/WildBlueIndustries/KerbalKomets/Templates/CRP
     as: MM_PotatoRoid.cfg
     find_matches_files: true
   - find: WildBlueIndustries/KerbalKomets/Templates/CRP.cfg

--- a/NetKAN/KerbalKomets.netkan
+++ b/NetKAN/KerbalKomets.netkan
@@ -7,7 +7,6 @@ tags:
   - plugin
   - planet-pack
 depends:
-  - name: ModuleManager
   - name: KerbalKomets-PlayMode
 install:
   - find: WildBlueIndustries


### PR DESCRIPTION
After #8944 I noticed that:

- KerbalKomets doesn't need its MM dep anymore (MM syntax is only used by the play modes)
- The CRP play mode is installing into the wrong folder (`CRP` part of the path is missing)

Now this is fixed.