### PR TITLE
Add RPM-Parts-Checklist

### DIFF
--- a/NetKAN/RPM-Parts-Checklist.netkan
+++ b/NetKAN/RPM-Parts-Checklist.netkan
@@ -1,8 +1,6 @@
-spec_version: v1.4
 identifier: RPM-Parts-Checklist
 $kref: '#/ckan/github/Fedex75/RPM_Parts_Checklist'
 ksp_version: '1.12.5'
-license: GPL-3.0
 tags:
   - plugin
   - crewed

--- a/NetKAN/RPM-Parts-Checklist.netkan
+++ b/NetKAN/RPM-Parts-Checklist.netkan
@@ -1,0 +1,13 @@
+spec_version: v1.4
+identifier: RPM-Parts-Checklist
+$kref: '#/ckan/github/Fedex75/RPM_Parts_Checklist'
+ksp_version: '1.12.5'
+license: GPL-3.0
+tags:
+  - plugin
+  - crewed
+depends:
+  - name: ASETProps
+install:
+  - find: RPM_Parts_Checklist
+    install_to: GameData

--- a/NetKAN/RPM-Parts-Checklist.netkan
+++ b/NetKAN/RPM-Parts-Checklist.netkan
@@ -6,6 +6,7 @@ license: GPL-3.0
 tags:
   - plugin
   - crewed
+  - first-person
 depends:
   - name: ASETProps
 install:


### PR DESCRIPTION
Adds PAW functionality to RPM pages.

https://github.com/Fedex75/RPM_Parts_Checklist/

Needs StoneBlue/ASET-Consolidated-Props#27 and a new release of that mod to merge. If that doesn't pan out, we may have to adjust the dependencies.

Fixes #9874.

This mod should be included in #9859.
