### PR TITLE
Force-allow KSPWheel on 1.12 while AVC is down

### DIFF
--- a/NetKAN/KSPWheel.netkan
+++ b/NetKAN/KSPWheel.netkan
@@ -1,26 +1,17 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "KSPWheel",
-    "$kref":        "#/ckan/github/shadowmage45/KSPWheel",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/152782-*"
-    },
-    "tags": [
-        "plugin",
-        "library"
-    ],
-    "install": [ {
-        "install_to": "GameData",
-        "find": "KSPWheel"
-    } ],
-    "x_netkan_override" : [
-        {
-            "version" : "1:0.16.14.33",
-            "override" : {
-                "ksp_version_max": "1.12.99"
-            }
-        }
-    ]
-}
+spec_version: v1.4
+identifier: KSPWheel
+$kref: '#/ckan/github/shadowmage45/KSPWheel'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/152782-*
+tags:
+  - plugin
+  - library
+install:
+  - install_to: GameData
+    find: KSPWheel
+x_netkan_override:
+  - version: 1:0.16.14.33
+    override:
+      ksp_version_max: 1.12

--- a/NetKAN/KSPWheel.netkan
+++ b/NetKAN/KSPWheel.netkan
@@ -14,5 +14,13 @@
     "install": [ {
         "install_to": "GameData",
         "find": "KSPWheel"
-    } ]
+    } ],
+    "x_netkan_override" : [
+        {
+            "version" : "1:0.16.14.33",
+            "override" : {
+                "ksp_version_max": "1.12.99"
+            }
+        }
+    ]
 }


### PR DESCRIPTION
This works around the issue where the remote version file (which gives this compatibility) is hosted on the AVC server, which is down (as it sometimes is).