### PR TITLE
Update kOS-Astrogator dep min version for Astrogator

### DIFF
--- a/NetKAN/kOS-Astrogator.netkan
+++ b/NetKAN/kOS-Astrogator.netkan
@@ -15,7 +15,7 @@ tags:
   - plugin
 depends:
   - name: Astrogator
-    min_version: v0.10.4
+    min_version: v1.0.0
   - name: kOS
 supports:
   - name: Astrogator


### PR DESCRIPTION
See HebaruSan/Astrogator#32. Version v1.0.0 is now required.

___

ckan compat add 1.11 1.12
