### PR TITLE
Split out play modes for ClassicStockResources

### DIFF
--- a/NetKAN/Buffalo.netkan
+++ b/NetKAN/Buffalo.netkan
@@ -1,49 +1,42 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "Buffalo",
-    "name":         "Buffalo",
-    "author":       "Angel-125",
-    "$kref":        "#/ckan/github/Angel-125/Buffalo",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that no new play modes were added to the Templates folder",
-    "license":      "GPL-3.0",
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/122617-*"
-    },
-    "tags": [
-        "parts",
-        "crewed"
-    ],
-    "depends": [
-        { "name": "Buffalo-PlayMode" },
-        { "name": "ModuleManager"    },
-        { "name": "WildBlueTools"    },
-        { "name": "KerbalActuators"  }
-    ],
-    "supports": [
-        { "name": "ConnectedLivingSpace" },
-        { "name": "TACLS"                },
-        { "name": "USI-LS"               },
-        { "name": "Snacks"               }
-    ],
-    "recommends": [
-        { "name": "Snacks"                   },
-        { "name": "ExtraPlanetaryLaunchpads" },
-        { "name": "KIS"                      },
-        { "name": "KAS"                      },
-        { "name": "ASET"                     },
-        { "name": "ASETAvionics"             }
-    ],
-    "install": [ {
-        "find":       "Buffalo",
-        "install_to": "GameData/WildBlueIndustries",
-        "filter":     [ "Ships", "Templates" ]
-    }, {
-        "find":       "Buffalo/Templates/Common",
-        "install_to": "GameData/WildBlueIndustries/Buffalo/Templates"
-    }, {
-        "find":       "Ships/SPH",
-        "install_to": "Ships"
-    } ]
-}
+spec_version: v1.4
+identifier: Buffalo
+name: Buffalo
+author: Angel-125
+$kref: '#/ckan/github/Angel-125/Buffalo'
+$vref: '#/ckan/ksp-avc'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that no new play modes were added to the Templates folder
+license: GPL-3.0
+resources:
+  homepage: http://forum.kerbalspaceprogram.com/index.php?/topic/122617-*
+tags:
+  - parts
+  - crewed
+depends:
+  - name: Buffalo-PlayMode
+  - name: ModuleManager
+  - name: WildBlueTools
+  - name: ClassicStockResources
+  - name: KerbalActuators
+supports:
+  - name: ConnectedLivingSpace
+  - name: TACLS
+  - name: USI-LS
+  - name: Snacks
+recommends:
+  - name: Snacks
+  - name: ExtraPlanetaryLaunchpads
+  - name: KIS
+  - name: KAS
+  - name: ASET
+  - name: ASETAvionics
+install:
+  - find: Buffalo
+    install_to: GameData/WildBlueIndustries
+    filter:
+      - Ships
+      - Templates
+  - find: Buffalo/Templates/Common
+    install_to: GameData/WildBlueIndustries/Buffalo/Templates
+  - find: Ships/SPH
+    install_to: Ships

--- a/NetKAN/ClassicStockResources-PlayMode-ClassicStock.netkan
+++ b/NetKAN/ClassicStockResources-PlayMode-ClassicStock.netkan
@@ -1,6 +1,6 @@
 spec_version: v1.24
 identifier: ClassicStockResources-PlayMode-ClassicStock
-name: Classic Stock Resources Classic Sock Play Mode
+name: Classic Stock Resources Classic Stock Play Mode
 author: Angel-125
 $kref: '#/ckan/github/Angel-125/ClassicStockResources'
 $vref: '#/ckan/ksp-avc'

--- a/NetKAN/ClassicStockResources-PlayMode-ClassicStock.netkan
+++ b/NetKAN/ClassicStockResources-PlayMode-ClassicStock.netkan
@@ -1,0 +1,28 @@
+spec_version: v1.24
+identifier: ClassicStockResources-PlayMode-ClassicStock
+name: Classic Stock Resources Classic Sock Play Mode
+author: Angel-125
+$kref: '#/ckan/github/Angel-125/ClassicStockResources'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+resources:
+  homepage: https://github.com/Angel-125/ClassicStockResources
+tags:
+  - library
+  - resources
+provides:
+  - ClassicStockResources-PlayMode
+conflicts:
+  - name: CommunityResourcePack
+  - name: ClassicStockResources-PlayMode
+depends:
+  - name: ModuleManager
+  - name: ClassicStockResources
+  - name: WildBlue-PlayMode-ClassicStock
+install:
+  - find: ClassicStockResources/Templates
+    include_only:
+      - Storage
+      - Utility
+      - Production
+    install_to: GameData/WildBlueIndustries/ClassicStockResources

