### PR TITLE
Fix StockDepthMaskConfig find_regexp

### DIFF
--- a/NetKAN/StockDepthMaskConfig.netkan
+++ b/NetKAN/StockDepthMaskConfig.netkan
@@ -8,7 +8,8 @@ depends:
   - name: ModuleManager
   - name: DepthMask
 install:
-  - find_regexp: Stock_DepthMask_Config-[0-9.]+
+  - find_regexp: StockDepthMaskConfig
     install_to: GameData
     filter:
+      - .git
       - .gitattributes


### PR DESCRIPTION
This mod is currently failing with:
> No files found matching find_regexp="Stock_DepthMask_Config-[0-9.]+" to install!

Release 1.0 for which this stanza has been written has been removed from SpaceDock.
With release 1.1 the mod had no root folder at all in the zip, but all the files directly.
Now with release 1.2 an above there is an easily installable  `StockDepthMaskConfig` folder.