### PR TITLE
Remove redundant recommends from AutomatedScreenshots

### DIFF
--- a/NetKAN/AutomatedScreenshots.netkan
+++ b/NetKAN/AutomatedScreenshots.netkan
@@ -1,42 +1,23 @@
-{
-	"spec_version": "v1.4",
-	"identifier": "AutomatedScreenshots",
-	"name": "Automated Screenshots & Saves",
-	"abstract": "automated screenshots",
-	"author": "linuxgurugamer",
-	"license": "GPL-3.0",
-	"$kref": "#/ckan/github/linuxgurugamer/AutomatedScreenshots",
-	"$vref": "#/ckan/ksp-avc",
-	"resources": {
-		"homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/116979-*",
-		"spacedock": "https://spacedock.info/mod/43/Automated%20Screenshots%20&%20Saves",
-		"repository": "https://github.com/linuxgurugamer/AutomatedScreenshots",
-		"x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/Automated_Screenshots__Saves/Automated_Screenshots__Saves-1456622044.5102704.png"
-	},
-	"tags": [
-		"plugin",
-		"convenience"
-	],
-	"depends": [
-		{
-			"name": "ToolbarController"
-		},
-		{
-			"name": "ClickThroughBlocker"
-		}
-	],
-	"recommends": [
-		{
-			"name": "ToolbarController"
-		},
-		{
-			"name": "ClickThroughBlocker"
-		}
-	],
-	"install": [
-		{
-			"find": "AutomatedScreenshots",
-			"install_to": "GameData"
-		}
-	]
-}
+spec_version: v1.4
+identifier: AutomatedScreenshots
+name: Automated Screenshots & Saves
+abstract: automated screenshots
+author: linuxgurugamer
+license: GPL-3.0
+$kref: '#/ckan/github/linuxgurugamer/AutomatedScreenshots'
+$vref: '#/ckan/ksp-avc'
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/116979-*
+  spacedock: https://spacedock.info/mod/43/Automated%20Screenshots%20&%20Saves
+  repository: https://github.com/linuxgurugamer/AutomatedScreenshots
+  x_screenshot: >-
+    https://spacedock.info/content/linuxgurugamer_179/Automated_Screenshots__Saves/Automated_Screenshots__Saves-1456622044.5102704.png
+tags:
+  - plugin
+  - convenience
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: AutomatedScreenshots
+    install_to: GameData


### PR DESCRIPTION
#7729 changed this mod to also recommend its dependencies. There's no point to that; since the mods are in `depends`, they must always be installed, unlike `recommends` which the user is supposed to be able to opt out of.

Now the recommendations are removed. Also YAMLized.

Noticed while randomly scrolling through mods looking for one with lots of relationships to illustrate a point for KSP-CKAN/CKAN#3616.
