### PR TITLE
Add missing Lazarus dependencies

### DIFF
--- a/NetKAN/Lazarus-Content.netkan
+++ b/NetKAN/Lazarus-Content.netkan
@@ -13,7 +13,9 @@ tags:
 depends:
   - name: ModuleManager
   - name: Kopernicus
+  - name: INSTANTIATOR
   - name: VertexMitchellNetravaliHeightMap
+  - name: VertexColorMapEmissive
   - name: Lazarus
 recommends:
   - name: EnvironmentalVisualEnhancements

--- a/NetKAN/Lazarus.netkan
+++ b/NetKAN/Lazarus.netkan
@@ -1,8 +1,7 @@
 spec_version: v1.18
 identifier: Lazarus
 name: Lazarus Core
-abstract: >-
-  System replacer and interstellar additions mod
+abstract: System replacer and interstellar additions mod
 $kref: '#/ckan/github/hmelioo/Lazarus/asset_match/Core'
 ksp_version: 1.12
 license: CC-BY-NC-ND
@@ -14,7 +13,9 @@ tags:
 depends:
   - name: ModuleManager
   - name: Kopernicus
+  - name: INSTANTIATOR
   - name: VertexMitchellNetravaliHeightMap
+  - name: VertexColorMapEmissive
   - name: Lazarus-Content
 recommends:
   - name: EnvironmentalVisualEnhancements


### PR DESCRIPTION
Some relationship updates were missed in #10055.

- <https://github.com/hmelioo/Lazarus/releases/tag/1.2>

> REQUIREMENTS
> Kopernicus
> Scatterer
> EVE (NOT VOLUMETRICS)
> Instantiator
> NiakoUtils
> NOW REQUIRES: DUCKWEED'S VERTEXCOLORMAPEMISSIVE https://spacedock.info/mod/3620/VertexColorMapEmissive

Author confirms that EVE and Scatterer should remain recommended.

Now dependencies on `INSTANTIATOR` and `VertexColorMapEmissive` are added.

___

Needed for `INSTANTIATOR` (!):

ckan compat add 1.3
