### PR TITLE
Update GitHub Actions from v2 to v4

### DIFF
--- a/.github/workflows/inflate.yml
+++ b/.github/workflows/inflate.yml
@@ -14,18 +14,18 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Get NetKAN repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
                   fetch-depth: 0
             - name: Get CKAN-meta repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                   repository: KSP-CKAN/CKAN-meta
                   path: .CKAN-meta
             - name: Cache downloads
               if: ${{ github.event_name == 'pull_request' }}
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: .cache
                   key: downloads-${{ github.run_id }}

--- a/.github/workflows/manual_inflate.yml
+++ b/.github/workflows/manual_inflate.yml
@@ -10,11 +10,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Get NetKAN repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                   path: NetKAN
             - name: Get CKAN-meta repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                   repository: KSP-CKAN/CKAN-meta
                   path: CKAN-meta


### PR DESCRIPTION
`actions/checkout` and `actions/cache` both have v4 available, and we're using v2. Now both are updated to v4.