### PR TITLE
Point KourageousTourists at Lisias' fork on spacedock

### DIFF
--- a/NetKAN/KourageousTourists.netkan
+++ b/NetKAN/KourageousTourists.netkan
@@ -13,5 +13,3 @@ tags:
   - config
   - crewed
   - career
-depends:
-  - name: KSPe

--- a/NetKAN/KourageousTourists.netkan
+++ b/NetKAN/KourageousTourists.netkan
@@ -10,6 +10,5 @@ license:
   - restricted
 tags:
   - plugin
-  - config
   - crewed
   - career

--- a/NetKAN/KourageousTourists.netkan
+++ b/NetKAN/KourageousTourists.netkan
@@ -1,12 +1,17 @@
-{
-    "spec_version": "v1.4",
-    "identifier":   "KourageousTourists",
-    "$kref":        "#/ckan/spacedock/1613",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "crewed",
-        "career"
-    ]
-}
+spec_version: v1.18
+identifier: KourageousTourists
+author:
+  - whale_2
+  - LisiasT
+$kref: '#/ckan/spacedock/3206'
+$vref: '#/ckan/ksp-avc'
+license:
+  - GPL-2.0
+  - restricted
+tags:
+  - plugin
+  - config
+  - crewed
+  - career
+depends:
+  - name: KSPe

--- a/NetKAN/KourageousTourists.netkan
+++ b/NetKAN/KourageousTourists.netkan
@@ -2,7 +2,7 @@ spec_version: v1.18
 identifier: KourageousTourists
 author:
   - whale_2
-  - LisiasT
+  - Lisias
 $kref: '#/ckan/spacedock/3206'
 $vref: '#/ckan/ksp-avc'
 license:


### PR DESCRIPTION
Note: transfer was approved by original author here: https://forum.kerbalspaceprogram.com/topic/209560-ksp-131-kourageous-tourists-l-0601-2022-1128/#comment-4224575

A few issues/questions for @Lisias :

* Despite using the same identifier, ckan will use the name of the mod from spacedock - i.e. "Kourageous Tourists /L."  If you're OK with that there's nothing we need to do, or else we can override it in the netkan.
* I explicitly listed the authors here because your spacedock listing doesn't have whale_2 listed as an author (nor should it necessarily, unless you want them to be able to modify your releases etc).  Since the original license was MIT I think listing whale_2 in CKAN is required, but in any case it's nice to give credit to previous authors and I don't think you'd have a problem with this anyway.  Of course let me know if you have any objections.
* Some of your mods use "Lisias" and some use "LisiasT" in the author field - which would you prefer?  I think since your spacedock account is named Lisias the ones that are auto-populated from there are using that name.  We might want to make these more consistent at some point.
* Note that your original PR used `replaced-by` metadata.  Simply re-using the old identifier is cleaner as long as the previous mod author is OK with it (as they seem to be).  We only have one example of `replaced-by` in use and it's a case where multiple mods were combined into one.
* Your [installation instructions](https://github.com/net-lisias-ksp/KourageousTourists/blob/master/INSTALL.md) say that KSPe is a dependency, but it's not indexed on CKAN.  And I just noticed that the release notes say "Replaces KSPe external dependency with embedded KSPe.Light" - can you clarify what is actually needed here?
* Any changes to the tags I chose? https://github.com/KSP-CKAN/CKAN/wiki/Suggested-Tags
* Any other recommend/suggest/supports relationships you want to include?  Please review the relationships documentation here if you haven't in a while, it's changed recently: https://github.com/KSP-CKAN/CKAN/blob/master/Spec.md#relationships
* CKAN now supports multiple-host metadata, in case you want to support downloading from both SpaceDock and Github in case one goes down.  But specifying that in the metadata is pretty clunky - if that's something you're interested in doing we can always add it later.