### PR TITLE
Override bad version file URL properties

### DIFF
--- a/NetKAN/HooliganLabsAirships.netkan
+++ b/NetKAN/HooliganLabsAirships.netkan
@@ -3,6 +3,8 @@ identifier: HooliganLabsAirships
 $kref: '#/ckan/spacedock/3040'
 $vref: '#/ckan/ksp-avc'
 license: MIT
+resources:
+  remote-avc: https://raw.githubusercontent.com/net-lisias-ksp/HLAirshipsCore/master/HLAirshipsCore.version
 tags:
   - plugin
   - parts

--- a/NetKAN/MOTHS.netkan
+++ b/NetKAN/MOTHS.netkan
@@ -3,6 +3,8 @@ identifier: MOTHS
 $kref: '#/ckan/spacedock/2986'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY
+resources:
+  remote-avc: https://raw.githubusercontent.com/AtomikkuSan/M.O.T.H.S./main/AtomicTech/ThermalPond.version
 tags:
   - parts
 depends:

--- a/NetKAN/PicoPortShielded.netkan
+++ b/NetKAN/PicoPortShielded.netkan
@@ -1,28 +1,23 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "PicoPortShielded",
-    "$kref":        "#/ckan/spacedock/2245",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts"
-    ],
-    "install": [ {
-        "find":       "KGEx",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "PicoPort" }
-    ],
-    "suggests": [
-        { "name": "ODFC-Refueled"   },
-        { "name": "KerbalChangelog" },
-        { "name": "PicoPort4AllSizes" },
-        { "name": "DockingPortDescriptions" }
-    ],
-    "supports": [
-        { "name": "ConnectedLivingSpace" },
-        { "name": "TweakScale" }
-    ]
-}
+spec_version: v1.4
+identifier: PicoPortShielded
+$kref: '#/ckan/spacedock/2245'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+resources:
+  remote-avc: https://raw.githubusercontent.com/zer0Kerbal/ShieldedPicoPorts/master/ShieldedPicoPorts.version
+tags:
+  - parts
+install:
+  - find: KGEx
+    install_to: GameData
+depends:
+  - name: ModuleManager
+  - name: PicoPort
+suggests:
+  - name: ODFC-Refueled
+  - name: KerbalChangelog
+  - name: PicoPort4AllSizes
+  - name: DockingPortDescriptions
+supports:
+  - name: ConnectedLivingSpace
+  - name: TweakScale

--- a/NetKAN/RSSVE-HR.netkan
+++ b/NetKAN/RSSVE-HR.netkan
@@ -6,6 +6,7 @@ $vref: '#/ckan/ksp-avc'
 license: CC-BY-SA-4.0
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/153511-rssve
+  remote-avc: https://raw.githubusercontent.com/KSP-RO/RSSVE/master/RSSVE/RSSVE.version
 tags:
   - plugin
   - graphics

--- a/NetKAN/RSSVE-LR.netkan
+++ b/NetKAN/RSSVE-LR.netkan
@@ -6,6 +6,7 @@ $vref: '#/ckan/ksp-avc'
 license: CC-BY-SA-4.0
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/153511-rssve
+  remote-avc: https://raw.githubusercontent.com/KSP-RO/RSSVE/master/RSSVE/RSSVE.version
 tags:
   - plugin
   - graphics

--- a/NetKAN/StarshipLaunchExpansion.netkan
+++ b/NetKAN/StarshipLaunchExpansion.netkan
@@ -3,6 +3,8 @@ identifier: StarshipLaunchExpansion
 $kref: '#/ckan/spacedock/2814'
 $vref: '#/ckan/ksp-avc'
 license: MIT
+resources:
+  remote-avc: https://raw.githubusercontent.com/SAMCG14/StarshipLaunchExpansion/Main/GameData/StarshipLaunchExpansion/Versioning/StarshipLaunchExpansion.version
 tags:
   - parts
 depends:

--- a/NetKAN/USI-NuclearRockets.netkan
+++ b/NetKAN/USI-NuclearRockets.netkan
@@ -10,6 +10,7 @@ release_status: development
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/121597-*
   manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/
+  remote-avc: https://raw.githubusercontent.com/UmbraSpaceIndustries/NuclearRockets/main/FOR_RELEASE/GameData/UmbraSpaceIndustries/NuclearRockets/NuclearRockets.version
 tags:
   - parts
 depends:

--- a/NetKAN/WildBlueCore.netkan
+++ b/NetKAN/WildBlueCore.netkan
@@ -10,6 +10,7 @@ $vref: '#/ckan/ksp-avc'
 license: GPL-3.0
 resources:
   manual: https://github.com/Angel-125/WildBlueCore/wiki
+  remote-avc: https://raw.githubusercontent.com/Angel-125/WildBlueCore/main/ReleaseFolder/GameData/WildBlueIndustries/00WildBlueCore/WildBlueCore.version
 tags:
   - plugin
   - library


### PR DESCRIPTION
These mods have bad `URL` properties in their version files. Usually we submit pull requests to the upstream repo to fix this; sometimes they sit unmerged, sometimes they're merged but no new release is forthcoming, sometimes they get re-broken by more edits between merge and release. This clutters the status page.

Now they're overridden as per KSP-CKAN/CKAN#3451. There are other mods with the same error but without a remote version file for an override, which are left unchanged.
