### PR TITLE
Update scatterer Sompatibility

### DIFF
--- a/NetKAN/Scatterer-config.netkan
+++ b/NetKAN/Scatterer-config.netkan
@@ -19,6 +19,10 @@ install:
     filter: Sunflares
 x_netkan_override:
   - version:
+      - '>=3:v0.0829'
+    override:
+      ksp_version_min: '1.9'
+  - version:
       - '>=3:v0.0723'
       - '<3:v0.0824'
     override:

--- a/NetKAN/Scatterer-sunflare.netkan
+++ b/NetKAN/Scatterer-sunflare.netkan
@@ -22,6 +22,10 @@ install:
     install_to: GameData/Scatterer/config
 x_netkan_override:
   - version:
+      - '>=3:v0.0829'
+    override:
+      ksp_version_min: '1.9'
+  - version:
       - '>=3:v0.0723'
       - '<3:v0.0824'
     override:

--- a/NetKAN/Scatterer.netkan
+++ b/NetKAN/Scatterer.netkan
@@ -19,6 +19,10 @@ install:
     filter_regexp: config\/.*
 x_netkan_override:
   - version:
+      - '>=3:v0.0829'
+    override:
+      ksp_version_min: '1.9'
+  - version:
       - '>=3:v0.0723'
       - '<3:v0.0824'
     override:


### PR DESCRIPTION
Hello, I'm about to release an update which restores compatibility to 1.9-1.12.x

I'm not sure I did this correctly though?  The [spec page](https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md) explains how to use the operators but there seems to be no mention of what the `3:` preceding the version number does. In doubt I just pushed it like this.