### PR TITLE
De-meta NearFutureSolar to fix dependency issues

### DIFF
--- a/NetKAN/NearFutureSolar-Core.netkan
+++ b/NetKAN/NearFutureSolar-Core.netkan
@@ -1,8 +1,17 @@
-{
-    "spec_version"  : "v1.4",
-    "identifier"    : "NearFutureSolar-Core",
-    "$kref"         : "#/ckan/netkan/https://github.com/post-kerbin-mining-corporation/NearFutureSolar/raw/master/CKAN/NearFutureSolar-Core.netkan",
-    "tags": [
-        "plugin"
-    ]
-}
+spec_version: v1.4
+identifier: NearFutureSolar-Core
+name: Near Future Solar Core
+abstract: >-
+  Near Future Solar plugin stand-alone, for adding functionality to other mods.
+  Contains no parts and does nothing by itself.
+author: Nertea (Chris Adderley)
+$kref: '#/ckan/spacedock/559'
+$vref: '#/ckan/ksp-avc/NearFutureSolar.version'
+license: MIT
+tags:
+  - plugin
+depends:
+  - name: NearFutureSolar
+install:
+  - file: GameData/NearFutureSolar/Plugins/NearFutureSolar.dll
+    install_to: GameData/NearFutureSolar/Plugins

--- a/NetKAN/NearFutureSolar.netkan
+++ b/NetKAN/NearFutureSolar.netkan
@@ -1,8 +1,25 @@
-{
-    "spec_version"  : "v1.4",
-    "identifier"    : "NearFutureSolar",
-    "$kref"         : "#/ckan/netkan/https://github.com/post-kerbin-mining-corporation/NearFutureSolar/raw/master/CKAN/NearFutureSolar.netkan",
-    "tags": [
-        "parts"
-    ]
-}
+spec_version: v1.4
+identifier: NearFutureSolar
+abstract: New solar panels in a variety of sizes and types
+author: Nertea (Chris Adderley)
+$kref: '#/ckan/spacedock/559'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/155465-*
+tags:
+  - parts
+depends:
+  - name: NearFutureSolar-Core
+  - name: B9PartSwitch
+  - name: ModuleManager
+suggests:
+  - name: CommunityTechTree
+  - name: NearFutureConstruction
+  - name: NearFutureElectrical
+  - name: NearFuturePropulsion
+  - name: NearFutureSpacecraft
+install:
+  - find: NearFutureSolar
+    install_to: GameData
+    filter: NearFutureSolar.dll


### PR DESCRIPTION
## Problem

If you install NearFutureSolar-Core by itself, a `GameData/NearFutureSolar` folder is created, which makes ModuleManager treat NearFutureSolar as installed. This will break mods that use `:NEEDS[]` directives to turn code on and off with and without that mod.

#9964 fixed an analogous situation with CryoTanks from the same author by removing its metanetkan. We tried to get the metanetkan fixed, but it seems to no longer be maintained.

## Changes

- Now NearFutureSolar and NearFutureSolar-Core also no longer use metanetkans
- Now NearFutureSolar-Core depends on NearFutureSolar, to effectively eliminate the split

Fixes #9922.
