### PR TITLE
Add KopernicusExpansionContinueder dep to Udarka

### DIFF
--- a/NetKAN/Udarka.netkan
+++ b/NetKAN/Udarka.netkan
@@ -11,6 +11,7 @@ depends:
   - name: EnvironmentalVisualEnhancements
   - name: Scatterer
   - name: Singularity
+  - name: KopernicusExpansionContinueder
 recommends:
   - name: TUFX
   - name: DistantObject


### PR DESCRIPTION
In #9543 I noted that this mod was bundling KopernicusExpansionContinueder, which wasn't in CKAN. Since it wasn't explicitly mentioned as a hard dependency, I guessed/hoped that it would work without it.

Now KopernicusExpansionContinueder has been added in #9655, so it's added to this mod as a dependency.

___

ckan compat add 1.12
