### PR TITLE
Kerbalism and official config packs metadata updates

### DIFF
--- a/NetKAN/Kerbalism-Config-Default.netkan
+++ b/NetKAN/Kerbalism-Config-Default.netkan
@@ -18,7 +18,8 @@
     ],
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "Kerbalism"     }
+        { "name": "CommunityResourcePack" },
+        { "name": "Kerbalism" }
     ],
     "conflicts": [
         { "name": "Kerbalism-Config" },

--- a/NetKAN/Kerbalism-Config-ScienceOnly.netkan
+++ b/NetKAN/Kerbalism-Config-ScienceOnly.netkan
@@ -14,6 +14,7 @@
     "provides": [ "Kerbalism-Config" ],
     "depends": [
         { "name": "ModuleManager" },
+        { "name": "CommunityResourcePack" },
         { "name": "Kerbalism" }
     ],
     "conflicts": [

--- a/NetKAN/Kerbalism.netkan
+++ b/NetKAN/Kerbalism.netkan
@@ -18,22 +18,12 @@
         "resources"
     ],
     "depends": [
-        { "name": "CommunityResourcePack" },
-        { "name": "Kerbalism-Config"      },
-        { "name": "Harmony2"              }
+        { "name": "Kerbalism-Config" },
+        { "name": "KSPCommunityFixes" },
+        { "name": "Harmony2" }
     ],
     "recommends": [
         { "name": "KerbalChangelog" }
-    ],
-    "supports": [
-        { "name": "ConnectedLivingSpace"       },
-        { "name": "CryoTanks"                  },
-        { "name": "KerbalAtomics"              },
-        { "name": "KerbalPlanetaryBaseSystems" },
-        { "name": "NearFutureElectrical"       },
-        { "name": "NearFutureSolar"            },
-        { "name": "NearFutureSpacecraft"       },
-        { "name": "SCANsat"                    }
     ],
     "install": [ {
         "find":       "Kerbalism",


### PR DESCRIPTION
- Added "depends" on KSPCommunityFixes for Kerbalism core. Technically not a hard dependency but it fixes several game-breaking bugs that particularly affect Kerbalism and I'm getting tired of asking users to install it.
- Moved "depends" on CommunityResourcePack from Kerbalism core to configs. It isn't actually a core dependency and alternate config packs may not want it installed.
- Removed all "supports" from Kerbalism core. Most of them are actually not that well supported, and alternate config packs might have a different view on what is supported.