### PR TITLE
Update PRVE Scatterer dependency version

### DIFF
--- a/NetKAN/PhotoRealisticVisualEnhancement.netkan
+++ b/NetKAN/PhotoRealisticVisualEnhancement.netkan
@@ -13,9 +13,9 @@ conflicts:
 depends:
   - name: ModuleManager
   - name: Scatterer-config
-    version: 3:v0.0772
+    version: 3:v0.0835
   - name: Scatterer
-    version: 3:v0.0772
+    version: 3:v0.0835
   - name: EnvironmentalVisualEnhancements
   - name: Kopernicus
   - name: RealSolarSystem


### PR DESCRIPTION
The latest version of this mod is updated for compatibility with the latest Scatterer versions, so now the dependencies are updated.

Fixes #9131.