### PR TITLE
Update krefs for ValiZockt name change

### DIFF
--- a/NetKAN/RealFuels-Stock.netkan
+++ b/NetKAN/RealFuels-Stock.netkan
@@ -1,39 +1,31 @@
-{
-    "spec_version" : "v1.4",
-    "identifier"   : "RealFuels-Stock",
-    "name"         : "RealFuels-Stock",
-    "abstract"     : "Adds RealFuels configs to stock and many mods' engines, keeping engine role as designed to fit with stock and stock-aligned mods.",
-    "author"       : [ "Raptor831", "ValiZockt" ],
-    "license"      : "CC-BY-SA-4.0",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/194394-*"
-    },
-    "tags": [
-        "config",
-        "resources"
-    ],
-    "$kref": "#/ckan/github/ValiZockt/RealFuels-Stock",
-    "$vref": "#/ckan/ksp-avc",
-    "install": [
-        {
-            "find":       "RealFuels-Stock",
-            "install_to": "GameData"
-        }
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "RealFuels" }
-    ],
-    "provides" : [
-        "RealPlumeConfigs",
-        "RealFuels-Engine-Configs"
-    ],
-
-    "recommends": [
-        { "name": "RealPlume" }
-    ],
-    "conflicts": [
-        { "name": "RealPlume-StockConfigs" },
-        { "name": "RFStockalike" }
-    ]
-}
+spec_version: v1.4
+identifier: RealFuels-Stock
+name: RealFuels-Stock
+abstract: >-
+  Adds RealFuels configs to stock and many mods' engines, keeping engine role as
+  designed to fit with stock and stock-aligned mods.
+author:
+  - Raptor831
+  - ValentinBischof
+$kref: '#/ckan/github/ValentinBischof/RealFuels-Stock'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-SA-4.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/194394-*
+tags:
+  - config
+  - resources
+depends:
+  - name: ModuleManager
+  - name: RealFuels
+provides:
+  - RealPlumeConfigs
+  - RealFuels-Engine-Configs
+recommends:
+  - name: RealPlume
+conflicts:
+  - name: RealPlume-StockConfigs
+  - name: RFStockalike
+install:
+  - find: RealFuels-Stock
+    install_to: GameData

--- a/NetKAN/SmartDockingAid.netkan
+++ b/NetKAN/SmartDockingAid.netkan
@@ -1,19 +1,16 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "SmartDockingAid",
-    "name":         "Smart Docking Aid",
-    "abstract":     "Smart Docking Aid adds two new SAS modes to level 3 probe cores and level 3 pilots: Parallel- & Parallel+",
-    "$kref":        "#/ckan/github/ValiZockt/SmartDockingAid",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/197141-*"
-    },
-    "tags": [
-        "plugin",
-        "control"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ]
-}
+spec_version: v1.4
+identifier: SmartDockingAid
+name: Smart Docking Aid
+abstract: >-
+  Smart Docking Aid adds two new SAS modes to level 3 probe cores and level 3
+  pilots: Parallel- & Parallel+
+$kref: '#/ckan/github/ValentinBischof/SmartDockingAid'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/197141-*
+tags:
+  - plugin
+  - control
+depends:
+  - name: ModuleManager


### PR DESCRIPTION
See https://github.com/KSP-CKAN/CKAN-meta/compare/0191dd4b771bd9886ffeeea0189ecfaef1b31eac...1252839a77, ValiZockt is now @ValentinBischof. We have two netkans with the old name in the `$kref`, which are now updated so we are not at the mercy of GitHub's temperamental redirects.