### PR TITLE
Fix RadialHeatShields install location

### DIFF
--- a/NetKAN/RadialHeatShields.netkan
+++ b/NetKAN/RadialHeatShields.netkan
@@ -11,8 +11,8 @@ tags:
 depends:
   - name: ModuleManager
 install:
-  - find: RadialHeatShields
-    install_to: GameData
+  - file: GameData/OrionSpaceIndustries/RadialHeatShields
+    install_to: GameData/OrionSpaceIndustries
     filter:
       - __MACOSX
       - .DS_Store


### PR DESCRIPTION
CKAN installs this mod to `GameData/RadialHeatShields`, however it needs to be placed in `GameData/OrionSpaceIndustries/RadialHeatShields` according to the zip.

![image](https://user-images.githubusercontent.com/28812678/188126324-ecf0bef9-9e67-4c43-bc7a-313c619ef03d.png)
