### PR TITLE
Updates Pathfinder to recommend Buffalo 2 and not depend on Buffalo

### DIFF
--- a/NetKAN/Pathfinder.netkan
+++ b/NetKAN/Pathfinder.netkan
@@ -19,10 +19,10 @@ depends:
   - name: ModuleManager
   - name: KerbalActuators
   - name: WildBlueTools
-  - name: Buffalo
 recommends:
   - name: KAS
   - name: KIS
+  - name: Buffalo2
 supports:
   - name: ConnectedLivingSpace
   - name: TACLS


### PR DESCRIPTION
The original Buffalo has been supplanted by Buffalo2 (which is already in CKAN).
This update removes the Buffalo dependency and recommends Buffalo 2 in its place.