### PR TITLE
De-meta UmbraSpaceIndustries mods

### DIFF
--- a/NetKAN/AlcubierreStandalone.netkan
+++ b/NetKAN/AlcubierreStandalone.netkan
@@ -1,9 +1,23 @@
-{
-    "spec_version" : "v1.16",
-    "identifier" : "AlcubierreStandalone",
-    "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/UmbraSpaceIndustries/CKAN/master/AlcubierreStandalone.netkan",
-    "x_netkan_license_ok": true,
-    "tags": [
-        "parts"
-    ]
-}
+spec_version: v1.4
+identifier: AlcubierreStandalone
+name: Alcubierre Warp Drive (Stand-alone)
+abstract: >-
+  The Alcubierre drive works by moving space around your ship, not through
+  acceleration.
+author: RoverDude
+$kref: '#/ckan/github/UmbraSpaceIndustries/WarpDrive'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/90899-*
+  manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/
+tags:
+  - parts
+conflicts:
+  - name: SETI-CommunityTechTree
+depends:
+  - name: ModuleManager
+install:
+  - find: UmbraSpaceIndustries/WarpDrive
+    install_to: GameData/UmbraSpaceIndustries

--- a/NetKAN/CommunityCategoryKit.netkan
+++ b/NetKAN/CommunityCategoryKit.netkan
@@ -1,11 +1,16 @@
-{
-    "spec_version" : "v1.16",
-    "identifier" : "CommunityCategoryKit",
-    "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/UmbraSpaceIndustries/CKAN/master/CommunityCategoryKit.netkan",
-    "x_netkan_license_ok": true,
-    "tags": [
-        "plugin",
-        "config",
-        "convenience"
-    ]
-}
+spec_version: 1
+identifier: CommunityCategoryKit
+name: Community Category Kit
+abstract: Common parts categories for KSP mods
+author: RoverDude
+$kref: '#/ckan/github/UmbraSpaceIndustries/CommunityCategoryKit'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/149840-*
+  manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/
+tags:
+  - plugin
+  - config
+  - convenience

--- a/NetKAN/CommunityResourcePack.netkan
+++ b/NetKAN/CommunityResourcePack.netkan
@@ -1,12 +1,18 @@
-
-    {
-        "spec_version" : "v1.16",
-        "identifier" : "CommunityResourcePack",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/UmbraSpaceIndustries/CKAN/master/CommunityResourcePack.netkan",
-        "tags": [
-            "config",
-            "library",
-            "resources"
-        ],
-        "x_netkan_license_ok": true
-    }
+spec_version: 1
+identifier: CommunityResourcePack
+name: Community Resource Pack
+abstract: Common resources for KSP mods
+author: RoverDude
+$kref: '#/ckan/github/UmbraSpaceIndustries/CommunityResourcePack'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/83007-*
+  manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/
+tags:
+  - config
+  - library
+  - resources
+depends:
+  - name: ModuleManager

--- a/NetKAN/CommunityResourcePack.netkan
+++ b/NetKAN/CommunityResourcePack.netkan
@@ -14,5 +14,3 @@ tags:
   - config
   - library
   - resources
-depends:
-  - name: ModuleManager

