### PR TITLE
Vref for StarshipLaunchExpansion, fix rec

### DIFF
--- a/NetKAN/StarshipLaunchExpansion.netkan
+++ b/NetKAN/StarshipLaunchExpansion.netkan
@@ -1,6 +1,7 @@
 spec_version: v1.4
 identifier: StarshipLaunchExpansion
 $kref: '#/ckan/spacedock/2814'
+$vref: '#/ckan/ksp-avc'
 license: MIT
 tags:
   - parts
@@ -8,6 +9,6 @@ depends:
   - name: ModuleManager
   - name: B9PartSwitch
 recommends:
-  - name: StarshipLaunchExpansion
+  - name: StarshipExpansionProject
   - name: HangarExtender
   - name: KerbalKonstructs


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/171433205-93dadeb6-7092-405d-a365-e88e44b1454d.png)

Also this mod is recommending itself.

Now a vref is added and it recommends StarshipExpansionProject as it should have in #8662.