### PR TITLE
Resolve ColdJ Military Planes file conflicts

### DIFF
--- a/NetKAN/ColdJsMilitaryPlanesF16.netkan
+++ b/NetKAN/ColdJsMilitaryPlanesF16.netkan
@@ -9,7 +9,18 @@ tags:
 install:
   - find: CJMP
     install_to: GameData
-    filter: Craft
+    filter:
+      - Craft
+      - Readme.txt
+      - License.txt
+  - find: Readme.txt
+    find_matches_files: true
+    install_to: GameData/CJMP
+    as: Readme-F16.txt
+  - find: License.txt
+    find_matches_files: true
+    install_to: GameData/CJMP
+    as: License-F16.txt
   - find: Craft
     install_to: Ships
     as: SPH


### PR DESCRIPTION
## Problem

Both `ColdJsMilitaryPlanes` and `ColdJsMilitaryPlanesF16` contain `GameData/CJMP/License.txt` and `GameData/CJMP/Readme.txt`.

- Users who manually install both mods will overwrite these files during the install, and since the `Readme.txt` files are not the same, they will only have the readme file for one or the other mod, depending on the order of installation.
- For CKAN users, an error is emitted during installation instead:
  ```
  Oh no! We tried to overwrite a file owned by another mod!
  Please try a `ckan update` and try again.
  
  If this problem re-occurs, then it may be a packaging bug.
  Please report it at:
  
  https://github.com/KSP-CKAN/NetKAN/issues/new/choose
  
  Please include the following information in your report:
  
  File      : GameData/CJMP/License.txt
  Installing Mod : ColdJsMilitaryPlanesF16
  Owning Mod: ColdJsMilitaryPlanes
  CKAN Version   : v1.34.4
  ```

## Changes

Now the files from the F16 mod are installed under new names specific to that mod, `Readme-F16.txt` and `License-F16.txt`. This will ensure that all files are installed without overwrites or conflicts.

Fixes #10154.

___

ckan compat add 1.12
ckan install ColdJsMilitaryPlanes ColdJsMilitaryPlanesF16