--- a/NetKAN/Karbonite.netkan
+++ b/NetKAN/Karbonite.netkan
@@ -1,10 +1,49 @@
-{
-    "spec_version": "v1.16",
-    "identifier": "Karbonite",
-    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/UmbraSpaceIndustries/CKAN/master/Karbonite.netkan",
-    "x_netkan_license_ok": true,
-    "tags": [
-        "parts",
-        "resources"
-    ]
-}
+spec_version: v1.4
+identifier: Karbonite
+name: Karbonite
+abstract: >-
+  A newly discovered mineral that has hydrocarbon-like properties and is perfect
+  for processing into a fuel. It's easily mined from the surface, and can be
+  found in liquid or gaseous forms on certain planets.
+comment: This may be renamed to USI-Karbonite in the future
+author: RoverDude
+$kref: '#/ckan/github/UmbraSpaceIndustries/Karbonite'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: '1'
+license: restricted
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/83948-*
+  manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/
+tags:
+  - parts
+  - resources
+depends:
+  - name: FirespitterCore
+    min_version: v7.6.0
+  - name: ModuleManager
+    min_version: 2.8.0
+  - name: USITools
+    min_version: 0.9.0.0
+  - name: CommunityResourcePack
+    min_version: 0.7.0.0
+  - name: USI-Core
+    min_version: 0.4.0.0
+suggests:
+  - name: TextureReplacer
+provides:
+  - USI-Karbonite
+conflicts:
+  - name: SETI-CommunityTechTree
+install:
+  - find: UmbraSpaceIndustries/Karbonite
+    install_to: GameData/UmbraSpaceIndustries
+  - find: UmbraSpaceIndustries/KarbonitePlus
+    install_to: GameData/UmbraSpaceIndustries
+x_netkan_override:
+  - version: 0.6.2
+    delete:
+      - ksp_version
+    override:
+      ksp_version_min: 1.0.2
+      ksp_version_max: 1.0.4

--- a/NetKAN/Konstruction.netkan
+++ b/NetKAN/Konstruction.netkan
@@ -1,7 +1,8 @@
-spec_version: 1
+spec_version: v1.2
 identifier: Konstruction
 name: Konstruction
-abstract: Weldable docking ports, cranes, magnets, and other construction equipment!
+abstract: >-
+  Weldable docking ports, cranes, magnets, and other construction equipment!
 author: RoverDude
 $kref: '#/ckan/github/UmbraSpaceIndustries/Konstruction'
 $vref: '#/ckan/ksp-avc'

--- a/NetKAN/Konstruction.netkan
+++ b/NetKAN/Konstruction.netkan
@@ -1,9 +1,28 @@
-{
-    "spec_version" : "v1.16",
-    "identifier" : "Konstruction",
-    "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/UmbraSpaceIndustries/CKAN/master/Konstruction.netkan",
-    "x_netkan_license_ok": true,
-    "tags": [
-        "parts"
-    ]
-}
+spec_version: 1
+identifier: Konstruction
+name: Konstruction
+abstract: Weldable docking ports, cranes, magnets, and other construction equipment!
+author: RoverDude
+$kref: '#/ckan/github/UmbraSpaceIndustries/Konstruction'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/149233-*
+  manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+    min_version: 2.8.0
+  - name: USITools
+    min_version: 0.9.0.0
+  - name: CommunityResourcePack
+    min_version: 0.7.0.0
+conflicts:
+  - name: SETI-CommunityTechTree
+install:
+  - file: GameData/UmbraSpaceIndustries/Akita
+    install_to: GameData/UmbraSpaceIndustries
+  - file: GameData/UmbraSpaceIndustries/Konstruction
+    install_to: GameData/UmbraSpaceIndustries

--- a/NetKAN/MalemuteRover.netkan
+++ b/NetKAN/MalemuteRover.netkan
@@ -1,11 +1,32 @@
-{
-    "spec_version": "v1.16",
-    "identifier": "MalemuteRover",
-    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/UmbraSpaceIndustries/CKAN/master/MalemuteRover.netkan",
-    "x_netkan_license_ok": true,
-    "tags": [
-        "parts",
-        "crewed",
-        "science"
-    ]
-}
+spec_version: v1.4
+identifier: MalemuteRover
+name: Malemute Rover
+abstract: A 1.25m rover platform for exploration and science collecting!
+author: RoverDude
+$kref: '#/ckan/github/UmbraSpaceIndustries/Malemute'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/139668-*
+  manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/
+tags:
+  - parts
+  - crewed
+  - science
+depends:
+  - name: FirespitterCore
+    min_version: v7.6.0
+  - name: ModuleManager
+    min_version: 2.8.0
+  - name: USITools
+    min_version: 0.9.0.0
+  - name: CommunityResourcePack
+    min_version: 0.7.0.0
+  - name: CommunityCategoryKit
+    min_version: 2.0.0.0
+conflicts:
+  - name: SETI-CommunityTechTree
+install:
+  - find: UmbraSpaceIndustries/Malemute
+    install_to: GameData/UmbraSpaceIndustries

