### PR TITLE
Work around bad version on GitHub for CelestialRescale

### DIFF
--- a/NetKAN/CelestialRescale.netkan
+++ b/NetKAN/CelestialRescale.netkan
@@ -8,6 +8,10 @@ install:
   - find: CelestialRescale
     install_to: GameData
     filter_regexp: \.pdb$
+x_netkan_version_edit:
+  find: ^v\.
+  replace: v
+  strict: false
 ---
 spec_version: v1.34
 identifier: CelestialRescale


### PR DESCRIPTION
![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/c0681b66-cf8c-4598-92c7-2fc391f81e6c)

<https://github.com/SpaceNerd24/Celestial-Rescale/releases>

![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/c947c0d4-ccf2-4360-ba3e-befd666abb87)

`v.` should be just `v`