### PR TITLE
Add missing HabTech2 dependencies

### DIFF
--- a/NetKAN/HabTech2.netkan
+++ b/NetKAN/HabTech2.netkan
@@ -11,8 +11,11 @@ depends:
   - name: ModuleManager
   - name: B9PartSwitch
   - name: CommunityResourcePack
+  - name: Benjee10-SharedAssets
+  - name: HabTechProps
+  - name: HabTechRobotics
   - name: Waterfall
-  - name: KIS
+  - name: BreakingGround-DLC
 recommends:
   - name: NewTantares
   - name: BluedogDB

--- a/NetKAN/HabTechRobotics.netkan
+++ b/NetKAN/HabTechRobotics.netkan
@@ -1,0 +1,17 @@
+spec_version: v1.4
+identifier: HabTechRobotics
+$kref: '#/ckan/github/benjee10/htRobotics'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+tags:
+  - parts
+  - library
+depends:
+  - name: ModuleManager
+  - name: B9PartSwitch
+suggests:
+  - name: Habtech2
+  - name: ShuttleOrbiterConstructionKit
+install:
+  - find: htRobotics
+    install_to: GameData

--- a/NetKAN/HabTechRobotics.netkan
+++ b/NetKAN/HabTechRobotics.netkan
@@ -13,5 +13,5 @@ suggests:
   - name: Habtech2
   - name: ShuttleOrbiterConstructionKit
 install:
-  - find: htRobotics
+  - find: GameData/htRobotics
     install_to: GameData


### PR DESCRIPTION
#9456 indexed this mod based on the dependencies listed in the SpaceDock description, which were out of date.

- <https://spacedock.info/mod/2078/HabTech2>
- <https://forum.kerbalspaceprogram.com/index.php?/topic/133501-112x-bg-habtech2-stockalike-iss-parts-100-the-final-update/>

Now they're updated to reflect the forum thread (and the newly updated SpaceDock description).

As part of this, `HabTechRobotics` is added as well since it is a bundled dependency.

- <https://github.com/benjee10/htRobotics>

___

ckan compat add 1.12
