### PR TITLE
Reorder RationalResources's conflicting recommendations

### DIFF
--- a/NetKAN/RationalResources.netkan
+++ b/NetKAN/RationalResources.netkan
@@ -10,8 +10,8 @@ tags:
 depends:
   - name: ModuleManager
 recommends:
-  - name: CommunityResourcePack
   - name: ClassicStockResources
+  - name: CommunityResourcePack
   - name: RationalResourcesCompanion
   - name: SCANsat
 suggests:


### PR DESCRIPTION
See https://github.com/KSP-CKAN/NetKAN/pull/9896#issuecomment-1879791620, RationalResources currently recommends two mods with an indirect conflict, which trips `ckan install` when `--no-recommends` isn't passed (which is what the meta tester does).

Now ClassicStockResources comes before CommunityResourcePack so the conflict can be resolved automatically.
