### PR TITLE
Filter Scale_Redist.dll out of TweakScale

### DIFF
--- a/NetKAN/TweakScale.netkan
+++ b/NetKAN/TweakScale.netkan
@@ -23,6 +23,7 @@ tags:
 install:
   - file: GameData/TweakScale
     install_to: GameData
+    filter: Scale_Redist.dll
 depends:
   - name: TweakScale-Redist
   - name: ModuleManager


### PR DESCRIPTION
I have an external tool that installs 999_Scale_Redist.dll on the GameData for people that do manual installation and forget to install the Redist.

Such tool **is not** available on CKAN installs for obvious reasons, so the presence of the "reference dll" is not a problem (it's inside `PluginData`, a folder KSP doesn't touch).

However ZeroMiniAVC recently started to inspect 3rd parties folders for duplicates, and bluntly ignores that anything inside `PluginData` is not loaded by KSP and then started to pesky users about the presence of the "reference DLL".

The goal of this pull request is to prevent this file to be installed by CKAN, avoiding spurious support calls from people complaining about what's a misfeature on the ZeroMiniAVC tool and not a real problem.