### PR TITLE
Set resources.remote-avc for mods with bad version file URL properties

### DIFF
--- a/NetKAN/AllAboard.netkan
+++ b/NetKAN/AllAboard.netkan
@@ -1,24 +1,19 @@
-{
-    "spec_version" : "v1.4",
-    "identifier"   : "AllAboard",
-    "name"         : "All Aboard!",
-    "abstract"     : "Allows Kerbals to board vessels through Docking Ports",
-    "$kref"        : "#/ckan/github/severedsolo/AllAboard",
-    "$vref"        : "#/ckan/ksp-avc",
-    "license"      : "MIT",
-    "resources" : {
-        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/190983-18x-*"
-    },
-    "tags": [
-        "plugin",
-        "crewed",
-        "convenience"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "install": [ {
-        "find":       "AllAboard",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.4
+identifier: AllAboard
+name: All Aboard!
+abstract: Allows Kerbals to board vessels through Docking Ports
+$kref: '#/ckan/github/severedsolo/AllAboard'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/190983-18x-*
+  remote-avc: https://github.com/severedsolo/AllAboard/raw/master/GameData/AllAboard/AllAboard.version
+tags:
+  - plugin
+  - crewed
+  - convenience
+depends:
+  - name: ModuleManager
+install:
+  - find: AllAboard
+    install_to: GameData

--- a/NetKAN/AtomicTechIncJunkyards.netkan
+++ b/NetKAN/AtomicTechIncJunkyards.netkan
@@ -3,6 +3,8 @@ identifier: AtomicTechIncJunkyards
 $kref: '#/ckan/spacedock/2891'
 $vref: '#/ckan/ksp-avc'
 license: BSD-3-clause
+resources:
+  remote-avc: https://github.com/JamesErvin-5/AtomicTech-Inc.-Junkyards/raw/main/AtomicTech/RadioactiveJunkyards.version
 tags:
   - parts
 depends:

--- a/NetKAN/CanaveralPads.netkan
+++ b/NetKAN/CanaveralPads.netkan
@@ -7,6 +7,7 @@ $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-4.0
 resources:
   homepage: https://github.com/KSP-RO/CanaveralPads/tree/main/GameData/CanaveralPads
+  remote-avc: https://github.com/KSP-RO/CanaveralPads/raw/main/GameData/CanaveralPads/CanaveralPads.version
 tags:
   - graphics
 depends:

--- a/NetKAN/ConnectedLivingSpace.netkan
+++ b/NetKAN/ConnectedLivingSpace.netkan
@@ -1,22 +1,23 @@
-{
-    "spec_version"      : "v1.4",
-    "identifier"        : "ConnectedLivingSpace",
-    "name"              : "Connected Living Space",
-    "abstract"          : "Identify and make use of living spaces that are connected to each other on a vessel.",
-    "author"            : [ "Codepoet", "Papa_Joe", "Micha" ],
-    "$kref"             : "#/ckan/github/codepoetpbowden/ConnectedLivingSpace",
-    "$vref"             : "#/ckan/ksp-avc",
-    "license"           : "CC-BY-NC-SA-4.0",
-    "resources"         : {
-        "homepage"      : "http://forum.kerbalspaceprogram.com/index.php?showtopic=192130",
-        "repository"    : "https://github.com/codepoetpbowden/ConnectedLivingSpace",
-        "bugtracker"    : "https://github.com/codepoetpbowden/ConnectedLivingSpace/issues"
-    },
-    "tags"              : [
-        "plugin",
-        "crewed"
-    ],
-    "depends"           : [
-        { "name"        : "ModuleManager" }
-    ]
-}
+spec_version: v1.4
+identifier: ConnectedLivingSpace
+name: Connected Living Space
+abstract: >-
+  Identify and make use of living spaces that are connected to each other on a
+  vessel.
+author:
+  - Codepoet
+  - Papa_Joe
+  - Micha
+$kref: '#/ckan/github/codepoetpbowden/ConnectedLivingSpace'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+resources:
+  homepage: http://forum.kerbalspaceprogram.com/index.php?showtopic=192130
+  repository: https://github.com/codepoetpbowden/ConnectedLivingSpace
+  bugtracker: https://github.com/codepoetpbowden/ConnectedLivingSpace/issues
+  remote-avc: https://github.com/codepoetpbowden/ConnectedLivingSpace/raw/master/Distribution/GameData/ConnectedLivingSpace/ConnectedLivingSpace.version
+tags:
+  - plugin
+  - crewed
+depends:
+  - name: ModuleManager

--- a/NetKAN/ContractConfigurator-ExplorationPlus.netkan
+++ b/NetKAN/ContractConfigurator-ExplorationPlus.netkan
@@ -1,23 +1,18 @@
-{
-    "spec_version" : "v1.4",
-    "identifier"   : "ContractConfigurator-ExplorationPlus",
-    "$kref"        : "#/ckan/github/severedsolo/ExplorationPlus",
-    "name"         : "Contract Pack: Exploration Plus",
-    "abstract"     : "Overhaul of the stock Exploration contracts",
-    "license"      : "CC-BY-NC-SA-4.0",
-    "$vref"        : "#/ckan/ksp-avc",
-    "resources" : {
-        "homepage" : "http://forum.kerbalspaceprogram.com/index.php?/topic/156338-*"
-    },
-    "tags": [
-        "config",
-        "career"
-    ],
-    "depends" : [
-        { "name" : "ContractConfigurator" }
-    ],
-    "install": [ {
-        "find":       "ContractPacks",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.4
+identifier: ContractConfigurator-ExplorationPlus
+$kref: '#/ckan/github/severedsolo/ExplorationPlus'
+name: 'Contract Pack: Exploration Plus'
+abstract: Overhaul of the stock Exploration contracts
+license: CC-BY-NC-SA-4.0
+$vref: '#/ckan/ksp-avc'
+resources:
+  homepage: http://forum.kerbalspaceprogram.com/index.php?/topic/156338-*
+  remote-avc: https://github.com/severedsolo/ExplorationPlus/raw/master/ExplorationPlus.version
+tags:
+  - config
+  - career
+depends:
+  - name: ContractConfigurator
+install:
+  - find: ContractPacks
+    install_to: GameData

--- a/NetKAN/DMTanks-AeroRTG.netkan
+++ b/NetKAN/DMTanks-AeroRTG.netkan
@@ -1,36 +1,31 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "DMTanks-AeroRTG",
-    "author":       [ "Bezzier", "DaMichel", "zer0Kerbal" ],
-    "$kref":        "#/ckan/spacedock/2338",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-SA-3.0",
-    "resources": {
-        "repository": "https://github.com/zer0Kerbal/DaMichel/tree/master/GameData/DaMichel/AeroRadial"
-    },
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "DMTanks-SphericalTanks" },
-        { "name": "DMTanks-Fuselage"       },
-        { "name": "DMTanks-CargoBays"      }
-    ],
-    "suggests": [
-        { "name": "SimpleConstruction"      },
-        { "name": "NotSoSimpleConstruction" },
-        { "name": "SimpleLogistics"         }
-    ],
-    "supports": [
-        { "name": "TweakScale"      },
-        { "name": "KerbalChangelog" },
-        { "name": "ODFC"            }
-    ],
-    "install" : [ {
-        "find":       "DaMichel",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.4
+identifier: DMTanks-AeroRTG
+author:
+  - Bezzier
+  - DaMichel
+  - zer0Kerbal
+$kref: '#/ckan/spacedock/2338'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-SA-3.0
+resources:
+  repository: >-
+    https://github.com/zer0Kerbal/DaMichel/tree/master/GameData/DaMichel/AeroRadial
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+recommends:
+  - name: DMTanks-SphericalTanks
+  - name: DMTanks-Fuselage
+  - name: DMTanks-CargoBays
+suggests:
+  - name: SimpleConstruction
+  - name: NotSoSimpleConstruction
+  - name: SimpleLogistics
+supports:
+  - name: TweakScale
+  - name: KerbalChangelog
+  - name: ODFC
+install:
+  - find: DaMichel
+    install_to: GameData

--- a/NetKAN/DMTanks-CargoBays.netkan
+++ b/NetKAN/DMTanks-CargoBays.netkan
@@ -1,35 +1,31 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "DMTanks-CargoBays",
-    "author":       [ "Bezzier", "DaMichel", "zer0Kerbal" ],
-    "$kref":        "#/ckan/spacedock/2339",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-SA-3.0",
-    "resources": {
-        "repository": "https://github.com/zer0Kerbal/DaMichel/tree/master/GameData/DaMichel/CargoBays"
-    },
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "DMTanks-AeroRTG"        },
-        { "name": "DMTanks-SphericalTanks" },
-        { "name": "DMTanks-Fuselage"       }
-    ],
-    "suggests": [
-        { "name": "SimpleConstruction"      },
-        { "name": "NotSoSimpleConstruction" },
-        { "name": "SimpleLogistics"         }
-    ],
-    "supports": [
-        { "name": "TweakScale"      },
-        { "name": "KerbalChangelog" }
-    ],
-    "install": [ {
-        "find":       "DaMichel",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.4
+identifier: DMTanks-CargoBays
+author:
+  - Bezzier
+  - DaMichel
+  - zer0Kerbal
+$kref: '#/ckan/spacedock/2339'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-SA-3.0
+resources:
+  repository: >-
+    https://github.com/zer0Kerbal/DaMichel/tree/master/GameData/DaMichel/CargoBays
+  remote-avc: https://github.com/zer0Kerbal/DaMichel/raw/master/GameData/DaMichel/CargoBays/CargoBays.version
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+recommends:
+  - name: DMTanks-AeroRTG
+  - name: DMTanks-SphericalTanks
+  - name: DMTanks-Fuselage
+suggests:
+  - name: SimpleConstruction
+  - name: NotSoSimpleConstruction
+  - name: SimpleLogistics
+supports:
+  - name: TweakScale
+  - name: KerbalChangelog
+install:
+  - find: DaMichel
+    install_to: GameData

--- a/NetKAN/DMTanks-Fuselage.netkan
+++ b/NetKAN/DMTanks-Fuselage.netkan
@@ -1,36 +1,32 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "DMTanks-Fuselage",
-    "author":       [ "Bezzier", "DaMichel", "zer0Kerbal" ],
-    "$kref":        "#/ckan/spacedock/2340",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-3.0",
-    "resources": {
-        "repository": "https://github.com/zer0Kerbal/DaMichel/tree/master/GameData/DaMichel/Fuselage"
-    },
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "DMTanks-SphericalTanks" },
-        { "name": "DMTanks-CargoBays"      },
-        { "name": "DMTanks-AeroRTG"        }
-    ],
-    "suggests": [
-        { "name": "SimpleConstruction"      },
-        { "name": "NotSoSimpleConstruction" },
-        { "name": "SimpleLogistics"         }
-    ],
-    "supports": [
-        { "name": "TweakScale"             },
-        { "name": "KerbalChangelog"        },
-        { "name": "RealFuels"              }
-    ],
-    "install": [ {
-        "find":       "DaMichel",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.4
+identifier: DMTanks-Fuselage
+author:
+  - Bezzier
+  - DaMichel
+  - zer0Kerbal
+$kref: '#/ckan/spacedock/2340'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-3.0
+resources:
+  repository: >-
+    https://github.com/zer0Kerbal/DaMichel/tree/master/GameData/DaMichel/Fuselage
+  remote-avc: https://github.com/zer0Kerbal/DaMichel/raw/master/GameData/DaMichel/Fuselage/Fuselage.version
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+recommends:
+  - name: DMTanks-SphericalTanks
+  - name: DMTanks-CargoBays
+  - name: DMTanks-AeroRTG
+suggests:
+  - name: SimpleConstruction
+  - name: NotSoSimpleConstruction
+  - name: SimpleLogistics
+supports:
+  - name: TweakScale
+  - name: KerbalChangelog
+  - name: RealFuels
+install:
+  - find: DaMichel
+    install_to: GameData

--- a/NetKAN/DMTanks-SphericalTanks.netkan
+++ b/NetKAN/DMTanks-SphericalTanks.netkan
@@ -1,35 +1,31 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "DMTanks-SphericalTanks",
-    "author":       [ "Bezzier", "DaMichel", "zer0Kerbal" ],
-    "$kref":        "#/ckan/spacedock/2342",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-SA-3.0",
-    "resources": {
-        "repository": "https://github.com/zer0Kerbal/DaMichel/tree/master/GameData/DaMichel/SphericalTanks"
-    },
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "DMTanks-AeroRTG"   },
-        { "name": "DMTanks-CargoBays" },
-        { "name": "DMTanks-Fuselage"  }
-    ],
-    "supports": [
-        { "name": "TweakScale"             },
-        { "name": "KerbalChangelog"        },
-        { "name": "B9PartSwitch"           },
-        { "name": "Snacks"                 },
-        { "name": "TACLS"                  },
-        { "name": "InterstellarFuelSwitch" },
-        { "name": "RealFuels"              }
-    ],
-    "install": [ {
-        "find":       "DaMichel",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.4
+identifier: DMTanks-SphericalTanks
+author:
+  - Bezzier
+  - DaMichel
+  - zer0Kerbal
+$kref: '#/ckan/spacedock/2342'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-SA-3.0
+resources:
+  repository: >-
+    https://github.com/zer0Kerbal/DaMichel/tree/master/GameData/DaMichel/SphericalTanks
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+recommends:
+  - name: DMTanks-AeroRTG
+  - name: DMTanks-CargoBays
+  - name: DMTanks-Fuselage
+supports:
+  - name: TweakScale
+  - name: KerbalChangelog
+  - name: B9PartSwitch
+  - name: Snacks
+  - name: TACLS
+  - name: InterstellarFuelSwitch
+  - name: RealFuels
+install:
+  - find: DaMichel
+    install_to: GameData

--- a/NetKAN/DockingPortDescriptions.netkan
+++ b/NetKAN/DockingPortDescriptions.netkan
@@ -1,23 +1,18 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "DockingPortDescriptions",
-    "$kref":        "#/ckan/spacedock/2246",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "plugin"
-    ],
-    "install": [ {
-        "find":       "KGEx",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "suggests": [
-        { "name": "ODFC-Refueled"   },
-        { "name": "KerbalChangelog" },
-        { "name": "PicoPortShielded" }
-    ],
-    "x_via": "Automated SpaceDock CKAN submission"
-}
+spec_version: v1.4
+identifier: DockingPortDescriptions
+$kref: '#/ckan/spacedock/2246'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+resources:
+  remote-avc: https://github.com/zer0Kerbal/DockingPortDescriptions/raw/master/DockingPortDescriptions.version
+tags:
+  - plugin
+install:
+  - find: KGEx
+    install_to: GameData
+depends:
+  - name: ModuleManager
+suggests:
+  - name: ODFC-Refueled
+  - name: KerbalChangelog
+  - name: PicoPortShielded

--- a/NetKAN/DraggableNavball.netkan
+++ b/NetKAN/DraggableNavball.netkan
@@ -1,11 +1,8 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "DraggableNavball",
-    "$kref":        "#/ckan/spacedock/1024",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "convenience"
-    ]
-}
+spec_version: v1.4
+identifier: DraggableNavball
+$kref: '#/ckan/spacedock/1024'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - convenience

--- a/NetKAN/DuoPods.netkan
+++ b/NetKAN/DuoPods.netkan
@@ -1,15 +1,15 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "DuoPods",
-    "author":       [ "dupods", "zer0Kerbal" ],
-    "$kref":        "#/ckan/spacedock/2357",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-2.0",
-    "tags": [
-        "parts",
-        "crewed"
-    ],
-    "supports": [
-        { "name": "KerbalChangelog" }
-    ]
-}
+spec_version: v1.4
+identifier: DuoPods
+author:
+  - dupods
+  - zer0Kerbal
+$kref: '#/ckan/spacedock/2357'
+$vref: '#/ckan/ksp-avc'
+license: GPL-2.0
+resources:
+  remote-avc: https://github.com/zer0Kerbal/DuoPods/raw/main/DuoPods.version
+tags:
+  - parts
+  - crewed
+supports:
+  - name: KerbalChangelog

--- a/NetKAN/Heisenberg-PlayMode-CRP.netkan
+++ b/NetKAN/Heisenberg-PlayMode-CRP.netkan
@@ -4,7 +4,8 @@ name: Heisenberg CRP Play Mode
 $kref: '#/ckan/github/Angel-125/Airships'
 $vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version'
 x_netkan_staging: true
-x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+x_netkan_staging_reason:  >-
+ Make sure that all .txt files for this play mode are installed as .cfg
 license: restricted
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*

--- a/NetKAN/Heisenberg-PlayMode-CRP.netkan
+++ b/NetKAN/Heisenberg-PlayMode-CRP.netkan
@@ -1,56 +1,42 @@
-{
-    "spec_version": "v1.18",
-    "identifier":   "Heisenberg-PlayMode-CRP",
-    "name":         "Heisenberg CRP Play Mode",
-    "$kref":        "#/ckan/github/Angel-125/Airships",
-    "$vref":        "#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "restricted",
-    "resources": {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*",
-        "repository": "https://github.com/Angel-125/Airships"
-    },
-    "tags": [
-        "config"
-    ],
-    "provides": [
-        "Heisenberg-PlayMode"
-    ],
-    "conflicts": [
-        { "name": "Heisenberg-PlayMode" }
-    ],
-    "depends": [
-        { "name": "Heisenberg"            },
-        { "name": "ModuleManager"         },
-        { "name": "WildBlue-PlayMode-CRP" }
-    ],
-    "install": [ {
-        "find":       "WildBlueIndustries/Heisenberg/Templates/CRP.cfg",
-        "install_to": "GameData/WildBlueIndustries/Heisenberg/Templates",
-        "find_matches_files": true
-    }, {
-        "find":       "Heisenberg/Templates/CRP/BisonISRU.txt",
-        "install_to": "GameData/WildBlueIndustries/Heisenberg/Templates/CRP",
-        "as":         "BisonISRU.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "Heisenberg/Templates/CRP/GondoLab.txt",
-        "install_to": "GameData/WildBlueIndustries/Heisenberg/Templates/CRP",
-        "as":         "GondoLab.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "Heisenberg/Templates/CRP/MM_GyroRing.txt",
-        "install_to": "GameData/WildBlueIndustries/Heisenberg/Templates/CRP",
-        "as":         "MM_GyroRing.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "Heisenberg/Templates/CRP/MM_Snacks.txt",
-        "install_to": "GameData/WildBlueIndustries/Heisenberg/Templates/CRP",
-        "as":         "MM_Snacks.cfg",
-        "find_matches_files": true
-    } ]
-}
+spec_version: v1.18
+identifier: Heisenberg-PlayMode-CRP
+name: Heisenberg CRP Play Mode
+$kref: '#/ckan/github/Angel-125/Airships'
+$vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: restricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*
+  repository: https://github.com/Angel-125/Airships
+  remote-avc: https://github.com/Angel-125/Airships/raw/master/GameData/WildBlueIndustries/Heisenberg/Airships.version
+tags:
+  - config
+provides:
+  - Heisenberg-PlayMode
+conflicts:
+  - name: Heisenberg-PlayMode
+depends:
+  - name: Heisenberg
+  - name: ModuleManager
+  - name: WildBlue-PlayMode-CRP
+install:
+  - find: WildBlueIndustries/Heisenberg/Templates/CRP.cfg
+    install_to: GameData/WildBlueIndustries/Heisenberg/Templates
+    find_matches_files: true
+  - find: Heisenberg/Templates/CRP/BisonISRU.txt
+    install_to: GameData/WildBlueIndustries/Heisenberg/Templates/CRP
+    as: BisonISRU.cfg
+    find_matches_files: true
+  - find: Heisenberg/Templates/CRP/GondoLab.txt
+    install_to: GameData/WildBlueIndustries/Heisenberg/Templates/CRP
+    as: GondoLab.cfg
+    find_matches_files: true
+  - find: Heisenberg/Templates/CRP/MM_GyroRing.txt
+    install_to: GameData/WildBlueIndustries/Heisenberg/Templates/CRP
+    as: MM_GyroRing.cfg
+    find_matches_files: true
+  - find: Heisenberg/Templates/CRP/MM_Snacks.txt
+    install_to: GameData/WildBlueIndustries/Heisenberg/Templates/CRP
+    as: MM_Snacks.cfg
+    find_matches_files: true

--- a/NetKAN/Heisenberg-PlayMode-CRP.netkan
+++ b/NetKAN/Heisenberg-PlayMode-CRP.netkan
@@ -5,7 +5,7 @@ $kref: '#/ckan/github/Angel-125/Airships'
 $vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version'
 x_netkan_staging: true
 x_netkan_staging_reason:  >-
- Make sure that all .txt files for this play mode are installed as .cfg
+  Make sure that all .txt files for this play mode are installed as .cfg
 license: restricted
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*

--- a/NetKAN/Heisenberg-PlayMode-ClassicStock.netkan
+++ b/NetKAN/Heisenberg-PlayMode-ClassicStock.netkan
@@ -1,36 +1,28 @@
-{
-    "spec_version": "v1.16",
-    "identifier":   "Heisenberg-PlayMode-ClassicStock",
-    "name":         "Heisenberg Classic Stock Play Mode",
-    "$kref":        "#/ckan/github/Angel-125/Airships",
-    "$vref":        "#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "restricted",
-    "resources": {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*",
-        "repository": "https://github.com/Angel-125/Airships"
-    },
-    "tags": [
-        "config"
-    ],
-    "provides": [
-        "Heisenberg-PlayMode"
-    ],
-    "conflicts": [
-        { "name": "Heisenberg-PlayMode" }
-    ],
-    "depends": [
-        { "name": "Heisenberg"                     },
-        { "name": "WildBlue-PlayMode-ClassicStock" },
-        { "name": "ModuleManager"                  }
-    ],
-    "install": [ {
-        "find":       "WildBlueIndustries/Heisenberg/Templates/ClassicStock",
-        "install_to": "GameData/WildBlueIndustries/Heisenberg/Templates"
-    }, {
-        "find":       "WildBlueIndustries/Heisenberg/Templates/ClassicStock.cfg",
-        "install_to": "GameData/WildBlueIndustries/Heisenberg/Templates",
-        "find_matches_files": true
-    } ]
-}
+spec_version: v1.16
+identifier: Heisenberg-PlayMode-ClassicStock
+name: Heisenberg Classic Stock Play Mode
+$kref: '#/ckan/github/Angel-125/Airships'
+$vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: restricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*
+  repository: https://github.com/Angel-125/Airships
+  remote-avc: https://github.com/Angel-125/Airships/raw/master/GameData/WildBlueIndustries/Heisenberg/Airships.version
+tags:
+  - config
+provides:
+  - Heisenberg-PlayMode
+conflicts:
+  - name: Heisenberg-PlayMode
+depends:
+  - name: Heisenberg
+  - name: WildBlue-PlayMode-ClassicStock
+  - name: ModuleManager
+install:
+  - find: WildBlueIndustries/Heisenberg/Templates/ClassicStock
+    install_to: GameData/WildBlueIndustries/Heisenberg/Templates
+  - find: WildBlueIndustries/Heisenberg/Templates/ClassicStock.cfg
+    install_to: GameData/WildBlueIndustries/Heisenberg/Templates
+    find_matches_files: true

--- a/NetKAN/Heisenberg-PlayMode-ClassicStock.netkan
+++ b/NetKAN/Heisenberg-PlayMode-ClassicStock.netkan
@@ -4,7 +4,8 @@ name: Heisenberg Classic Stock Play Mode
 $kref: '#/ckan/github/Angel-125/Airships'
 $vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version'
 x_netkan_staging: true
-x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+x_netkan_staging_reason:  >-
+ Make sure that all .txt files for this play mode are installed as .cfg
 license: restricted
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*

--- a/NetKAN/Heisenberg-PlayMode-ClassicStock.netkan
+++ b/NetKAN/Heisenberg-PlayMode-ClassicStock.netkan
@@ -5,7 +5,7 @@ $kref: '#/ckan/github/Angel-125/Airships'
 $vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version'
 x_netkan_staging: true
 x_netkan_staging_reason:  >-
- Make sure that all .txt files for this play mode are installed as .cfg
+  Make sure that all .txt files for this play mode are installed as .cfg
 license: restricted
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*

--- a/NetKAN/Heisenberg-PlayMode-Pristine.netkan
+++ b/NetKAN/Heisenberg-PlayMode-Pristine.netkan
@@ -4,7 +4,8 @@ name: Heisenberg Pristine Play Mode
 $kref: '#/ckan/github/Angel-125/Airships'
 $vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version'
 x_netkan_staging: true
-x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+x_netkan_staging_reason:  >-
+ Make sure that all .txt files for this play mode are installed as .cfg
 license: restricted
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*

--- a/NetKAN/Heisenberg-PlayMode-Pristine.netkan
+++ b/NetKAN/Heisenberg-PlayMode-Pristine.netkan
@@ -1,38 +1,30 @@
-{
-    "spec_version": "v1.18",
-    "identifier":   "Heisenberg-PlayMode-Pristine",
-    "name":         "Heisenberg Pristine Play Mode",
-    "$kref":        "#/ckan/github/Angel-125/Airships",
-    "$vref":        "#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "restricted",
-    "resources": {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*",
-        "repository": "https://github.com/Angel-125/Airships"
-    },
-    "tags": [
-        "config"
-    ],
-    "provides": [
-        "Heisenberg-PlayMode"
-    ],
-    "conflicts": [
-        { "name": "Heisenberg-PlayMode" }
-    ],
-    "depends": [
-        { "name": "Heisenberg"                 },
-        { "name": "ModuleManager"              },
-        { "name": "WildBlue-PlayMode-Pristine" }
-    ],
-    "install": [ {
-        "find":       "WildBlueIndustries/Heisenberg/Templates/Pristine.cfg",
-        "install_to": "GameData/WildBlueIndustries/Heisenberg/Templates",
-        "find_matches_files": true
-    }, {
-        "find":       "Heisenberg/Templates/Pristine/MM_Pristine.txt",
-        "install_to": "GameData/WildBlueIndustries/Heisenberg/Templates/Pristine",
-        "as":         "MM_Pristine.cfg",
-        "find_matches_files": true
-    } ]
-}
+spec_version: v1.18
+identifier: Heisenberg-PlayMode-Pristine
+name: Heisenberg Pristine Play Mode
+$kref: '#/ckan/github/Angel-125/Airships'
+$vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: restricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*
+  repository: https://github.com/Angel-125/Airships
+  remote-avc: https://github.com/Angel-125/Airships/raw/master/GameData/WildBlueIndustries/Heisenberg/Airships.version
+tags:
+  - config
+provides:
+  - Heisenberg-PlayMode
+conflicts:
+  - name: Heisenberg-PlayMode
+depends:
+  - name: Heisenberg
+  - name: ModuleManager
+  - name: WildBlue-PlayMode-Pristine
+install:
+  - find: WildBlueIndustries/Heisenberg/Templates/Pristine.cfg
+    install_to: GameData/WildBlueIndustries/Heisenberg/Templates
+    find_matches_files: true
+  - find: Heisenberg/Templates/Pristine/MM_Pristine.txt
+    install_to: GameData/WildBlueIndustries/Heisenberg/Templates/Pristine
+    as: MM_Pristine.cfg
+    find_matches_files: true

--- a/NetKAN/Heisenberg-PlayMode-Pristine.netkan
+++ b/NetKAN/Heisenberg-PlayMode-Pristine.netkan
@@ -5,7 +5,7 @@ $kref: '#/ckan/github/Angel-125/Airships'
 $vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version'
 x_netkan_staging: true
 x_netkan_staging_reason:  >-
- Make sure that all .txt files for this play mode are installed as .cfg
+  Make sure that all .txt files for this play mode are installed as .cfg
 license: restricted
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*

--- a/NetKAN/Heisenberg-PlayMode-Simplified.netkan
+++ b/NetKAN/Heisenberg-PlayMode-Simplified.netkan
@@ -1,38 +1,30 @@
-{
-    "spec_version": "v1.18",
-    "identifier":   "Heisenberg-PlayMode-Simplified",
-    "name":         "Heisenberg Simplified Play Mode",
-    "$kref":        "#/ckan/github/Angel-125/Airships",
-    "$vref":        "#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "restricted",
-    "resources": {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*",
-        "repository": "https://github.com/Angel-125/Airships"
-    },
-    "tags": [
-        "config"
-    ],
-    "provides": [
-        "Heisenberg-PlayMode"
-    ],
-    "conflicts": [
-        { "name": "Heisenberg-PlayMode" }
-    ],
-    "depends": [
-        { "name": "Heisenberg"                   },
-        { "name": "ModuleManager"                },
-        { "name": "WildBlue-PlayMode-Simplified" }
-    ],
-    "install": [ {
-        "find":       "WildBlueIndustries/Heisenberg/Templates/Simplified.cfg",
-        "install_to": "GameData/WildBlueIndustries/Heisenberg/Templates",
-        "find_matches_files": true
-    }, {
-        "find":       "Heisenberg/Templates/Simplified/MM_NuclearGyro.txt",
-        "install_to": "GameData/WildBlueIndustries/Heisenberg/Templates/Simplified",
-        "as":         "MM_NuclearGyro.cfg",
-        "find_matches_files": true
-    } ]
-}
+spec_version: v1.18
+identifier: Heisenberg-PlayMode-Simplified
+name: Heisenberg Simplified Play Mode
+$kref: '#/ckan/github/Angel-125/Airships'
+$vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: restricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*
+  repository: https://github.com/Angel-125/Airships
+  remote-avc: https://github.com/Angel-125/Airships/raw/master/GameData/WildBlueIndustries/Heisenberg/Airships.version
+tags:
+  - config
+provides:
+  - Heisenberg-PlayMode
+conflicts:
+  - name: Heisenberg-PlayMode
+depends:
+  - name: Heisenberg
+  - name: ModuleManager
+  - name: WildBlue-PlayMode-Simplified
+install:
+  - find: WildBlueIndustries/Heisenberg/Templates/Simplified.cfg
+    install_to: GameData/WildBlueIndustries/Heisenberg/Templates
+    find_matches_files: true
+  - find: Heisenberg/Templates/Simplified/MM_NuclearGyro.txt
+    install_to: GameData/WildBlueIndustries/Heisenberg/Templates/Simplified
+    as: MM_NuclearGyro.cfg
+    find_matches_files: true

--- a/NetKAN/Heisenberg-PlayMode-Simplified.netkan
+++ b/NetKAN/Heisenberg-PlayMode-Simplified.netkan
@@ -4,7 +4,8 @@ name: Heisenberg Simplified Play Mode
 $kref: '#/ckan/github/Angel-125/Airships'
 $vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version'
 x_netkan_staging: true
-x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+x_netkan_staging_reason:  >-
+ Make sure that all .txt files for this play mode are installed as .cfg
 license: restricted
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*

--- a/NetKAN/Heisenberg-PlayMode-Simplified.netkan
+++ b/NetKAN/Heisenberg-PlayMode-Simplified.netkan
@@ -5,7 +5,7 @@ $kref: '#/ckan/github/Angel-125/Airships'
 $vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version'
 x_netkan_staging: true
 x_netkan_staging_reason:  >-
- Make sure that all .txt files for this play mode are installed as .cfg
+  Make sure that all .txt files for this play mode are installed as .cfg
 license: restricted
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*

--- a/NetKAN/Heisenberg.netkan
+++ b/NetKAN/Heisenberg.netkan
@@ -3,7 +3,8 @@ identifier: Heisenberg
 $kref: '#/ckan/github/Angel-125/Airships'
 $vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version'
 x_netkan_staging: true
-x_netkan_staging_reason: Make sure that no new play modes were added to the Templates folder
+x_netkan_staging_reason: >-
+  Make sure that no new play modes were added to the Templates folder
 license: restricted
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*

--- a/NetKAN/Heisenberg.netkan
+++ b/NetKAN/Heisenberg.netkan
@@ -8,6 +8,7 @@ license: restricted
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/150702-*
   repository: https://github.com/Angel-125/Airships
+  remote-avc: https://github.com/Angel-125/Airships/raw/master/GameData/WildBlueIndustries/Heisenberg/Airships.version
 tags:
   - parts
   - plugin

--- a/NetKAN/KerbalActuators.netkan
+++ b/NetKAN/KerbalActuators.netkan
@@ -1,19 +1,16 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "KerbalActuators",
-    "author":       "Angel125",
-    "$kref":        "#/ckan/github/Angel-125/KerbalActuators",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "parts"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "install": [ {
-        "find":       "WildBlueIndustries",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.4
+identifier: KerbalActuators
+author: Angel125
+$kref: '#/ckan/github/Angel-125/KerbalActuators'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+resources:
+  remote-avc: https://github.com/Angel-125/KerbalActuators/raw/master/GameData/WildBlueIndustries/001KerbalActuators/KerbalActuators.version
+tags:
+  - plugin
+  - parts
+depends:
+  - name: ModuleManager
+install:
+  - find: WildBlueIndustries
+    install_to: GameData

--- a/NetKAN/KerbalJointReinforcementNext.netkan
+++ b/NetKAN/KerbalJointReinforcementNext.netkan
@@ -1,27 +1,25 @@
-{
-    "spec_version"   : "v1.4",
-    "identifier"     : "KerbalJointReinforcementNext",
-    "name"           : "Kerbal Joint Reinforcement - Next",
-    "abstract"       : "Fixes the problem of unstable joints",
-    "author"         : [ "ferram4", "Rudolf Meier" ],
-    "$kref"          : "#/ckan/github/meirumeiru/Kerbal-Joint-Reinforcement/asset_match/KerbalJointReinforcement_v[0-9]+\\.[0-9]+\\.[0-9]+\\.zip",
-    "$vref"          : "#/ckan/ksp-avc",
-    "x_netkan_allow_out_of_order": true,
-    "license"        : "GPL-3.0",
-    "release_status" : "stable",
-    "conflicts"      : [
-        { "name": "KerbalJointReinforcement" }
-    ],
-    "resources"      : {
-        "homepage"   : "https://forum.kerbalspaceprogram.com/index.php?/topic/184206-*",
-        "repository" : "https://github.com/meirumeiru/Kerbal-Joint-Reinforcement"
-    },
-    "tags"           : [
-        "plugin",
-        "physics"
-    ],
-    "install"        : [ {
-        "file"       : "GameData/KerbalJointReinforcement",
-        "install_to" : "GameData"
-    } ]
-}
+spec_version: v1.4
+identifier: KerbalJointReinforcementNext
+name: Kerbal Joint Reinforcement - Next
+abstract: Fixes the problem of unstable joints
+author:
+  - ferram4
+  - Rudolf Meier
+$kref: >-
+  #/ckan/github/meirumeiru/Kerbal-Joint-Reinforcement/asset_match/KerbalJointReinforcement_v[0-9]+\.[0-9]+\.[0-9]+\.zip
+$vref: '#/ckan/ksp-avc'
+x_netkan_allow_out_of_order: true
+license: GPL-3.0
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/184206-*
+  repository: https://github.com/meirumeiru/Kerbal-Joint-Reinforcement
+  remote-avc: https://github.com/meirumeiru/Kerbal-Joint-Reinforcement/raw/master/Resources/GameData/KerbalJointReinforcement/KerbalJointReinforcement.version
+tags:
+  - plugin
+  - physics
+conflicts:
+  - name: KerbalJointReinforcement
+install:
+  - file: GameData/KerbalJointReinforcement
+    install_to: GameData

--- a/NetKAN/KerbalKomets-PlayMode-CRP.netkan
+++ b/NetKAN/KerbalKomets-PlayMode-CRP.netkan
@@ -4,7 +4,8 @@ name: KerbalKomets CRP Play Mode
 $kref: '#/ckan/spacedock/1249'
 $vref: '#/ckan/ksp-avc'
 x_netkan_staging: true
-x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+x_netkan_staging_reason: >-
+  Make sure that all .txt files for this play mode are installed as .cfg
 license: GPL-3.0
 resources:
   remote-avc: https://github.com/Angel-125/KerbalKomets/raw/master/GameData/WildBlueIndustries/KerbalKomets/KerbalKomets.version

--- a/NetKAN/KerbalKomets-PlayMode-CRP.netkan
+++ b/NetKAN/KerbalKomets-PlayMode-CRP.netkan
@@ -6,6 +6,8 @@ $vref: '#/ckan/ksp-avc'
 x_netkan_staging: true
 x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
 license: GPL-3.0
+resources:
+  remote-avc: https://github.com/Angel-125/KerbalKomets/raw/master/GameData/WildBlueIndustries/KerbalKomets/KerbalKomets.version
 tags:
   - config
 provides:

--- a/NetKAN/KerbalKomets-PlayMode-ClassicStock.netkan
+++ b/NetKAN/KerbalKomets-PlayMode-ClassicStock.netkan
@@ -4,7 +4,8 @@ name: KerbalKomets Classic Stock Play Mode
 $kref: '#/ckan/spacedock/1249'
 $vref: '#/ckan/ksp-avc'
 x_netkan_staging: true
-x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+x_netkan_staging_reason: >-
+  Make sure that all .txt files for this play mode are installed as .cfg
 license: GPL-3.0
 resources:
   remote-avc: https://github.com/Angel-125/KerbalKomets/raw/master/GameData/WildBlueIndustries/KerbalKomets/KerbalKomets.version

--- a/NetKAN/KerbalKomets-PlayMode-ClassicStock.netkan
+++ b/NetKAN/KerbalKomets-PlayMode-ClassicStock.netkan
@@ -6,6 +6,8 @@ $vref: '#/ckan/ksp-avc'
 x_netkan_staging: true
 x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
 license: GPL-3.0
+resources:
+  remote-avc: https://github.com/Angel-125/KerbalKomets/raw/master/GameData/WildBlueIndustries/KerbalKomets/KerbalKomets.version
 tags:
   - config
 provides:

--- a/NetKAN/KerbalKomets.netkan
+++ b/NetKAN/KerbalKomets.netkan
@@ -3,6 +3,8 @@ identifier: KerbalKomets
 $kref: '#/ckan/spacedock/1249'
 $vref: '#/ckan/ksp-avc'
 license: GPL-3.0
+resources:
+  remote-avc: https://github.com/Angel-125/KerbalKomets/raw/master/GameData/WildBlueIndustries/KerbalKomets/KerbalKomets.version
 tags:
   - plugin
   - planet-pack

--- a/NetKAN/KerbalKomets.netkan
+++ b/NetKAN/KerbalKomets.netkan
@@ -2,6 +2,9 @@ spec_version: v1.10
 identifier: KerbalKomets
 $kref: '#/ckan/spacedock/1249'
 $vref: '#/ckan/ksp-avc'
+x_netkan_staging: true
+x_netkan_staging_reason: >-
+  Make sure that no new play modes were added to the Templates folder
 license: GPL-3.0
 resources:
   remote-avc: https://github.com/Angel-125/KerbalKomets/raw/master/GameData/WildBlueIndustries/KerbalKomets/KerbalKomets.version

--- a/NetKAN/KerbalOccupationColors.netkan
+++ b/NetKAN/KerbalOccupationColors.netkan
@@ -1,32 +1,25 @@
-{
-    "spec_version": "v1.18",
-    "identifier":   "KerbalOccupationColors",
-    "abstract":     "Automatically assigns the Future Suit's light colors based on occupation",
-    "$kref":        "#/ckan/github/Starwaster/Kerbal-Occupation-Colors",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "Unlicense",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/185931-*",
-        "repository": "https://github.com/Starwaster/Kerbal-Occupation-Colors"
-    },
-    "tags": [
-        "plugin",
-        "information",
-        "crewed"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "install": [ {
-        "find": "KerbalOccupationColors",
-        "install_to": "GameData"
-    } ],
-    "x_netkan_override": [
-        {
-            "version": [ ">=v1.2.0", "<=v1.2.0.1" ],
-            "override": {
-                "ksp_version_min": "1.7.3"
-            }
-        }
-    ]
-}
+spec_version: v1.18
+identifier: KerbalOccupationColors
+abstract: Automatically assigns the Future Suit's light colors based on occupation
+$kref: '#/ckan/github/Starwaster/Kerbal-Occupation-Colors'
+$vref: '#/ckan/ksp-avc'
+license: Unlicense
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/185931-*
+  repository: https://github.com/Starwaster/Kerbal-Occupation-Colors
+  remote-avc: https://github.com/Starwaster/Kerbal-Occupation-Colors/raw/master/GameData/KerbalOccupationColors/KerbalOccupationColors.version
+tags:
+  - plugin
+  - information
+  - crewed
+depends:
+  - name: ModuleManager
+install:
+  - find: KerbalOccupationColors
+    install_to: GameData
+x_netkan_override:
+  - version:
+      - '>=v1.2.0'
+      - <=v1.2.0.1
+    override:
+      ksp_version_min: 1.7.3

--- a/NetKAN/KerbalOccupationColors.netkan
+++ b/NetKAN/KerbalOccupationColors.netkan
@@ -1,6 +1,7 @@
 spec_version: v1.18
 identifier: KerbalOccupationColors
-abstract: Automatically assigns the Future Suit's light colors based on occupation
+abstract: >-
+  Automatically assigns the Future Suit's light colors based on occupation
 $kref: '#/ckan/github/Starwaster/Kerbal-Occupation-Colors'
 $vref: '#/ckan/ksp-avc'
 license: Unlicense

--- a/NetKAN/KipLowProfileHubs.netkan
+++ b/NetKAN/KipLowProfileHubs.netkan
@@ -1,27 +1,26 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "KipLowProfileHubs",
-    "author":       [ "CaptainKipard", "micha" ],
-    "$kref":        "#/ckan/spacedock/2457",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts",
-        "crewed"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "KipEng-Agency" }
-    ],
-    "suggests": [
-        { "name": "ConnectedLivingSpace" },
-        { "name": "IFILS"                },
-        { "name": "Snacks"               },
-        { "name": "TACLS"                }
-    ],
-    "install": [ {
-        "find":       "KipEng",
-        "install_to": "GameData",
-        "filter":     [ "Agencies" ]
-    } ]
-}
+spec_version: v1.4
+identifier: KipLowProfileHubs
+author:
+  - CaptainKipard
+  - micha
+$kref: '#/ckan/spacedock/2457'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+resources:
+  remote-avc: https://github.com/mwerle/KipLowProfileHubs/raw/primary/GameData/KipEng/KipLowProfileHubs/KipLowProfileHubs.version
+tags:
+  - parts
+  - crewed
+depends:
+  - name: ModuleManager
+  - name: KipEng-Agency
+suggests:
+  - name: ConnectedLivingSpace
+  - name: IFILS
+  - name: Snacks
+  - name: TACLS
+install:
+  - find: KipEng
+    install_to: GameData
+    filter:
+      - Agencies

--- a/NetKAN/Mk-33.netkan
+++ b/NetKAN/Mk-33.netkan
@@ -6,6 +6,7 @@ license: restricted
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/194713-*
   repository: https://github.com/Angel-125/Mk-33
+  remote-avc: https://github.com/Angel-125/Mk-33/raw/master/ReleaseFolder/GameData/WildBlueIndustries/Mk-33/Mk33.version
 tags:
   - parts
   - plugin

--- a/NetKAN/Mk2Y.netkan
+++ b/NetKAN/Mk2Y.netkan
@@ -1,22 +1,20 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "Mk2Y",
-    "author":       [ "Yarbrough08", "zer0Kerbal" ],
-    "$kref":        "#/ckan/spacedock/2358",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts",
-        "crewed"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "supports": [
-        { "name": "KerbalChangelog" }
-    ],
-    "install": [ {
-        "find":       "Yarbrough",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.4
+identifier: Mk2Y
+author:
+  - Yarbrough08
+  - zer0Kerbal
+$kref: '#/ckan/spacedock/2358'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+resoures:
+  remote-avc: https://github.com/zer0Kerbal/Mk2Y/raw/master/Mk2Y.version
+tags:
+  - parts
+  - crewed
+depends:
+  - name: ModuleManager
+supports:
+  - name: KerbalChangelog
+install:
+  - find: Yarbrough
+    install_to: GameData

--- a/NetKAN/MoarKerbals.netkan
+++ b/NetKAN/MoarKerbals.netkan
@@ -1,35 +1,32 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "MoarKerbals",
-    "author":       [ "strideknight", "zer0Kerbal" ],
-    "$kref":        "#/ckan/spacedock/2324",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts",
-        "plugin",
-        "crewed"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "KerbalStats"           },
-        { "name": "CommunityResourcePack" }
-    ],
-    "suggests": [
-        { "name": "StockalikeMiningExtension" },
-        { "name": "KIS"                       },
-        { "name": "KAS"                       },
-        { "name": "NotSoSimpleConstruction"   },
-        { "name": "InfernalRoboticsNext"      },
-        { "name": "SimpleConstruction"        },
-        { "name": "SimpleLogistics"           },
-        { "name": "ODFC"                      }
-    ],
-    "supports": [
-        { "name": "KerbalChangelog" },
-        { "name": "USI-LS"          },
-        { "name": "UKS"             }
-    ]
-}
+spec_version: v1.4
+identifier: MoarKerbals
+author:
+  - strideknight
+  - zer0Kerbal
+$kref: '#/ckan/spacedock/2324'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+resources:
+  remote-avc: https://github.com/zer0Kerbal/MoarKerbals/raw/master/MoarKerbals.version
+tags:
+  - parts
+  - plugin
+  - crewed
+depends:
+  - name: ModuleManager
+recommends:
+  - name: KerbalStats
+  - name: CommunityResourcePack
+suggests:
+  - name: StockalikeMiningExtension
+  - name: KIS
+  - name: KAS
+  - name: NotSoSimpleConstruction
+  - name: InfernalRoboticsNext
+  - name: SimpleConstruction
+  - name: SimpleLogistics
+  - name: ODFC
+supports:
+  - name: KerbalChangelog
+  - name: USI-LS
+  - name: UKS

--- a/NetKAN/MoarKerbalsParts.netkan
+++ b/NetKAN/MoarKerbalsParts.netkan
@@ -3,6 +3,8 @@ identifier: MoarKerbalsParts
 $kref: '#/ckan/spacedock/2898'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-4.0
+resources:
+  remote-avc: https://github.com/zer0Kerbal/MoarKerbalsParts/raw/master/MoarKerbalsParts.version
 tags:
   - parts
   - crewed

--- a/NetKAN/MoreHitchhikers.netkan
+++ b/NetKAN/MoreHitchhikers.netkan
@@ -1,26 +1,21 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "MoreHitchhikers",
-    "$kref":        "#/ckan/spacedock/2244",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts",
-        "crewed"
-    ],
-    "install": [ {
-        "find":       "KGEx",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "suggests": [
-        { "name": "ODFC-Refueled"   },
-        { "name": "KerbalChangelog" }
-    ],
-    "supports": [
-        { "name": "ConnectedLivingSpace" },
-        { "name": "Kerbalism"            }
-    ]
-}
+spec_version: v1.4
+identifier: MoreHitchhikers
+$kref: '#/ckan/spacedock/2244'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+resources:
+  remote-avc: https://github.com/zer0Kerbal/KGEx/raw/master/KGEx.version
+tags:
+  - parts
+  - crewed
+install:
+  - find: KGEx
+    install_to: GameData
+depends:
+  - name: ModuleManager
+suggests:
+  - name: ODFC-Refueled
+  - name: KerbalChangelog
+supports:
+  - name: ConnectedLivingSpace
+  - name: Kerbalism

--- a/NetKAN/MoreServos.netkan
+++ b/NetKAN/MoreServos.netkan
@@ -5,6 +5,7 @@ $vref: '#/ckan/ksp-avc'
 license: restricted
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/186546-*
+  remote-avc: https://github.com/Angel-125/MoreServos/raw/master/GameData/WildBlueIndustries/MoreServos/MoreServos.version
 tags:
   - parts
 depends:

--- a/NetKAN/NotSoSimpleConstruction.netkan
+++ b/NetKAN/NotSoSimpleConstruction.netkan
@@ -1,38 +1,31 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "NotSoSimpleConstruction",
-    "$kref":        "#/ckan/spacedock/1078",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "crewed"
-    ],
-    "provides": [
-        "NSSC"
-    ],
-    "depends": [
-        { "name": "ModuleManager"      },
-        { "name": "SimpleConstruction" }
-    ],
-    "recommends": [
-        { "name": "Toolbar"     },
-        { "name": "KerbalStats" },
-        { "name": "KIS"         },
-        { "name": "KAS"         }
-    ],
-    "suggests": [
-        { "name": "SimpleLogistics"           },
-        { "name": "CommunityResourcePack"     },
-        { "name": "StockalikeMiningExtension" },
-        { "name": "InfernalRoboticsNext"      }
-    ],
-    "supports": [
-        { "name": "KerbalChangelog" },
-        { "name": "Kethane"         }
-    ],
-    "install": [ {
-        "find":       "NotSoSimpleConstruction",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.4
+identifier: NotSoSimpleConstruction
+$kref: '#/ckan/spacedock/1078'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+resources:
+  remote-avc: https://github.com/zer0Kerbal/NotSoSimpleConstruction/raw/master/NotSoSimpleConstruction.version
+tags:
+  - plugin
+  - crewed
+provides:
+  - NSSC
+depends:
+  - name: ModuleManager
+  - name: SimpleConstruction
+recommends:
+  - name: Toolbar
+  - name: KerbalStats
+  - name: KIS
+  - name: KAS
+suggests:
+  - name: SimpleLogistics
+  - name: CommunityResourcePack
+  - name: StockalikeMiningExtension
+  - name: InfernalRoboticsNext
+supports:
+  - name: KerbalChangelog
+  - name: Kethane
+install:
+  - find: NotSoSimpleConstruction
+    install_to: GameData

--- a/NetKAN/ODFC-Refueled-CopyPatches.netkan
+++ b/NetKAN/ODFC-Refueled-CopyPatches.netkan
@@ -1,20 +1,17 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "ODFC-Refueled-CopyPatches",
-    "$kref":        "#/ckan/spacedock/2221",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "config",
-        "parts",
-        "convenience"
-    ],
-    "install": [ {
-        "find":       "OnDemandFuelCells",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "ODFC-Refueled" }
-    ]
-}
+spec_version: v1.4
+identifier: ODFC-Refueled-CopyPatches
+$kref: '#/ckan/spacedock/2221'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+resources:
+  remote-avc: https://github.com/zer0Kerbal/ODFCr/raw/master/OnDemandFuelCells.version
+tags:
+  - config
+  - parts
+  - convenience
+install:
+  - find: OnDemandFuelCells
+    install_to: GameData
+depends:
+  - name: ModuleManager
+  - name: ODFC-Refueled

--- a/NetKAN/ODFC-Refueled-ModifyPatches.netkan
+++ b/NetKAN/ODFC-Refueled-ModifyPatches.netkan
@@ -1,19 +1,16 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "ODFC-Refueled-ModifyPatches",
-    "$kref":        "#/ckan/spacedock/2220",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "config",
-        "convenience"
-    ],
-    "install": [ {
-        "find":       "OnDemandFuelCells",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "ODFC-Refueled" }
-    ]
-}
+spec_version: v1.4
+identifier: ODFC-Refueled-ModifyPatches
+$kref: '#/ckan/spacedock/2220'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+resources:
+  remote-avc: https://github.com/zer0Kerbal/ODFCr/raw/master/OnDemandFuelCells.version
+tags:
+  - config
+  - convenience
+install:
+  - find: OnDemandFuelCells
+    install_to: GameData
+depends:
+  - name: ModuleManager
+  - name: ODFC-Refueled

