### PR TITLE
Fix ModularRocketSystem install

### DIFF
--- a/NetKAN/ModularRocketSystem.netkan
+++ b/NetKAN/ModularRocketSystem.netkan
@@ -24,7 +24,7 @@ conflicts:
 depends:
   - name: ModuleManager
 install:
-  - file: NecroBones
+  - find: NecroBones
     install_to: GameData
   - find: Ships/SPH
     install_to: Ships

--- a/NetKAN/ModularRocketSystem.netkan
+++ b/NetKAN/ModularRocketSystem.netkan
@@ -24,9 +24,7 @@ conflicts:
 depends:
   - name: ModuleManager
 install:
-  - file: ModRocketSys
+  - file: NecroBones
     install_to: GameData
-    filter_regexp:
-      - \.craft$
-  - find_regexp: \.craft$
-    install_to: Ships/SPH
+  - find: Ships/SPH
+    install_to: Ships


### PR DESCRIPTION
Accidentally committed the rename to master in ef5d666b9196b5e68307fdd4fedce3826c4a94e3 instead of making a PR. An inflation error occurred because the folder structure has changed.

![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/95086b24-3c7b-4619-a2a7-66300e6eac56)

<https://github.com/KSP-CKAN/NetKAN/actions/runs/5501979465/jobs/10025932810>

<https://spacedock.info/mod/86/Modular%20Rocket%20Systems>

Fixes #9696.