### PR TITLE
Make TheKramsieChallengePlanetPack conflict with its provides

### DIFF
--- a/NetKAN/TheKramsieChallengePlanetPack.netkan
+++ b/NetKAN/TheKramsieChallengePlanetPack.netkan
@@ -9,6 +9,9 @@ tags:
 provides:
   - Scatterer-config
   - Scatterer-sunflare
+conflicts:
+  - name: Scatterer-config
+  - name: Scatterer-sunflare
 depends:
   - name: ModuleManager
   - name: Kopernicus


### PR DESCRIPTION
The list of `Scatterer-config` providers has a quirk:

![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/c980824b-445e-4b0b-a677-8cd53b0fccf5)

Most of them also `conflict` with other providers, but not `TheKramsieChallengePlanetPack`. I think this just got missed in #9469.

Noticed while looking into some enhancements to the provided mods prompt for @JonnyOThan.

Now the conflicts are added.