### PR TITLE
Update WYGWatchYourGforces.netkan

### DIFF
--- a/NetKAN/WYGWatchYourGforces.netkan
+++ b/NetKAN/WYGWatchYourGforces.netkan
@@ -8,7 +8,7 @@ tags:
   - crewed
 depends:
   - name: ModuleManager
-suggests:
+conflicts:
   - name: DeadlyReentry
 install:
   - find: WYG


### PR DESCRIPTION
Deadly Reentry author notified me he had a method for G-forces limits on parts too, so those 2 mods shouldn't coexist together in the same KSP install.
Sorry for the changes/inconvenience.