### PR TITLE
Filter out KerbalWind's settings file

### DIFF
--- a/NetKAN/KerbalWind.netkan
+++ b/NetKAN/KerbalWind.netkan
@@ -19,3 +19,7 @@ conflicts:
   - name: FARWind
 depends:
   - name: FAR
+install:
+  - find: KerbalWind
+    install_to: GameData
+    filter: settings.cfg


### PR DESCRIPTION
See https://github.com/KSP-CKAN/NetKAN/issues/9307#issuecomment-1231782217, this mod contains a settings file, but it will work without it. Now it's filtered out so it won't be overwritten at upgrade.