### PR TITLE
Change GasGiantsEnhanced dep on RSS to rec

### DIFF
--- a/NetKAN/GasGiantsEnhanced.netkan
+++ b/NetKAN/GasGiantsEnhanced.netkan
@@ -10,4 +10,5 @@ depends:
   - name: Kopernicus
   - name: EnvironmentalVisualEnhancements
   - name: Scatterer
+recommends:
   - name: RealSolarSystem


### PR DESCRIPTION
This mod can be used with either RSS or [KSRSS](https://forum.kerbalspaceprogram.com/index.php?/topic/192818-beta-ksrss-07-kerbin-or-x25-sized-rss/), but currently we have it depending on RSS. If a user wants to use KSRSS instead, there's no way to not install RSS.

KSRSS is not in CKAN and is hosted on GitLab, so the best we can do is to allow RSS to be removed. So now RSS is recommended instead of a depends.

Fixes #9000.