### PR TITLE
Add kOS-Addons-Ferram

### DIFF
--- a/NetKAN/kOS-AddOns-Ferram.netkan
+++ b/NetKAN/kOS-AddOns-Ferram.netkan
@@ -1,5 +1,5 @@
 spec_version: v1.4
-identifier: kOS-Addons-Ferram
+identifier: kOS-AddOns-Ferram
 $kref: '#/ckan/github/giuliodondi/kOS-Ferram'
 x_netkan_github:
   use_source_archive: true

--- a/NetKAN/kOS-Addons-Ferram.netkan
+++ b/NetKAN/kOS-Addons-Ferram.netkan
@@ -7,7 +7,8 @@ ksp_version: '1.12'
 license: GPL-3.0
 tags:
   - plugin
-  - physics
+  - control
+  - information
 depends:
   - name: kOS
   - name: FAR

--- a/NetKAN/kOS-Addons-Ferram.netkan
+++ b/NetKAN/kOS-Addons-Ferram.netkan
@@ -1,0 +1,16 @@
+spec_version: v1.4
+identifier: kOS-Addons-Ferram
+$kref: '#/ckan/github/giuliodondi/kOS-Ferram'
+x_netkan_github:
+  use_source_archive: true
+ksp_version: '1.12'
+license: GPL-3.0
+tags:
+  - plugin
+  - physics
+depends:
+  - name: kOS
+  - name: FAR
+install:
+  - find: kOS-Addons
+    install_to: GameData


### PR DESCRIPTION
This is an addon for kOS providing access to FAR's API.

- https://github.com/giuliodondi/kOS-Ferram

The releases don't have normal assets, but the DLL is in the source ZIP, so we use that.

After this, users will be able to install this mod with CKAN instead of manually, which will prevent the error in giuliodondi/kOS-Ferram#3. (Though technically the renaming of the DLL already did that.)

Fixes #9856.

FYI to @giuliodondi.