--- a/NetKAN/ClassicStockResources.netkan
+++ b/NetKAN/ClassicStockResources.netkan
@@ -9,8 +9,6 @@ resources:
 tags:
   - library
   - resources
-conflicts:
-  - name: CommunityResourcePack
 depends:
   - name: ModuleManager
   - name: ClassicStockResources-PlayMode

--- a/NetKAN/ClassicStockResources.netkan
+++ b/NetKAN/ClassicStockResources.netkan
@@ -13,7 +13,10 @@ conflicts:
   - name: CommunityResourcePack
 depends:
   - name: ModuleManager
-  - name: WildBlue-PlayMode-ClassicStock
+  - name: ClassicStockResources-PlayMode
 install:
   - find: ClassicStockResources
     install_to: GameData/WildBlueIndustries
+    filter: Templates
+  - find: ClassicStockResources/Templates/Common
+    install_to: GameData/WildBlueIndustries/ClassicStockResources/Templates

--- a/NetKAN/ClassicStockResources.netkan
+++ b/NetKAN/ClassicStockResources.netkan
@@ -1,23 +1,19 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "ClassicStockResources",
-    "author":       "Angel-125",
-    "$kref":        "#/ckan/github/Angel-125/ClassicStockResources",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "resources": {
-        "homepage": "https://github.com/Angel-125/ClassicStockResources"
-    },
-    "tags": [
-        "library",
-        "resources"
-    ],
-    "depends": [
-        { "name": "ModuleManager"                  },
-        { "name": "WildBlue-PlayMode-ClassicStock" }
-    ],
-    "install": [ {
-        "find":       "ClassicStockResources",
-        "install_to": "GameData/WildBlueIndustries"
-    } ]
-}
+spec_version: v1.4
+identifier: ClassicStockResources
+author: Angel-125
+$kref: '#/ckan/github/Angel-125/ClassicStockResources'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+resources:
+  homepage: https://github.com/Angel-125/ClassicStockResources
+tags:
+  - library
+  - resources
+conflicts:
+  - name: CommunityResourcePack
+depends:
+  - name: ModuleManager
+  - name: WildBlue-PlayMode-ClassicStock
+install:
+  - find: ClassicStockResources
+    install_to: GameData/WildBlueIndustries

--- a/NetKAN/DSEV.netkan
+++ b/NetKAN/DSEV.netkan
@@ -16,6 +16,7 @@ depends:
   - name: DSEV-PlayMode
   - name: ModuleManager
   - name: WildBlueTools
+  - name: ClassicStockResources
   - name: NearFutureProps
   - name: KerbalActuators
 recommends:

--- a/NetKAN/Heisenberg.netkan
+++ b/NetKAN/Heisenberg.netkan
@@ -18,6 +18,7 @@ depends:
   - name: Heisenberg-PlayMode
   - name: ModuleManager
   - name: WildBlueTools
+  - name: ClassicStockResources
   - name: HooliganLabsAirships
   - name: KerbalActuators
 recommends:

--- a/NetKAN/MOLE.netkan
+++ b/NetKAN/MOLE.netkan
@@ -16,6 +16,7 @@ depends:
   - name: MOLE-PlayMode
   - name: ModuleManager
   - name: WildBlueTools
+  - name: ClassicStockResources
   - name: KerbalActuators
 recommends:
   - name: ASETProps

--- a/NetKAN/Pathfinder.netkan
+++ b/NetKAN/Pathfinder.netkan
@@ -19,6 +19,7 @@ depends:
   - name: ModuleManager
   - name: KerbalActuators
   - name: WildBlueTools
+  - name: ClassicStockResources
 recommends:
   - name: KAS
   - name: KIS

--- a/NetKAN/Pathfinder.netkan
+++ b/NetKAN/Pathfinder.netkan
@@ -36,5 +36,3 @@ install:
       - Templates
   - find: Pathfinder/Templates/Common
     install_to: GameData/WildBlueIndustries/Pathfinder/Templates
-  - file: GameData/WBIPlayMode.cfg
-    install_to: GameData

