### PR TITLE
Remove PlanetShine's repository override

### DIFF
--- a/NetKAN/PlanetShine.netkan
+++ b/NetKAN/PlanetShine.netkan
@@ -9,7 +9,6 @@ $vref: '#/ckan/ksp-avc'
 license: Apache-2.0
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/173138-*
-  repository: https://github.com/prestja/ksp-planetshine
 tags:
   - plugin
   - graphics


### PR DESCRIPTION
#9011 switched this mod to a new fork, but it left `resources.repository` pointing to the old fork. This made KSP-CKAN/CKAN-meta#2844 more confusing to investigate. Now it's removed so the `GitHubTransformer` can set it to the correct value automatically.