### PR TITLE
Fix ModeratelyPlaneRelated install

### DIFF
--- a/NetKAN/ModeratelyPlaneRelated.netkan
+++ b/NetKAN/ModeratelyPlaneRelated.netkan
@@ -7,4 +7,4 @@ tags:
   - crewed
 depends:
   - name: ModuleManager
-  - name: Firespitter
+  - name: B9PartSwitch

--- a/NetKAN/ModeratelyPlaneRelated.netkan
+++ b/NetKAN/ModeratelyPlaneRelated.netkan
@@ -8,7 +8,3 @@ tags:
 depends:
   - name: ModuleManager
   - name: Firespitter
-install:
-  - find: Moderately-Plane-Related
-    install_to: GameData
-    filter: .DS_Store


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/191767174-17172a38-8217-43cd-9980-f6c9db293a68.png)

Now it matches the identifier, so the default stanza is used.

Also the dependencies are updated to reflect the latest README.