--- a/NetKAN/SoundingRockets.netkan
+++ b/NetKAN/SoundingRockets.netkan
@@ -1,4 +1,4 @@
-spec_version: 1
+spec_version: v1.2
 identifier: SoundingRockets
 name: Sounding Rockets!
 abstract: Adds a series of low tech sounding rockets to the 'start' node.

--- a/NetKAN/SoundingRockets.netkan
+++ b/NetKAN/SoundingRockets.netkan
@@ -1,9 +1,23 @@
-{
-    "spec_version": "v1.16",
-    "identifier": "SoundingRockets",
-    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/UmbraSpaceIndustries/CKAN/master/SoundingRockets.netkan",
-    "x_netkan_license_ok": true,
-    "tags": [
-        "parts"
-    ]
-}
+spec_version: 1
+identifier: SoundingRockets
+name: Sounding Rockets!
+abstract: Adds a series of low tech sounding rockets to the 'start' node.
+author: RoverDude
+$kref: '#/ckan/github/UmbraSpaceIndustries/SoundingRockets'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/92434-*
+  manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+  - name: USITools
+    min_version: 0.9.0.0
+conflicts:
+  - name: SETI-CommunityTechTree
+install:
+  - file: GameData/UmbraSpaceIndustries/SoundingRockets
+    install_to: GameData/UmbraSpaceIndustries

--- a/NetKAN/UKS.netkan
+++ b/NetKAN/UKS.netkan
@@ -1,11 +1,58 @@
-{
-    "spec_version" : "v1.16",
-    "identifier" : "UKS",
-    "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/UmbraSpaceIndustries/CKAN/master/UKS.netkan",
-    "x_netkan_license_ok": true,
-    "tags": [
-        "plugin",
-        "parts",
-        "crewed"
-    ]
-}
+spec_version: v1.4
+identifier: UKS
+author: RoverDude
+name: USI Kolonization Systems (MKS/OKS)
+abstract: >-
+  A series of interlocking modules for building long-term, self sustaining
+  colonies in orbit and on other planets and moons.
+description: >-
+  MKS introduces a series of parts specifically designed to provide
+  self-sustaining life support for your Kerbals. While the parts will function
+  without a life support mod, the design is centered around providing an
+  appropriate challenge where players will weigh the costs, risks, and rewards
+  of supplying missions exclusively with carried life support supplies, or in
+  making the investment in a permanent colony. That being said, this is not just
+  a single greenhouse part (although food production is part of the mod).
+  Rather, it brings an entire colonization end-game to KSP in a fun and
+  challenging way.
+$kref: '#/ckan/github/UmbraSpaceIndustries/MKS'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: '1'
+license: restricted
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/154587-*
+  manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/
+tags:
+  - plugin
+  - parts
+  - crewed
+provides:
+  - MKS
+depends:
+  - name: FirespitterCore
+    min_version: v7.6.0
+  - name: ModuleManager
+    min_version: 2.8.0
+  - name: USITools
+    min_version: 0.9.0.0
+  - name: CommunityResourcePack
+    min_version: 0.7.0.0
+  - name: CommunityCategoryKit
+    min_version: 2.0.0.0
+  - name: USI-Core
+    min_version: 0.4.0.0
+  - name: Konstruction
+    min_version: 0.2.0.0
+suggests:
+  - name: USI-LS
+    min_version: 0.6.0.0
+conflicts:
+  - name: SETI-CommunityTechTree
+install:
+  - find: UmbraSpaceIndustries/MKS
+    install_to: GameData/UmbraSpaceIndustries
+  - find: UmbraSpaceIndustries/Karibou
+    install_to: GameData/UmbraSpaceIndustries
+  - find: UmbraSpaceIndustries/WOLF
+    install_to: GameData/UmbraSpaceIndustries

