### PR TITLE
Add resources.spacedock to StarilexMk1NeedleIVA

### DIFF
--- a/NetKAN/StarilexMk1NeedleIVA.netkan
+++ b/NetKAN/StarilexMk1NeedleIVA.netkan
@@ -8,6 +8,7 @@ ksp_version: '1.12.3'
 license: CC-BY-NC-SA
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/209466-*
+  spacedock: https://spacedock.info/mod/3113
 tags:
   - config
   - crewed


### PR DESCRIPTION
This mod was uploaded to SpaceDock after we added it in #9326 and GitLab krefs for it in KSP-CKAN/CKAN#3661.

https://spacedock.info/mod/3113/Starilex%20Intra-Vehicular%20Solutions:%20MKI%20Pod%20'Needle'

Now `resources.spacedock` links to that page.