### PR TITLE
Add KerbolsHumbleNeighboringStars and VertexMitchellNetravaliHeightMap

### DIFF
--- a/NetKAN/KerbolsHumbleNeighboringStars.netkan
+++ b/NetKAN/KerbolsHumbleNeighboringStars.netkan
@@ -1,0 +1,23 @@
+spec_version: v1.18
+identifier: KerbolsHumbleNeighboringStars
+$kref: '#/ckan/github/parkerman-com/KHNS'
+author: 'An Amongus Sussy Player'
+ksp_version_min: '1.10'
+license: restricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/207835-*/
+tags:
+  - plugin
+  - config
+  - planet-pack
+depends:
+  - name: Kopernicus
+  - name: ModuleManager
+  - name: VertexMitchellNetravaliHeightMap
+recommends:
+  - name: EnvironmentalVisualEnhancements
+suggests:
+  - name: Scatterer
+install:
+  - find: KHNS
+    install_to: GameData

--- a/NetKAN/VertexMitchellNetravaliHeightMap.netkan
+++ b/NetKAN/VertexMitchellNetravaliHeightMap.netkan
@@ -1,0 +1,17 @@
+spec_version: v1.18
+identifier: VertexMitchellNetravaliHeightMap
+name: Vertex Mitchell-Netravali Filtered Heightmap
+$kref: '#/ckan/github/pkmniako/Kopernicus_VertexMitchellNetravaliHeightMap'
+ksp_version: '1.12'
+license: MIT
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/207768-*/
+tags:
+  - plugin
+  - library
+  - graphics
+depends:
+  - name: Kopernicus
+install:
+  - find: MitchellNetravali
+    install_to: GameData/000_NiakoUtils


### PR DESCRIPTION
Adding KHNS has been requested by the author, and adding the dependency has been okayed by its author (Niako, on Discord seen as "Duck Trademark")

<details>

![discord](https://user-images.githubusercontent.com/28812678/164893782-ca4108dc-862d-4544-bbe1-950719fc6e6d.png)
</details>

KHNS bundles some Scatterer configs, but they are only for the new planets so no `provides` required.
We'll likely have to epoch once this mod is out of alpha due to the `Alpha-` prefix for all existing releases.


Links:
- https://forum.kerbalspaceprogram.com/index.php?/topic/207835-khns-kerbols-humble-neighboring-stars/
- https://forum.kerbalspaceprogram.com/index.php?/topic/207768-112-niakos-kopernicus-utilities-smoother-heightmaps/
- https://github.com/parkerman-com/KHNS
- https://github.com/parkerman-com/KHNS/releases
- https://github.com/pkmniako/Kopernicus_VertexMitchellNetravaliHeightMap
- https://github.com/pkmniako/Kopernicus_VertexMitchellNetravaliHeightMap/releases