### PR TITLE
Update FerramAerospaceResearchContinued dependencies

### DIFF
--- a/NetKAN/FerramAerospaceResearchContinued.netkan
+++ b/NetKAN/FerramAerospaceResearchContinued.netkan
@@ -21,7 +21,8 @@
     "depends" : [
         { "name" : "ModuleManager" },
         { "name" : "ModularFlightIntegrator" },
-        { "name" : "TweakScale-Redist" }
+        { "name" : "TweakScale-Redist" },
+        { "name" : "KSPBurst" }
     ],
     "install" : [
         {


### PR DESCRIPTION
Next version of FerramAerospaceResearchContinued will depend on KSPBurst.

Also, could you change the indexed versioning to be dependent on the release tag instead of master branch? I'm not sure which field needs to be changed and to what. Thanks.