### PR TITLE
Make WBI ClassicStock, Pristine, and Simplified play modes conflict with CRP

### DIFF
--- a/NetKAN/WildBlue-PlayMode-ClassicStock.netkan
+++ b/NetKAN/WildBlue-PlayMode-ClassicStock.netkan
@@ -23,7 +23,8 @@
         "WildBlue-PlayMode"
     ],
     "conflicts": [
-        { "name": "WildBlue-PlayMode" }
+        { "name": "WildBlue-PlayMode" },
+        { "name": "CommunityResourcePack" }
     ],
     "install": [ {
         "find":       "000WildBlueTools/Templates/ClassicStock",

--- a/NetKAN/WildBlue-PlayMode-Pristine.netkan
+++ b/NetKAN/WildBlue-PlayMode-Pristine.netkan
@@ -21,6 +21,7 @@ provides:
   - KerbalKomets-PlayMode
 conflicts:
   - name: WildBlue-PlayMode
+  - name: CommunityResourcePack
 install:
   - find: 000WildBlueTools/Templates/Pristine/MM_Pristine.txt
     install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/Pristine

--- a/NetKAN/WildBlue-PlayMode-Simplified.netkan
+++ b/NetKAN/WildBlue-PlayMode-Simplified.netkan
@@ -23,6 +23,7 @@ provides:
   - KerbalKomets-PlayMode
 conflicts:
   - name: WildBlue-PlayMode
+  - name: CommunityResourcePack
 install:
   - find: 000WildBlueTools/Templates/Simplified/Storage/OmniStorage.txt
     install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/Simplified/Storage


### PR DESCRIPTION
i.e. you must use the CRP or USI play modes if you're using CRP.