### PR TITLE
Post-migration SpaceDock catch-up 2

### DIFF
--- a/NetKAN/ColorChangingSmokeGenerator.netkan
+++ b/NetKAN/ColorChangingSmokeGenerator.netkan
@@ -1,5 +1,5 @@
 spec_version: v1.4
-identifier: ColorChangingSmokeGenrator
+identifier: ColorChangingSmokeGenerator
 $kref: '#/ckan/spacedock/3106'
 license: MIT
 tags:

--- a/NetKAN/ColorChangingSmokeGenerator.netkan
+++ b/NetKAN/ColorChangingSmokeGenerator.netkan
@@ -1,0 +1,10 @@
+spec_version: v1.4
+identifier: ColorChangingSmokeGenrator
+$kref: '#/ckan/spacedock/3106'
+license: MIT
+tags:
+  - parts
+  - graphics
+install:
+  - find: Advanced Weapons Pack
+    install_to: GameData

--- a/NetKAN/KerbalBall.netkan
+++ b/NetKAN/KerbalBall.netkan
@@ -1,0 +1,10 @@
+spec_version: v1.4
+identifier: KerbalBall
+$kref: '#/ckan/spacedock/3111'
+license: CC-BY-SA-4.0
+tags:
+  - parts
+  - crewed
+install:
+  - find: HampsterCJ
+    install_to: GameData

--- a/NetKAN/LudicrousParts.netkan
+++ b/NetKAN/LudicrousParts.netkan
@@ -1,12 +1,15 @@
-spec_version: v1.4
+spec_version: v1.10
 identifier: LudicrousParts
 $kref: '#/ckan/spacedock/3108'
+ksp_version_min: '1.8'
 license: GPL-2.0
 tags:
   - plugin
   - parts
 depends:
   - name: ModuleManager
+conflicts:
+  - name: ProceduralParts
 install:
   - find: LudicrousParts
     install_to: GameData

--- a/NetKAN/LudicrousParts.netkan
+++ b/NetKAN/LudicrousParts.netkan
@@ -1,0 +1,13 @@
+spec_version: v1.4
+identifier: LudicrousParts
+$kref: '#/ckan/spacedock/3108'
+license: GPL-2.0
+tags:
+  - plugin
+  - parts
+depends:
+  - name: ModuleManager
+install:
+  - find: LudicrousParts
+    install_to: GameData
+    filter_regexp: \.pdb$

--- a/NetKAN/ShadoUFO.netkan
+++ b/NetKAN/ShadoUFO.netkan
@@ -7,6 +7,8 @@ tags:
   - crewed
 depends:
   - name: ModuleManager
+suggests:
+  - name: CaerfinonsSuits
 install:
   - find: SHADOUFOCJ
     install_to: GameData

--- a/NetKAN/ShadoUFO.netkan
+++ b/NetKAN/ShadoUFO.netkan
@@ -1,0 +1,15 @@
+spec_version: v1.4
+identifier: ShadoUFO
+$kref: '#/ckan/spacedock/3105'
+license: CC-BY-SA-4.0
+tags:
+  - parts
+  - crewed
+depends:
+  - name: ModuleManager
+install:
+  - find: SHADOUFOCJ
+    install_to: GameData
+    filter: SPH
+  - find: SHADOUFOCJ/SPH
+    install_to: Ships

--- a/NetKAN/StockalikeAircraftCarrierDecks.netkan
+++ b/NetKAN/StockalikeAircraftCarrierDecks.netkan
@@ -6,6 +6,9 @@ tags:
   - parts
 depends:
   - name: ModuleManager
+supports:
+  - name: CommunityCategoryKit
+  - name: Heisenberg
 install:
   - find: SACDCJ
     install_to: GameData

--- a/NetKAN/StockalikeAircraftCarrierDecks.netkan
+++ b/NetKAN/StockalikeAircraftCarrierDecks.netkan
@@ -1,0 +1,11 @@
+spec_version: v1.4
+identifier: StockalikeAircraftCarrierDecks
+$kref: '#/ckan/spacedock/3110'
+license: CC-BY-SA-4.0
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+install:
+  - find: SACDCJ
+    install_to: GameData


### PR DESCRIPTION
SpaceDock migrated to new hosting, but the whitelisted webhook IPs have not been updated, so we're in another period of having to add new mods manually. These are the recently uploaded mods with CKAN badges:

- https://spacedock.info/mod/3105/SHADO%20UFO
- https://spacedock.info/mod/3106/Color%20changing%20smoke%20generator
- https://spacedock.info/mod/3108/LudicrousParts
- https://spacedock.info/mod/3110/S.A.C.D
- https://spacedock.info/mod/3111/Kerbal%20Ball

Follow-up to #9336.