--- a/NetKAN/WildBlue-PlayMode-CRP.netkan
+++ b/NetKAN/WildBlue-PlayMode-CRP.netkan
@@ -1,151 +1,123 @@
-{
-    "spec_version": "v1.18",
-    "identifier":   "WildBlue-PlayMode-CRP",
-    "name":         "WildBlueIndustries CRP Play Mode",
-    "abstract":     "CRP mode provides an extensive set of resource converter templates and parts that make use of the Community Resource Pack (CRP).",
-    "author":       "Angel-125",
-    "$kref":        "#/ckan/github/Angel-125/WildBlueTools",
-    "$vref":        "#/ckan/ksp-avc/WildBlueTools.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "GPL-3.0",
-    "tags": [
-        "config"
-    ],
-    "depends": [
-        { "name": "WildBlueTools"         },
-        { "name": "ModuleManager"         },
-        { "name": "CommunityResourcePack" }
-    ],
-    "provides": [
-        "WildBlue-PlayMode"
-    ],
-    "conflicts": [
-        { "name": "WildBlue-PlayMode" }
-    ],
-    "install": [ {
-        "find": "000WildBlueTools/Templates/CRP/Production/MM_SAFER.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Production",
-        "as": "MM_SAFER.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Production/OmniConverters.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Production",
-        "as": "OmniConverters.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/Coolant.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "Coolant.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/Dirt.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "Dirt.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/ExoticMinerals.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "ExoticMinerals.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/Fertilzer.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "Fertilzer.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/FusionPellets.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "FusionPellets.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/Glykerol.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "Glykerol.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/Karborundrum.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "Karborundrum.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/Konkrete.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "Konkrete.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/KonstructionEquipment.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "KonstructionEquipment.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/KonstructionKonkrete.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "KonstructionKonkrete.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/Lead.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "Lead.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/LiquidHydrogen.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "LiquidHydrogen.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/MetallicOre.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "MetallicOre.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/Metals.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "Metals.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/Minerals.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "Minerals.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/Organics.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "Organics.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/RareMetals.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "RareMetals.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/ResearchKits.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "ResearchKits.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/Rock.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "Rock.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/Slag.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "Slag.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/Uraninite.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "Uraninite.cfg",
-        "find_matches_files": true
-    }, {
-        "find": "000WildBlueTools/Templates/CRP/Storage/XenonGas.txt",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage",
-        "as": "XenonGas.cfg",
-        "find_matches_files": true
-    }, {
-        "find":       "000WildBlueTools/Templates/CRP.cfg",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates",
-        "find_matches_files": true
-    } ]
-}
+spec_version: v1.18
+identifier: WildBlue-PlayMode-CRP
+name: WildBlueIndustries CRP Play Mode
+abstract: >-
+  CRP mode provides an extensive set of resource converter templates and parts
+  that make use of the Community Resource Pack (CRP).
+author: Angel-125
+$kref: '#/ckan/github/Angel-125/WildBlueTools'
+$vref: '#/ckan/ksp-avc/WildBlueTools.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: GPL-3.0
+tags:
+  - config
+depends:
+  - name: WildBlueTools
+  - name: ModuleManager
+  - name: CommunityResourcePack
+provides:
+  - WildBlue-PlayMode
+  - ClassicStockResources-PlayMode
+conflicts:
+  - name: WildBlue-PlayMode
+install:
+  - find: 000WildBlueTools/Templates/CRP/Production/MM_SAFER.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Production
+    as: MM_SAFER.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Production/OmniConverters.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Production
+    as: OmniConverters.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/Coolant.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: Coolant.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/Dirt.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: Dirt.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/ExoticMinerals.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: ExoticMinerals.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/Fertilzer.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: Fertilzer.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/FusionPellets.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: FusionPellets.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/Glykerol.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: Glykerol.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/Karborundrum.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: Karborundrum.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/Konkrete.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: Konkrete.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/KonstructionEquipment.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: KonstructionEquipment.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/KonstructionKonkrete.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: KonstructionKonkrete.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/Lead.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: Lead.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/LiquidHydrogen.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: LiquidHydrogen.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/MetallicOre.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: MetallicOre.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/Metals.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: Metals.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/Minerals.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: Minerals.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/Organics.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: Organics.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/RareMetals.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: RareMetals.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/ResearchKits.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: ResearchKits.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/Rock.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: Rock.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/Slag.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: Slag.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/Uraninite.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: Uraninite.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP/Storage/XenonGas.txt
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Storage
+    as: XenonGas.cfg
+    find_matches_files: true
+  - find: 000WildBlueTools/Templates/CRP.cfg
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates
+    find_matches_files: true

