### PR TITLE
Remove FoxDefenseContracts install workarounds

### DIFF
--- a/NetKAN/FoxDefenseContracts.netkan
+++ b/NetKAN/FoxDefenseContracts.netkan
@@ -11,8 +11,9 @@ depends:
 install:
   - find: FoxDefenseContracts
     install_to: GameData
-    filter_regexp:
-      - \.git
-      - FoxDefenseContracts/FoxDefenseContracts
-  - find: FoxDefenseContracts/FoxDefenseContracts
+  - find: FDC_Armor
     install_to: GameData
+  - file: GameData/Changelog.txt
+    install_to: GameData/FoxDefenseContracts
+  - file: GameData/README.md
+    install_to: GameData/FoxDefenseContracts


### PR DESCRIPTION
## Problem

![image](https://user-images.githubusercontent.com/1559108/168312641-a8457127-27ce-42e5-8552-745d3f8d53ae.png)

## Cause

In #9123 we updated the `install` property for this mod to compensate for some problems with how the previous release was packaged. After reporting these problems on the forum, the author pretty quickly uploaded a fixed version, which doesn't have all the paths we were picking out of the broken one.

## Changes

Now the `install` is redone based on the latest upload.

___

ckan compat add 1.9