### PR TITLE
Vref for ModularPods, TDProps

### DIFF
--- a/NetKAN/ModularPods.netkan
+++ b/NetKAN/ModularPods.netkan
@@ -1,18 +1,14 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "ModularPods",
-    "$kref":        "#/ckan/spacedock/1017",
-    "license":      "CC-BY-SA-4.0",
-    "tags": [
-        "parts",
-        "crewed"
-    ],
-    "install": [ {
-        "find":       "ModPods",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "TDProps"       }
-    ]
-}
+spec_version: v1.4
+identifier: ModularPods
+$kref: '#/ckan/spacedock/1017'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-SA-4.0
+tags:
+  - parts
+  - crewed
+depends:
+  - name: ModuleManager
+  - name: TDProps
+install:
+  - find: ModPods
+    install_to: GameData

--- a/NetKAN/TDProps.netkan
+++ b/NetKAN/TDProps.netkan
@@ -1,16 +1,8 @@
-{
-    "spec_version": "v1.18",
-    "identifier":   "TDProps",
-    "$kref":        "#/ckan/spacedock/1546",
-    "license":      "MIT",
-    "tags": [
-        "library",
-        "crewed"
-    ],
-    "install": [ {
-        "find_regexp": "TDProps",
-        "install_to": "GameData",
-        "as": "TDProps",
-        "filter": [ ".git", ".gitattributes" ]
-    } ]
-}
+spec_version: v1.4
+identifier: TDProps
+$kref: '#/ckan/spacedock/1546'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - library
+  - crewed


### PR DESCRIPTION
#9026 just unfroze these.

![image](https://user-images.githubusercontent.com/1559108/157260693-afc4404e-7bbb-4911-b9ad-e427b4e4c040.png)

- `$vref`s are added
- YAMLized
- Default install stanza and lower spec version for `TDProps`