### PR TITLE
DSEV: adjust recommendations according to content in cfg files

### DIFF
--- a/NetKAN/DSEV.netkan
+++ b/NetKAN/DSEV.netkan
@@ -21,10 +21,10 @@ depends:
   - name: KerbalActuators
 recommends:
   - name: RasterPropMonitor-Core
+  - name: AvionicsSystems
   - name: ASETProps
+  - name: ASETAvionics
   - name: InfernalRobotics
-suggests:
-  - name: ASET
 install:
   - find: WildBlueIndustries/DSEV
     install_to: GameData/WildBlueIndustries


### PR DESCRIPTION
While working on a bug related to RPM and DSEV, I discovered that it uses ASET Avionics props, and most of the IVAs have been converted to use MAS to drive them (the RPM versions are still there but renamed to .txt)