### PR TITLE
Add Parallax-Scatter-Textures requirement

### DIFF
--- a/NetKAN/Parallax-ScatterTextures.netkan
+++ b/NetKAN/Parallax-ScatterTextures.netkan
@@ -1,0 +1,31 @@
+{
+    "spec_version": "v1.4",
+    "identifier":   "Parallax-ScatterTextures",
+    "name":         "Parallax - Scatter Textures",
+    "abstract":     "Parallax textures for the scatters on the stock planets",
+    "author":       "Linx",
+    "$kref":        "#/ckan/github/Gameslinx/Tessellation/asset_match/Scatter",
+    "license":      "CC-BY-NC-ND-4.0",
+    "resources": {
+        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/197024-*"
+    },
+    "tags": [
+        "config",
+        "graphics"
+    ],
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "Parallax" },
+        { "name": "Parallax-StockTextures" }
+    ],
+    "provides": [
+        "Parallax-Scatter-Textures"
+    ],
+    "conflicts": [
+        { "name": "Parallax-Scatter-Textures" }
+    ],
+    "install": [{
+        "find":       "Parallax_ScatterTextures",
+        "install_to": "GameData"
+    }]
+}

--- a/NetKAN/Parallax-ScatterTextures.netkan
+++ b/NetKAN/Parallax-ScatterTextures.netkan
@@ -1,31 +1,23 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "Parallax-ScatterTextures",
-    "name":         "Parallax - Scatter Textures",
-    "abstract":     "Parallax textures for the scatters on the stock planets",
-    "author":       "Linx",
-    "$kref":        "#/ckan/github/Gameslinx/Tessellation/asset_match/Scatter",
-    "license":      "CC-BY-NC-ND-4.0",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/197024-*"
-    },
-    "tags": [
-        "config",
-        "graphics"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "Parallax" },
-        { "name": "Parallax-StockTextures" }
-    ],
-    "provides": [
-        "Parallax-Scatter-Textures"
-    ],
-    "conflicts": [
-        { "name": "Parallax-Scatter-Textures" }
-    ],
-    "install": [{
-        "find":       "Parallax_ScatterTextures",
-        "install_to": "GameData"
-    }]
-}
+spec_version: v1.4
+identifier: Parallax-ScatterTextures
+name: Parallax - Scatter Textures
+abstract: Parallax textures for the scatters on the stock planets
+author: Linx
+$kref: '#/ckan/github/Gameslinx/Tessellation/asset_match/Scatter'
+license: CC-BY-NC-ND-4.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/197024-*
+tags:
+  - config
+  - graphics
+provides:
+  - Parallax-Scatter-Textures
+conflicts:
+  - name: Parallax-Scatter-Textures
+depends:
+  - name: ModuleManager
+  - name: Parallax
+  - name: Parallax-StockTextures
+install:
+  - find: Parallax_ScatterTextures
+    install_to: GameData

--- a/NetKAN/Parallax-ScatterTextures.netkan
+++ b/NetKAN/Parallax-ScatterTextures.netkan
@@ -19,5 +19,5 @@ depends:
   - name: Parallax
   - name: Parallax-StockTextures
 install:
-  - find: Parallax_ScatterTextures
+  - find: Parallax_StockTextures
     install_to: GameData

--- a/NetKAN/Parallax-StockScatterTextures.netkan
+++ b/NetKAN/Parallax-StockScatterTextures.netkan
@@ -1,6 +1,6 @@
 spec_version: v1.4
-identifier: Parallax-ScatterTextures
-name: Parallax - Scatter Textures
+identifier: Parallax-StockScatterTextures
+name: Parallax - Stock Scatter Textures
 abstract: Parallax textures for the scatters on the stock planets
 author: Linx
 $kref: '#/ckan/github/Gameslinx/Tessellation/asset_match/Scatter'

--- a/NetKAN/Parallax-StockTextures.netkan
+++ b/NetKAN/Parallax-StockTextures.netkan
@@ -3,7 +3,7 @@ identifier: Parallax-StockTextures
 name: Parallax - Stock Planet Textures
 abstract: Parallax textures for the stock planets
 author: Linx
