### PR TITLE
Vref for ArtemisConstructionKit

### DIFF
--- a/NetKAN/ArtemisConstructionKit.netkan
+++ b/NetKAN/ArtemisConstructionKit.netkan
@@ -1,6 +1,7 @@
 spec_version: v1.18
 identifier: ArtemisConstructionKit
 $kref: '#/ckan/spacedock/3098'
+$vref: '#/ckan/ksp-avc'
 license: restricted
 tags:
   - parts


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/189497793-61592bb9-0557-4295-8ff4-c577f63941ab.png)

Presumably added in the latest release, since there are only two on SpaceDock.