### PR TITLE
Pin KerbalImprovedSaveSystem min compat

### DIFF
--- a/NetKAN/KerbalImprovedSaveSystem.netkan
+++ b/NetKAN/KerbalImprovedSaveSystem.netkan
@@ -1,20 +1,14 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "KerbalImprovedSaveSystem",
-    "$kref":        "#/ckan/spacedock/583",
-    "x_netkan_force_v" : true,
-    "license":      "MIT",
-    "tags": [
-        "plugin"
-    ],
-    "x_netkan_override": [
-        {
-            "version": "2.1.0",
-            "delete": [ "ksp_version" ],
-            "override": {
-                "ksp_version_min": "1.1.3",
-                "ksp_version_max": "1.2.2"
-            }
-        }
-    ]
-}
+spec_version: v1.4
+identifier: KerbalImprovedSaveSystem
+$kref: '#/ckan/spacedock/583'
+x_netkan_force_v: true
+license: MIT
+tags:
+  - plugin
+x_netkan_override:
+  - version: v2.4.2
+    override:
+      ksp_version_min: '1.9'
+  - version: v2.1.0
+    override:
+      ksp_version_min: 1.1.3


### PR DESCRIPTION
This mod has been updating the same release's compatibility via SpaceDock since KSP 1.9. Now it spans that range.

There's an existing override that wasn't working because `version` was missing a `v`, which is now fixed.