### PR TITLE
Filter game DLLs from RocketEmporium

### DIFF
--- a/NetKAN/RocketEmporium.netkan
+++ b/NetKAN/RocketEmporium.netkan
@@ -1,4 +1,4 @@
-spec_version: v1.4
+spec_version: v1.10
 identifier: RocketEmporium
 $kref: '#/ckan/github/KSPKatten/RocketEmporium'
 $vref: '#/ckan/ksp-avc'


### PR DESCRIPTION
While the bot was generating KSP-CKAN/CKAN-meta#2747 thanks to a random GitHub glitch, it pointed out a mod packaging problem:

![image](https://user-images.githubusercontent.com/1559108/171442214-493415c7-9ee9-4b93-b086-782e70e8a8a9.png)

Those "extra" files are DLLs from the game that aren't supposed to be there. This was reported by a user and confirmed by the author 2.5 years ago (but not fixed):

![image](https://user-images.githubusercontent.com/1559108/171442455-d8ed2e50-f5da-42a6-8027-548cc56561bf.png)

Now those files won't be installed by CKAN.
