### PR TITLE
Fix BakerOperatingSystem install

### DIFF
--- a/NetKAN/BakerOperatingSystem.netkan
+++ b/NetKAN/BakerOperatingSystem.netkan
@@ -11,6 +11,6 @@ install:
   - find: Baker Operating System
     install_to: GameData
 x_netkan_override:
-  - version: >=2.1.0
+  - version: '>=2.1.0'
     override:
       ksp_version_min: '1.8'

--- a/NetKAN/BakerOperatingSystem.netkan
+++ b/NetKAN/BakerOperatingSystem.netkan
@@ -8,7 +8,7 @@ tags:
 depends:
   - name: kOS
 install:
-  - find: Baker Os
+  - find: Baker Operating System
     install_to: GameData
 x_netkan_override:
   - version: 2.1.0

--- a/NetKAN/BakerOperatingSystem.netkan
+++ b/NetKAN/BakerOperatingSystem.netkan
@@ -11,6 +11,6 @@ install:
   - find: Baker Operating System
     install_to: GameData
 x_netkan_override:
-  - version: 2.1.0
+  - version: >=2.1.0
     override:
       ksp_version_min: '1.8'


### PR DESCRIPTION
This mod's folder structure has changed.

![image](https://user-images.githubusercontent.com/1559108/178409833-919d86d0-9486-4e94-8a21-b636d398a0a7.png)

There's also a version file now, but it has a `.txt` extension instead of `.version`, and we can't override Netkan's search logic to match that.

___

ckan compat add 1.11