### PR TITLE
Create BDB-Methalox.netkan

### DIFF
--- a/NetKAN/BDB-Methalox.netkan
+++ b/NetKAN/BDB-Methalox.netkan
@@ -1,0 +1,22 @@
+spec_version: v1.4
+identifier: BDB-Methalox
+name: "Bluedog Extras - Methalox Variants"
+abstract: "Optional patch for BDB to add methalox variants to several of the cryogenic engines"
+author: "Rodger"
+license: CC-BY-NC-SA-4.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/122020-1123
+tags:
+  - config
+$kref: '#/ckan/spacedock/442'
+ksp_version_min: 1.11
+ksp_version_max: 1.12.99
+install:
+  - find: MethaloxEngines
+    install_to: GameData/Bluedog_DB_Extras
+  - find: MethaloxRL10
+    install_to: GameData/Bluedog_DB_Extras
+depends:
+  - name: BluedogDB
+  - name: CryoTanks
+  - name: ModuleManager


### PR DESCRIPTION
.netkan for an optional patch included in the BDB main download, but not installed automatically