### PR TITLE
Add new dependencies for ArtemisConstructionKit

### DIFF
--- a/NetKAN/ArtemisConstructionKit.netkan
+++ b/NetKAN/ArtemisConstructionKit.netkan
@@ -11,6 +11,9 @@ depends:
   - name: AnimatedDecouplers
   - name: Benjee10-SharedAssets
   - name: HabTechProps
+  - name: DeployableEngines
+  - name: CommunityResourcePack
+  - name: SimpleAdjustableFairings
 recommends:
   - name: Shabby
   - name: Shaddy


### PR DESCRIPTION
This mod has added several new dependencies since #9304.
Now it's updated based on the list in the SpaceDock entry description and repository.

Thanks to Discord user Sofie for pointing this out.

___

ckan compat add 1.11 1.12