### PR TITLE
Stable solution to IXSWarpship-Blueshift versioning

### DIFF
--- a/NetKAN/IXSWarpship-Blueshift.netkan
+++ b/NetKAN/IXSWarpship-Blueshift.netkan
@@ -3,6 +3,9 @@ identifier: IXSWarpship-Blueshift
 $kref: '#/ckan/github/Araym-KSP/IXS-Warship-for-Blueshift'
 x_netkan_github:
   use_source_archive: true
+x_netkan_version_edit:
+  find: ^v\.?(?<version>.+)$
+  replace: v.${version}
 license: GPL-3.0
 tags:
   - config


### PR DESCRIPTION
## Problem

This error persists:

![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/d32b8ea6-b8c8-4d84-9579-e11273b7c422)

## Cause

This mod's intended version format is `v.X.Y.Z`, **with** a leading dot after the `v`, but the dot is missing in the most recent version:

<https://github.com/Araym-KSP/IXS-Warship-for-Blueshift/releases>

![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/83481a03-cb15-4248-b14d-53eb3ecb4a77)

Typically authors use `vX.Y.Z`, so normally we'd use a version-editing property to remove the dot, but in this case the _omission_ of the leading period is the exception.

The GitHub releases API fails to return the most recent release in about 0.005% of cases (that's what the message means by "unreliable server"). Instead, it presents the NetKAN bot the release before that as if it was the most recent. There's no way to detect that this has happened, so we need to establish rules that handle it smoothly.

When this glitch happens for this mod, this glitch causes the `v.1.0.6` release to be redundantly re-indexed, because `v.1.0.6` is considered later than `v1.0.7.1` thanks to the dot after its `v`. We already have an epoch to put these versions in the right order, but that just causes `1:v.1.0.6` to be generated, which is still considered later than `1:v1.0.7.1` due to the dot:

<https://github.com/KSP-CKAN/CKAN-meta/tree/master/IXSWarpship-Blueshift>

![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/4193493e-ae27-40e6-a6ff-e31e37a0a5f8)

This has happened before, and I've just been deleting the extra versions, but if that's all we do, we'll have to keep deleting them ad infinitum:

- https://github.com/KSP-CKAN/CKAN-meta/commit/a94c4755011d696be30b5c5f7d28128cbc6cb05a
- https://github.com/KSP-CKAN/CKAN-meta/commit/142579e48acbaee5b148d7912c3a8f1b5cc3fe51

## Changes

Now we use a version-editing property to add the missing dot for this mod's versions. Once we clean up the mess in CKAN-meta, the redundant version won't come back this time.
