### PR TITLE
Switch FoxDefenseContracts to BDArmoryForRunwayProject

### DIFF
--- a/NetKAN/FoxDefenseContracts.netkan
+++ b/NetKAN/FoxDefenseContracts.netkan
@@ -9,7 +9,7 @@ depends:
   - name: ModuleManager
   - name: BDArmoryContinued
 install:
-  - find: FoxDefenseContracts
+  - find: BDArmoryForRunwayProject
     install_to: GameData
   - find: FDC_Armor
     install_to: GameData

--- a/NetKAN/FoxDefenseContracts.netkan
+++ b/NetKAN/FoxDefenseContracts.netkan
@@ -7,9 +7,9 @@ tags:
   - combat
 depends:
   - name: ModuleManager
-  - name: BDArmoryContinued
+  - name: BDArmory
 install:
-  - find: BDArmoryForRunwayProject
+  - find: FoxDefenseContracts
     install_to: GameData
   - find: FDC_Armor
     install_to: GameData


### PR DESCRIPTION
This mod's February 2021 release changed its dependency from BDArmoryContinued to 
BDArmoryForRunwayProject (since rebranded "BDArmory Plus")

![image](https://user-images.githubusercontent.com/1559108/186432575-f14ff202-1e62-406b-b128-021540fc4f03.png)

![image](https://user-images.githubusercontent.com/1559108/186432973-d9e02fb4-b91c-4863-b4fa-32e0c27605bd.png)

Now the dependency is updated to `BDArmory` in the netkan, which is in the `provides` list of both mods. We'll update the historical releases from then on as well.