--- a/NetKAN/ODFC-Refueled.netkan
+++ b/NetKAN/ODFC-Refueled.netkan
@@ -1,38 +1,31 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "ODFC-Refueled",
-    "$kref":        "#/ckan/spacedock/2223",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "plugin",
-        "convenience"
-    ],
-    "install": [ {
-        "find":       "OnDemandFuelCells",
-        "install_to": "GameData"
-    } ],
-    "provides": [
-        "ODFC"
-    ],
-    "conflicts": [
-        { "name": "ODFC"  }
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "suggests": [
-        { "name": "BluedogDB"                 },
-        { "name": "StockalikeMiningExtension" },
-        { "name": "UniversalStorage"          },
-        { "name": "UniversalStorage2"         },
-        { "name": "RLAReborn"                 }
-    ],
-    "supports": [
-        { "name": "AllYAll"               },
-        { "name": "CommunityResourcePack" },
-        { "name": "BackgroundProcessing"  },
-        { "name": "BackgroundResources"   },
-        { "name": "KerbalChangelog"       }
-    ]
-}
+spec_version: v1.4
+identifier: ODFC-Refueled
+$kref: '#/ckan/spacedock/2223'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+resources:
+  remote-avc: https://github.com/zer0Kerbal/ODFCr/raw/master/OnDemandFuelCells.version
+tags:
+  - plugin
+  - convenience
+install:
+  - find: OnDemandFuelCells
+    install_to: GameData
+provides:
+  - ODFC
+conflicts:
+  - name: ODFC
+depends:
+  - name: ModuleManager
+suggests:
+  - name: BluedogDB
+  - name: StockalikeMiningExtension
+  - name: UniversalStorage
+  - name: UniversalStorage2
+  - name: RLAReborn
+supports:
+  - name: AllYAll
+  - name: CommunityResourcePack
+  - name: BackgroundProcessing
+  - name: BackgroundResources
+  - name: KerbalChangelog

