### PR TITLE
Let Spectra's internal ckan files set its relationships

### DIFF
--- a/NetKAN/Spectra-JoolShineOnLaythe.netkan
+++ b/NetKAN/Spectra-JoolShineOnLaythe.netkan
@@ -8,10 +8,6 @@ license: MIT
 tags:
   - config
   - graphics
-depends:
-  - name: ModuleManager
-  - name: Scatterer
-  - name: Spectra
 install:
   - find: Step 3- Extras/Jool shine on Laythe
     install_to: GameData

--- a/NetKAN/Spectra-KerbinLaytheSnow.netkan
+++ b/NetKAN/Spectra-KerbinLaytheSnow.netkan
@@ -8,9 +8,6 @@ license: MIT
 tags:
   - config
   - graphics
-depends:
-  - name: EnvironmentalVisualEnhancements
-  - name: Spectra
 install:
   - find: Step 3- Extras/Kerbin Laythe snow
     install_to: GameData

--- a/NetKAN/Spectra-MinmusGeysers.netkan
+++ b/NetKAN/Spectra-MinmusGeysers.netkan
@@ -8,10 +8,6 @@ license: MIT
 tags:
   - config
   - graphics
-depends:
-  - name: EnvironmentalVisualEnhancements
-  - name: ModuleManager
-  - name: Spectra
 install:
   - find: Step 3- Extras/Minmus Geysers
     install_to: GameData

--- a/NetKAN/Spectra-MinmusScatterer.netkan
+++ b/NetKAN/Spectra-MinmusScatterer.netkan
@@ -8,10 +8,6 @@ license: MIT
 tags:
   - config
   - graphics
-depends:
-  - name: ModuleManager
-  - name: Scatterer
-  - name: Spectra
 install:
   - find: Step 3- Extras/Minmus Scatterer
     install_to: GameData

--- a/NetKAN/Spectra-VibrantSunsets.netkan
+++ b/NetKAN/Spectra-VibrantSunsets.netkan
@@ -8,10 +8,6 @@ license: MIT
 tags:
   - config
   - graphics
-depends:
-  - name: ModuleManager
-  - name: Scatterer
-  - name: Spectra
 install:
   - find: Step 3- Extras/Vibrant sunsets
     install_to: GameData

--- a/NetKAN/Spectra.netkan
+++ b/NetKAN/Spectra.netkan
@@ -1,9 +1,7 @@
 spec_version: v1.4
 identifier: Spectra
 name: Spectra
-abstract: >-
-  A well optimized and breathtakingly beautiful revamp of all celestial bodies
-  in KSP
+abstract: An optimized atmosphere revamp for all stock celestial bodies
 $kref: '#/ckan/spacedock/1505'
 $vref: '#/ckan/ksp-avc'
 x_netkan_force_v: true

--- a/NetKAN/Spectra.netkan
+++ b/NetKAN/Spectra.netkan
@@ -18,29 +18,6 @@ provides:
   - EnvironmentalVisualEnhancements-Config-stock
 conflicts:
   - name: EnvironmentalVisualEnhancements-Config
-depends:
-  - name: EnvironmentalVisualEnhancements
-  - name: ModuleManager
-  - name: Scatterer-sunflare-default
-suggests:
-  - name: Spectra-VibrantSunsets
-  - name: CollisionFXReUpdated
-  - name: CrewLight
-  - name: EngineLightRelit
-  - name: HafCoSpaceCenter
-  - name: IndicatorLights
-  - name: IndicatorLightsCommunityExtensions
-  - name: KSPRC-CityLights
-  - name: PlanetShine
-  - name: PlanetShine-Config-Default
-  - name: RealPlume-StockConfigs
-  - name: ReentryParticleEffect
-  - name: ReStock
-  - name: ShipEffectsContinued
-  - name: SpaceplaneCorrections
-recommends:
-  - name: Scatterer
-  - name: DistantObject
 install:
   - file: Step 2- Spectra/Spectra
     install_to: GameData


### PR DESCRIPTION
See KSP-CKAN/CKAN#3615, we are planning to move Spectra's relationships to internal .ckan files so @Avera9eJoe can manage them more easily. This PR removes them from the netkans. It should not be merged until there is a new Spectra release containing the corresponding internal .ckan files.

https://spacedock.info/mod/1505/Spectra
