### PR TITLE
Clean up replaced-by in frozen netkans

### DIFF
--- a/NetKAN/KeminiResearchProgram.frozen
+++ b/NetKAN/KeminiResearchProgram.frozen
@@ -19,7 +19,7 @@
 		{ "name": "Corvus125mTwoKerbalPod" },
 		{ "name": "K2CommandPodCont" }
 	],
-	"replaced-by" : { "name": "NehemiahEngineeringOrbitalScience" }
+	"replaced_by" : { "name": "NehemiahEngineeringOrbitalScience" },
 	"install": [
 		{
 			"file": "NehemiahInc/Kemini",

--- a/NetKAN/KerbalEnvironmentalEffectsStudy.frozen
+++ b/NetKAN/KerbalEnvironmentalEffectsStudy.frozen
@@ -20,7 +20,7 @@
 		{ "name": "K2CommandPodCont" },
 		{ "name": "UniversalStorage" }
 	],
-	"replaced-by" : { "name": "NehemiahEngineeringOrbitalScience" }
+	"replaced_by" : { "name": "NehemiahEngineeringOrbitalScience" },
 	"install": [
 		{
 			"file": "NehemiahInc/KEES",

--- a/NetKAN/KerbalLifeScience.frozen
+++ b/NetKAN/KerbalLifeScience.frozen
@@ -15,7 +15,7 @@
 		{ "name": "NehemiahScienceCommon", "min_version": "1:0.7b2" },
 		{ "name": "NehemiahMultiPurposeParts", "min_version": "1:0.7b2" }
 	],
-	"replaced-by" : { "name": "NehemiahEngineeringOrbitalScience" }
+	"replaced_by" : { "name": "NehemiahEngineeringOrbitalScience" },
 	"install": [
 		{
 			"file": "NehemiahInc/KerbalLifeScience",

--- a/NetKAN/NehemiahInc-Complete.frozen
+++ b/NetKAN/NehemiahInc-Complete.frozen
@@ -22,14 +22,14 @@
 		{ "name": "UniversalStorage" }
 	],
 	"provides"          : [
-		{ "name"             : "NehemiahScienceCommon" }
+		{ "name"             : "NehemiahScienceCommon" },
 		{ "name"             : "NehemiahMultiPurposeParts" },
 		{ "name"             : "KeminiResearchProgram" },
 		{ "name"             : "KerbalEnvironmentalEffectsStudy" },
 		{ "name"             : "KerbalLifeScience" },
 		{ "name"             : "OrbitalMaterialScience" }
 	],
-	"replaced-by" : { "name": "NehemiahEngineeringOrbitalScience" }
+	"replaced_by" : { "name": "NehemiahEngineeringOrbitalScience" },
 	"install": [
 		{
 			"file": "NehemiahInc",

--- a/NetKAN/NehemiahMultiPurposeParts.frozen
+++ b/NetKAN/NehemiahMultiPurposeParts.frozen
@@ -15,7 +15,7 @@
 		{ "name": "DockingPortAlignmentIndicator" },
 		{ "name": "UniversalStorage" }
 	],
-	"replaced-by" : { "name": "NehemiahEngineeringOrbitalScience" }
+	"replaced_by" : { "name": "NehemiahEngineeringOrbitalScience" },
 	"install": [
 		{
 			"file": "NehemiahInc/MultiPurposeParts",

--- a/NetKAN/NehemiahScienceCommon.frozen
+++ b/NetKAN/NehemiahScienceCommon.frozen
@@ -10,7 +10,7 @@
 	"resources": {
 		"homepage": "http://forum.kerbalspaceprogram.com/index.php?showtopic=149298"
 	},
-	"replaced-by" : { "name": "NehemiahEngineeringOrbitalScience" }
+	"replaced_by" : { "name": "NehemiahEngineeringOrbitalScience" },
 	"install": [
 		{
 			"file": "NehemiahInc/NE_Science_Common",

--- a/NetKAN/OrbitalMaterialScience.frozen
+++ b/NetKAN/OrbitalMaterialScience.frozen
@@ -15,8 +15,7 @@
         { "name": "NehemiahScienceCommon", "min_version": "1:0.7b2" },
         { "name": "NehemiahMultiPurposeParts", "min_version": "1:0.7b2" }
     ],
-    "replaced-by" : { "name": "NehemiahEngineeringOrbitalScience" }
-    },
+    "replaced_by" : { "name": "NehemiahEngineeringOrbitalScience" },
     "install": [
         {
             "file": "NehemiahInc/OMS",


### PR DESCRIPTION
## Problems

#7100 introduced some syntax errors (extra braces, missing commas) and used `replaced-by` instead of `replaced_by`. This had no effect since the affected modules were already frozen, but it's possible that someone might copy-paste this metdata in the future if they want to do something similar.

## Changes

Now these problems are fixed. This will have no effect other than reducing the risk of bad metadata in other mods.

A future PR in CKAN-meta will probably add `replaced_by` to the old .ckan files that were intended to be updated by #7100.

Fixes #10109.