--- a/NetKAN/OhScrap.netkan
+++ b/NetKAN/OhScrap.netkan
@@ -4,6 +4,8 @@ name: OhScrap (OHS)
 $kref: '#/ckan/spacedock/2364'
 $vref: '#/ckan/ksp-avc'
 license: MIT
+resources:
+  remote-avc: https://github.com/zer0Kerbal/OhScrap/raw/master/OhScrap.version
 tags:
   - plugin
   - editor

--- a/NetKAN/ProceduralFairings-ForEverything.netkan
+++ b/NetKAN/ProceduralFairings-ForEverything.netkan
@@ -1,15 +1,13 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "ProceduralFairings-ForEverything",
-    "$kref":        "#/ckan/netkan/https://raw.githubusercontent.com/KSP-RO/ProceduralFairings-ForEverything/master/ProceduralFairings-ForEverything.netkan",
-    "license":      "CC-BY-SA",
-    "tags": [
-        "parts"
-    ],
-    "x_netkan_override": [ {
-        "version": "v0.3.0",
-        "override": {
-            "ksp_version_max": "1.11"
-        }
-    } ]
-}
+spec_version: v1.4
+identifier: ProceduralFairings-ForEverything
+$kref: >-
+  #/ckan/netkan/https://raw.githubusercontent.com/KSP-RO/ProceduralFairings-ForEverything/master/ProceduralFairings-ForEverything.netkan
+license: CC-BY-SA
+resources:
+  remote-avc: https://github.com/KSP-RO/ProceduralFairings-ForEverything/raw/master/GameData/ProceduralFairings-ForEverything/ProceduralFairings-ForEverything.version
+tags:
+  - parts
+x_netkan_override:
+  - version: v0.3.0
+    override:
+      ksp_version_max: '1.11'

