### PR TITLE
Split Lazarus to work around GitHub release asset limit

### DIFF
--- a/NetKAN/Lazarus-Content.netkan
+++ b/NetKAN/Lazarus-Content.netkan
@@ -1,9 +1,8 @@
 spec_version: v1.18
-identifier: Lazarus
-name: Lazarus Core
-abstract: >-
-  System replacer and interstellar additions mod
-$kref: '#/ckan/github/hmelioo/Lazarus/asset_match/Core'
+identifier: Lazarus-Content
+name: Lazarus Content
+abstract: Additional files for Lazarus beyond GitHub's 2 GiB release asset limit
+$kref: '#/ckan/github/hmelioo/Lazarus/asset_match/Content'
 ksp_version: 1.12
 license: CC-BY-NC-ND
 resources:
@@ -15,7 +14,7 @@ depends:
   - name: ModuleManager
   - name: Kopernicus
   - name: VertexMitchellNetravaliHeightMap
-  - name: Lazarus-Content
+  - name: Lazarus
 recommends:
   - name: EnvironmentalVisualEnhancements
   - name: Scatterer


### PR DESCRIPTION
This mod has recently been uploaded to GitHub insteaad of SpaceDock because of network timeout issues (like many very large planet mods). 

- <https://spacedock.info/mod/3157/Lazarus>
- <https://github.com/hmelioo/Lazarus>

The ZIP has been split into 2 parts to work around GitHub's 2 GiB release asset limit.

![image](https://github.com/KSP-CKAN/NetKAN/assets/1559108/d417769d-e067-44ec-a5b0-e7966a562059)

Now `Lazarus` is updated to point to the `Core` asset, and a `Lazarus-Content` module is added for the `Content` asset.
