### PR TITLE
Mark GroundEffect compatible with 1.12

### DIFF
--- a/NetKAN/GroundEffect.netkan
+++ b/NetKAN/GroundEffect.netkan
@@ -1,22 +1,16 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "GroundEffect",
-    "$kref":        "#/ckan/github/Capital-Asterisk/KSP_GroundEffect",
-    "ksp_version_min": "1.3",
-    "ksp_version_max": "1.11",
-    "license":      "MIT",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/183500-*"
-    },
-    "tags": [
-        "plugin",
-        "physics"
-    ],
-    "conflicts": [
-        { "name": "FAR" }
-    ],
-    "install": [ {
-        "find":       "GroundEffect.dll",
-        "install_to": "GameData/GroundEffect"
-    } ]
-}
+spec_version: v1.4
+identifier: GroundEffect
+$kref: '#/ckan/github/Capital-Asterisk/KSP_GroundEffect'
+ksp_version_min: '1.3'
+ksp_version_max: '1.12'
+license: MIT
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/183500-*
+tags:
+  - plugin
+  - physics
+conflicts:
+  - name: FAR
+install:
+  - find: GroundEffect.dll
+    install_to: GameData/GroundEffect


### PR DESCRIPTION
The author does not draw a distinction between 1.11 and 1.12:

![image](https://user-images.githubusercontent.com/1559108/148559776-ff47037e-f0b5-48e5-a2c1-ac1d8f1531e8.png)