### PR TITLE
Fix ASET Consolidated installs

### DIFF
--- a/NetKAN/MK12PodIVAReplacementbyASET.netkan
+++ b/NetKAN/MK12PodIVAReplacementbyASET.netkan
@@ -32,9 +32,11 @@ x_netkan_override:
       ksp_version_min: '1.4'
       ksp_version_max: '1.7'
 install:
-  - find: ASET_StockRpl_IVAs
+  - find: ASET
     install_to: GameData
     include_only:
       - Assets
-      - ASET_StckRplc_Mk1-2_Pod.cfg
-      - RPM_ASET_StckRplc_Mk1-2_Pod_Patch.cfg
+      - FreeIVA_ASET_SRI_Mk1-2.3_Pod.cfg
+      - RevIVA_ASET_SRI_Mk1-2.3_Pod.cfg
+      - RPM_ASET_SRI_Mk1-2.3_Pod.cfg
+      - ASET_SRI_Mk1-2.3_Pod.cfg

--- a/NetKAN/Mk1CockpitIVAReplbyASET.netkan
+++ b/NetKAN/Mk1CockpitIVAReplbyASET.netkan
@@ -23,8 +23,10 @@ recommends:
   - name: FAR
     min_version: 0.15.7.2
 install:
-  - find: ASET_StockRpl_IVAs
+  - find: ASET
     install_to: GameData
     include_only:
       - ASET_StckRplc_Mk1_Cockpit.cfg
-      - RPM_ASET_StckRplc_Mk1_Cockpit_Patch.cfg
+      - RevIVA_ASET_SRI_Mk1_Cockpit.cfg
+      - RPM_ASET_SRI_Mk1_Cockpit.cfg
+      - ASET_SRI_Mk1_Cockpit.cfg

--- a/NetKAN/Mk1LanderCanIVAReplbyASET.netkan
+++ b/NetKAN/Mk1LanderCanIVAReplbyASET.netkan
@@ -18,8 +18,9 @@ depends:
   - name: RasterPropMonitor-Core
     min_version: 0.28.0
 install:
-  - find: ASET_StockRpl_IVAs
+  - find: ASET
     install_to: GameData
     include_only:
-      - ASET_StckRplc_Mk1_LCan.cfg
-      - RPM_ASET_StckRplc_Mk1_LCan_Patch.cfg
+      - RevIVA_ASET_SRI_Mk1_LCan.cfg
+      - RPM_ASET_SRI_Mk1_LCan.cfg
+      - ASET_SRI_Mk1_LCan.cfg


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/224127664-a3f5eb50-d28b-482c-ac9b-ca12e95edd0a.png)

This mod is trying to mash together three mods that don't need to be, which were previously indexed separately. (This was probably the right approach, since it allows users to choose whether to install each piece rather than making it all-or-nothing.) Accordingly it/they were adopted in #9560 using `include_only` to select the files for each part.

Now the filenames have changed, and since we're selecting them with `include_only`, two of the mods now had no files to install. The third one has no inflation error or warning because it installs the `Assets` folder, despite the `include_only` clause still matching nothing.

Now the filenames are updated.

Note that we also need to update the install for the previous version, as we were supposed to create a `GameData/ASET` folder rather than just copying the folder that's in the ZIP to GameData (this has been changed in the latest release).
