### PR TITLE
Declares a conflict with TweakScaleRescaled-Redist

### DIFF
--- a/NetKAN/TweakScale-Redist.netkan
+++ b/NetKAN/TweakScale-Redist.netkan
@@ -12,6 +12,8 @@ x_netkan_force_v: true
 license:
   - WTFPL
 release_status: stable
+conflicts:
+  - name: TweakScaleRescaled-Redist
 tags:
   - plugin
   - library


### PR DESCRIPTION
`TweakScaleRescaled-Redist` is being offered as an option when installing `TweakScale`, whats a mistake - while I can guarantee compatibility with the current interfaces, I can't say the same for future new ones.