### PR TITLE
Remove Singularity compat hard coding

### DIFF
--- a/NetKAN/Singularity.netkan
+++ b/NetKAN/Singularity.netkan
@@ -8,6 +8,6 @@ tags:
   - plugin
   - graphics
 x_netkan_override:
-  version: 0.991
-  override:
-    ksp_version_min: '1.8'
+  - version: 0.991
+    override:
+      ksp_version_min: '1.8'

--- a/NetKAN/Singularity.netkan
+++ b/NetKAN/Singularity.netkan
@@ -1,15 +1,13 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "Singularity",
-    "$kref":        "#/ckan/spacedock/2420",
-    "ksp_version_min": "1.8",
-    "ksp_version_max": "1.9",
-    "license":      "MIT",
-    "resources": {
-        "manual": "https://github.com/LGhassen/Singularity/wiki"
-    },
-    "tags": [
-        "plugin",
-        "graphics"
-    ]
-}
+spec_version: v1.4
+identifier: Singularity
+$kref: '#/ckan/spacedock/2420'
+license: MIT
+resources:
+  manual: https://github.com/LGhassen/Singularity/wiki
+tags:
+  - plugin
+  - graphics
+x_netkan_override:
+  version: 0.991
+  override:
+    ksp_version_min: '1.8'


### PR DESCRIPTION
Singularity was set up with hard coded compatibility in #7885 because SpaceDock didn't match the forum thread.
Now this is replaced by a min compat override for the latest version.

https://spacedock.info/mod/2420/Singularity

Closes KSP-CKAN/CKAN-meta#2633.