### PR TITLE
Install BoosterGuidance crafts in Ships

### DIFF
--- a/NetKAN/BoosterGuidance.netkan
+++ b/NetKAN/BoosterGuidance.netkan
@@ -1,17 +1,19 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "BoosterGuidance",
-    "$kref":        "#/ckan/spacedock/3018",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "control"
-    ],
-    "depends": [
-        { "name": "ModuleManager"       },
-        { "name": "SpaceTuxLibrary"     },
-        { "name": "ToolbarController"   },
-        { "name": "ClickThroughBlocker" }
-    ]
-}
+spec_version: v1.4
+identifier: BoosterGuidance
+$kref: '#/ckan/spacedock/3018'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - control
+depends:
+  - name: ModuleManager
+  - name: SpaceTuxLibrary
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: BoosterGuidance
+    install_to: GameData
+    filter: Ships
+  - find: Ships/VAB
+    install_to: Ships


### PR DESCRIPTION
A warning was missed in #9077:

https://github.com/KSP-CKAN/NetKAN/pull/9077/checks

![image](https://user-images.githubusercontent.com/1559108/163811847-02fc206c-68d9-4b3c-8057-a872495d8c81.png)

Now the crafts are installed to `Ships/VAB`.