### PR TITLE
VesselView depends on VesselView-UI-Toolbar

### DIFF
--- a/NetKAN/VesselView.netkan
+++ b/NetKAN/VesselView.netkan
@@ -8,7 +8,7 @@ tags:
   - plugin
   - information
 depends:
-  - name: VesselView-UI
+  - name: VesselView-UI-Toolbar
   - name: ToolbarController
   - name: ClickThroughBlocker
 install:


### PR DESCRIPTION
The intention was that you could use either VV-RPM or VV-Toolbar, but until that gets fixed CKAN should probably just install all 3.

@linuxgurugamer for visibility
