### PR TITLE
Epoch BDArmoryExtended

### DIFF
--- a/NetKAN/BDArmoryExtended.netkan
+++ b/NetKAN/BDArmoryExtended.netkan
@@ -5,6 +5,7 @@ abstract: >-
   for all features of BDA not already present in the base mod and a
   balanced expansion of weapon options
 $kref: '#/ckan/github/BrettRyland/BDArmory-Extended'
+x_netkan_epoch: 1
 ksp_version_min: '1.9'
 license: CC0
 tags:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1559108/230728183-36170fca-8b99-4736-85bd-998bc3b56b60.png)

For once this isn't GitHub's API's fault; the mod really had an out-of-order release, due to thinking that the `0` in `1.09.2` is significant:

https://github.com/BrettRyland/BDArmory-Extended/releases

![image](https://user-images.githubusercontent.com/1559108/230728230-b05b1624-38fc-4b40-8187-02cb2ce65ec1.png)

![image](https://user-images.githubusercontent.com/1559108/230728255-077335cf-0b8d-405e-a6a6-374a266df23d.png)
