### PR TITLE
Update actions/checkout action to v3

### DIFF
--- a/.github/workflows/inflate.yml
+++ b/.github/workflows/inflate.yml
@@ -22,8 +22,8 @@ jobs:
               with:
                   repository: KSP-CKAN/CKAN-meta
                   path: .CKAN-meta
-            - name: Try to figure out why git is failing
-              run: git rev-parse HEAD
+            - name: Find out what version of git is here
+              run: git --version
             - name: Cache downloads
               if: ${{ github.event_name == 'pull_request' }}
               uses: actions/cache@v2

--- a/.github/workflows/inflate.yml
+++ b/.github/workflows/inflate.yml
@@ -31,7 +31,7 @@ jobs:
                   restore-keys: |
                       downloads-
             - name: Test modified netkans
-              uses: KSP-CKAN/xKAN-meta_testing@master
+              uses: techman83/xKAN-meta_testing@feat/debugging
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -40,7 +40,6 @@ jobs:
                   source: commits
                   diff meta root: .CKAN-meta
                   pull request url: ${{ github.event.pull_request.url }}
-                  log level: debug
             - name: Chmod cached files so actions/cache and actions/upload-artifact can read them
               run: sudo chmod -R a+r .cache
               if: ${{ always() }}

--- a/.github/workflows/inflate.yml
+++ b/.github/workflows/inflate.yml
@@ -22,8 +22,8 @@ jobs:
               with:
                   repository: KSP-CKAN/CKAN-meta
                   path: .CKAN-meta
-            - name: Set all directories as git safe
-              run: git config --global --add safe.directory '*'
+            - name: Try to figure out why git is failing
+              run: git rev-parse HEAD
             - name: Cache downloads
               if: ${{ github.event_name == 'pull_request' }}
               uses: actions/cache@v2

--- a/.github/workflows/inflate.yml
+++ b/.github/workflows/inflate.yml
@@ -22,6 +22,8 @@ jobs:
               with:
                   repository: KSP-CKAN/CKAN-meta
                   path: .CKAN-meta
+            - name: Set all directories as git safe
+              run: git config --global --add safe.directory '*'
             - name: Cache downloads
               if: ${{ github.event_name == 'pull_request' }}
               uses: actions/cache@v2

--- a/.github/workflows/inflate.yml
+++ b/.github/workflows/inflate.yml
@@ -13,12 +13,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Get NetKAN repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
                   fetch-depth: 0
             - name: Get CKAN-meta repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                   repository: KSP-CKAN/CKAN-meta
                   path: .CKAN-meta

--- a/.github/workflows/inflate.yml
+++ b/.github/workflows/inflate.yml
@@ -40,6 +40,7 @@ jobs:
                   source: commits
                   diff meta root: .CKAN-meta
                   pull request url: ${{ github.event.pull_request.url }}
+                  log level: debug
             - name: Chmod cached files so actions/cache and actions/upload-artifact can read them
               run: sudo chmod -R a+r .cache
               if: ${{ always() }}

--- a/.github/workflows/inflate.yml
+++ b/.github/workflows/inflate.yml
@@ -22,8 +22,6 @@ jobs:
               with:
                   repository: KSP-CKAN/CKAN-meta
                   path: .CKAN-meta
-            - name: Find out what version of git is here
-              run: git --version
             - name: Cache downloads
               if: ${{ github.event_name == 'pull_request' }}
               uses: actions/cache@v2


### PR DESCRIPTION
## Problem

The metadata tester is broken. It now emits this every time it runs:
  
```
  Traceback (most recent call last):
    File "/usr/local/bin/ckanmetatester", line 11, in <module>
      load_entry_point('CkanMetaTester==0.1', 'console_scripts', 'ckanmetatester')()
    File "/usr/local/lib/python3.7/dist-packages/ckan_meta_tester/__init__.py", line 24, in test_metadata
      environ.get('INPUT_DIFF_META_ROOT'))
    File "/usr/local/lib/python3.7/dist-packages/ckan_meta_tester/ckan_meta_tester.py", line 74, in test_metadata
      for file in self.files_to_test(source):
    File "/usr/local/lib/python3.7/dist-packages/ckan_meta_tester/ckan_meta_tester.py", line 231, in files_to_test
      return self.paths_from_diff(self.branch_diff(Repo('.')))
    File "/usr/local/lib/python3.7/dist-packages/ckan_meta_tester/ckan_meta_tester.py", line 241, in branch_diff
      logging.debug('Looking for merge base between %s and %s', start_ref, repo.head.commit.hexsha)
    File "/usr/local/lib/python3.7/dist-packages/git/refs/symbolic.py", line 226, in _get_commit
      obj = self._get_object()
    File "/usr/local/lib/python3.7/dist-packages/git/refs/symbolic.py", line 219, in _get_object
      return Object.new_from_sha(self.repo, hex_to_bin(self.dereference_recursive(self.repo, self.path)))
    File "/usr/local/lib/python3.7/dist-packages/git/objects/base.py", line 94, in new_from_sha
      oinfo = repo.odb.info(sha1)
    File "/usr/local/lib/python3.7/dist-packages/git/db.py", line 40, in info
      hexsha, typename, size = self._git.get_object_header(bin_to_hex(binsha))
    File "/usr/local/lib/python3.7/dist-packages/git/cmd.py", line [13](https://github.com/KSP-CKAN/NetKAN/actions/runs/3895070850/jobs/6678636081#step:6:14)83, in get_object_header
      return self.__get_object_header(cmd, ref)
    File "/usr/local/lib/python3.7/dist-packages/git/cmd.py", line 1370, in __get_object_header
      return self._parse_object_header(cmd.stdout.readline())
    File "/usr/local/lib/python3.7/dist-packages/git/cmd.py", line 13[29](https://github.com/KSP-CKAN/NetKAN/actions/runs/3895070850/jobs/6678636081#step:6:30), in _parse_object_header
      raise ValueError("SHA could not be resolved, git returned: %r" % (header_line.strip()))
  ValueError: SHA could not be resolved, git returned: b''
```

## Causes (speculative)

1. `git` added a "safe directories" feature in mid-2022, which causes it to print an error without even parsing the repo config if the current user doesn't own a repo, to prevent other users from forcing the current user to run code. [Adding KSP 1.12.5 to the embedded build map](https://github.com/KSP-CKAN/CKAN/commit/d01144406c1e80d609477280056f030f07da8f9f) probably updated the docker image to use a newer version of `git` including these changes.
2. Presumably such an ownership discrepancy exists somewhere in the labyrinthine gnarled bowels of the GitHub workflow runtime
3. GitPython doesn't handle this error intelligently, see gitpython-developers/GitPython#1016; it just returns an empty string somewhere internally, confusing itself

I have not personally loaded up the current docker image and simulated running it in order to probe the details of exactly what's happening in the filesystem. But I find this a plausible explanation for the problem, and if it doesn't work out, we can continue investigating and try something else.

## Changes

Now we upgrade from v2 to v3 of actions/checkout, which ignores "safe directories" by default (see actions/checkout#762 and actions/checkout#770), and should mitigate this if that's the cause.

See KSP-CKAN/xKAN-meta_testing#89, which this doesn't seem to actually fix.
