### PR TITLE
Add conflicts to ErsteSterne and KHNS for provides

### DIFF
--- a/NetKAN/ErsteSterne.netkan
+++ b/NetKAN/ErsteSterne.netkan
@@ -8,6 +8,9 @@ tags:
 provides:
   - Scatterer-config
   - Scatterer-sunflare
+conflicts:
+  - name: Scatterer-config
+  - name: Scatterer-sunflare
 depends:
   - name: ModuleManager
   - name: Kopernicus

--- a/NetKAN/KerbolsHumbleNeighboringStars.netkan
+++ b/NetKAN/KerbolsHumbleNeighboringStars.netkan
@@ -10,6 +10,9 @@ tags:
   - plugin
   - config
   - planet-pack
+conflicts:
+  - name: Scatterer-config
+  - name: Scatterer-sunflare
 provides:
   - Scatterer-config
   - Scatterer-sunflare


### PR DESCRIPTION
In #9184 and #9128 we added `Scatterer-config` and `Scatterer-sunflare` to the `provides` for two mods. These identifiers are supposed to be mutually exclusive, in that if you try to install multiple mods providing them, they won't work. Historically we've added conflicts for other mods, but we missed it in these cases.

Now both of these mods conflict with the identifiers they provide.
I'll also do this in CKAN-meta if needed.

Noticed while tracking down some weird behavior in the relationship resolver for KSP-CKAN/CKAN#3635.