### PR TITLE
Get CorrectifTraductionFrancaise homepage from SpaceDock

### DIFF
--- a/NetKAN/CorrectifTraductionFrancaise.netkan
+++ b/NetKAN/CorrectifTraductionFrancaise.netkan
@@ -2,7 +2,5 @@ spec_version: v1.18
 identifier: CorrectifTraductionFrancaise
 $kref: '#/ckan/spacedock/3443'
 license: MIT
-resources:
-  homepage: https://discord.gg/GTUqwydTWD
 tags:
   - config


### PR DESCRIPTION
I thought CorrectifTraductionFrancaise would rely on its Discord server for support, but now there's a forum thread. 

https://forum.kerbalspaceprogram.com/topic/218994-correctif-traduction-fran%C3%A7aise/

So now SpaceDock can specify the homepage.
