### PR TITLE
Add Harmony2 dep to HUDReplacer 1.2.0 and later

### DIFF
--- a/NetKAN/HUDReplacer.netkan
+++ b/NetKAN/HUDReplacer.netkan
@@ -9,3 +9,8 @@ resources:
 tags:
   - plugin
   - graphics
+x_netkan_override:
+  - version: '>=1.2.0'
+    override:
+      depends:
+        - name: Harmony2


### PR DESCRIPTION
- <https://forum.kerbalspaceprogram.com/index.php?/topic/216056-wip-112x-hudreplacer-v121-pre/&do=findComment&comment=4290832>

![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/067c5359-0e73-4c67-b502-2c5b73fb9710)

The pre-releases mean we can't just add it as a regular `depends`, which would add it to the current latest non-prerelease 1.1.0 version, so this PR uses `x_netkan_override` to make it version-specific. As soon as a version equal to or greater than 1.2.0 is released, the new relationship will be added.

Testing with and without the `--prerelease` parameter confirmed that the dependency is pulled in for the newer versions and not the older versions.
