### PR TITLE
Add ExtremePlaneContracts

### DIFF
--- a/NetKAN/ExtremePlaneContracts.netkan
+++ b/NetKAN/ExtremePlaneContracts.netkan
@@ -1,0 +1,18 @@
+spec_version: v1.4
+identifier: ExtremePlaneContracts
+abstract: Want difficult challenges for planes?
+$kref: '#/ckan/github/StarshipSLS/ExtremePlaneContracts'
+x_netkan_github:
+  use_source_archive: true
+license: MIT
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/209839-*
+  spacedock: https://spacedock.info/mod/3122
+tags:
+  - config
+  - career
+depends:
+  - name: ContractConfigurator
+install:
+  - find: ContractPacks
+    install_to: GameData

--- a/NetKAN/ExtremePlaneContracts.netkan
+++ b/NetKAN/ExtremePlaneContracts.netkan
@@ -1,13 +1,7 @@
 spec_version: v1.4
 identifier: ExtremePlaneContracts
-abstract: Want difficult challenges for planes?
-$kref: '#/ckan/github/StarshipSLS/ExtremePlaneContracts'
-x_netkan_github:
-  use_source_archive: true
+$kref: '#/ckan/spacedock/3122'
 license: MIT
-resources:
-  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/209839-*
-  spacedock: https://spacedock.info/mod/3122
 tags:
   - config
   - career


### PR DESCRIPTION
KSP-CKAN/NetKAN-Infra#277 has been fixed :tada:, but this one snuck in just before that.

- https://github.com/StarshipSLS/ExtremePlaneContracts
- https://spacedock.info/mod/3122/Extreme%20Plane%20Contracts
- https://forum.kerbalspaceprogram.com/index.php?/topic/209839-112x-extreme-plane-contracts/

~~I'm getting a 404 trying to download it from SpaceDock, so this netkan gets it from the source archive on GitHub, but hopefully the SpaceDock problem will be resolved and we can switch the kref back.~~
Author retried and it works now, kref switched to SpaceDock.

Tagging @StarshipSLS as an FYI.