### PR TITLE
Move Scatterer to dependencies of KHNS

### DIFF
--- a/NetKAN/KerbolsHumbleNeighboringStars.netkan
+++ b/NetKAN/KerbolsHumbleNeighboringStars.netkan
@@ -13,11 +13,10 @@ tags:
 depends:
   - name: Kopernicus
   - name: ModuleManager
+  - name: Scatterer
   - name: VertexMitchellNetravaliHeightMap
 recommends:
   - name: EnvironmentalVisualEnhancements
-suggests:
-  - name: Scatterer
 install:
   - find: KHNS
     install_to: GameData


### PR DESCRIPTION
The author pinged me on Discord that with the [latest update](https://github.com/parkerman-com/KHNS/releases/tag/Beta-1.1) Scatterer is now a hard dependency.