### PR TITLE
Fix BuranEnergia install

### DIFF
--- a/NetKAN/BuranEnergia.netkan
+++ b/NetKAN/BuranEnergia.netkan
@@ -5,6 +5,10 @@ license: GPL-3.0
 tags:
   - parts
   - crewed
+depends:
+  - name: ModuleManager
 install:
-  - find: Buran Energia
+  - find: DECQ_ENERGIA
+    install_to: GameData
+  - find: Alcentar_Add-ons
     install_to: GameData

--- a/NetKAN/BuranEnergia.netkan
+++ b/NetKAN/BuranEnergia.netkan
@@ -5,8 +5,6 @@ license: GPL-3.0
 tags:
   - parts
   - crewed
-depends:
-  - name: ModuleManager
 install:
   - find: DECQ_ENERGIA
     install_to: GameData


### PR DESCRIPTION
This mod's folder structure changed in its latest release. The `Buran Energia` folder was replaced by two new folders, but there were no inflation errors because there's also a `RealismOverhaul/RO_SuggestedMods/Buran Energia` folder, which is being installed instead of the right folder.

Now we install the two folders that replaced the original one.