--- a/NetKAN/USI-ART.netkan
+++ b/NetKAN/USI-ART.netkan
@@ -1,10 +1,34 @@
-{
-    "spec_version": "v1.16",
-    "identifier": "USI-ART",
-    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/UmbraSpaceIndustries/CKAN/master/USI-ART.netkan",
-    "x_netkan_license_ok": true,
-    "tags": [
-        "parts",
-        "resources"
-    ]
-}
+spec_version: v1.4
+identifier: USI-ART
+name: USI Asteroid Recycling Technologies
+abstract: >-
+  Allows you to remove asteroid mass and attach multiple reconfigurable storage
+  tanks to the asteroid's surface.
+author: RoverDude
+$kref: '#/ckan/github/UmbraSpaceIndustries/ART'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: '1'
+license: restricted
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/82809-*
+  manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/
+tags:
+  - parts
+  - resources
+depends:
+  - name: FirespitterCore
+    min_version: v7.6.0
+  - name: ModuleManager
+    min_version: 2.8.0
+  - name: USITools
+    min_version: 0.9.0.0
+  - name: CommunityResourcePack
+    min_version: 0.7.0.0
+  - name: USI-Core
+    min_version: 0.4.0.0
+conflicts:
+  - name: SETI-CommunityTechTree
+install:
+  - find: UmbraSpaceIndustries/ART
+    install_to: GameData/UmbraSpaceIndustries

--- a/NetKAN/USI-Core.netkan
+++ b/NetKAN/USI-Core.netkan
@@ -1,9 +1,31 @@
-{
-    "spec_version" : "v1.16",
-    "identifier" : "USI-Core",
-    "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/UmbraSpaceIndustries/CKAN/master/USI-Core.netkan",
-    "x_netkan_license_ok": true,
-    "tags": [
-        "parts"
-    ]
-}
+spec_version: 1
+identifier: USI-Core
+name: USI Core
+abstract: Kontainers, Reactors and shared tools for USI mods
+author: RoverDude
+$kref: '#/ckan/github/UmbraSpaceIndustries/USI_Core'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/122420-*
+  manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/
+tags:
+  - parts
+depends:
+  - name: FirespitterCore
+    min_version: v7.6.0
+  - name: ModuleManager
+    min_version: 2.8.0
+  - name: USITools
+    min_version: 0.9.0.0
+  - name: CommunityResourcePack
+    min_version: 0.7.0.0
+conflicts:
+  - name: SETI-CommunityTechTree
+install:
+  - file: GameData/UmbraSpaceIndustries
+    install_to: GameData
+    filter:
+      - FX
+      - Konstruction

--- a/NetKAN/USI-EXP.netkan
+++ b/NetKAN/USI-EXP.netkan
@@ -1,9 +1,32 @@
-{
-    "spec_version": "v1.16",
-    "identifier": "USI-EXP",
-    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/UmbraSpaceIndustries/CKAN/master/USI-EXP.netkan",
-    "x_netkan_license_ok": true,
-    "tags": [
-        "parts"
-    ]
-}
+spec_version: v1.4
+identifier: USI-EXP
+name: USI Exploration Pack
+abstract: PackRat Rover and parts geared towards planetary exploration
+author: RoverDude
+$kref: '#/ckan/github/UmbraSpaceIndustries/ExplorationPack'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/78242-*
+  manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/
+tags:
+  - parts
+depends:
+  - name: FirespitterCore
+    min_version: v7.6.0
+  - name: ModuleManager
+    min_version: 2.8.0
+  - name: USITools
+    min_version: 0.9.0.0
+  - name: CommunityResourcePack
+    min_version: 0.7.0.0
+conflicts:
+  - name: SETI-CommunityTechTree
+install:
+  - find: UmbraSpaceIndustries/ExpPack
+    install_to: GameData/UmbraSpaceIndustries
+  - find: UmbraSpaceIndustries/SrvPack
+    install_to: GameData/UmbraSpaceIndustries
+  - find: UmbraSpaceIndustries/SubPack/Otter
+    install_to: GameData/UmbraSpaceIndustries/SubPack

