### PR TITLE
Fix Spectras Extras installs

### DIFF
--- a/NetKAN/Spectra-JoolShineOnLaythe.netkan
+++ b/NetKAN/Spectra-JoolShineOnLaythe.netkan
@@ -13,5 +13,5 @@ depends:
   - name: Scatterer
   - name: Spectra
 install:
-  - find: Step 3- Extras/Jool shine on Laythe
+  - find: Step 3- Extras/Jool shine on Laythe/Spectra_Scatterer
     install_to: GameData/Spectra

--- a/NetKAN/Spectra-KerbinLaytheSnow.netkan
+++ b/NetKAN/Spectra-KerbinLaytheSnow.netkan
@@ -12,5 +12,7 @@ depends:
   - name: EnvironmentalVisualEnhancements
   - name: Spectra
 install:
-  - find: Step 3- Extras/Kerbin Laythe snow
+  - find: Step 3- Extras/Kerbin Laythe snow/Spectra_EVE
+    install_to: GameData/Spectra
+  - find: Step 3- Extras/Kerbin Laythe snow/Spectra_Scatterer
     install_to: GameData/Spectra

--- a/NetKAN/Spectra-KerbinLaytheSnow.netkan
+++ b/NetKAN/Spectra-KerbinLaytheSnow.netkan
@@ -14,5 +14,5 @@ depends:
 install:
   - find: Step 3- Extras/Kerbin Laythe snow/Spectra_EVE
     install_to: GameData/Spectra
-  - find: Step 3- Extras/Kerbin Laythe snow/Spectra_Scatterer
+  - find: Step 3- Extras/Kerbin Laythe snow/Spectra_textures
     install_to: GameData/Spectra


### PR DESCRIPTION
#9233 and #9234 were merged too soon, the `Spectra_EVE` and `Spectra_Scatterer` folders are supposed to be installed into `Spectra` directly without extra parent folders. Confirmed with author via Discord VM.