### PR TITLE
Limit CraftManager compatibility to KSP 1.8-1.9

### DIFF
--- a/NetKAN/CraftManager.netkan
+++ b/NetKAN/CraftManager.netkan
@@ -6,9 +6,9 @@
     "license"      : "CC-BY-4.0",
     "abstract"     : "Craft Manager is a replacement for the stock craft list in the editors that adds a bunch features the stock list lacks and opens much faster.\nSearch, Sort and Organize your craft, view and load craft from any save, move/copy them between saves, transfer them between editors, load your subassemblies in the same interface.\nCraft can be tagged with custom tags which you can manually assign. Tags can also be given a rule so they also auto associate with craft.",
     "ksp_version_min": "1.8",
+    "ksp_version_max": "1.9",
     "resources": {
         "homepage"  : "https://KerbalX.com/CraftManager",
-        "bugtracker": "https://github.com/Sujimichi/CraftManager/issues",
         "repository": "https://github.com/Sujimichi/CraftManager"
     },
     "tags": [


### PR DESCRIPTION
Forum thread says KSP 1.3-1.9:
https://forum.kerbalspaceprogram.com/index.php?/topic/174596-13x-19x-craft-manager%C2%A0-search-sort-tag-share-your-craft/
![image](https://user-images.githubusercontent.com/28812678/167297586-231a11e1-7aa9-4041-8595-36b47ff72be6.png)

1.3 - 1.7 are covered by earlier releases:
![image](https://user-images.githubusercontent.com/28812678/167297632-27981690-ba32-4075-b0f6-1612fea31340.png)

So the latest one is 1.8-1.9 only.