-$kref: '#/ckan/github/Gameslinx/Tessellation/asset_match/Textures'
+$kref: '#/ckan/github/Gameslinx/Tessellation/asset_match/StockTextures'
 license: CC-BY-NC-ND-4.0
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/197024-*

--- a/NetKAN/Parallax-StockTextures.netkan
+++ b/NetKAN/Parallax-StockTextures.netkan
@@ -1,30 +1,23 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "Parallax-StockTextures",
-    "name":         "Parallax - Stock Planet Textures",
-    "abstract":     "Parallax textures for the stock planets",
-    "author":       "Linx",
-    "$kref":        "#/ckan/github/Gameslinx/Tessellation/asset_match/Textures",
-    "license":      "CC-BY-NC-ND-4.0",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/197024-*"
-    },
-    "tags": [
-        "config",
-        "graphics"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "Parallax" }
-    ],
-    "provides": [
-        "Parallax-Textures"
-    ],
-    "conflicts": [
-        { "name": "Parallax-Textures" }
-    ],
-    "install": [{
-        "find":       "Parallax_StockTextures",
-        "install_to": "GameData"
-    }]
-}
+spec_version: v1.4
+identifier: Parallax-StockTextures
+name: Parallax - Stock Planet Textures
+abstract: Parallax textures for the stock planets
+author: Linx
+$kref: '#/ckan/github/Gameslinx/Tessellation/asset_match/Textures'
+license: CC-BY-NC-ND-4.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/197024-*
+tags:
+  - config
+  - graphics
+provides:
+  - Parallax-Textures
+conflicts:
+  - name: Parallax-Textures
+depends:
+  - name: ModuleManager
+  - name: Parallax
+  - name: Parallax-StockScatterTextures
+install:
+  - find: Parallax_StockTextures
+    install_to: GameData

--- a/NetKAN/Parallax.netkan
+++ b/NetKAN/Parallax.netkan
@@ -1,31 +1,24 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "Parallax",
-    "name":         "Parallax",
-    "abstract":     "A PBR tessellation shader for planetary textures",
-    "author":       "Linx",
-    "$kref":        "#/ckan/github/Gameslinx/Tessellation/asset_match/^Parallax-[0-9.]+\\.zip$",
-    "ksp_version_min":  "1.11",
-    "ksp_version_max":  "1.12",
-    "license":          "CC-BY-NC-ND-4.0",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/197024-*"
-    },
-    "tags": [
-        "plugin",
-        "library",
-        "graphics"
-    ],
-    "depends": [
-        { "name": "Kopernicus"        },
-        { "name": "Parallax-Textures" },
-        { "name": "Parallax-Scatter-Textures" }
-    ],
-    "recommends": [
-        { "name": "Scatterer" }
-    ],
-    "install": [ {
-        "find":       "Parallax",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.4
+identifier: Parallax
+name: Parallax
+abstract: A PBR tessellation shader for planetary textures
+author: Linx
+$kref: '#/ckan/github/Gameslinx/Tessellation/asset_match/^Parallax-[0-9.]+\.zip$'
+ksp_version_min: '1.11'
+ksp_version_max: '1.12'
+license: CC-BY-NC-ND-4.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/197024-*
+tags:
+  - plugin
+  - library
+  - graphics
+depends:
+  - name: Kopernicus
+  - name: Parallax-Textures
+  - name: Parallax-Scatter-Textures
+recommends:
+  - name: Scatterer
+install:
+  - find: Parallax
+    install_to: GameData

--- a/NetKAN/Parallax.netkan
+++ b/NetKAN/Parallax.netkan
@@ -18,7 +18,8 @@
     ],
     "depends": [
         { "name": "Kopernicus"        },
-        { "name": "Parallax-Textures" }
+        { "name": "Parallax-Textures" },
+        { "name": "Parallax-Scatter-Textures" }
     ],
     "recommends": [
         { "name": "Scatterer" }


### PR DESCRIPTION
Parallax_ScatterTextures is required alongside Parallax_StockTextures as of release 2.0.0. If stock textures are installed, these must also be installed. However, installing Parallax will not prompt either the stock textures or scatter textures to download.

https://github.com/Gameslinx/Tessellation