### PR TITLE
Add ROUtils and RONoCareer

### DIFF
--- a/NetKAN/RONoCareer.netkan
+++ b/NetKAN/RONoCareer.netkan
@@ -1,0 +1,6 @@
+spec_version: v1.4
+identifier: RONoCareer
+$kref: '#/ckan/netkan/https://raw.githubusercontent.com/KSP-RO/RONoCareer/master/RONoCareer.netkan'
+x_netkan_license_ok: true
+tags:
+  - career

--- a/NetKAN/ROUtils.netkan
+++ b/NetKAN/ROUtils.netkan
@@ -1,0 +1,6 @@
+spec_version: v1.4
+identifier: ROUtils
+$kref: '#/ckan/netkan/https://raw.githubusercontent.com/KSP-RO/ROUtils/master/ROUtils.netkan'
+x_netkan_license_ok: true
+tags:
+  - plugin


### PR DESCRIPTION
@HebaruSan for once I actually made the mods (including netkan!) before making the PR. Woot!

(FYI the plan for these are that ROUtils will be a dependency for most KSP-RO mods, but should not be installed on its own; and RONoCareer will go into the express install in an any_of with RP-1 so that folks can choose to install RO but _not_ RP-1, finally. It's purely a stub so the any_of can work, so it doesn't actually do anything other than exist and be findable by CKAN.)