--- a/NetKAN/RealBattery.netkan
+++ b/NetKAN/RealBattery.netkan
@@ -1,22 +1,19 @@
-{
-    "spec_version" : 1,
-    "identifier"   : "RealBattery",
-    "abstract"     : "Realistic behaving electrical storage. Including state of the art Li-Ion rechargeable batteries!",
-    "$kref"        : "#/ckan/github/blackliner/RealBattery",
-    "$vref"        : "#/ckan/ksp-avc",
-    "license"      : "MIT",
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/151164-*"
-    },
-    "tags": [
-        "plugin",
-        "physics"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "CommunityResourcePack" }
-    ],
-    "recommends": [
-        { "name" : "DynamicBatteryStorage" }
-    ]
-}
+spec_version: 1
+identifier: RealBattery
+abstract: >-
+  Realistic behaving electrical storage. Including state of the art Li-Ion
+  rechargeable batteries!
+$kref: '#/ckan/github/blackliner/RealBattery'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+resources:
+  homepage: http://forum.kerbalspaceprogram.com/index.php?/topic/151164-*
+  remote-avc: https://github.com/blackliner/RealBattery/raw/master/RealBattery/GameData/RealBattery/RealBattery.version
+tags:
+  - plugin
+  - physics
+depends:
+  - name: ModuleManager
+  - name: CommunityResourcePack
+recommends:
+  - name: DynamicBatteryStorage

