### PR TITLE
Updates for PhotoRealisticVisualEnhancement

### DIFF
--- a/NetKAN/PhotoRealisticVisualEnhancement-64k.netkan
+++ b/NetKAN/PhotoRealisticVisualEnhancement-64k.netkan
@@ -2,7 +2,7 @@ spec_version: v1.4
 identifier: PhotoRealisticVisualEnhancement-64k
 name: PRVE 64k
 abstract: 64k Earth ground textures for PhotoRealisticVisualEnhancement
-$kref: '#/ckan/github/SpaceODY/PRVE/asset_match/PRVE64k-[0-9.]+\.zip'
+$kref: '#/ckan/github/SpaceODY/PRVE/asset_match/PRVE-64k\.*'
 ksp_version: 1.12.3
 license: CC-BY-NC-SA-4.0
 tags:

--- a/NetKAN/PhotoRealisticVisualEnhancement-LowRes.netkan
+++ b/NetKAN/PhotoRealisticVisualEnhancement-LowRes.netkan
@@ -1,6 +1,6 @@
 spec_version: v1.4
-identifier: PhotoRealisticVisualEnhancement
-$kref: '#/ckan/github/SpaceODY/PRVE/asset_match/PRVEv?[0-9.]+\.zip'
+identifier: PhotoRealisticVisualEnhancement-LowRes
+$kref: '#/ckan/github/SpaceODY/PRVE/asset_match/PRVE-LR\.*'
 ksp_version: 1.12.3
 license: CC-BY-NC-SA-4.0
 tags:
@@ -10,7 +10,7 @@ provides:
   - EnvironmentalVisualEnhancements-Config
 conflicts:
   - name: EnvironmentalVisualEnhancements-Config
-  - name: PhotoRealisticVisualEnhancement-LowRes
+  - name: PhotoRealisticVisualEnhancement
 depends:
   - name: ModuleManager
   - name: Scatterer-config


### PR DESCRIPTION
https://github.com/SpaceODY/PRVE

- Filename format for 64k changed from `PRVE64k-` to `PRVE-64k`
- New low res variant added starting as copy of regular variant
- Conflicts added between low res and regular. One conflict would be enough for the relationship resolver, but this way it will show up under the Relationships tab for both mods.

Fixes #9222.