### PR TITLE
Update InfernalRoboticsNext.netkan

### DIFF
--- a/NetKAN/InfernalRoboticsNext.netkan
+++ b/NetKAN/InfernalRoboticsNext.netkan
@@ -17,20 +17,17 @@
         "plugin"
     ],
     "conflicts"      : [
-        { "name": "InfernalRobotics"         },
-        { "name": "KerbalJointReinforcement" }
+        { "name": "InfernalRobotics" }
     ],
     "depends": [
-        { "name": "ModuleManager"     },
-        { "name": "TweakScale-Redist" }
+        { "name": "ModuleManager" }
     ],
     "recommends"     : [
         { "name": "KerbalJointReinforcementNext" }
     ],
     "install"        : [ {
         "file"       : "GameData/MagicSmokeIndustries",
-        "install_to" : "GameData",
-        "filter"     : "Scale_Redist.dll"
+        "install_to" : "GameData"
     } ],
     "x_netkan_override": [ {
         "version": "v3.0.0",


### PR DESCRIPTION
TweakScale or TweakScaleRedist is no longer used in the mod and has been removed completly

there is no incompatibility known with KJR-continued (anymore)