### PR TITLE
Get DMTanks repositories from SpaceDock again

### DIFF
--- a/NetKAN/DMTanks-AeroRTG.netkan
+++ b/NetKAN/DMTanks-AeroRTG.netkan
@@ -7,6 +7,8 @@ author:
 $kref: '#/ckan/spacedock/2338'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-SA-3.0
+resources:
+  remote-avc: https://raw.githubusercontent.com/zer0Kerbal/AeroRadial/master/AeroRadial.version
 tags:
   - parts
 depends:

--- a/NetKAN/DMTanks-AeroRTG.netkan
+++ b/NetKAN/DMTanks-AeroRTG.netkan
@@ -7,9 +7,6 @@ author:
 $kref: '#/ckan/spacedock/2338'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-SA-3.0
-resources:
-  repository: >-
-    https://github.com/zer0Kerbal/DaMichel/tree/master/GameData/DaMichel/AeroRadial
 tags:
   - parts
 depends:

--- a/NetKAN/DMTanks-CargoBays.netkan
+++ b/NetKAN/DMTanks-CargoBays.netkan
@@ -7,10 +7,6 @@ author:
 $kref: '#/ckan/spacedock/2339'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-SA-3.0
-resources:
-  repository: >-
-    https://github.com/zer0Kerbal/DaMichel/tree/master/GameData/DaMichel/CargoBays
-  remote-avc: https://github.com/zer0Kerbal/DaMichel/raw/master/GameData/DaMichel/CargoBays/CargoBays.version
 tags:
   - parts
 depends:

--- a/NetKAN/DMTanks-CargoBays.netkan
+++ b/NetKAN/DMTanks-CargoBays.netkan
@@ -7,6 +7,8 @@ author:
 $kref: '#/ckan/spacedock/2339'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-SA-3.0
+resources:
+  remote-avc: https://raw.githubusercontent.com/zer0Kerbal/CargoBays/master/CargoBays.version
 tags:
   - parts
 depends:

--- a/NetKAN/DMTanks-Fuselage.netkan
+++ b/NetKAN/DMTanks-Fuselage.netkan
@@ -7,10 +7,6 @@ author:
 $kref: '#/ckan/spacedock/2340'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-3.0
-resources:
-  repository: >-
-    https://github.com/zer0Kerbal/DaMichel/tree/master/GameData/DaMichel/Fuselage
-  remote-avc: https://github.com/zer0Kerbal/DaMichel/raw/master/GameData/DaMichel/Fuselage/Fuselage.version
 tags:
   - parts
 depends:

--- a/NetKAN/DMTanks-Fuselage.netkan
+++ b/NetKAN/DMTanks-Fuselage.netkan
@@ -7,6 +7,8 @@ author:
 $kref: '#/ckan/spacedock/2340'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-3.0
+resources:
+  remote-avc: https://raw.githubusercontent.com/zer0Kerbal/Fuselage/master/Fuselage.version
 tags:
   - parts
 depends:

--- a/NetKAN/DMTanks-SphericalTanks.netkan
+++ b/NetKAN/DMTanks-SphericalTanks.netkan
@@ -7,9 +7,6 @@ author:
 $kref: '#/ckan/spacedock/2342'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-SA-3.0
-resources:
-  repository: >-
-    https://github.com/zer0Kerbal/DaMichel/tree/master/GameData/DaMichel/SphericalTanks
 tags:
   - parts
 depends:

--- a/NetKAN/DMTanks-SphericalTanks.netkan
+++ b/NetKAN/DMTanks-SphericalTanks.netkan
@@ -7,6 +7,8 @@ author:
 $kref: '#/ckan/spacedock/2342'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-SA-3.0
+resources:
+  remote-avc: https://raw.githubusercontent.com/zer0Kerbal/SphericalTanks/master/SphericalTanks.version
 tags:
   - parts
 depends:


### PR DESCRIPTION
Since #8567, these mods have been split into their own new repositories and SpaceDock has been updated, so hard-coding the link in the netkans breaks the links instead of fixing them.

Now we get the links from SpaceDock again.

~~I'm not sure of the status of the `remote-avc` links. For now I've removed them, and if we get inflation warnings I'll put them back and update them.~~
Yup, gotta keep and update the overrides.
