### PR TITLE
Create BDB-RealNames.netkan

### DIFF
--- a/NetKAN/BDB-RealNames.netkan
+++ b/NetKAN/BDB-RealNames.netkan
@@ -1,0 +1,18 @@
+spec_version: v1.4
+identifier: BDB-RealNames
+name: "Bluedog Extras - Real Names patch"
+abstract: "Optional patch for BDB to change part names from kerbalised ones to ones based on real-life"
+license: CC-BY-NC-SA-4.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/122020-1123
+tags:
+  - config
+$kref: '#/ckan/spacedock/442'
+ksp_version_min: 1.11
+ksp_version_max: 1.12.99
+install:
+  - find: BDB_RealNames
+    install_to: GameData/Bluedog_DB_Extras
+depends:
+  - name: BluedogDB
+  - name: ModuleManager


### PR DESCRIPTION
.netkan for an optional patch included in the BDB main download, but not installed automatically