### PR TITLE
Specify minimum version of Astrogator for kOS-Astrogator

### DIFF
--- a/NetKAN/kOS-Astrogator.netkan
+++ b/NetKAN/kOS-Astrogator.netkan
@@ -15,6 +15,7 @@ tags:
   - plugin
 depends:
   - name: Astrogator
+    min_version: v0.10.4
   - name: kOS
 supports:
   - name: Astrogator


### PR DESCRIPTION
I almost forgot, versions of Astrogator prior to the current latest won't work for kOS-Astrogator because the `KSPAssembly` attribute wasn't set. Now that'll be reflected in CKAN just in case anybody has an old version installed.

This is an update to #9357.

___

ckan compat add 1.11
