### PR TITLE
Names and authors for ASET IVA adoptions

### DIFF
--- a/NetKAN/MK12PodIVAReplacementbyASET.netkan
+++ b/NetKAN/MK12PodIVAReplacementbyASET.netkan
@@ -1,5 +1,9 @@
 spec_version: v1.24
 identifier: MK12PodIVAReplacementbyASET
+name: MK1-2 IVA Replacement by ASET
+author:
+  - alexustas
+  - StoneBlue
 $kref: '#/ckan/spacedock/3241'
 $vref: '#/ckan/ksp-avc'
 x_netkan_epoch: 1

--- a/NetKAN/Mk1CockpitIVAReplbyASET.netkan
+++ b/NetKAN/Mk1CockpitIVAReplbyASET.netkan
@@ -1,5 +1,9 @@
 spec_version: v1.24
 identifier: Mk1CockpitIVAReplbyASET
+name: Mk1 Cockpit IVA Replacement by ASET
+author:
+  - alexustas
+  - StoneBlue
 $kref: '#/ckan/spacedock/3241'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-3.0

--- a/NetKAN/Mk1LanderCanIVAReplbyASET.netkan
+++ b/NetKAN/Mk1LanderCanIVAReplbyASET.netkan
@@ -1,5 +1,9 @@
 spec_version: v1.24
 identifier: Mk1LanderCanIVAReplbyASET
+name: Mk1 Lander Can IVA Replacement by ASET
+author:
+  - alexustas
+  - StoneBlue
 $kref: '#/ckan/spacedock/3241'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-3.0


### PR DESCRIPTION
## Problems

In #9560:

- I forgot to set the `name` property on three modules sharing a `$kref`, so they all got indexed with the same name, which is confusing
- SpaceDock also doesn't have the original author, which is also therefore missing from the metadata

## Changes

- Now the `name` is set to distinguish the modules based on their previous names
- Now the `author` is set to credit the original author
