### PR TITLE
Make IXSWarpshipOS depend on warp drive mods

### DIFF
--- a/NetKAN/IXSWarpshipOS.netkan
+++ b/NetKAN/IXSWarpshipOS.netkan
@@ -1,35 +1,29 @@
-{
-    "spec_version": "v1.16",
-    "identifier":   "IXSWarpshipOS",
-    "$kref":        "#/ckan/spacedock/589",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "CommunityResourcePack" },
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "WarpDrive" },
-        { "name": "AlcubierreStandalone" }
-    ],
-    "suggests": [
-        { "name": "SpacedocksRedeployed" },
-        { "name": "CommunityTechTree" }
-    ],
-    "conflicts": [
-        { "name": "WarpShip" },
-        { "name": "KSPInterstellarExtended" }
-    ],
-    "install": [ {
-        "find"       : "IXSWarpShipOS",
-        "install_to" : "GameData",
-        "filter"     : [ ".DS_Store", "Example Craft", "old Spacedocks.zip" ]
-    }, {
-        "find"               : "IXS01 Warpship Prototype.craft",
-        "install_to"         : "Ships/VAB",
-        "find_matches_files" : true
-    } ]
-}
+spec_version: v1.26
+identifier: IXSWarpshipOS
+$kref: '#/ckan/spacedock/589'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+depends:
+  - name: CommunityResourcePack
+  - name: ModuleManager
+  - any_of:
+      - name: AlcubierreStandalone
+      - name: WarpDrive
+suggests:
+  - name: SpacedocksRedeployed
+  - name: CommunityTechTree
+conflicts:
+  - name: WarpShip
+  - name: KSPInterstellarExtended
+install:
+  - find: IXSWarpShipOS
+    install_to: GameData
+    filter:
+      - .DS_Store
+      - Example Craft
+      - old Spacedocks.zip
+  - find: IXS01 Warpship Prototype.craft
+    install_to: Ships/VAB
+    find_matches_files: true

--- a/NetKAN/WarpDrive.netkan
+++ b/NetKAN/WarpDrive.netkan
@@ -1,21 +1,17 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "WarpDrive",
-    "$kref":        "#/ckan/github/linuxgurugamer/KSP-WarpDrive",
-	"$vref": 		"#/ckan/ksp-avc",
-	"abstract":		"A stand-alone warp-drive, similiar to Interstellar",
-	"author": 		"linuxgurugamer",
- 	"x_netkan_license_ok": true,
-	"license": 		"GPL-3.0",
-    "tags": [
-        "plugin",
-        "parts"
-    ],
-    "conflicts": [
-        { "name": "KSPInterstellarExtended" }
-    ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ]
-}
+spec_version: v1.4
+identifier: WarpDrive
+abstract: A stand-alone warp-drive, similiar to Interstellar
+author: linuxgurugamer
+$kref: '#/ckan/github/linuxgurugamer/KSP-WarpDrive'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/194174-*
+tags:
+  - plugin
+  - parts
+conflicts:
+  - name: KSPInterstellarExtended
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker


### PR DESCRIPTION
## Problems

- IXSWarpshipOS recommends AlcubierreStandalone and WarpDrive, but it really _requires_ one or the other (but that wasn't possible to represent in metadata back then, see #6079 and #6080)
- WarpDrive has a forum thread, but it's missing from the CKAN metadata

## Changes

- Now these relationships are moved to a `depends.any_of` clause
- Now WarpDrive's netkan has `resources.homepage` set to its forum thread

Fixes #9562.