--- a/NetKAN/USI-FTT.netkan
+++ b/NetKAN/USI-FTT.netkan
@@ -1,9 +1,32 @@
-{
-    "spec_version" : "v1.16",
-    "identifier" : "USI-FTT",
-    "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/UmbraSpaceIndustries/CKAN/master/USI-FTT.netkan",
-    "x_netkan_license_ok": true,
-    "tags": [
-        "parts"
-    ]
-}
+spec_version: v1.4
+identifier: USI-FTT
+name: USI Freight Transport Technologies
+abstract: >-
+  A series of modular parts for all of your hauling, mining, and exploration
+  needs!
+author: RoverDude
+$kref: '#/ckan/github/UmbraSpaceIndustries/FTT'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/82730-*
+  manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/
+tags:
+  - parts
+depends:
+  - name: FirespitterCore
+    min_version: v7.6.0
+  - name: ModuleManager
+    min_version: 2.8.0
+  - name: USITools
+    min_version: 0.9.0.0
+  - name: CommunityResourcePack
+    min_version: 0.7.0.0
+  - name: USI-Core
+    min_version: 0.4.0.0
+conflicts:
+  - name: SETI-CommunityTechTree
+install:
+  - find: UmbraSpaceIndustries/FTT
+    install_to: GameData/UmbraSpaceIndustries

--- a/NetKAN/USI-LS.netkan
+++ b/NetKAN/USI-LS.netkan
@@ -1,11 +1,31 @@
-{
-    "spec_version" : "v1.16",
-    "identifier" : "USI-LS",
-    "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/UmbraSpaceIndustries/CKAN/master/USI-LS.netkan",
-    "x_netkan_license_ok": true,
-    "tags": [
-        "plugin",
-        "parts",
-        "crewed"
-    ]
-}
+spec_version: v1.4
+identifier: USI-LS
+name: USI Life Support
+abstract: UmbraSpaceIndustries take on life support
+author: RoverDude
+$kref: '#/ckan/github/UmbraSpaceIndustries/USI-LS'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/105202-*
+  manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/
+tags:
+  - plugin
+  - parts
+  - crewed
+depends:
+  - name: ModuleManager
+    min_version: 2.8.0
+  - name: USITools
+    min_version: 0.9.0.0
+  - name: CommunityResourcePack
+    min_version: 0.7.0.0
+  - name: CommunityCategoryKit
+    min_version: 2.0.0.0
+conflicts:
+  - name: SETI-CommunityTechTree
+  - name: TACLS
+install:
+  - find: UmbraSpaceIndustries/LifeSupport
+    install_to: GameData/UmbraSpaceIndustries

