### PR TITLE
Add optional JNSQ rescale mods to stock (1x) and real (10x) size

### DIFF
--- a/NetKAN/JNSQ-PartRebalancer-10x.netkan
+++ b/NetKAN/JNSQ-PartRebalancer-10x.netkan
@@ -1,17 +1,25 @@
 spec_version: v1.4
 identifier: JNSQ-PartRebalancer-10x
-name: JNSQ PartRebalancer 10x
-abstract: Rebalances the mass of parts and the density of propellants to give rockets more life-like mass ratios
-$kref: '#/ckan/netkan/https://raw.githubusercontent.com/Galileo88/JNSQ/master/CKAN/JNSQ.netkan'
+name: JNSQ Part Rebalancer 10x
+abstract: >-
+  Rebalances the mass of parts and the density of propellants
+  to give rockets more life-like mass ratios
+$kref: '#/ckan/github/Galileo88/JNSQ'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-ND-3.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/184880-*
 tags:
   - config
   - planet-pack
-provides: []
+conflicts:
+  - name: RealismOverhaul
+  - name: SMURFF
 depends:
   - name: ModuleManager
   - name: JNSQ-Rescale-10x
-suggests: []
-conflicts: []
+recommends:
+  - name: BetterSRBs
 install:
   - find: JNSQ_Rescale/PartRebalancer10x/GameData/PartRebalancer10x
     install_to: GameData

--- a/NetKAN/JNSQ-PartRebalancer-10x.netkan
+++ b/NetKAN/JNSQ-PartRebalancer-10x.netkan
@@ -1,0 +1,17 @@
+spec_version: v1.4
+identifier: JNSQ-PartRebalancer-10x
+name: JNSQ PartRebalancer 10x
+abstract: Rebalances the mass of parts and the density of propellants to give rockets more life-like mass ratios
+$kref: '#/ckan/netkan/https://raw.githubusercontent.com/Galileo88/JNSQ/master/CKAN/JNSQ.netkan'
+tags:
+  - config
+  - planet-pack
+provides: []
+depends:
+  - name: ModuleManager
+  - name: JNSQ-Rescale-10x
+suggests: []
+conflicts: []
+install:
+  - find: JNSQ_Rescale/PartRebalancer10x/GameData/PartRebalancer10x
+    install_to: GameData

--- a/NetKAN/JNSQ-Rescale-10x.netkan
+++ b/NetKAN/JNSQ-Rescale-10x.netkan
@@ -1,0 +1,19 @@
+spec_version: v1.4
+identifier: JNSQ-Rescale-10x
+name: JNSQ Rescale 10x
+abstract: JNSQ rescaled to 10 times stock size (approximately real scale)
+$kref: '#/ckan/netkan/https://raw.githubusercontent.com/Galileo88/JNSQ/master/CKAN/JNSQ.netkan'
+tags:
+  - config
+  - planet-pack
+provides: []
+depends:
+  - name: ModuleManager
+  - name: JNSQ
+conflicts:
+  - name: JNSQ-Rescale-1x
+suggests:
+  - name: JNSQ-PartRebalancer-10x
+install:
+  - find: JNSQ_Rescale/Rescale_10X/GameData/JNSQ_Rescale
+    install_to: GameData

--- a/NetKAN/JNSQ-Rescale-10x.netkan
+++ b/NetKAN/JNSQ-Rescale-10x.netkan
@@ -2,11 +2,14 @@ spec_version: v1.4
 identifier: JNSQ-Rescale-10x
 name: JNSQ Rescale 10x
 abstract: JNSQ rescaled to 10 times stock size (approximately real scale)
-$kref: '#/ckan/netkan/https://raw.githubusercontent.com/Galileo88/JNSQ/master/CKAN/JNSQ.netkan'
+$kref: '#/ckan/github/Galileo88/JNSQ'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-ND-3.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/184880-*
 tags:
   - config
   - planet-pack
-provides: []
 depends:
   - name: ModuleManager
   - name: JNSQ

--- a/NetKAN/JNSQ-Rescale-1x.netkan
+++ b/NetKAN/JNSQ-Rescale-1x.netkan
@@ -2,17 +2,19 @@ spec_version: v1.4
 identifier: JNSQ-Rescale-1x
 name: JNSQ Rescale 1x
 abstract: JNSQ rescaled to approximately stock size
-$kref: '#/ckan/netkan/https://raw.githubusercontent.com/Galileo88/JNSQ/master/CKAN/JNSQ.netkan'
+$kref: '#/ckan/github/Galileo88/JNSQ'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-ND-3.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/184880-*
 tags:
   - config
   - planet-pack
-provides: []
 depends:
   - name: ModuleManager
   - name: JNSQ
 conflicts:
   - name: JNSQ-Rescale-10x
-suggests: []
 install:
   - find: JNSQ_Rescale/Rescale_1X/GameData/JNSQ_Rescale
     install_to: GameData

--- a/NetKAN/JNSQ-Rescale-1x.netkan
+++ b/NetKAN/JNSQ-Rescale-1x.netkan
@@ -1,0 +1,18 @@
+spec_version: v1.4
+identifier: JNSQ-Rescale-1x
+name: JNSQ Rescale 1x
+abstract: JNSQ rescaled to approximately stock size
+$kref: '#/ckan/netkan/https://raw.githubusercontent.com/Galileo88/JNSQ/master/CKAN/JNSQ.netkan'
+tags:
+  - config
+  - planet-pack
+provides: []
+depends:
+  - name: ModuleManager
+  - name: JNSQ
+conflicts:
+  - name: JNSQ-Rescale-10x
+suggests: []
+install:
+  - find: JNSQ_Rescale/Rescale_1X/GameData/JNSQ_Rescale
+    install_to: GameData


### PR DESCRIPTION
These optional mods are already included in the JNSQ distribution itself, this PR merely makes them installable in CKAN.

- <https://github.com/Galileo88/JNSQ>
