### PR TITLE
Install whole subfolders of Spectra Extras

### DIFF
--- a/NetKAN/Spectra-JoolShineOnLaythe.netkan
+++ b/NetKAN/Spectra-JoolShineOnLaythe.netkan
@@ -1,4 +1,4 @@
-spec_version: v1.4
+spec_version: v1.18
 identifier: Spectra-JoolShineOnLaythe
 name: Jool shine on Laythe for Spectra
 abstract: Jool shine on Laythe
@@ -13,5 +13,6 @@ depends:
   - name: Scatterer
   - name: Spectra
 install:
-  - find: Step 3- Extras/Jool shine on Laythe/Spectra_Scatterer
-    install_to: GameData/Spectra
+  - find: Step 3- Extras/Jool shine on Laythe
+    install_to: GameData
+    as: Spectra

--- a/NetKAN/Spectra-KerbinLaytheSnow.netkan
+++ b/NetKAN/Spectra-KerbinLaytheSnow.netkan
@@ -1,4 +1,4 @@
-spec_version: v1.4
+spec_version: v1.18
 identifier: Spectra-KerbinLaytheSnow
 name: Kerbin and Laythe snow for Spectra
 abstract: Kerbin Laythe snow
@@ -12,7 +12,6 @@ depends:
   - name: EnvironmentalVisualEnhancements
   - name: Spectra
 install:
-  - find: Step 3- Extras/Kerbin Laythe snow/Spectra_EVE
-    install_to: GameData/Spectra
-  - find: Step 3- Extras/Kerbin Laythe snow/Spectra_textures
-    install_to: GameData/Spectra
+  - find: Step 3- Extras/Kerbin Laythe snow
+    install_to: GameData
+    as: Spectra

--- a/NetKAN/Spectra-MinmusGeysers.netkan
+++ b/NetKAN/Spectra-MinmusGeysers.netkan
@@ -1,4 +1,4 @@
-spec_version: v1.4
+spec_version: v1.18
 identifier: Spectra-MinmusGeysers
 name: Minmus Geysers for Spectra
 abstract: Kerbin Laythe snow
@@ -13,7 +13,6 @@ depends:
   - name: ModuleManager
   - name: Spectra
 install:
-  - find: Step 3- Extras/Minmus Geysers/Spectra_EVE
-    install_to: GameData/Spectra
-  - find: Step 3- Extras/Minmus Geysers/Spectra_textures
-    install_to: GameData/Spectra
+  - find: Step 3- Extras/Minmus Geysers
+    install_to: GameData
+    as: Spectra

--- a/NetKAN/Spectra-MinmusScatterer.netkan
+++ b/NetKAN/Spectra-MinmusScatterer.netkan
@@ -1,4 +1,4 @@
-spec_version: v1.4
+spec_version: v1.18
 identifier: Spectra-MinmusScatterer
 name: Minmus Scatterer for Spectra
 abstract: Scatterer for Minmus
@@ -13,7 +13,6 @@ depends:
   - name: Scatterer
   - name: Spectra
 install:
-  - find: Step 3- Extras/Minmus Scatterer/Spectra_EVE
-    install_to: GameData/Spectra
-  - find: Step 3- Extras/Minmus Scatterer/Spectra_Scatterer
-    install_to: GameData/Spectra
+  - find: Step 3- Extras/Minmus Scatterer
+    install_to: GameData
+    as: Spectra

--- a/NetKAN/Spectra-VibrantSunsets.netkan
+++ b/NetKAN/Spectra-VibrantSunsets.netkan
@@ -1,4 +1,4 @@
-spec_version: v1.4
+spec_version: v1.18
 identifier: Spectra-VibrantSunsets
 name: Vibrant sunsets for Spectra
 abstract: Intense sunsets
@@ -13,5 +13,6 @@ depends:
   - name: Scatterer
   - name: Spectra
 install:
-  - find: Step 3- Extras/Vibrant sunsets/Spectra_Scatterer
-    install_to: GameData/Spectra
+  - find: Step 3- Extras/Vibrant sunsets
+    install_to: GameData
+    as: Spectra


### PR DESCRIPTION
## Background

Spectra has "Extras" that look like this:

![image](https://user-images.githubusercontent.com/1559108/181301545-c77d548d-9041-47c4-a50d-b864341d678a.png)

## Problem

In #9238 and #9236 and #9235 and #9231 we set up netkans to install these by selecting the `Spectra_EVE`, `Spectra_Scatterer`, and `Spectra_textures` folders and installing them to `GameData/Spectra`. While this gives a correct result, it's somewhat inflexible; if @Avera9eJoe subsequently decides for example to add a `Minmus Geysers/Spectra_Scatterer` folder, we would need to update the netkan to install that. (Also I have some ulterior motives related to internal .ckan files which may come to fruition at a later time.)

## Changes

Now we select the main folder for each Extra and use `as` to rename it to Spectra and install it to GameData. This should still produce a correct install but with more futureproofing for these modules. The `spec_version`s are updated to v1.18 to allow use of `as`.