### PR TITLE
Make NavUtilities forks mutually exclusive

### DIFF
--- a/NetKAN/NavUtilitiesContinued.netkan
+++ b/NetKAN/NavUtilitiesContinued.netkan
@@ -8,6 +8,8 @@ tags:
   - crewed
 provides:
   - NavUtilities
+conflicts:
+  - name: NavUtilities
 depends:
   - name: ModuleManager
 install:

--- a/NetKAN/NavUtilitiesUpdated.netkan
+++ b/NetKAN/NavUtilitiesUpdated.netkan
@@ -9,6 +9,8 @@ tags:
   - crewed
 provides:
   - NavUtilities
+conflicts:
+  - name: NavUtilities
 depends:
   - name: ModuleManager
   - name: ClickThroughBlocker


### PR DESCRIPTION
## Problem

@JonnyOThan forwarded this screenshot from a user:

![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/181e8975-8595-41c0-8537-7ad9adb136b8)

## Cause

That error is from this code in `NavUtilitiesUpdated`:

<https://github.com/linuxgurugamer/NavInstruments/blob/master/Source/NavUtilLib/InstallChecker.cs>

It says:

> This will also detect duplicate copies because only one can be in the right place.

So that user must have installed both forks, and `NavUtilitiesUpdated` detected `NavUtilitiesContinued` and didn't like where it was installed.

## Changes

Now the forks of `NavUtilities` conflict with each other, since they don't play nice together.
