### PR TITLE
Fix gpp scatterer version

### DIFF
--- a/NetKAN/GPP.netkan
+++ b/NetKAN/GPP.netkan
@@ -28,7 +28,7 @@ depends:
 conflicts:
   - name: StockVisualEnhancements
   - name: Scatterer
-    min_version: '3:v0.0825b'
+    min_version: '3:v0.0825'
 recommends:
   - name: Strategia
   - name: FinalFrontier

--- a/NetKAN/GPPSecondary.netkan
+++ b/NetKAN/GPPSecondary.netkan
@@ -23,7 +23,7 @@ conflicts:
   - name: GPP
   - name: StockVisualEnhancements
   - name: Scatterer
-    min_version: '3:v0.0825b'
+    min_version: '3:v0.0825'
 depends:
   - name: ModuleManager
   - name: Kopernicus

--- a/NetKAN/GrannusExpansionPack.netkan
+++ b/NetKAN/GrannusExpansionPack.netkan
@@ -10,7 +10,7 @@ tags:
   - planet-pack
 conflicts:
   - name: Scatterer
-    min_version: '3:v0.0825b'
+    min_version: '3:v0.0825'
 depends:
   - name: ModuleManager
   - name: Kopernicus


### PR DESCRIPTION
In #8880 and #8881 the scatterer version for GPP was set, but it incorrectly allowed scatterer 0.0852 to be installed.