### PR TITLE
Remove unnecessary dependencies of DE-IVAExtension

### DIFF
--- a/NetKAN/DE-IVAExtension.netkan
+++ b/NetKAN/DE-IVAExtension.netkan
@@ -14,8 +14,6 @@ depends:
   - name: ModuleManager
   - name: RasterPropMonitor-Core
   - name: ASETProps
-  - name: ToolbarController
-  - name: ClickThroughBlocker
 supports:
   - name: ProbeControlRoom
 install:


### PR DESCRIPTION
These dependencies are no longer needed, per https://forum.kerbalspaceprogram.com/topic/211932-112x-de_ivaextension-adopted-aset-ivas-for-all-stock-pods/