### PR TITLE
Switch to main Shabby version file

### DIFF
--- a/NetKAN/Shabby.netkan
+++ b/NetKAN/Shabby.netkan
@@ -1,10 +1,8 @@
 spec_version: v1.10
 identifier: Shabby
 abstract: Shader asset bundle loader for KSP
-author:
-  - taniwha
-  - Andrew Cassidy
-$kref: '#/ckan/ksp-avc/https://pileof.rocks/KSP/Shabby.version'
+author: taniwha
+$kref: '#/ckan/ksp-avc/http://taniwha.org/~bill/Shabby.version'
 $vref: '#/ckan/ksp-avc'
 license: GPL-3.0
 resources:


### PR DESCRIPTION
In #8922 we indexed Shabby based on an alternate version file at https://pileof.rocks/KSP/Shabby.version because it was the only way to index a release that worked with Conformal Decals, but apparently this was a fly-by-night release that wasn't really integrated with the main Shabby workflows or kept up to date with development, because now the inverse is true; the taniwha.org file has 0.3.0 but @drewcassidy's is stuck at 0.2.0. Noticed while investigating KSP-CKAN/CKAN#3623.

Now it's switched to the more official one, which should cause 0.3.0 to be indexed and allow installation allongside Shaddy.
