### PR TITLE
Fix VertexHeightOblateAdvanced install path

### DIFF
--- a/NetKAN/VertexHeightOblateAdvanced.netkan
+++ b/NetKAN/VertexHeightOblateAdvanced.netkan
@@ -11,3 +11,6 @@ depends:
 install:
   - find_regexp: .*DuckweedUtils
     install_to: GameData
+    filter:
+      - LICENSE
+      - README.md

--- a/NetKAN/VertexHeightOblateAdvanced.netkan
+++ b/NetKAN/VertexHeightOblateAdvanced.netkan
@@ -9,6 +9,5 @@ depends:
   - name: ModuleManager
   - name: Kopernicus
 install:
-  - find: VertexHeightOblateAdvanced
-    install_to: GameData/000_DuckweedUtils
-x_via: Automated SpaceDock CKAN submission
+  - find_regexp: .*DuckweedUtils
+    install_to: GameData

--- a/NetKAN/VertexHeightOblateAdvanced.netkan
+++ b/NetKAN/VertexHeightOblateAdvanced.netkan
@@ -11,6 +11,3 @@ depends:
 install:
   - find_regexp: .*DuckweedUtils
     install_to: GameData
-    filter:
-      - LICENSE
-      - README.md


### PR DESCRIPTION
This mod's install path changed from `GameData/000_DuckweedUtils/VertexHeightOblateAdvanced` to `GameData/001_DuckweedUtils/VertexHeightOblateAdvanced`, but the CKAN metadata is "deep linking" to the original path. This was done because there were LICENSE and README.md files in `GameData/000_DuckweedUtils`, which would have caused a file conflict if another mod did the same thing.

Now we use a regex so the mod can pick whatever path it wants, and the author has moved the LICENSE and README.md into the `VertexHeightOblateAdvanced` folder.
