### PR TITLE
FreeIVA Updates

### DIFF
--- a/NetKAN/FreeIva.netkan
+++ b/NetKAN/FreeIva.netkan
@@ -14,8 +14,9 @@ depends:
   - name: ModuleManager
 recommends:
   - name: ThroughTheEyesOfaKerbal
-suggests:
   - name: Reviva
+  - name: B9PartSwitch
+suggests:
   - name: RasterPropMonitor
   - name: DE-IVAExtension
   - name: AvionicsSystems
@@ -25,3 +26,6 @@ supports:
   - name: Buffalo2
   - name: KerbalPlanetaryBaseSystems
   - name: Kerbalism-Config-Default
+  - name: Mk2Expansion
+  - name: Mk3Expansion
+  - name: NearFutureSpacecraft


### PR DESCRIPTION
Move reviva and b9ps to recommendations, because they're rellevant for stock parts

add newly supported mods