### PR TITLE
Spectra Vibrant Sunsets and install fix

### DIFF
--- a/NetKAN/Spectra-VibrantSunsets.netkan
+++ b/NetKAN/Spectra-VibrantSunsets.netkan
@@ -1,3 +1,4 @@
+spec_version: v1.4
 identifier: Spectra-VibrantSunsets
 name: Vibrant sunsets for Spectra
 abstract: Intense sunsets

--- a/NetKAN/Spectra-VibrantSunsets.netkan
+++ b/NetKAN/Spectra-VibrantSunsets.netkan
@@ -9,6 +9,7 @@ tags:
   - config
   - graphics
 depends:
+  - name: ModuleManager
   - name: Spectra
 install:
   - find: Step 3- Extras/Vibrant sunsets/Spectra_Scatterer

--- a/NetKAN/Spectra-VibrantSunsets.netkan
+++ b/NetKAN/Spectra-VibrantSunsets.netkan
@@ -1,0 +1,14 @@
+identifier: Spectra-VibrantSunsets
+name: Vibrant sunsets for Spectra
+abstract: Intense sunsets
+$kref: '#/ckan/spacedock/1505'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - config
+  - graphics
+depends:
+  - name: Spectra
+install:
+  - find: Step 3- Extras/Vibrant sunsets/Spectra_Scatterer
+    install_to: GameData/Spectra

--- a/NetKAN/Spectra.netkan
+++ b/NetKAN/Spectra.netkan
@@ -1,52 +1,46 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "Spectra",
-    "name":         "Spectra",
-    "abstract":     "A well optimized and breathtakingly beautiful revamp of all celestial bodies in KSP",
-    "$kref":        "#/ckan/spacedock/1505",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_force_v": true,
-    "license":      "MIT",
-    "release_status": "stable",
-    "tags": [
-        "config",
-        "planet-pack",
-        "graphics"
-    ],
-    "provides": [
-        "EnvironmentalVisualEnhancements-Config",
-        "EnvironmentalVisualEnhancements-Config-stock"
-    ],
-    "conflicts": [
-        { "name": "EnvironmentalVisualEnhancements-Config" }
-    ],
-    "depends": [
-        { "name": "EnvironmentalVisualEnhancements" },
-        { "name": "ModuleManager" },
-        { "name": "Scatterer-sunflare-default" }
-    ],
-    "suggests": [
-        { "name": "CollisionFXReUpdated"               },
-        { "name": "CrewLight"                          },
-        { "name": "EngineLightRelit"                   },
-        { "name": "HafCoSpaceCenter"                   },
-        { "name": "IndicatorLights"                    },
-        { "name": "IndicatorLightsCommunityExtensions" },
-        { "name": "KSPRC-CityLights"                   },
-        { "name": "PlanetShine"                        },
-        { "name": "PlanetShine-Config-Default"         },
-        { "name": "RealPlume-StockConfigs"             },
-        { "name": "ReentryParticleEffect"              },
-        { "name": "ReStock"                            },
-        { "name": "ShipEffectsContinued"               },
-        { "name": "SpaceplaneCorrections"              }
-    ],
-    "recommends": [
-        { "name": "Scatterer"                       },
-        { "name": "DistantObject"                   }
-    ],
-    "install": [ {
-        "file":       "Step 2 - Spectra/Spectra",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.4
+identifier: Spectra
+name: Spectra
+abstract: >-
+  A well optimized and breathtakingly beautiful revamp of all celestial bodies
+  in KSP
+$kref: '#/ckan/spacedock/1505'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+license: MIT
+release_status: stable
+tags:
+  - config
+  - planet-pack
+  - graphics
+provides:
+  - EnvironmentalVisualEnhancements-Config
+  - EnvironmentalVisualEnhancements-Config-stock
+conflicts:
+  - name: EnvironmentalVisualEnhancements-Config
+depends:
+  - name: EnvironmentalVisualEnhancements
+  - name: ModuleManager
+  - name: Scatterer-sunflare-default
+suggests:
+  - name: Spectra-VibrantSunsets
+  - name: CollisionFXReUpdated
+  - name: CrewLight
+  - name: EngineLightRelit
+  - name: HafCoSpaceCenter
+  - name: IndicatorLights
+  - name: IndicatorLightsCommunityExtensions
+  - name: KSPRC-CityLights
+  - name: PlanetShine
+  - name: PlanetShine-Config-Default
+  - name: RealPlume-StockConfigs
+  - name: ReentryParticleEffect
+  - name: ReStock
+  - name: ShipEffectsContinued
+  - name: SpaceplaneCorrections
+recommends:
+  - name: Scatterer
+  - name: DistantObject
+install:
+  - file: Step 2- Spectra/Spectra
+    install_to: GameData


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/180794280-277f0a49-fedb-466e-9fe0-a987823ed472.png)

- That install is changed from `2 -` to `2-` to match the latest version
- A new `Spectra-VibrantSunsets` module is added, suggested by `Spectra`, which installs from the `Step 3- Extras` folder
