### PR TITLE
Make Parallax 2.0.0 modules conflict with <2.0.0 releases

### DIFF
--- a/NetKAN/Parallax-StockScatterTextures.netkan
+++ b/NetKAN/Parallax-StockScatterTextures.netkan
@@ -14,6 +14,8 @@ provides:
   - Parallax-Scatter-Textures
 conflicts:
   - name: Parallax-Scatter-Textures
+  - name: Parallax
+    version_max: '1.3.1'
 depends:
   - name: ModuleManager
   - name: Parallax

--- a/NetKAN/Parallax-StockTextures.netkan
+++ b/NetKAN/Parallax-StockTextures.netkan
@@ -14,6 +14,8 @@ provides:
   - Parallax-Textures
 conflicts:
   - name: Parallax-Textures
+  - name: Parallax
+    version_max: '1.3.1'
 depends:
   - name: ModuleManager
   - name: Parallax

--- a/NetKAN/Parallax.netkan
+++ b/NetKAN/Parallax.netkan
@@ -13,6 +13,9 @@ tags:
   - plugin
   - library
   - graphics
+conflicts:
+  - name: Parallax-StockTextures
+    version_max: '1.3.1'
 depends:
   - name: Kopernicus
   - name: Parallax-Textures


### PR DESCRIPTION
The core Parallax >=2.0.0 only works with the StockTextures and Textures >=2.0.0, so it makes sense to enforce this.

RP-1 depends on Parallax and Parallax-StockTextures 1.3.1, however making the dependency versioned doesn't work, as the relationship resolver pulls in the newer module of the other one when looking at the dependencies of whichever is listed first.
Then it fails with "Parallax - Stock Planet Textures 2.0.0 required, but an version is in the resolver".
https://github.com/KSP-RO/RP-1-ExpressInstall-Graphics/blob/d60207f63f0ef254095e7d4d3e3342dc1abdbc53/RP-1-ExpressInstall-Graphics-High.netkan#L18-L21

Now we make the latest (2.0.0) and all future Parallax releases conflict with Parallax-StockTextures <=1.3.1,
Parallax-StockTextures with Parallax <=1.3.1, and Parallax-StockScatterTextures with Parallax <=1.3.1.

In local testing this did fix the install problem for RP-1, making the resolver correctly pull in the 1.3.1 releases of the two modules.

It might make sense to add similar conflicts to earlier Parallax releases, but this fixes the immediate problem.