### PR TITLE
Unfreeze BakerOperatingSystem

### DIFF
--- a/NetKAN/BakerOperatingSystem.netkan
+++ b/NetKAN/BakerOperatingSystem.netkan
@@ -10,3 +10,7 @@ depends:
 install:
   - find: Baker Os
     install_to: GameData
+x_netkan_override:
+  - version: 2.1.0
+    override:
+      ksp_version_min: '1.8'


### PR DESCRIPTION
See KSP-CKAN/CKAN-meta#2822 and #9191 and KSP-CKAN/CKAN-meta#2823, this mod had some extra versions as a compatibility workaround, but as per the author they've been removed, so it's now unfrozen with an override for the min compat.