### PR TITLE
Trim extra characters from SRBWaterfallEffects versions

### DIFF
--- a/NetKAN/SRBWaterfallEffects.netkan
+++ b/NetKAN/SRBWaterfallEffects.netkan
@@ -1,7 +1,7 @@
 spec_version: v1.18
 identifier: SRBWaterfallEffects
 $kref: '#/ckan/spacedock/2992'
-x_netkan_version_edit: ^(?<version>[^ ]+).*$
+x_netkan_version_edit: ^(?<version>[^" ]+).*$
 license: CC-BY-NC-SA
 tags:
   - config

--- a/NetKAN/SRBWaterfallEffects.netkan
+++ b/NetKAN/SRBWaterfallEffects.netkan
@@ -1,6 +1,7 @@
 spec_version: v1.18
 identifier: SRBWaterfallEffects
 $kref: '#/ckan/spacedock/2992'
+x_netkan_version_edit: ^(?<version>[^ ]+).*$
 license: CC-BY-NC-SA
 tags:
   - config


### PR DESCRIPTION
## Problem

CKAN-meta now has a file with an illegal name on Windows:

```
$ git pull --all
Fetching upstream
Fetching origin
error: invalid path 'SRBWaterfallEffects/SRBWaterfallEffects-1-0.3 "The Prettier Plumes Update".ckan'
```

And the mirrorer is spamming Discord every 5 minutes:

![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/ad34a5ce-3774-4dc2-8016-8fa9a21d0468)

## Cause

A mod version string was created containing a space and some quote characters, which propagated into the usual places where they're not allowed.

## Changes

Now a netkan version edit directive trims characters from the version string for this mod starting at the first space or quote, keeping only the part at the beginning that actually describes a version number. This will involve another epoch increment to ensure users will be updated to the fixed version.

A subsequent change in NetKAN-Infra will purge the queue entries that are spamming Discord, and a subsequent pull request in CKAN-meta will purge the illegal filename.