--- a/NetKAN/WildBlue-PlayMode-ClassicStock.netkan
+++ b/NetKAN/WildBlue-PlayMode-ClassicStock.netkan
@@ -1,37 +1,33 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "WildBlue-PlayMode-ClassicStock",
-    "name":         "WildBlueIndustries Classic Stock Play Mode",
-    "abstract":     "Back in KSP 0.19, developers NovaSilisko and HarvesteR proposed a resource system that included Propellium, Oxium, Nitronite, Water, Blutonium, Hexagen, and Zeonium that ultimately converted into the resources we know today as LiquidFuel, Oxidizer, MonoPropellant, and XenonGas. You can see their concept image here: i.imgur.com/08hdJyj.png This play mode is inspired by their vision and adds some additional resources and converters to round out your templates.",
-    "author":       "Angel-125",
-    "$kref":        "#/ckan/github/Angel-125/WildBlueTools",
-    "$vref":        "#/ckan/ksp-avc/WildBlueTools.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "GPL-3.0",
-    "tags": [
-        "config"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "WildBlueTools" }
-    ],
-    "suggests": [
-        { "name": "ClassicStockResources" }
-    ],
-    "provides": [
-        "WildBlue-PlayMode"
-    ],
-    "conflicts": [
-        { "name": "WildBlue-PlayMode" },
-        { "name": "CommunityResourcePack" }
-    ],
-    "install": [ {
-        "find":       "000WildBlueTools/Templates/ClassicStock",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates"
-    }, {
-        "find":       "000WildBlueTools/Templates/ClassicStock.cfg",
-        "install_to": "GameData/WildBlueIndustries/000WildBlueTools/Templates",
-        "find_matches_file": true
-    } ]
-}
+spec_version: v1.4
+identifier: WildBlue-PlayMode-ClassicStock
+name: WildBlueIndustries Classic Stock Play Mode
+abstract: >-
+  Back in KSP 0.19, developers NovaSilisko and HarvesteR proposed a resource
+  system that included Propellium, Oxium, Nitronite, Water, Blutonium, Hexagen,
+  and Zeonium that ultimately converted into the resources we know today as
+  LiquidFuel, Oxidizer, MonoPropellant, and XenonGas. You can see their concept
+  image here: i.imgur.com/08hdJyj.png This play mode is inspired by their vision
+  and adds some additional resources and converters to round out your templates.
+author: Angel-125
+$kref: '#/ckan/github/Angel-125/WildBlueTools'
+$vref: '#/ckan/ksp-avc/WildBlueTools.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: GPL-3.0
+tags:
+  - config
+depends:
+  - name: ModuleManager
+  - name: WildBlueTools
+  - name: ClassicStockResources
+provides:
+  - WildBlue-PlayMode
+conflicts:
+  - name: WildBlue-PlayMode
+  - name: CommunityResourcePack
+install:
+  - find: 000WildBlueTools/Templates/ClassicStock
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates
+  - find: 000WildBlueTools/Templates/ClassicStock.cfg
+    install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates
+    find_matches_file: true

--- a/NetKAN/WildBlue-PlayMode-Pristine.netkan
+++ b/NetKAN/WildBlue-PlayMode-Pristine.netkan
@@ -19,6 +19,7 @@ provides:
   - WildBlue-PlayMode
   - Buffalo-PlayMode
   - KerbalKomets-PlayMode
+  - ClassicStockResources-PlayMode
 conflicts:
   - name: WildBlue-PlayMode
   - name: CommunityResourcePack

--- a/NetKAN/WildBlue-PlayMode-Simplified.netkan
+++ b/NetKAN/WildBlue-PlayMode-Simplified.netkan
@@ -21,6 +21,7 @@ provides:
   - DSEV-PlayMode
   - MOLE-PlayMode
   - KerbalKomets-PlayMode
+  - ClassicStockResources-PlayMode
 conflicts:
   - name: WildBlue-PlayMode
   - name: CommunityResourcePack


### PR DESCRIPTION
## Motivations

These mods bundle ClassicStockResources:

- DSEV
- Pathfinder
- MOLE
- Heisenberg
- Buffalo

If you install any of them manually and choose the ClassicStock play mode, the ClassicStockResources configs will be active. However, if you install with CKAN and pick the ClassicStock play mode, ClassicStockResources is **not** installed (unless the user chooses it). This isn't the expected/intended state of the mod in that case.

In addition, most but not all of ClassicStockResources's .cfg files are renamed to .txt if you pick any play mode other than ClassicStock. But in CKAN you can end up with all or none of the .cfg files when you should only have one.

Finally, PathFinder installs `GameData/WBIPlayMode.cfg`, which is bad because it means this file will be overwritten at install and upgrade.

## Changes

- Now the ClassicStock play mode depends on ClassicStockResources, so it will always be installed if you pick the ClassicStock play mode in CKAN
- Now ClassicStockResources-PlayMode-ClassicStock is created to model the state of having ClassicStockResources installed and choosing the ClassicStock play mode. Installing ClassicStockResources without this module will model the state of choosing some other play mode.
  - ClassicStockResources-PlayMode-ClassicStock conflicts with CommunityResourcePack, because these are incompatible. The main module does not conflict, because you can have it installed while using another play mode.
  - Now the mods that bundle ClassicStockResources depend on it, to ensure that they always have access to that one file that doesn't get renamed to .txt in other play modes
- Now `GameData/WBIPlayMode.cfg` is no longer installed by Pathfinder

Fixes #9899 (once the historical PR in CKAN-meta is done).
Fixes #9905.
