### PR TITLE
Consistent versioning for PlanesWithPurposes

### DIFF
--- a/NetKAN/PlanesWithPurposes.netkan
+++ b/NetKAN/PlanesWithPurposes.netkan
@@ -1,6 +1,7 @@
 spec_version: v1.34
 identifier: PlanesWithPurposes
 $kref: '#/ckan/github/TudorAerospace/PWP'
+x_netkan_version_edit: ^v(?<version>.*)$
 license: MIT
 tags:
   - career


### PR DESCRIPTION
This mod is multi-hosted, but the latest upload on GitHub has a `v` prefix that no other version has had.

Now it'll be pruned at inflation.
