### PR TITLE
Add KSPCF as dependency to ProceduralParts

### DIFF
--- a/NetKAN/ProceduralParts.netkan
+++ b/NetKAN/ProceduralParts.netkan
@@ -16,7 +16,8 @@
         "parts"
     ],
     "depends" : [
-        { "name" : "ModuleManager" }
+        { "name" : "ModuleManager" },
+        { "name" : "KSPCommunityFixes" }
     ],
     "suggests" : [
         { "name" : "PPTextures" },


### PR DESCRIPTION
As of the latest version of ProceduralParts, KSPCF is needed. Adding as a dependency