### PR TITLE
De-meta CryoTanks to fix dependency issues

### DIFF
--- a/NetKAN/CryoTanks-Core.netkan
+++ b/NetKAN/CryoTanks-Core.netkan
@@ -1,8 +1,19 @@
-{
-    "spec_version"   : "v1.4",
-    "identifier"     : "CryoTanks-Core",
-    "$kref"         : "#/ckan/netkan/https://github.com/post-kerbin-mining-corporation/CryoTanks/raw/master/CKAN/CryoTanks-Core.netkan",
-    "tags": [
-        "plugin"
-    ]
-}
+spec_version: v1.4
+identifier: CryoTanks-Core
+name: Cryo Tanks Core
+abstract: >-
+  Cryo Tanks plugin stand-alone, for adding functionality to other mods.
+  Contains no parts and does nothing by itself.
+author: Nertea (Chris Adderley)
+$kref: '#/ckan/github/post-kerbin-mining-corporation/CryoTanks'
+$vref: '#/ckan/ksp-avc/CryoTanks.version'
+license: MIT
+resources:
+  homepage: https://github.com/post-kerbin-mining-corporation/CryoTanks/wiki
+tags:
+  - plugin
+depends:
+  - name: CryoTanks
+install:
+  - file: GameData/CryoTanks/Plugins/SimpleBoiloff.dll
+    install_to: GameData/CryoTanks/Plugins

--- a/NetKAN/CryoTanks.netkan
+++ b/NetKAN/CryoTanks.netkan
@@ -1,8 +1,26 @@
-{
-    "spec_version"   : "v1.4",
-    "identifier"     : "CryoTanks",
-    "$kref"         : "#/ckan/netkan/https://github.com/post-kerbin-mining-corporation/CryoTanks/raw/master/CKAN/CryoTanks.netkan",
-    "tags": [
-        "parts"
-    ]
-}
+spec_version: v1.4
+identifier: CryoTanks
+name: Cryo Tanks
+abstract: >-
+  Liquid Hydrogen fuel tanks and Liquid Hydrogen storage for most stock tanks
+author: Nertea (Chris Adderley)
+$kref: '#/ckan/github/post-kerbin-mining-corporation/CryoTanks'
+$vref: '#/ckan/ksp-avc/CryoTanks.version'
+license: restricted
+resources:
+  homepage: https://github.com/post-kerbin-mining-corporation/CryoTanks/wiki
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+  - name: CryoTanks-Core
+  - name: B9PartSwitch
+  - name: CommunityResourcePack
+  - name: DynamicBatteryStorage
+supports:
+  - name: KerbalAtomics
+  - name: CryoEngines
+install:
+  - find: CryoTanks
+    install_to: GameData
+    filter: SimpleBoiloff.dll

--- a/NetKAN/SkyhawkScienceSystem.netkan
+++ b/NetKAN/SkyhawkScienceSystem.netkan
@@ -18,7 +18,7 @@ depends:
   - name: BluedogDB
   - name: CommunityResourcePack
 recommends:
-  - name: CryoTanks-Core
+  - name: CryoTanks
   - name: Kopernicus
   - name: RationalResources
   - name: RationalResourcesNuclearFamily


### PR DESCRIPTION
## Problems

- Starting in version 1.6.0, CryoTanks bundles B9PartSwitch:
  ![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/54f2d104-9c4e-49ff-bcea-847abefc29f3)
  But its metanetkan has not been updated to reflect this dependency. @JonnyOThan submitted a fix in January, see post-kerbin-mining-corporation/CryoTanks#138, but it has not been merged.
- Installing CryoTanks-Core by itself creates a `GameData/CryoTanks` directory, which will cause ModuleManager to treat the full CryoTanks as installed. This would break any mods that use `:NEEDS[CryoTanks]` syntax to turn changes on or off depending on whether the full CryoTanks is present, including parts and so forth.
- SkyhawkScienceSystem recommends CryoTanks-Core, but there's no indication that this is more correct than recommending CryoTanks, so it might be breaking things

## Changes

- Now CryoTanks and CryoTanks-Core no longer use a metanetkan
- Now CryoTanks depends on B9PartSwitch
- Now CryoTanks-Core depends on CryoTanks to ensure one won't be installed without the other, effectively cancelling out the split
- Now SkyhawkScienceSystem recommends CryoTanks instead of CryoTanks-Core

Fixes #9894. (A historical PR in CKAN-meta should probably retrofit the B9PartSwitch dependency back to 1.6.0.)
Fixes #9911.
