### PR TITLE
Fix NTChineseRocketsPack install

### DIFF
--- a/NetKAN/NTChineseRocketsPack.netkan
+++ b/NetKAN/NTChineseRocketsPack.netkan
@@ -13,8 +13,14 @@ depends:
 recommends:
   - name: KerbalJointReinforcement
 install:
-  - find: NTCP
+  - find: NCAP
     install_to: GameData
   - find: Readme.txt
     find_matches_files: true
     install_to: GameData/NTCP
+  - find: Changelog.txt
+    find_matches_files: true
+    install_to: GameData/NTCP
+  - find_regexp: CRAFT FILES/Craft files
+    install_to: Ships
+    as: VAB


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/173877125-7949aebf-c3cb-44fe-925a-475d319293f6.png)

- `NTCP` is replaced by `NCAP` (confirmed in the README)
- There's a `CRAFT FILES` folder containing some sample craft
- Might as well also install the changelog
