### PR TITLE
Create RP-1.netkan

### DIFF
--- a/NetKAN/RP-1.netkan
+++ b/NetKAN/RP-1.netkan
@@ -1,0 +1,13 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "RP-1",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/KSP-RO/RP-1/master/RP-1.netkan",
+    "x_netkan_license_ok": true,
+    "tags": [
+        "plugin",
+        "config",
+        "parts",
+        "career",
+        "science"
+    ]
+}


### PR DESCRIPTION
This will (a) allow us to maintain a legacy version of RP-1 (using the old identifier) for folks finishing old saves, and (b) unify the identifier with the mod name (and now the repo name).