### PR TITLE
Set resources.remote-avc for mods with bad version file URL properties

### DIFF
--- a/NetKAN/CollisionFXReUpdated.netkan
+++ b/NetKAN/CollisionFXReUpdated.netkan
@@ -1,21 +1,19 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "CollisionFXReUpdated",
-    "$kref":        "#/ckan/spacedock/2426",
-    "$vref":        "#/ckan/ksp-avc",
-    "author":       [ "pizzaoverhead", "SlimJimDodger", "VoidCosmos" ],
-    "license":      "GPL-2.0",
-    "tags": [
-        "plugin",
-        "graphics"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "install": [
-        {
-            "find"       : "GameData/CollisionFXReUpdated",
-            "install_to" : "GameData"
-        }
-    ]
-}
+spec_version: v1.4
+identifier: CollisionFXReUpdated
+$kref: '#/ckan/spacedock/2426'
+$vref: '#/ckan/ksp-avc'
+author:
+  - pizzaoverhead
+  - SlimJimDodger
+  - VoidCosmos
+license: GPL-2.0
+resources:
+  remote-avc: https://github.com/VoidCosmo/CollisionFX-ReUpdated/raw/master/GameData/CollisionFXReUpdated/Versioning/CollisionFX-ReUpdated.version
+tags:
+  - plugin
+  - graphics
+depends:
+  - name: ModuleManager
+install:
+  - find: GameData/CollisionFXReUpdated
+    install_to: GameData

--- a/NetKAN/KSCExtended.netkan
+++ b/NetKAN/KSCExtended.netkan
@@ -1,27 +1,23 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "KSCExtended",
-    "$kref":        "#/ckan/spacedock/2062",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "config",
-        "buildings"
-    ],
-    "depends": [
-        { "name": "KerbalKonstructs"     },
-        { "name": "TundraSpaceCenter"    },
-        { "name": "StockalikeStructures" },
-        { "name": "ModuleManager"        }
-    ],
-    "conflicts": [
-        { "name": "GPP" }
-    ],
-    "recommends": [
-        { "name": "TundraExploration"                     },
-        { "name": "BluedogDB"                             },
-        { "name": "ShuttleLiftingBodyCormorantAeronology" },
-        { "name": "ModularLaunchPads"                     },
-        { "name": "KerbinSideRemastered"                  }
-    ]
-}
+spec_version: v1.4
+identifier: KSCExtended
+$kref: '#/ckan/spacedock/2062'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+resources:
+  remote-avc: https://github.com/JadeOfMaar/KSC_Extended/raw/main/GameData/KSCExtended/Version/KSC_Extended.version
+tags:
+  - config
+  - buildings
+depends:
+  - name: KerbalKonstructs
+  - name: TundraSpaceCenter
+  - name: StockalikeStructures
+  - name: ModuleManager
+conflicts:
+  - name: GPP
+recommends:
+  - name: TundraExploration
+  - name: BluedogDB
+  - name: ShuttleLiftingBodyCormorantAeronology
+  - name: ModularLaunchPads
+  - name: KerbinSideRemastered

--- a/NetKAN/MandatoryRCS.netkan
+++ b/NetKAN/MandatoryRCS.netkan
@@ -1,27 +1,25 @@
-{
-    "spec_version" : "v1.20",
-    "identifier"   : "MandatoryRCS",
-    "abstract"     : "Several modifications to make RCS thrusters mandatory to have authority on your vessel orientation. Nerf reaction wheels so they provide only stabilization and don't respond to pilot or SAS input. Also make angular velocity and SAS orientation hold persistent trough timewarps and reloads.",
-    "$kref"        : "#/ckan/github/gotmachine/MandatoryRCS",
-    "$vref"        : "#/ckan/ksp-avc",
-    "x_netkan_epoch": 1,
-    "license"      : "Unlicense",
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/154658-*"
-    },
-    "tags": [
-        "plugin",
-        "physics"
-    ],
-	"depends": [
-        { "name": "ModuleManager" }
-    ],
-    "suggests": [
-        { "name": "RLAContinued" },
-        { "name": "RCSBuildAid" }
-    ],
-    "conflicts": [
-        { "name": "PersistentRotation" },
-        { "name": "SemiSaturatableRW" }
-    ]
-}
+spec_version: v1.20
+identifier: MandatoryRCS
+abstract: >-
+  Several modifications to make RCS thrusters mandatory to have authority on
+  your vessel orientation. Nerf reaction wheels so they provide only
+  stabilization and don't respond to pilot or SAS input. Also make angular
+  velocity and SAS orientation hold persistent trough timewarps and reloads.
+$kref: '#/ckan/github/gotmachine/MandatoryRCS'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: 1
+license: Unlicense
+resources:
+  homepage: http://forum.kerbalspaceprogram.com/index.php?/topic/154658-*
+  remote-avc: https://github.com/gotmachine/MandatoryRCS/raw/master/GameData/MandatoryRCS/MandatoryRCS.version
+tags:
+  - plugin
+  - physics
+depends:
+  - name: ModuleManager
+suggests:
+  - name: RLAContinued
+  - name: RCSBuildAid
+conflicts:
+  - name: PersistentRotation
+  - name: SemiSaturatableRW

