### PR TITLE
force_v for OblivionAerospace

### DIFF
--- a/NetKAN/OblivionAerospace.netkan
+++ b/NetKAN/OblivionAerospace.netkan
@@ -5,6 +5,7 @@ author:
   - zer0Kerbal
 $kref: '#/ckan/spacedock/3002'
 $vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
 license: CC-BY-SA
 tags:
   - parts


### PR DESCRIPTION
All previous versions of this mod started with a `v`, latest adoption dropped it, see KSP-CKAN/CKAN-meta#2690.

Now `x_netkan_force_v` is set to add the `v` instead of epoching.

Closes KSP-CKAN/CKAN-meta#2690.