### PR TITLE
Add Shabby dependency, remove license and homepage in favor of github autofill, remove install

### DIFF
--- a/NetKAN/PerSaveScreenshots.netkan
+++ b/NetKAN/PerSaveScreenshots.netkan
@@ -1,10 +1,10 @@
 spec_version: v1.27
 identifier: PerSaveScreenshots
 $kref: '#/ckan/github/DeltaDizzy/PerSaveScreenshots'
+ksp_version: 1.12
 license: MIT
 tags:
   - plugin
   - convenience
-ksp_version: '1.12'
 depends:
   - name: Shabby

--- a/NetKAN/PerSaveScreenshots.netkan
+++ b/NetKAN/PerSaveScreenshots.netkan
@@ -1,4 +1,4 @@
-spec_version: v1.27
+spec_version: v1.4
 identifier: PerSaveScreenshots
 $kref: '#/ckan/github/DeltaDizzy/PerSaveScreenshots'
 ksp_version: 1.12

--- a/NetKAN/PerSaveScreenshots.netkan
+++ b/NetKAN/PerSaveScreenshots.netkan
@@ -1,13 +1,11 @@
-spec_version: v1.4
+spec_version: v1.27
 identifier: PerSaveScreenshots
 $kref: '#/ckan/github/DeltaDizzy/PerSaveScreenshots'
-ksp_version: 1.12
-license: MIT
 resources:
   homepage: https://forum.kerbalspaceprogram.com/topic/219192-*
 tags:
   - plugin
   - convenience
-install:
-  - file: GameData/PerSaveScreenshots.dll
-    install_to: GameData/PerSaveScreenshots
+ksp_version: '1.12'
+depends:
+  - name: Shabby

--- a/NetKAN/PerSaveScreenshots.netkan
+++ b/NetKAN/PerSaveScreenshots.netkan
@@ -1,6 +1,7 @@
 spec_version: v1.27
 identifier: PerSaveScreenshots
 $kref: '#/ckan/github/DeltaDizzy/PerSaveScreenshots'
+license: MIT
 tags:
   - plugin
   - convenience

--- a/NetKAN/PerSaveScreenshots.netkan
+++ b/NetKAN/PerSaveScreenshots.netkan
@@ -1,8 +1,6 @@
 spec_version: v1.27
 identifier: PerSaveScreenshots
 $kref: '#/ckan/github/DeltaDizzy/PerSaveScreenshots'
-resources:
-  homepage: https://forum.kerbalspaceprogram.com/topic/219192-*
 tags:
   - plugin
   - convenience


### PR DESCRIPTION
An update using the new Shabby dependency is now out. License and Homepage were removed in favor of it pulling them from the github repo, and now the mod has a standard install structure so I also removed `install`. (Edits mostly generated via webtool)

- <https://github.com/DeltaDizzy/PerSaveScreenshots>
