### PR TITLE
Fix KerbalTelemetry install

### DIFF
--- a/NetKAN/KerbalTelemetry.netkan
+++ b/NetKAN/KerbalTelemetry.netkan
@@ -7,11 +7,6 @@ tags:
   - app
   - information
 install:
-  - find: Textures
+  - find: KerbalTelemetry
     install_to: GameData
     filter: .DS_Store
-  - find: WebServer
-    install_to: GameData
-    filter: .DS_Store
-  - find: Kerbal Telemetry.dll
-    install_to: GameData


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/200678353-045cd139-670d-486e-b77b-c139ca0edc8b.png)

The ZIP now has a proper `GameData/KerbalTelemetry` folder.