--- a/NetKAN/SLOTH.netkan
+++ b/NetKAN/SLOTH.netkan
@@ -5,6 +5,7 @@ $vref: '#/ckan/ksp-avc'
 license: restricted
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/186546-*
+  remote-avc: https://github.com/Angel-125/SLOTH/raw/master/GameData/WildBlueIndustries/SLOTH/Sloth.version
 tags:
   - parts
 depends:

--- a/NetKAN/ServoController.netkan
+++ b/NetKAN/ServoController.netkan
@@ -5,6 +5,7 @@ $vref: '#/ckan/ksp-avc'
 license: GPL-3.0
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/186546-*
+  remote-avc: https://github.com/Angel-125/ServoController/raw/master/GameData/WildBlueIndustries/ServoController/ServoController.version
 tags:
   - plugin
   - convenience

--- a/NetKAN/Snacks.netkan
+++ b/NetKAN/Snacks.netkan
@@ -1,41 +1,30 @@
-{
-    "spec_version" : "v1.4",
-    "identifier"   : "Snacks",
-    "name"         : "Snacks",
-    "abstract"     : "Add a simple life support system based on Snacks!",
-    "author"       : [ "tgruetzm", "Angel-125"],
-    "$kref"        : "#/ckan/github/Angel-125/Snacks",
-    "$vref"        : "#/ckan/ksp-avc",
-    "license"      : "MIT",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/149604-*"
-    },
-    "tags": [
-        "plugin",
-        "crewed"
-    ],
-    "install": [
-        {
-            "install_to": "GameData",
-            "find": "WildBlueIndustries"
-        }
-    ],
-    "depends": [
-        {
-            "name": "ModuleManager"
-        }
-    ],
-    "x_netkan_override": [
-        {
-            "version": "1.9.0",
-            "delete": [ "ksp_version_min" ]
-        },
-        {
-            "version": "1.8.0",
-            "delete": [ "ksp_version" ],
-            "override": {
-                "ksp_version" : "1.3"
-            }
-        }
-    ]
-}
+spec_version: v1.4
+identifier: Snacks
+name: Snacks
+abstract: Add a simple life support system based on Snacks!
+author:
+  - tgruetzm
+  - Angel-125
+$kref: '#/ckan/github/Angel-125/Snacks'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/149604-*
+  remote-avc: https://github.com/Angel-125/Snacks/raw/master/GameData/WildBlueIndustries/Snacks/Snacks.version
+tags:
+  - plugin
+  - crewed
+install:
+  - install_to: GameData
+    find: WildBlueIndustries
+depends:
+  - name: ModuleManager
+x_netkan_override:
+  - version: 1.9.0
+    delete:
+      - ksp_version_min
+  - version: 1.8.0
+    delete:
+      - ksp_version
+    override:
+      ksp_version: '1.3'

