### PR TITLE
Split RealChute Patches folder into separate module

### DIFF
--- a/NetKAN/RealChute.netkan
+++ b/NetKAN/RealChute.netkan
@@ -1,41 +1,36 @@
-{
-    "spec_version"   : 1,
-    "identifier"     : "RealChute",
-    "name"           : "RealChute Parachute Systems",
-    "abstract"       : "RealChute is a complete rework of the stock parachute module to fix a few of it's inconveniences and get more realistic results out of parachutes!",
-    "author"         : [ "stupid_chris", "sumghai" ],
-    "$kref"          : "#/ckan/github/ChrisViral/RealChute",
-    "$vref"          : "#/ckan/ksp-avc",
-    "license"        : "restricted",
-    "resources"      : {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/52931-0"
-    },
-    "tags": [
-        "plugin",
-        "parts",
-        "physics",
-        "sound"
-    ],
-    "depends" : [
-        { "name" : "ClickThroughBlocker" },
-        { "name" : "ToolbarController" }
-    ],
-    "recommends" : [
-        { "name" : "ModuleManager" }
-    ],
-    "x_netkan_override": [
-        {
-            "version": "1.3.2.3",
-            "override": {
-                "ksp_version_min": "1.0.2",
-                "ksp_version_max": "1.0.4"
-            }
-        },
-        {
-            "version": "v1.4",
-            "override": {
-                "ksp_version": "1.1.0"
-            }
-        }
-    ]
-}
+spec_version: v1.4
+identifier: RealChute
+name: RealChute Parachute Systems
+abstract: >-
+  Complete rework of the stock parachute module to fix a few of
+  its inconveniences and get more realistic results out of parachutes!
+author:
+  - stupid_chris
+  - sumghai
+$kref: '#/ckan/github/ChrisViral/RealChute'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+resources:
+  homepage: http://forum.kerbalspaceprogram.com/index.php?/topic/52931-0
+tags:
+  - plugin
+  - parts
+  - physics
+  - sound
+depends:
+  - name: ClickThroughBlocker
+  - name: ToolbarController
+recommends:
+  - name: RealChuteForStock
+install:
+  - find: RealChute
+    install_to: GameData
+    filter: Patches
+x_netkan_override:
+  - version: 1.3.2.3
+    override:
+      ksp_version_min: 1.0.2
+      ksp_version_max: 1.0.4
+  - version: v1.4
+    override:
+      ksp_version: 1.1.0

--- a/NetKAN/RealChuteForStock.netkan
+++ b/NetKAN/RealChuteForStock.netkan
@@ -1,0 +1,21 @@
+spec_version: v1.4
+identifier: RealChuteForStock
+name: RealChute for Stock
+abstract: Gives stock/ReStock parachutes RealChute capabilities
+author:
+  - stupid_chris
+  - sumghai
+$kref: '#/ckan/github/ChrisViral/RealChute'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+resources:
+  homepage: http://forum.kerbalspaceprogram.com/index.php?/topic/52931-0
+tags:
+  - config
+  - physics
+depends:
+  - name: ModuleManager
+  - name: RealChute
+install:
+  - find: RealChute/Patches
+    install_to: GameData/RealChute


### PR DESCRIPTION
An imminent release of `RealChute` will have a `Patches` folder instead of a `ModuleManager` folder. This is intended to be an optional patch for users who want to use the mod's features for stock parts; users who don't want this are not supposed to install the patch (they can still use the mod's own parts).

- <https://github.com/ChrisViral/RealChute>

Now a new `RealChuteForStock` module is added by request of the author. It installs the `Patches` folder, which is now filtered out of the main `RealChute` module.

(Need to wait for the new release before merge.)
