### PR TITLE
Update SpaceDustUnbound.netkan

### DIFF
--- a/NetKAN/SpaceDustUnbound.netkan
+++ b/NetKAN/SpaceDustUnbound.netkan
@@ -13,4 +13,4 @@ recommends:
   - name: GalaxiesUnbound-Core
   - name: OuterPlanetsMod
 suggests:
-  - name: BlueShift
+  - name: Blueshift


### PR DESCRIPTION
Fixes a typo in the Space Dust Unbound mod's netkan so that it correctly suggests the Blueshift mod by Angel-125

Fixes #9992.