--- a/NetKAN/MandatoryRCSPartPack.netkan
+++ b/NetKAN/MandatoryRCSPartPack.netkan
@@ -1,18 +1,14 @@
-{
-    "spec_version" : "v1.20",
-    "identifier"   : "MandatoryRCSPartPack",
-    "name"         : "MandatoryRCS Part Pack",
-    "abstract"     : "Small part pack to provide more RCS thrusters in a stockalike fashion",
-    "$kref"        : "#/ckan/github/gotmachine/MandatoryRCS-Part-Pack",
-    "$vref"        : "#/ckan/ksp-avc",
-    "license"      : "Unlicense",
-    "resources"    : {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/154658-*"
-    },
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ]
-}
+spec_version: v1.20
+identifier: MandatoryRCSPartPack
+name: MandatoryRCS Part Pack
+abstract: Small part pack to provide more RCS thrusters in a stockalike fashion
+$kref: '#/ckan/github/gotmachine/MandatoryRCS-Part-Pack'
+$vref: '#/ckan/ksp-avc'
+license: Unlicense
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/154658-*
+  remote-avc: https://github.com/gotmachine/MandatoryRCS-Part-Pack/raw/master/GameData/MandatoryRCSPartPack/MandatoryRCSPartPack.version
+tags:
+  - parts
+depends:
+  - name: ModuleManager

--- a/NetKAN/RealHeat.netkan
+++ b/NetKAN/RealHeat.netkan
@@ -1,33 +1,23 @@
-{
-    "spec_version" : "v1.4",
-    "identifier"   : "RealHeat",
-    "$kref"        : "#/ckan/github/KSP-RO/RealHeat",
-    "$vref"        : "#/ckan/ksp-avc",
-    "name"         : "RealHeat",
-    "abstract"     : "Improves the realism of KSP's thermodynamics.",
-    "license"      : "CC-BY-SA",
-    "resources"      : {
-        "homepage"   : "https://forum.kerbalspaceprogram.com/index.php?/topic/115066-*",
-        "repository" : "https://github.com/KSP-RO/RealHeat"
-    },
-    "tags": [
-        "plugin",
-        "physics"
-    ],
-    "depends"        : [
-        { "name": "ModuleManager"           },
-        { "name": "ModularFlightIntegrator" }
-    ],
-    "install"        : [ {
-        "find":       "RealHeat",
-        "install_to": "GameData"
-    } ],
-    "x_netkan_override" : [
-        {
-            "version" : "<= v3",
-            "override" : {
-                "ksp_version" : "1.0.5"
-            }
-        }
-    ]
-}
+spec_version: v1.4
+identifier: RealHeat
+$kref: '#/ckan/github/KSP-RO/RealHeat'
+$vref: '#/ckan/ksp-avc'
+name: RealHeat
+abstract: Improves the realism of KSP's thermodynamics
+license: CC-BY-SA
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/115066-*
+  remote-avc: https://github.com/KSP-RO/RealHeat/raw/master/RealHeat/RealHeat.version
+tags:
+  - plugin
+  - physics
+depends:
+  - name: ModuleManager
+  - name: ModularFlightIntegrator
+install:
+  - find: RealHeat
+    install_to: GameData
+x_netkan_override:
+  - version: <= v3
+    override:
+      ksp_version: 1.0.5

--- a/NetKAN/TransparentPods.netkan
+++ b/NetKAN/TransparentPods.netkan
@@ -1,27 +1,23 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "TransparentPods",
-    "$kref":        "#/ckan/spacedock/2212",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts",
-        "crewed"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "RasterPropMonitor"          },
-        { "name": "JSIAdvancedTransparentPods" }
-    ],
-    "suggests": [
-        { "name": "AllYAll"                      },
-        { "name": "DockingCamKURS"               },
-        { "name": "KIS"                          },
-        { "name": "KAS"                          },
-        { "name": "InfernalRoboticsNext"         },
-        { "name": "KerbalJointReinforcementNext" },
-        { "name": "KerbalChangelog"              }
-    ]
-}
+spec_version: v1.4
+identifier: TransparentPods
+$kref: '#/ckan/spacedock/2212'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+resources:
+  remote-avc: https://github.com/zer0Kerbal/TransparentPods/raw/master/TransparentPods.version
+tags:
+  - parts
+  - crewed
+depends:
+  - name: ModuleManager
+recommends:
+  - name: RasterPropMonitor
+  - name: JSIAdvancedTransparentPods
+suggests:
+  - name: AllYAll
+  - name: DockingCamKURS
+  - name: KIS
+  - name: KAS
+  - name: InfernalRoboticsNext
+  - name: KerbalJointReinforcementNext
+  - name: KerbalChangelog


### PR DESCRIPTION
This is #8975 for mods where the remote version file URL can be retrieved but isn't a version file.