### PR TITLE
Buffalo 2 requires Kerbal Actuators

### DIFF
--- a/NetKAN/Buffalo2.netkan
+++ b/NetKAN/Buffalo2.netkan
@@ -17,11 +17,10 @@ tags:
 depends:
   - name: ModuleManager
   - name: WildBlueCore
-supports:
   - name: KerbalActuators
+supports:
   - name: Snacks
 recommends:
-  - name: KerbalActuators
   - name: Snacks
   - name: ExtraPlanetaryLaunchpads
   - name: KIS


### PR DESCRIPTION
Moved KerbalActuators to the dependency list.