### PR TITLE
Put more specific Parallax texture dependencies first

### DIFF
--- a/NetKAN/Parallax-StockScatterTextures.netkan
+++ b/NetKAN/Parallax-StockScatterTextures.netkan
@@ -18,8 +18,8 @@ conflicts:
     max_version: '1.3.1'
 depends:
   - name: ModuleManager
-  - name: Parallax
   - name: Parallax-StockTextures
+  - name: Parallax
 install:
   - find: Parallax_StockTextures
     install_to: GameData

--- a/NetKAN/Parallax-StockTextures.netkan
+++ b/NetKAN/Parallax-StockTextures.netkan
@@ -18,8 +18,8 @@ conflicts:
     max_version: '1.3.1'
 depends:
   - name: ModuleManager
-  - name: Parallax
   - name: Parallax-StockScatterTextures
+  - name: Parallax
 install:
   - find: Parallax_StockTextures
     install_to: GameData


### PR DESCRIPTION
Parallax's stock texture modules' depend on Parallax first and each other second, which potentially creates an ambiguity for the relationship resolver that could result in prompting the user twice if there were other texture packages to choose from.

Now the relationships are reordered to make it easier on the resolver.
I'll do another PR in CKAN-meta for historical data.
