### PR TITLE
Remove unneeded dependencies for ProbeControlRoomRecontrolled

### DIFF
--- a/NetKAN/ProbeControlRoomRecontrolled.netkan
+++ b/NetKAN/ProbeControlRoomRecontrolled.netkan
@@ -14,9 +14,7 @@
     } ],
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "RasterPropMonitor-Core" },
-        { "name": "ToolbarController" },
-        { "name": "ClickThroughBlocker" }
+        { "name": "RasterPropMonitor-Core" }
     ],
     "conflicts": [
         { "name": "ProbeControlRoom" }


### PR DESCRIPTION
These are no longer necessary, per https://github.com/JonnyOThan/KSP-ProbeControlRoom/