### PR TITLE
Fix SRBWaterfallEffects install again again again

### DIFF
--- a/NetKAN/SRBWaterfallEffects.netkan
+++ b/NetKAN/SRBWaterfallEffects.netkan
@@ -13,5 +13,5 @@ depends:
   - name: SmokeScreen
   - name: TUFX
 install:
-  - find_regexp: SRBWE
+  - find_regexp: SWE
     install_to: GameData


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/181904108-c0bfd247-c9da-4834-b36c-3a369817c745.png)

Folder names this mod has used in the ZIP:

- `srb_waterfall_effects` (#9028)
- `SWE 2.0` (#9188)
- `GameData/SWE` (#9030)
- `SWE` (#9101)
- `SRBWE` (#9214)

... and now back to `SWE`.
