### PR TITLE
KHNS ships with a full Scatterer config & sunflare, provide them

### DIFF
--- a/NetKAN/KerbolsHumbleNeighboringStars.netkan
+++ b/NetKAN/KerbolsHumbleNeighboringStars.netkan
@@ -10,6 +10,9 @@ tags:
   - plugin
   - config
   - planet-pack
+provides:
+  - Scatterer-config
+  - Scatterer-sunflare
 depends:
   - name: Kopernicus
   - name: ModuleManager


### PR DESCRIPTION
#9127 added the Scatterer dependency to KHNS, but apparently it's one of the rare planet mods that ship a full Scatterer config instead of modifying it with a ModuleManager patch.
Now it provides `Scatterer-config` and `Scatterer-sunflare` so it doesn't pull in the default ones.