### PR TITLE
Improve Scatterer-sunflare's abstract

### DIFF
--- a/NetKAN/Scatterer-sunflare.netkan
+++ b/NetKAN/Scatterer-sunflare.netkan
@@ -1,7 +1,9 @@
 spec_version: v1.4
 identifier: Scatterer-sunflare
 name: Scatterer Sunflare
-abstract: The sunflare component of scatterer
+abstract: >-
+  Scatterer's default sunflare.
+  If you're not sure which one to pick, pick this.
 $kref: '#/ckan/spacedock/141'
 x_netkan_force_v: true
 x_netkan_epoch: '3'


### PR DESCRIPTION
If you install Scatterer, you're prompted to pick a sunflare. @JonnyOThan pointed out that the choice currently is intimidating and unclear, since there are many many options and the reasonable default just says "The sunflare component of scatterer".

Now it's updated to use less technical language ("component" removed), and to say that users who aren't sure should pick it.