--- a/NetKAN/USI-NuclearRockets.netkan
+++ b/NetKAN/USI-NuclearRockets.netkan
@@ -1,9 +1,27 @@
-{
-    "spec_version": "v1.16",
-    "identifier": "USI-NuclearRockets",
-    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/UmbraSpaceIndustries/CKAN/master/USI-NuclearRockets.netkan",
-    "x_netkan_license_ok": true,
-    "tags": [
-        "parts"
-    ]
-}
+spec_version: v1.4
+identifier: USI-NuclearRockets
+name: '''Project Orion'' Nuclear Pulse Engine'
+abstract: Nuclear Pulse Drives for KSP!
+author: RoverDude
+$kref: '#/ckan/github/UmbraSpaceIndustries/NuclearRockets'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+release_status: development
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/121597-*
+  manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+  - name: USITools
+    min_version: 0.9.0.0
+  - name: USI-Core
+    min_version: 0.4.0.0
+  - name: FirespitterCore
+    min_version: v7.6.0
+conflicts:
+  - name: SETI-CommunityTechTree
+install:
+  - find: UmbraSpaceIndustries/NuclearRockets
+    install_to: GameData/UmbraSpaceIndustries

--- a/NetKAN/USITools.netkan
+++ b/NetKAN/USITools.netkan
@@ -1,4 +1,4 @@
-spec_version: 1
+spec_version: v1.2
 identifier: USITools
 name: USI Tools
 abstract: Common libraries for Umbra Space Industries mods

--- a/NetKAN/USITools.netkan
+++ b/NetKAN/USITools.netkan
@@ -1,13 +1,27 @@
-
-    {
-        "spec_version" : "v1.16",
-        "identifier" : "USITools",
-        "$kref" : "#/ckan/netkan/https://raw.githubusercontent.com/UmbraSpaceIndustries/CKAN/master/USITools.netkan",
-        "x_netkan_license_ok": true,
-        "tags": [
-            "plugin",
-            "library",
-            "crewed",
-            "graphics"
-        ]
-    }
+spec_version: 1
+identifier: USITools
+name: USI Tools
+abstract: Common libraries for Umbra Space Industries mods
+author: RoverDude
+$kref: '#/ckan/github/UmbraSpaceIndustries/USITools'
+$vref: '#/ckan/ksp-avc/GameData/000_USITools/USITools.version'
+license: restricted
+release_status: stable
+resources:
+  manual: http://umbraspaceindustries.github.io/UmbraSpaceIndustries/
+tags:
+  - plugin
+  - library
+  - crewed
+  - graphics
+provides:
+  - USI-Tools
+conflicts:
+  - name: SETI-CommunityTechTree
+depends:
+  - name: ModuleManager
+install:
+  - file: GameData/000_USITools
+    install_to: GameData
+  - find: UmbraSpaceIndustries/FX
+    install_to: GameData/UmbraSpaceIndustries

--- a/NetKAN/USITools.netkan
+++ b/NetKAN/USITools.netkan
@@ -1,4 +1,4 @@
-spec_version: v1.2
+spec_version: v1.4
 identifier: USITools
 name: USI Tools
 abstract: Common libraries for Umbra Space Industries mods


### PR DESCRIPTION
## Problems

There are various problems with the USI mods' metanetkans:

- ![image](https://user-images.githubusercontent.com/1559108/171032401-1f850820-16a5-4ba0-bb30-ce9b5b8561fd.png)
  Orion's folder name was changed from `Orion` to `NuclearRockets`, and the metanetkan in this repo still has the old name.
- Some have dependencies that are probably outdated going by their bundled folders
- Some are missing a ModuleManager depends

## Initial attempts to fix

Since all these mods have metanetkans in the https://github.com/UmbraSpaceIndustries/CKAN repo, we have to submit pull requests to fix these problems. However, that process has broken down:

- UmbraSpaceIndustries/CKAN#27 was submitted four years ago to fix some of the relationships
- UmbraSpaceIndustries/CKAN#29 was submitted two years ago to fix some of the relationships
- UmbraSpaceIndustries/CKAN#32 was submitted two weeks ago to fix Orion's install folder

The maintainers of the metanetkans have been tagged on GitHub and notified on the KSP forum (definitely for the most recent one, probably for the earlier ones). But these pull requests haven't been merged or reviewed, and the incorrect metadata and inflation errors are still out there.

It seems the USI authors don't consider themselves primarily responsible for this metadata; rather they still want us to fix problems for them:

[![image](https://user-images.githubusercontent.com/1559108/173109805-d8e1ba7e-3422-4b3f-98e3-b54f399047cc.png)](https://forum.kerbalspaceprogram.com/index.php?/topic/154587-112x-modular-kolonization-system-mks/&do=findComment&comment=4139458)

The purpose of a metanetkan is to allow mod authors to take responsibility for active maintenance of their metadata, not to insert an absentee "middle man" between metadata and the ones maintaining it. The current arrangement is the worst of both worlds; we still have to fix things, but the fixes never actually go live.

## Changes

- Now the metadata from the metanetkans in the https://github.com/UmbraSpaceIndustries/CKAN repo is transferred back into the netkans in the main repo, and the metanetkans are no longer used
- ModuleManager dependencies are added where needed
- Various other dependencies are fixed
- The install path for Orion is fixed
- YAMLified
- `resources.homepage` now points to the forum thread for each mod. The previous landing page is moved to `resources.manual`, so it's still there but won't get in the way. All links are now HTTP**S**.

Closes UmbraSpaceIndustries/CKAN#27.
Closes UmbraSpaceIndustries/CKAN#29.
Closes UmbraSpaceIndustries/CKAN#32.

(I expect inflation errors related to `spec_version` in the first pass. We just need to know which ones they are.)