### PR TITLE
Fix Shabby max_version in conflicts section

### DIFF
--- a/NetKAN/Shaddy.netkan
+++ b/NetKAN/Shaddy.netkan
@@ -8,7 +8,7 @@ tags:
   - graphics
 conflicts:
   - name: Shabby
-    max_version: v0.2.0
+    max_version: 0.2.0.0
 depends:
   - name: ModuleManager
 recommends:


### PR DESCRIPTION
In #9240 I suggested `v0.2.0` should be the minimum version of Shabby that Shaddy supports. 

Now that Shabby 0.3.0.0 has been added to CKAN in #9262, and apparently, CKAN doesn't think 0.3.0.0 is above v0.2.0 and is stopping me from installing Shaddy v2.1 when Shabby 0.3.0.0 is installed. The reverse is also true: when Shaddy v2.1 is installed, I cannot install Shabby 0.3.0.0.

I have therefore changed the max_version of Shabby in the conflicts section from `v0.2.0` to `0.2.0.0` to match the version scheme Shabby uses.

![image](https://user-images.githubusercontent.com/22954985/184452772-9e8006bb-8700-486a-a21c-79a147e02525.png)  

![image](https://user-images.githubusercontent.com/22954985/184454174-4bec5be5-255c-45a5-a447-4e227b566617.png)

I am using CKAN v1.31.0 in case it is me who messed up something with CKAN.

Aso do we have to update the [meta file](https://github.com/KSP-CKAN/CKAN-meta/blob/master/Shaddy/Shaddy-v2.1.ckan)?

