### PR TITLE
Add WildBlueCore dep to Sandcastle

### DIFF
--- a/NetKAN/Sandcastle.netkan
+++ b/NetKAN/Sandcastle.netkan
@@ -12,6 +12,7 @@ tags:
   - crewed
 depends:
   - name: ModuleManager
+  - name: WildBlueCore
   - name: NearFutureProps
 recommends:
   - name: ExtraPlanetaryLaunchpads


### PR DESCRIPTION
WildBlueCore isn't mentioned as a dependency anywhere, but it's bundled in Sandcastle's ZIP, and an error is printed at game startup by KSPCommunityFixes if you run without it (as you will if you install with CKAN):

![image](https://user-images.githubusercontent.com/1559108/201346068-36e0e02f-a60b-493a-b612-06ed9da2998a.png)

Now the dependency is added.
