### PR TITLE
Add KopernicusExpansion dep to TechosStockPlanetRevamp

### DIFF
--- a/NetKAN/TechosStockPlanetRevamp.netkan
+++ b/NetKAN/TechosStockPlanetRevamp.netkan
@@ -9,6 +9,7 @@ depends:
   - name: ModuleManager
   - name: Kopernicus
   - name: VertexMitchellNetravaliHeightMap
+  - name: KopernicusExpansion
 install:
   - find: TPR
     install_to: GameData


### PR DESCRIPTION
This mod is missing its dependency on `KopernicusExpansion`:

![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/5ff19c92-4fd1-48b1-a236-44624bb0cd63)

- <https://spacedock.info/mod/3455/Techo's%20(Stock)%20Planet%20Revamp>

Now it's fixed.
