### PR TITLE
Rename BDArmoryForRunwayProject to BDArmoryPlus

### DIFF
--- a/NetKAN/BDArmoryForRunwayProject.netkan
+++ b/NetKAN/BDArmoryForRunwayProject.netkan
@@ -1,7 +1,7 @@
 {
     "spec_version":     "v1.18",
-    "identifier":       "BDArmoryForRunwayProject",
-    "author":           [ "BahamutoD", "Papa_Joe", "jrodrigv", "ouloul", "Scott Manley", "JR", "DocNappers", "Cl0by", "josue", "aubranium", "benbenwilde", "TheKurgan" ],
+    "identifier":       "BDArmoryPlus",
+    "author":           [ "BahamutoD", "Papa_Joe", "jrodrigv", "ouloul", "Scott Manley", "JR", "DocNappers", "SuicidalInsanity", "Cl0by", "josue", "aubranium", "benbenwilde", "TheKurgan" ],
     "$kref":            "#/ckan/spacedock/2487",
     "$vref":            "#/ckan/ksp-avc",
     "x_netkan_force_v": true,


### PR DESCRIPTION
- BDArmory for Runway Project is being re-branded as BDArmory Plus, the Spacedock link is remaining the same.