### PR TITLE
Declares `TweakScaleMakingHistoryConfigs` as a conflict.

### DIFF
--- a/NetKAN/TweakScale.netkan
+++ b/NetKAN/TweakScale.netkan
@@ -29,3 +29,5 @@ depends:
   - name: ModuleManager
     min_version: 2.7.1
   - name: KSP-Recall
+conflicts:
+    - name: TweakscaleMakingHistoryConfigs


### PR DESCRIPTION
This thing is old, the patching format is deprecated and I had revamped the patches on TweakScale. There's no way this thing would be usefull nowadays, and I'm starting to get tickets about it again.

Since the very source of the add'on (SpaceDock) is not providing it anymore, I don't see another way to solve this problem but to declare a conflict.

TweakScale works fine on previous versions of KSP, to in essence, TweakscaleMakingHistoryConfigs is really uneeded.