### PR TITLE
Update Kerbalism-Config-ScienceOnly.netkan

### DIFF
--- a/NetKAN/Kerbalism-Config-ScienceOnly.netkan
+++ b/NetKAN/Kerbalism-Config-ScienceOnly.netkan
@@ -15,7 +15,7 @@
     "depends": [
         { "name": "ModuleManager" },
         { "name": "CommunityResourcePack" },
-        { "name": "Kerbalism" }
+        { "name": "Kerbalism", "max_version" : "3.14"}
     ],
     "conflicts": [
         { "name": "Kerbalism-Config" }


### PR DESCRIPTION
The science-only config isn't maintained, and doesn't work with versions of Kerbalism core newer than 3.14