### PR TITLE
Fix EcoRocket license

### DIFF
--- a/NetKAN/EcoRocket.netkan
+++ b/NetKAN/EcoRocket.netkan
@@ -1,7 +1,7 @@
 spec_version: v1.18
 identifier: EcoRocket
 $kref: '#/ckan/spacedock/3050'
-license: MIT
+license: GPL-3.0
 tags:
   - parts
   - graphics


### PR DESCRIPTION
SpaceDock said MIT when #9185 was submitted, but it's been updated.

https://spacedock.info/mod/3050/EcoRocket

![image](https://user-images.githubusercontent.com/1559108/176355506-2b66d646-fcfe-421f-bf0a-6e59eb5c9fad.png)

https://forum.kerbalspaceprogram.com/index.php?/topic/208750-112x-arcaspace-ecorocket-for-ksp/#comment-4149638

![image](https://user-images.githubusercontent.com/1559108/176355430-a04701b7-5f48-4b2c-895a-8c8ce6041475.png)
