### PR TITLE
Only install generic crafts for ModularLaunchPads

### DIFF
--- a/NetKAN/ModularLaunchPads.netkan
+++ b/NetKAN/ModularLaunchPads.netkan
@@ -1,4 +1,4 @@
-spec_version: v1.4
+spec_version: v1.18
 identifier: ModularLaunchPads
 $kref: '#/ckan/spacedock/1767'
 license: CC-BY-NC-SA-4.0
@@ -15,8 +15,9 @@ recommends:
 install:
   - find: ModularLaunchPads
     install_to: GameData
-  - find: Ships/VAB
+  - find: Bare Assemblies
     install_to: Ships
+    as: VAB
 x_netkan_override:
   - version: 2.1.2
     override:


### PR DESCRIPTION
![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/55bcaa02-d69f-497d-b6d2-eb4205c34b0e)

This mod's craft files have been re-organized to avoid installing incompatible crafts:

![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/f3f5ffef-2116-42df-8a4f-235122eaa5f0)

- <https://github.com/AlphaMensae/Modular-Launch-Pads>

Now only the `Bare Assemblies` are installed, since the other two groups would be incompatible with some installs some of the time.

___

ckan compat add 1.12
