### PR TITLE
Force_v for KerbalKrashSystem.netkan

### DIFF
--- a/NetKAN/KerbalKrashSystem.netkan
+++ b/NetKAN/KerbalKrashSystem.netkan
@@ -1,27 +1,20 @@
-{
-    "spec_version":  "v1.4",
-    "identifier" :   "KerbalKrashSystem",
-    "author":        "EnzoMeertens",
-    "$kref":         "#/ckan/github/EnzoMeertens/KerbalKrashSystem",
-    "$vref":         "#/ckan/ksp-avc",
-    "x_netkan_epoch": "1",
-    "license":       "MIT",
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/129410-*",
-        "repository": "https://github.com/EnzoMeertens/KerbalKrashSystem"
-    },
-    "tags": [
-        "plugin",
-        "physics"
-    ],
-    "depends": [
-        {
-            "name": "ModuleManager",
-            "min_version": "2.6.25"
-        }
-    ],
-    "install": [ {
-        "find": "KerbalKrashSystem",
-        "install_to": "GameData"
-    } ]
-}
+spec_version: v1.4
+identifier: KerbalKrashSystem
+author: EnzoMeertens
+$kref: '#/ckan/github/EnzoMeertens/KerbalKrashSystem'
+x_netkan_force_v: true
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: '1'
+license: MIT
+resources:
+  homepage: http://forum.kerbalspaceprogram.com/index.php?/topic/129410-*
+  repository: https://github.com/EnzoMeertens/KerbalKrashSystem
+tags:
+  - plugin
+  - physics
+depends:
+  - name: ModuleManager
+    min_version: 2.6.25
+install:
+  - find: KerbalKrashSystem
+    install_to: GameData


### PR DESCRIPTION
![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/89e3307d-ea38-40d1-bdae-451119bbdd82)

A `v` prefix was dropped, which triggered an epoch in KSP-CKAN/CKAN-meta#2129, and the v0.4.7 version is now double indexed:

![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/4f9f7d33-8f6a-4357-90d8-f58c6d1053ab)

We'll need to do some clean-up in CKAN-meta in a subsequent PR.
