### PR TITLE
 Switch Rocket Sound Enhancment - Default repo, rename

### DIFF
--- a/NetKAN/RocketSoundEnhancement-Config-Default.netkan
+++ b/NetKAN/RocketSoundEnhancement-Config-Default.netkan
@@ -1,21 +1,16 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "RocketSoundEnhancement-Config-Default",
-    "name":         "Rocket Sound Enhancment - Default Configs",
-    "abstract":     "RSE sounds for stock engines, wheels, decouplers, and more",
-    "$kref":        "#/ckan/github/ensou04/RocketSoundEnhancement/asset_match/Configs",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "config",
-        "sound"
-    ],
-    "depends": [
-        { "name": "ModuleManager"          },
-        { "name": "RocketSoundEnhancement" }
-    ],
-    "install": [ {
-        "find":       "RocketSoundEnhancement",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.4
+identifier: RocketSoundEnhancement-Config-Default
+name: Rocket Sound Enhancment - Default
+abstract: RSE sounds for stock engines, wheels, decouplers, and more
+$kref: '#/ckan/github/ensou04/RocketSoundEnhancementDefault'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - config
+  - sound
+depends:
+  - name: ModuleManager
+  - name: RocketSoundEnhancement
+install:
+  - find: RocketSoundEnhancementDefault
+    install_to: GameData

--- a/NetKAN/RocketSoundEnhancement.netkan
+++ b/NetKAN/RocketSoundEnhancement.netkan
@@ -1,19 +1,13 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "RocketSoundEnhancement",
-    "abstract":     "Plugin for modders to add more detailed sound effects to the game, featuring a robust Layering System for use of multiple sounds",
-    "$kref":        "#/ckan/github/ensou04/RocketSoundEnhancement/asset_match/Plugin",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "sound"
-    ],
-    "recommends": [
-        { "name": "RocketSoundEnhancement-Config-Default" }
-    ],
-    "install": [ {
-        "find":       "RocketSoundEnhancement",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.4
+identifier: RocketSoundEnhancement
+abstract: >-
+  Plugin for modders to add more detailed sound effects to the game, featuring a
+  robust Layering System for use of multiple sounds
+$kref: '#/ckan/github/ensou04/RocketSoundEnhancement'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - sound
+recommends:
+  - name: RocketSoundEnhancement-Config-Default


### PR DESCRIPTION
The config module for RocketSoundEnhancement has been moved to its own repo.

- YAMLized both modules
- Pointed the config module to the new repo
- Removed the `asset_match`es that were stopping the current release from being indexed
- Removed "Configs" from the `name` as per author request
- Use default install stanza for RocketSoundEnhancement
- Update install stanza for config module to use new folder name

Fixes #9044.