### PR TITLE
Add TweakScale-Redist, filter DLL from IR and FAR

### DIFF
--- a/NetKAN/FerramAerospaceResearchContinued.netkan
+++ b/NetKAN/FerramAerospaceResearchContinued.netkan
@@ -20,13 +20,14 @@
     "conflicts" : [ { "name" : "AerodynamicModel" } ],
     "depends" : [
         { "name" : "ModuleManager" },
-        { "name" : "ModularFlightIntegrator" }
+        { "name" : "ModularFlightIntegrator" },
+        { "name" : "TweakScale-Redist" }
     ],
     "install" : [
         {
             "file"       : "GameData/FerramAerospaceResearch",
             "install_to" : "GameData",
-            "filter"     : "config.xml"
+            "filter"     : [ "config.xml", "Scale_Redist.dll" ]
         },
         {
             "file"        : "Ships",

--- a/NetKAN/InfernalRoboticsNext.netkan
+++ b/NetKAN/InfernalRoboticsNext.netkan
@@ -21,14 +21,16 @@
         { "name": "KerbalJointReinforcement" }
     ],
     "depends": [
-        { "name": "ModuleManager" }
+        { "name": "ModuleManager" },
+        { "name": "TweakScale-Redist" }
     ],
     "recommends"     : [
         { "name": "KerbalJointReinforcementNext" }
     ],
     "install"        : [ {
         "file"       : "GameData/MagicSmokeIndustries",
-        "install_to" : "GameData"
+        "install_to" : "GameData",
+        "filter"     : "Scale_Redist.dll"
     } ],
     "x_netkan_override": [ {
         "version": "v3.0.0",

--- a/NetKAN/InfernalRoboticsNext.netkan
+++ b/NetKAN/InfernalRoboticsNext.netkan
@@ -21,7 +21,7 @@
         { "name": "KerbalJointReinforcement" }
     ],
     "depends": [
-        { "name": "ModuleManager" },
+        { "name": "ModuleManager"     },
         { "name": "TweakScale-Redist" }
     ],
     "recommends"     : [

--- a/NetKAN/InfernalRoboticsRealismOverhaul.netkan
+++ b/NetKAN/InfernalRoboticsRealismOverhaul.netkan
@@ -17,12 +17,12 @@
         { "name": "InfernalRobotics-LegacyParts" }
     ],
     "depends": [
-        { "name": "ModuleManager" },
+        { "name": "ModuleManager"     },
         { "name": "TweakScale-Redist" }
     ],
     "install": [ {
         "find":       "MagicSmokeIndustries",
         "install_to": "GameData",
-        "filter"     : "Scale_Redist.dll"
+        "filter":     "Scale_Redist.dll"
     } ]
 }

--- a/NetKAN/InfernalRoboticsRealismOverhaul.netkan
+++ b/NetKAN/InfernalRoboticsRealismOverhaul.netkan
@@ -17,10 +17,12 @@
         { "name": "InfernalRobotics-LegacyParts" }
     ],
     "depends": [
-        { "name": "ModuleManager" }
+        { "name": "ModuleManager" },
+        { "name": "TweakScale-Redist" }
     ],
     "install": [ {
         "find":       "MagicSmokeIndustries",
-        "install_to": "GameData"
+        "install_to": "GameData",
+        "filter"     : "Scale_Redist.dll"
     } ]
 }

--- a/NetKAN/TweakScale-Redist.netkan
+++ b/NetKAN/TweakScale-Redist.netkan
@@ -1,0 +1,20 @@
+spec_version: v1.8
+identifier: TweakScale-Redist
+name: TweakScale Redistributable
+abstract: A library for other mods to integrate with TweakScale
+author:
+  - Biotronic
+  - pellinor
+  - LisiasT
+$kref: '#/ckan/spacedock/127'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+license:
+  - WTFPL
+release_status: stable
+tags:
+  - plugin
+  - library
+install:
+  - file: GameData/999_Scale_Redist.dll
+    install_to: GameData

--- a/NetKAN/TweakScale-Redist.netkan
+++ b/NetKAN/TweakScale-Redist.netkan
@@ -1,7 +1,7 @@
 spec_version: v1.8
 identifier: TweakScale-Redist
 name: TweakScale Redistributable
-abstract: A library for other mods to integrate with TweakScale
+abstract: A library for other mods to integrate with TweakScale. Does not provide the actual TweakScale features.
 author:
   - Biotronic
   - pellinor

--- a/NetKAN/TweakScale-Redist.netkan
+++ b/NetKAN/TweakScale-Redist.netkan
@@ -7,7 +7,7 @@ author:
   - pellinor
   - LisiasT
 $kref: '#/ckan/spacedock/127'
-$vref: '#/ckan/ksp-avc'
+$vref: '#/ckan/ksp-avc/GameData/TweakScale/TweakScale.version'
 x_netkan_force_v: true
 license:
   - WTFPL

--- a/NetKAN/TweakScale.netkan
+++ b/NetKAN/TweakScale.netkan
@@ -21,11 +21,10 @@ tags:
   - plugin
   - convenience
 install:
-  - file: GameData/999_Scale_Redist.dll
-    install_to: GameData
   - file: GameData/TweakScale
     install_to: GameData
 depends:
+  - name: TweakScale-Redist
   - name: ModuleManager
     min_version: 2.7.1
   - name: KSP-Recall


### PR DESCRIPTION
## Problem
See #9108, while the `Scale_Redist.dll` was [initially supposed to be redistributed by all mods](https://forum.kerbalspaceprogram.com/index.php?/topic/179030-ksp-130-tweakscale-under-lisias-management-24612-2022-0429/&do=findComment&comment=3686252) that need it (to integrate with TweakScale), this [has changed recently](https://forum.kerbalspaceprogram.com/index.php?/topic/179445-18-112-ferram-aerospace-research-continued-v01605-mader-030422/&do=findComment&comment=4100878), likely as a response to KSP 1.12.0-2's crash on duplicate DLLs bug.
![](https://cdn.discordapp.com/attachments/295199794102796288/962768597766270996/unknown.png)

## Solution
Now we split the `999_Scale_Redist.dll` into a separate module `TweakScale-Redist`.
TweakScale itself, InfernatRoboticsRealismOverhaul, InfernalRoboticsNext and FerramAerospaceResearchContinued have been updated to filter the `Scale_Redist.dll` and depend on TweakScale-Redist.

I couldn't find any other budlers looking through `dep:TweakScale`, `rec:TweakScale`, `sug:TweakScale`. We have to wait for user reports to find all of them.

According to the [README](https://github.com/net-lisias-ksp/TweakScale#license) the redist is licensed WTFPL.

Fixes #9108 