### PR TITLE
Create Wacapella.netkan

### DIFF
--- a/NetKAN/Wacapella.netkan
+++ b/NetKAN/Wacapella.netkan
@@ -1,0 +1,23 @@
+spec_version: v1.4
+identifier: Wacapella
+name: Wacapella
+abstract: Early sounding rockets
+author: 610yesnolovely (Harvey Thompson)
+license: MIT
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/210985-112x-wacapella-early-sounding-rockets-001-9th-dec-2022/
+tags:
+  - parts
+  - config
+  - uncrewed
+$kref: '#/ckan/github/harveyt/Wacapella'
+ksp_version: 1.12
+depends:
+  - name: ModuleManager
+  - name: CompletelyNonAggressiveRocketry
+  - name: Taerobee
+recommends:
+  - name: BluedogDB
+suggests:
+  - name: ContractConfigurator-HistoryofSpaceflight-PocketEdition
+  - name: SkyhawkScienceSystem


### PR DESCRIPTION
This is a mini-mod that balances and combines CNAR and Taerobee using ModuleManager only. Provides parts to build a WAC Corporal sounding rocket.

Tested using netkan.exe and installed on stock 1.12.4 using ckan (as per wiki).

- <https://github.com/harveyt/Wacapella>
- <https://forum.kerbalspaceprogram.com/index.php?/topic/210985-112x-wacapella-early-sounding-rockets-100-9th-dec-2022/>

___

ckan compat add 1.8