### PR TITLE
Add ROLoadingImages to CKAN

### DIFF
--- a/NetKAN/ROLoadingImages.netkan
+++ b/NetKAN/ROLoadingImages.netkan
@@ -1,0 +1,10 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "ROLoadingImages",
+    "$kref": "#/ckan/netkan/https://raw.githubusercontent.com/KSP-RO/ROLoadingImages/master/ROLoadingImages.netkan",
+    "x_netkan_license_ok": true,
+    "tags": [
+        "graphics",
+        "plugin"
+    ]
+}


### PR DESCRIPTION
Done via metanetkan. I think the tags are correct? _Is_ there a "Loading Screens" tag?

- <https://github.com/KSP-RO/ROLoadingImages>
- <https://raw.githubusercontent.com/KSP-RO/ROLoadingImages/master/ROLoadingImages.netkan>
