### PR TITLE
Fix NeidonPlus install again again

### DIFF
--- a/NetKAN/NeidonPlus.netkan
+++ b/NetKAN/NeidonPlus.netkan
@@ -11,3 +11,9 @@ depends:
   - name: Kopernicus
   - name: OuterPlanetsMod
   - name: VertexMitchellNetravaliHeightMap
+install:
+  - find: OPX-NeidonPlus
+    install_to: GameData
+    filter:
+      - __MACOSX
+      - .DS_Store


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ea51fa8a-f08c-4e93-8397-3968edab117b)

#9446 added an `OPM-` prefix, #9447 removed it, now there's an `OPX-` prefix and a bunch of Mac cruft.

#10104 is a different mod from the same authors with a similar setup.
