### PR TITLE
Handle KcalbelohSystem textures

### DIFF
--- a/NetKAN/KcalbelohSystem-Textures-4k.netkan
+++ b/NetKAN/KcalbelohSystem-Textures-4k.netkan
@@ -1,0 +1,18 @@
+spec_version: v1.4
+identifier: KcalbelohSystem-Textures-4k
+$kref: '#/ckan/github/jcyuan06/Kcalbeloh-System/asset_match/Textures-4k'
+license: CC-BY-NC-ND-4.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/203753-*
+tags:
+  - planet-pack
+  - graphics
+provides:
+  - KcalbelohSystem-Textures
+conflicts:
+  - name: KcalbelohSystem-Textures
+depends:
+  - name: KcalbelohSystem
+install:
+  - find: KcalbelohTextures
+    install_to: GameData

--- a/NetKAN/KcalbelohSystem-Textures-4k.netkan
+++ b/NetKAN/KcalbelohSystem-Textures-4k.netkan
@@ -1,5 +1,7 @@
 spec_version: v1.4
 identifier: KcalbelohSystem-Textures-4k
+name: Kcalbeloh System 4k Textures
+abstract: 4k textures for Kcalbeloh System
 $kref: '#/ckan/github/jcyuan06/Kcalbeloh-System/asset_match/Textures-4k'
 license: CC-BY-NC-ND-4.0
 resources:

--- a/NetKAN/KcalbelohSystem-Textures-8k.netkan
+++ b/NetKAN/KcalbelohSystem-Textures-8k.netkan
@@ -1,0 +1,18 @@
+spec_version: v1.4
+identifier: KcalbelohSystem-Textures-8k
+$kref: '#/ckan/github/jcyuan06/Kcalbeloh-System/asset_match/Textures-8k'
+license: CC-BY-NC-ND-4.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/203753-*
+tags:
+  - planet-pack
+  - graphics
+provides:
+  - KcalbelohSystem-Textures
+conflicts:
+  - name: KcalbelohSystem-Textures
+depends:
+  - name: KcalbelohSystem
+install:
+  - find: KcalbelohTextures
+    install_to: GameData

--- a/NetKAN/KcalbelohSystem-Textures-8k.netkan
+++ b/NetKAN/KcalbelohSystem-Textures-8k.netkan
@@ -1,5 +1,7 @@
 spec_version: v1.4
 identifier: KcalbelohSystem-Textures-8k
+name: Kcalbeloh System 8k Textures
+abstract: 8k textures for Kcalbeloh System
 $kref: '#/ckan/github/jcyuan06/Kcalbeloh-System/asset_match/Textures-8k'
 license: CC-BY-NC-ND-4.0
 resources:

--- a/NetKAN/KcalbelohSystem.netkan
+++ b/NetKAN/KcalbelohSystem.netkan
@@ -14,6 +14,7 @@ depends:
   - name: KSPCommunityFixes
   - name: KopernicusExpansionContinueder
   - name: VertexMitchellNetravaliHeightMap
+  - name: KcalbelohSystem-Textures
 recommends:
   - name: EnvironmentalVisualEnhancements
   - name: Scatterer


### PR DESCRIPTION
- <https://github.com/jcyuan06/Kcalbeloh-System>

This mod has split its textures into two separate 4k and 8k downloads.

Now they're added as modules, providing and conflicting with `KcalbelohSystem-Textures`, which the main module now depends on.

Fixes #9975.
