### PR TITLE
Fix Parallax conflict version deps

### DIFF
--- a/NetKAN/Parallax-StockScatterTextures.netkan
+++ b/NetKAN/Parallax-StockScatterTextures.netkan
@@ -15,7 +15,7 @@ provides:
 conflicts:
   - name: Parallax-Scatter-Textures
   - name: Parallax
-    version_max: '1.3.1'
+    max_version: '1.3.1'
 depends:
   - name: ModuleManager
   - name: Parallax

--- a/NetKAN/Parallax-StockTextures.netkan
+++ b/NetKAN/Parallax-StockTextures.netkan
@@ -15,7 +15,7 @@ provides:
 conflicts:
   - name: Parallax-Textures
   - name: Parallax
-    version_max: '1.3.1'
+    max_version: '1.3.1'
 depends:
   - name: ModuleManager
   - name: Parallax

--- a/NetKAN/Parallax.netkan
+++ b/NetKAN/Parallax.netkan
@@ -15,7 +15,7 @@ tags:
   - graphics
 conflicts:
   - name: Parallax-StockTextures
-    version_max: '1.3.1'
+    max_version: '1.3.1'
 depends:
   - name: Kopernicus
   - name: Parallax-Textures


### PR DESCRIPTION
In KSP-CKAN/NetKAN#9321, @infoman rightly points out a problem with that PR:

> But does ckan client even support `version_max` in conflicts? I don't see it being registered in `registry.json` and github search in this repo does not know about other records with version_max, and now parallax has conflict with it's own textures
> 
> maybe it should have been `max_version`?

https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md#relationships

Now it's `max_version`.