### PR TITLE
Add "config" to RSE-default display name

### DIFF
--- a/NetKAN/RocketSoundEnhancement-Config-Default.netkan
+++ b/NetKAN/RocketSoundEnhancement-Config-Default.netkan
@@ -1,6 +1,6 @@
 spec_version: v1.4
 identifier: RocketSoundEnhancement-Config-Default
-name: Rocket Sound Enhancement - Default
+name: Rocket Sound Enhancement - Default Config
 abstract: RSE sounds for stock engines, wheels, decouplers, and more
 $kref: '#/ckan/github/ensou04/RocketSoundEnhancementDefault'
 $vref: '#/ckan/ksp-avc'


### PR DESCRIPTION
There's some confusion about what this module is and whether it's necessary, this might help