### PR TITLE
Post-migration SpaceDock catch-up 1

### DIFF
--- a/NetKAN/KerbalFlightworksCompany.netkan
+++ b/NetKAN/KerbalFlightworksCompany.netkan
@@ -1,0 +1,11 @@
+spec_version: v1.4
+identifier: KerbalFlightworksCompany
+$kref: '#/ckan/spacedock/3116'
+license: CC-BY-NC-SA
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+install:
+  - find: KFW
+    install_to: GameData

--- a/NetKAN/KerbalFlightworksCompany.netkan
+++ b/NetKAN/KerbalFlightworksCompany.netkan
@@ -6,6 +6,15 @@ tags:
   - parts
 depends:
   - name: ModuleManager
+  - name: Firespitter
+recommends:
+  - name: TweakScale
+  - name: BDArmoryForRunwayProject
+suggests:
+  - name: AirplanePlus
+  - name: MK1StkOpenCockpit
+  - name: B9-PWings-Fork
+  - name: ConformalDecals
 install:
   - find: KFW
     install_to: GameData

--- a/NetKAN/OblivionBubblePatrolCraft.netkan
+++ b/NetKAN/OblivionBubblePatrolCraft.netkan
@@ -5,6 +5,8 @@ license: CC-BY-SA-4.0
 tags:
   - parts
   - crewed
+depends:
+  - name: ModuleAnimateGenericEffects
 install:
   - find: BubbleCJ
     install_to: GameData

--- a/NetKAN/OblivionBubblePatrolCraft.netkan
+++ b/NetKAN/OblivionBubblePatrolCraft.netkan
@@ -1,0 +1,10 @@
+spec_version: v1.4
+identifier: OblivionBubblePatrolCraft
+$kref: '#/ckan/spacedock/3114'
+license: CC-BY-SA-4.0
+tags:
+  - parts
+  - crewed
+install:
+  - find: BubbleCJ
+    install_to: GameData


### PR DESCRIPTION
SpaceDock migrated to new hosting, but the whitelisted webhook IPs have not been updated, so we're in another period of having to add new mods manually. These are the recently uploaded mods with CKAN badges:

- https://spacedock.info/mod/3114/Oblivion%20Bubble%20Patrol%20Craft
- https://spacedock.info/mod/3116/Kerbal%20Flightworks%20Company

___

ckan compat add 1.11
