### PR TITLE
Make KerbalField depend on the virtual BDArmory identifier

### DIFF
--- a/NetKAN/KerbalField.netkan
+++ b/NetKAN/KerbalField.netkan
@@ -1,15 +1,11 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "KerbalField",
-    "$kref":        "#/ckan/spacedock/1646",
-    "x_netkan_epoch": 3,
-    "license":      "CC-BY-SA",
-    "tags": [
-        "parts",
-        "combat"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "BDArmory"      }
-    ]
-}
+spec_version: v1.4
+identifier: KerbalField
+$kref: '#/ckan/spacedock/1646'
+x_netkan_epoch: 3
+license: CC-BY-SA
+tags:
+  - parts
+  - combat
+depends:
+  - name: ModuleManager
+  - name: BDArmory

--- a/NetKAN/KerbalField.netkan
+++ b/NetKAN/KerbalField.netkan
@@ -9,7 +9,7 @@
         "combat"
     ],
     "depends": [
-        { "name": "ModuleManager"     },
-        { "name": "BDArmoryContinued" }
+        { "name": "ModuleManager" },
+        { "name": "BDArmory"      }
     ]
 }


### PR DESCRIPTION
I got permission from the author on the ksp forums for this

![image](https://github.com/KSP-CKAN/NetKAN/assets/9804078/3a3a249c-221b-43d6-8b23-3bfcf0651630)

___

Previous time this came up: #9328
