### PR TITLE
Add TransferWindowPlanner - Fork

### DIFF
--- a/NetKAN/TransferWindowPlannerFork.netkan
+++ b/NetKAN/TransferWindowPlannerFork.netkan
@@ -4,15 +4,13 @@ name: Transfer Window Planner - Fork
 license: MIT
 $kref: '#/ckan/github/Nazfib/TransferWindowPlanner'
 $vref: '#/ckan/ksp-avc'
-install:
-  - find: TransferWindowPlanner
-    install_to: GameData/TriggerTech
+tags:
+  - plugin
+  - information
 recommends:
   - name: TriggerAu-Flags
 conflicts:
   - name: TransferWindowPlanner
-resources:
-  homepage: https://github.com/Nazfib/TransferWindowPlanner
-tags:
-  - plugin
-  - information
+install:
+  - find: TransferWindowPlanner
+    install_to: GameData/TriggerTech

--- a/NetKAN/TransferWindowPlannerFork.netkan
+++ b/NetKAN/TransferWindowPlannerFork.netkan
@@ -1,0 +1,18 @@
+spec_version: v1.4
+identifier: TransferWindowPlannerFork
+name: Transfer Window Planner - Fork
+license: MIT
+$kref: '#/ckan/github/Nazfib/TransferWindowPlanner'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: TransferWindowPlanner
+    install_to: GameData/TriggerTech
+recommends:
+  - name: TriggerAu-Flags
+conflicts:
+  - name: TransferWindowPlanner
+resources:
+  homepage: https://github.com/Nazfib/TransferWindowPlanner
+tags:
+  - plugin
+  - information

--- a/NetKAN/TransferWindowPlannerFork.netkan
+++ b/NetKAN/TransferWindowPlannerFork.netkan
@@ -4,6 +4,8 @@ name: Transfer Window Planner - Fork
 license: MIT
 $kref: '#/ckan/github/Nazfib/TransferWindowPlanner'
 $vref: '#/ckan/ksp-avc'
+resources:
+  homepage: https://discordapp.com/invite/ZGbR6nv
 tags:
   - plugin
   - information


### PR DESCRIPTION
I forked TWP to make it useful for transfers between planets that have non-zero inclination (by specifying which inclined parking orbit should be used). This is especially important in RSS, but also in stock it can reduce Δv requirements by several hundred m/s for some transfers. 
In the process, I updated it for 1.12.

It would be great to have on CKAN for easier installation, but I want it clear to users that it is a fork and not the original mod by TriggerAu.

Relates to Nazfib/TransferWindowPlanner#1.

___

https://github.com/Nazfib/TransferWindowPlanner