### PR TITLE
Remove FossilsMechazilla max compat override

### DIFF
--- a/NetKAN/FossilsMechazilla.netkan
+++ b/NetKAN/FossilsMechazilla.netkan
@@ -13,4 +13,3 @@ x_netkan_override:
   - version: '>=1.2'
     override:
       ksp_version_min: 1.10
-      ksp_version_max: 1.12


### PR DESCRIPTION
See conversation in #8872; this is now set to 1.12.3 compatibility on SpaceDock, so we only need to pin the minimum compatibility.