### PR TITLE
Install crafts folder to GameData for BDArmoryForRunwayProject

### DIFF
--- a/NetKAN/BDArmoryForRunwayProject.netkan
+++ b/NetKAN/BDArmoryForRunwayProject.netkan
@@ -1,34 +1,37 @@
-{
-    "spec_version":     "v1.18",
-    "identifier":       "BDArmoryForRunwayProject",
-    "author":           [ "BahamutoD", "Papa_Joe", "jrodrigv", "ouloul", "Scott Manley", "JR", "DocNappers", "Cl0by", "josue", "aubranium", "benbenwilde", "TheKurgan" ],
-    "$kref":            "#/ckan/spacedock/2487",
-    "$vref":            "#/ckan/ksp-avc",
-    "x_netkan_force_v": true,
-    "license":          "CC-BY-SA-2.0",
-    "tags": [
-        "plugin",
-        "parts",
-        "sound",
-        "combat"
-    ],
-    "provides": [
-        "BDArmory"
-    ],
-    "conflicts": [
-        { "name": "BDArmory" }
-    ],
-    "depends": [
-        { "name": "ModuleManager"        },
-        { "name": "PhysicsRangeExtender" }
-    ],
-    "install": [ {
-        "find":       "BDArmory",
-        "install_to": "GameData",
-        "filter":     [ "craft" ]
-    }, {
-        "find":       "craft",
-        "install_to": "Ships",
-        "as":         "SPH"
-    } ]
-}
+spec_version: v1.18
+identifier: BDArmoryForRunwayProject
+author:
+  - BahamutoD
+  - Papa_Joe
+  - jrodrigv
+  - ouloul
+  - Scott Manley
+  - JR
+  - DocNappers
+  - Cl0by
+  - josue
+  - aubranium
+  - benbenwilde
+  - TheKurgan
+$kref: '#/ckan/spacedock/2487'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+license: CC-BY-SA-2.0
+tags:
+  - plugin
+  - parts
+  - sound
+  - combat
+provides:
+  - BDArmory
+conflicts:
+  - name: BDArmory
+depends:
+  - name: ModuleManager
+  - name: PhysicsRangeExtender
+install:
+  - find: BDArmory
+    install_to: GameData
+  - find: craft
+    install_to: Ships
+    as: SPH


### PR DESCRIPTION
BDArmoryForRunwayProject has a `crafts` folder containing craft files, which CKAN installs to `Ships/SPH` so users can see them as sample crafts in the game.

However, in December 2021 (https://github.com/BrettRyland/BDArmory/pull/307/commits/e6df81e471102882af0be9813f5ed96f6c88b8a8), the BDArmoryPlus team started using this folder as the location for a craft file that they load at run time based on its path. They wrote C# code to look for the file in multiple places because CKAN was already treating it as a sample craft folder:

https://github.com/BrettRyland/BDArmory/blob/df836b190c40badc45031aa7eff092b35c363757/BDArmory/Competition/VesselSpawning/VesselSpawner.cs#L29-L30

```csharp
                _spawnProbeLocation = Path.Combine(KSPUtil.ApplicationRootPath, "GameData", "BDArmory", "craft", "SpawnProbe.craft"); // SpaceDock location
                if (!File.Exists(_spawnProbeLocation)) _spawnProbeLocation = Path.Combine(KSPUtil.ApplicationRootPath, "Ships", "SPH", "SpawnProbe.craft"); // CKAN location
```

Now we install the `crafts` folder to both places, so the "standard" path that the mod expects will be preserved.

FYI to @SuicidalInsanity, we're happy to update CKAN metadata to avoid mods having to implement workarounds like this.
