### PR TITLE
Add new dependency for RealAntennas

### DIFF
--- a/NetKAN/RealAntennas.netkan
+++ b/NetKAN/RealAntennas.netkan
@@ -11,6 +11,7 @@ tags:
 depends:
   - name: ModuleManager
   - name: KSPBurst
+  - name: ClickThroughBlocker
 conflicts:
   - name: RemoteTech
   - name: CommNetVisualization


### PR DESCRIPTION
RA v2.3 now uses (and therefore requires) clickthroughblocker