### PR TITLE
Relax spec version requirements for some recent mods

### DIFF
--- a/NetKAN/ColdJHotAirBalloon.netkan
+++ b/NetKAN/ColdJHotAirBalloon.netkan
@@ -1,4 +1,4 @@
-spec_version: v1.34
+spec_version: v1.12
 identifier: ColdJHotAirBalloon
 $kref: '#/ckan/spacedock/3635'
 license: CC-BY-SA-4.0
@@ -12,4 +12,3 @@ install:
     install_to: GameData
   - file: GameData/Craft/ZeppelinComplete.craft
     install_to: Ships/SPH
-x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/ColdJsHeliCarrier.netkan
+++ b/NetKAN/ColdJsHeliCarrier.netkan
@@ -1,4 +1,4 @@
-spec_version: v1.34
+spec_version: v1.4
 identifier: ColdJsHeliCarrier
 $kref: '#/ckan/spacedock/3652'
 license: CC-BY-SA-4.0
@@ -13,4 +13,3 @@ suggests:
 install:
   - find: HeliCar
     install_to: GameData
-x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/ColdJsMilitaryPlanes.netkan
+++ b/NetKAN/ColdJsMilitaryPlanes.netkan
@@ -1,4 +1,4 @@
-spec_version: v1.34
+spec_version: v1.18
 identifier: ColdJsMilitaryPlanes
 $kref: '#/ckan/spacedock/3576'
 license: restricted

--- a/NetKAN/ColdJsMilitaryPlanesF16.netkan
+++ b/NetKAN/ColdJsMilitaryPlanesF16.netkan
@@ -1,4 +1,4 @@
-spec_version: v1.34
+spec_version: v1.18
 identifier: ColdJsMilitaryPlanesF16
 $kref: '#/ckan/spacedock/3579'
 license: restricted
@@ -13,4 +13,3 @@ install:
   - find: Craft
     install_to: Ships
     as: SPH
-x_via: Automated SpaceDock CKAN submission


### PR DESCRIPTION
The `SpaceDockAdder` uses a `spec_version` of `v1.34` for all mods because it's required for multi-hosting.

https://github.com/KSP-CKAN/NetKAN-Infra/blob/99896de590583914c5155330391c694e92653110/netkan/netkan/spacedock_adder.py#L142

Single-hosted mods can use earlier spec versions. @linuxgurugamer reported not seeing some mods in CKAN v1.33.2.
Now they have the earliest viable spec version.
