### PR TITLE
Fix RustyStarRockets install path

### DIFF
--- a/NetKAN/RustyStarRockets.netkan
+++ b/NetKAN/RustyStarRockets.netkan
@@ -1,4 +1,4 @@
-spec_version: v1.2
+spec_version: v1.4
 identifier: RustyStarRockets
 $kref: '#/ckan/spacedock/207'
 $vref: '#/ckan/ksp-avc'

--- a/NetKAN/RustyStarRockets.netkan
+++ b/NetKAN/RustyStarRockets.netkan
@@ -29,3 +29,6 @@ suggests:
   - name: SimpleConstruction
   - name: SimpleLogistics
   - name: TweakScale
+install:
+  - find: RustyStar
+    install_to: GameData


### PR DESCRIPTION
## Problem

Discord user Frost pointed out that parts from RustyStarRockets weren't loading.

## Cause

#9522 used the default install stanza, which installs the identifier `RustyStarRockets` directly to GameData, leaving out part of the path; now it's fixed.

```
    MODEL { model = RustyStar/RustyStarRockets/Assets/rsr-capsule-0625/rsr-capsule-0625 }
```
