### PR TITLE
Vref for SuperfluousNodes

### DIFF
--- a/NetKAN/SuperfluousNodes.netkan
+++ b/NetKAN/SuperfluousNodes.netkan
@@ -1,6 +1,7 @@
 spec_version: v1.16
 identifier: SuperfluousNodes
 $kref: '#/ckan/spacedock/2064'
+$vref: '#/ckan/ksp-avc'
 license: MIT
 tags:
   - config


### PR DESCRIPTION
![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/7ff261dd-e1ce-426b-823f-2943d4ba66b4)

This mod added a version file.

- https://spacedock.info/mod/2064/Superfluous%20Nodes
- https://forum.kerbalspaceprogram.com/topic/181663-112-superfluous-nodes-07-plethora-of-extra-nodes-for-stock-parts/
