### PR TITLE
Remove Tantares SpaceDock and forum links

### DIFF
--- a/NetKAN/NewTantares.netkan
+++ b/NetKAN/NewTantares.netkan
@@ -6,9 +6,6 @@ author: Beale
 $kref: '#/ckan/github/Tantares/Tantares'
 ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
-resources:
-  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/73686-Tantares
-  spacedock: https://spacedock.info/mod/174/Tantares
 tags:
   - parts
   - crewed

--- a/NetKAN/NewTantaresLV.netkan
+++ b/NetKAN/NewTantaresLV.netkan
@@ -1,37 +1,24 @@
-{
-    "spec_version":    "v1.18",
-    "identifier":      "NewTantaresLV",
-    "name":            "Tantares LV - Soviet Rockets",
-    "abstract":        "Stockalike Soviet and European Launch Vehicles",
-    "author":          "Beale",
-    "$kref":           "#/ckan/github/Tantares/TantaresLV",
-    "$vref":           "#/ckan/ksp-avc",
-    "license":         "CC-BY-NC-SA-4.0",
-    "resources": {
-        "homepage":  "https://forum.kerbalspaceprogram.com/index.php?/topic/73686-Tantares",
-        "spacedock": "https://spacedock.info/mod/176/TantaresLV"
-    },
-    "tags": [
-        "parts"
-    ],
-    "provides": [
-        "TantaresLV"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "NewTantares" }
-    ],
-    "conflicts": [
-        { "name": "TantaresLV" }
-    ],
-    "install": [ {
-        "find":       "TantaresLV",
-        "install_to": "GameData"
-    }, {
-        "find":       "Crafts",
-        "install_to": "Ships",
-        "as":         "VAB"
-    } ]
-}
+spec_version: v1.18
+identifier: NewTantaresLV
+name: Tantares LV - Soviet Rockets
+abstract: Stockalike Soviet and European Launch Vehicles
+author: Beale
+$kref: '#/ckan/github/Tantares/TantaresLV'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+provides:
+  - TantaresLV
+depends:
+  - name: ModuleManager
+recommends:
+  - name: NewTantares
+conflicts:
+  - name: TantaresLV
+install:
+  - find: TantaresLV
+    install_to: GameData
+  - find: Crafts
+    install_to: Ships
+    as: VAB

--- a/NetKAN/TantaresSP.netkan
+++ b/NetKAN/TantaresSP.netkan
@@ -1,37 +1,25 @@
-{
-    "spec_version":    "v1.18",
-    "identifier":      "TantaresSP",
-    "name":            "Tantares SP - Soviet Space Probes",
-    "abstract":        "Soviet Space Probes and Interplanetary Spacecraft",
-    "author":          "Beale",
-    "$kref":           "#/ckan/github/Tantares/TantaresSP",
-    "$vref":           "#/ckan/ksp-avc",
-    "license":         "CC-BY-NC-SA-4.0",
-    "resources": {
-        "homepage":  "https://forum.kerbalspaceprogram.com/index.php?/topic/73686-Tantares",
-        "spacedock": "https://spacedock.info/mod/2498/TantaresSP"
-    },
-    "tags": [
-        "parts",
-        "uncrewed"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "NeptuneCamera" }
-    ],
-    "install": [ {
-        "find":       "TantaresSP",
-        "install_to": "GameData"
-    }, {
-        "find":       "Crafts",
-        "install_to": "Ships",
-        "as":         "VAB"
-    } ],
-    "x_netkan_version_edit": {
-        "find": "^[vV]?(?<version>.+)$",
-        "replace": "${version}",
-        "strict": true
-    }
-}
+spec_version: v1.18
+identifier: TantaresSP
+name: Tantares SP - Soviet Space Probes
+abstract: Soviet Space Probes and Interplanetary Spacecraft
+author: Beale
+$kref: '#/ckan/github/Tantares/TantaresSP'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+  - uncrewed
+depends:
+  - name: ModuleManager
+recommends:
+  - name: NeptuneCamera
+install:
+  - find: TantaresSP
+    install_to: GameData
+  - find: Crafts
+    install_to: Ships
+    as: VAB
+x_netkan_version_edit:
+  find: ^[vV]?(?<version>.+)$
+  replace: ${version}
+  strict: true


### PR DESCRIPTION
@Tantares said SpaceDock is no longer being used for these mods and requested for those links to be removed.

In addition, https://github.com/Tantares/Tantares has the forum thread link set up, so we'll pull that as well.

![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/4486e573-4ebd-4c38-b9fd-90f733b6db7f)
