### PR TITLE
Adding TweskScale Companion to CKAN

### DIFF
--- a/NetKAN/TweakScaleCompanion.netkan
+++ b/NetKAN/TweakScaleCompanion.netkan
@@ -1,0 +1,31 @@
+spec_version: v1.8
+identifier: TweakScaleCompanion
+name: TweakScale Companion
+abstract: >-
+  **TweakScale Companion Program** is a series of "Add'On's Add'Ons",
+  adding TweakScale /L support for third parties but decoupling the
+  target Add'On's life cycle from TweakScale's, easing maintenance
+  and distribution efforts. This package aims to make TweakScale
+  user's life easier at first installs with a (most of the time)
+  updated collection with all the currently available Companions
+  at once.
+author:
+  - LisiasT
+$kref: '#/ckan/spacedock/3202'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+license:
+  - restricted
+release_status: testing
+tags:
+  - plugin
+  - convenience
+install:
+  - file: GameData/TweakScaleCompanion
+    install_to: GameData
+depends:
+  - name: TweakScale
+  - name: ModuleManager
+conflicts:
+  - name: TweakScaleCompanion-ReStockPlus
+  - name: AirplanePlusThings


### PR DESCRIPTION
I'm kick starting a new TweakScale's related package, TweakScale Companion, with all the Companions available to make life easier to everybody (including me).

All sub-packages are known to behave nicely when the target add'on is not installed, making this an ideal solution for lazy installers that were bugging me for years about how TweakScale was easier to install in the old, buggier times.

However, I had to declare two add'ons as conflict due the reasons specified below:

* `TweakScaleCompanion-ReStockPlus`
    * It's already included on the package.
    * I don't want to supersede it because not everyone that uses Restock is willing to cope with a "everything and the kitchen's sink" distribution model. So people that wants to use only Restock doesn't have to shove all that files in their GameData just for it.
* `AirplanePlusThings`
    * There're already AirplanePlus patches on this package, and they are incompatible with `AirplanePlusThings`
        * Having both of them installed is theoretically possible, but I would like to avoid the burden to support this weird setup. And would be the point?

Every single Companion is available separately on GitHub under their original licenses (compatible with the license used on this one). The [README.md](https://github.com/net-lisias-ksp/TweakScaleCompanion/blob/master/README.md) on the package lists them.

There's , however, a problem that I'm unsure how to solve.

There's a file on an old add'on called `LShipPartsRequired`, part of [Large Boat Parts Pack](https://spacedock.info/mod/167/Large%20Boat%20Parts%20Pack) that have absolutely terrible patches in one file, that thing would patch indiscriminately so many 3rd party parts that I could't managed to counter-patch the mess, so the only viable solution was to rewrite that config file myself and replace the original when it's present.

The name of the file is `GameData/LShipPartsRequired/LBP_tweakableComplete.cfg` on the my zip package, and it needs to replace the original file on the existing KSP installation.

What would be the best way to cope with that on CKAN? Right now, this netkan does nothing about, and if the LBPP is installed a huge TweakScale FATALITIES storm will fall on the user's head - prompting them to ask for help on Forum where I will tell the user to replace manually the file.