### PR TITLE
ArtemisConstructionKit.netkan - Add PlumeParty as a dependency

### DIFF
--- a/NetKAN/ArtemisConstructionKit.netkan
+++ b/NetKAN/ArtemisConstructionKit.netkan
@@ -20,6 +20,7 @@ recommends:
 install:
   - find: Benjee10_Orion
     install_to: GameData
+    filter: PlumeParty
   - find: Craft Files
     install_to: Ships
     as: VAB

--- a/NetKAN/ArtemisConstructionKit.netkan
+++ b/NetKAN/ArtemisConstructionKit.netkan
@@ -11,6 +11,7 @@ depends:
   - name: AnimatedDecouplers
   - name: Benjee10-SharedAssets
   - name: HabTechProps
+  - name: PlumeParty
 recommends:
   - name: Shabby
   - name: Shaddy


### PR DESCRIPTION
When this Pull Request, to remove PlumeParty out from being bundled within the mod's Benjee10_Orion folder, gets merged and a new distribution is released, this metadata will require updating to require PlumeParty (just the core package, not the Stock configs) as a dependency.

https://github.com/benjee10/Benjee10_Orion/pull/14

___

ckan compat add 1.12