--- a/NetKAN/StandardPropulsionSystems.netkan
+++ b/NetKAN/StandardPropulsionSystems.netkan
@@ -1,15 +1,11 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "StandardPropulsionSystems",
-    "$kref":        "#/ckan/spacedock/226",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts"
-    ],
-    "install": [ {
-        "find":       "SPS",
-        "install_to": "GameData",
-        "filter":     ".DS_Store"
-    } ]
-}
+spec_version: v1.4
+identifier: StandardPropulsionSystems
+$kref: '#/ckan/spacedock/226'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+install:
+  - find: SPS
+    install_to: GameData
+    filter: .DS_Store

--- a/NetKAN/Telemagic.netkan
+++ b/NetKAN/Telemagic.netkan
@@ -1,14 +1,12 @@
-{
-    "spec_version": "v1.16",
-    "identifier":   "Telemagic",
-    "$kref":        "#/ckan/spacedock/1627",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin"
-    ],
-    "install": [ {
-        "find":       "Telemagic",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.16
+identifier: Telemagic
+$kref: '#/ckan/spacedock/1627'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+resources:
+  remote-avc: https://github.com/Hotel26/Telemagic/raw/master/Telemagic/Telemagic.version
+tags:
+  - plugin
+install:
+  - find: Telemagic
+    install_to: GameData

--- a/NetKAN/Timekeeper.netkan
+++ b/NetKAN/Timekeeper.netkan
@@ -1,16 +1,13 @@
-{
-    "spec_version" : 1,
-    "identifier"   : "Timekeeper",
-    "abstract"     : "Counts orbits and sols for your vessels.",
-    "author"       : "Garwel",
-    "$kref"        : "#/ckan/github/GarwelGarwel/Timekeeper",
-    "$vref"        : "#/ckan/ksp-avc",
-    "license"      : "MIT",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/178121-*"
-    },
-    "tags": [
-        "plugin",
-        "information"
-    ]
-}
+spec_version: 1
+identifier: Timekeeper
+abstract: Counts orbits and sols for your vessels.
+author: Garwel
+$kref: '#/ckan/github/GarwelGarwel/Timekeeper'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/178121-*
+  remote-avc: https://github.com/GarwelGarwel/Timekeeper/raw/master/GameData/Timekeeper/Timekeeper.version
+tags:
+  - plugin
+  - information


### PR DESCRIPTION
Now that KSP-CKAN/CKAN#3451 is merged, we take advantage of it by overriding `resources.remote-avc` for mods that have a bad `URL` property in their version files. This will ensure that CKAN has the up to date versioning metadata and restore to the authors their ability to control that metadata after release.

Most of these have already had pull requests submitted; some haven't merged yet, some have merged but not released a new version.

A few mods with this warning are not included here because I was not able to find any version file for them online (no repo or missing from repo). A few of those I converted to YAML before looking for version files, so they are here and still have the warning.

If any of these mods release new versions with fixed version files, that should be fine unless the remote version files are moved to new locations, in which case the bot will alert us with new inflation warnings.

___

ckan compat add 1.11