### PR TITLE
Update SpaceDustUnbound's relationships

### DIFF
--- a/NetKAN/SpaceDustUnbound.netkan
+++ b/NetKAN/SpaceDustUnbound.netkan
@@ -10,6 +10,7 @@ depends:
   - name: SpaceDust
   - name: CommunityResourcePack
 recommends:
-  - name: GalaxiesUnbound
+  - name: GalaxiesUnbound-Core
   - name: OuterPlanetsMod
+suggests:
   - name: BlueShift


### PR DESCRIPTION
#9117 requested the GalaxiesUnbound recommendation to be changed to GalaxiesUnbound-Core (which we should have done in #8996) and BlueShift to be suggested instead of recommended. This is now done.

Fixes #9117.