### PR TITLE
Fix NeidonPlus install

### DIFF
--- a/NetKAN/NeidonPlus.netkan
+++ b/NetKAN/NeidonPlus.netkan
@@ -11,3 +11,6 @@ depends:
   - name: Kopernicus
   - name: OuterPlanetsMod
   - name: VertexMitchellNetravaliHeightMap
+install:
+  - find: OPM-NeidonPlus
+    install_to: GameData


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/202917714-2103c24c-8b5e-47de-8f70-5adaf97b00bc.png)

The folder now has an `OPM-` prefix.
