### PR TITLE
Fix RSSOrigins compatibility

### DIFF
--- a/NetKAN/RSSOrigin-CelestialsPack-Centaurs.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-Centaurs.netkan
@@ -7,6 +7,7 @@ license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack
 depends:
+  - name: ModuleManager
   - name: RSSOrigin
 install:
   - find: RSSOrigin

--- a/NetKAN/RSSOrigin-CelestialsPack-Centaurs.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-Centaurs.netkan
@@ -2,7 +2,7 @@ spec_version: v1.27
 identifier: RSSOrigin-CelestialsPack-Centaurs
 name: RSS-Origin CelestialsPack Centaurs
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.CelestialsPack.Centaurs.zip'
-$vref: '#/ckan/ksp-avc'
+ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack

--- a/NetKAN/RSSOrigin-CelestialsPack-Comets.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-Comets.netkan
@@ -2,7 +2,7 @@ spec_version: v1.27
 identifier: RSSOrigin-CelestialsPack-Comets
 name: RSS-Origin CelestialsPack Comets
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.CelestialsPack.Comets.zip'
-$vref: '#/ckan/ksp-avc'
+ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack

--- a/NetKAN/RSSOrigin-CelestialsPack-Comets.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-Comets.netkan
@@ -7,6 +7,7 @@ license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack
 depends:
+  - name: ModuleManager
   - name: RSSOrigin
 install:
   - find: RSSOrigin

--- a/NetKAN/RSSOrigin-CelestialsPack-InterstellarObjects.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-InterstellarObjects.netkan
@@ -7,6 +7,7 @@ license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack
 depends:
+  - name: ModuleManager
   - name: RSSOrigin
 install:
   - find: RSSOrigin

--- a/NetKAN/RSSOrigin-CelestialsPack-InterstellarObjects.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-InterstellarObjects.netkan
@@ -2,7 +2,7 @@ spec_version: v1.27
 identifier: RSSOrigin-CelestialsPack-InterstellarObjects
 name: RSS-Origin CelestialsPack InterstellarObjects
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.CelestialsPack.InterstellarObjects.zip'
-$vref: '#/ckan/ksp-avc'
+ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack

--- a/NetKAN/RSSOrigin-CelestialsPack-JupiterMoons.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-JupiterMoons.netkan
@@ -2,7 +2,7 @@ spec_version: v1.27
 identifier: RSSOrigin-CelestialsPack-JupiterMoons
 name: RSS-Origin CelestialsPack JupiterMoons
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.CelestialsPack.JupiterMoons.zip'
-$vref: '#/ckan/ksp-avc'
+ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack

--- a/NetKAN/RSSOrigin-CelestialsPack-JupiterMoons.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-JupiterMoons.netkan
@@ -7,6 +7,7 @@ license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack
 depends:
+  - name: ModuleManager
   - name: RSSOrigin
 install:
   - find: RSSOrigin

--- a/NetKAN/RSSOrigin-CelestialsPack-JupiterTrojans.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-JupiterTrojans.netkan
@@ -7,6 +7,7 @@ license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack
 depends:
+  - name: ModuleManager
   - name: RSSOrigin
 install:
   - find: RSSOrigin

--- a/NetKAN/RSSOrigin-CelestialsPack-JupiterTrojans.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-JupiterTrojans.netkan
@@ -2,7 +2,7 @@ spec_version: v1.27
 identifier: RSSOrigin-CelestialsPack-JupiterTrojans
 name: RSS-Origin CelestialsPack JupiterTrojans
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.CelestialsPack.JupiterTrojans.zip'
-$vref: '#/ckan/ksp-avc'
+ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack

--- a/NetKAN/RSSOrigin-CelestialsPack-MainBeltAsteroids.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-MainBeltAsteroids.netkan
@@ -2,7 +2,7 @@ spec_version: v1.27
 identifier: RSSOrigin-CelestialsPack-MainBeltAsteroids
 name: RSS-Origin CelestialsPack MainBeltAsteroids
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.CelestialsPack.MainBeltAsteroids.zip'
-$vref: '#/ckan/ksp-avc'
+ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack

--- a/NetKAN/RSSOrigin-CelestialsPack-MainBeltAsteroids.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-MainBeltAsteroids.netkan
@@ -7,6 +7,7 @@ license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack
 depends:
+  - name: ModuleManager
   - name: RSSOrigin
 install:
   - find: RSSOrigin

--- a/NetKAN/RSSOrigin-CelestialsPack-MarsCrossers.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-MarsCrossers.netkan
@@ -2,7 +2,7 @@ spec_version: v1.27
 identifier: RSSOrigin-CelestialsPack-MarsCrossers
 name: RSS-Origin CelestialsPack MarsCrossers
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.CelestialsPack.MarsCrossers.zip'
-$vref: '#/ckan/ksp-avc'
+ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack

--- a/NetKAN/RSSOrigin-CelestialsPack-MarsCrossers.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-MarsCrossers.netkan
@@ -7,6 +7,7 @@ license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack
 depends:
+  - name: ModuleManager
   - name: RSSOrigin
 install:
   - find: RSSOrigin

--- a/NetKAN/RSSOrigin-CelestialsPack-NearEarthObjects.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-NearEarthObjects.netkan
@@ -7,6 +7,7 @@ license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack
 depends:
+  - name: ModuleManager
   - name: RSSOrigin
 install:
   - find: RSSOrigin

--- a/NetKAN/RSSOrigin-CelestialsPack-NearEarthObjects.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-NearEarthObjects.netkan
@@ -2,7 +2,7 @@ spec_version: v1.27
 identifier: RSSOrigin-CelestialsPack-NearEarthObjects
 name: RSS-Origin CelestialsPack NearEarthObjects
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.CelestialsPack.NearEarthObjects.zip'
-$vref: '#/ckan/ksp-avc'
+ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack

--- a/NetKAN/RSSOrigin-CelestialsPack-NeptuneMoons.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-NeptuneMoons.netkan
@@ -7,6 +7,7 @@ license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack
 depends:
+  - name: ModuleManager
   - name: RSSOrigin
 install:
   - find: RSSOrigin

--- a/NetKAN/RSSOrigin-CelestialsPack-NeptuneMoons.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-NeptuneMoons.netkan
@@ -2,7 +2,7 @@ spec_version: v1.27
 identifier: RSSOrigin-CelestialsPack-NeptuneMoons
 name: RSS-Origin CelestialsPack NeptuneMoons
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.CelestialsPack.NeptuneMoons.zip'
-$vref: '#/ckan/ksp-avc'
+ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack

--- a/NetKAN/RSSOrigin-CelestialsPack-PlutoMoons.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-PlutoMoons.netkan
@@ -7,6 +7,7 @@ license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack
 depends:
+  - name: ModuleManager
   - name: RSSOrigin
 install:
   - find: RSSOrigin

--- a/NetKAN/RSSOrigin-CelestialsPack-PlutoMoons.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-PlutoMoons.netkan
@@ -2,7 +2,7 @@ spec_version: v1.27
 identifier: RSSOrigin-CelestialsPack-PlutoMoons
 name: RSS-Origin CelestialsPack PlutoMoons
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.CelestialsPack.PlutoMoons.zip'
-$vref: '#/ckan/ksp-avc'
+ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack

--- a/NetKAN/RSSOrigin-CelestialsPack-SaturnMoons.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-SaturnMoons.netkan
@@ -2,7 +2,7 @@ spec_version: v1.27
 identifier: RSSOrigin-CelestialsPack-SaturnMoons
 name: RSS-Origin CelestialsPack SaturnMoons
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.CelestialsPack.SaturnMoons.zip'
-$vref: '#/ckan/ksp-avc'
+ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack

--- a/NetKAN/RSSOrigin-CelestialsPack-SaturnMoons.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-SaturnMoons.netkan
@@ -7,6 +7,7 @@ license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack
 depends:
+  - name: ModuleManager
   - name: RSSOrigin
 install:
   - find: RSSOrigin

--- a/NetKAN/RSSOrigin-CelestialsPack-TransNeptunianObjects.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-TransNeptunianObjects.netkan
@@ -7,6 +7,7 @@ license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack
 depends:
+  - name: ModuleManager
   - name: RSSOrigin
 install:
   - find: RSSOrigin

--- a/NetKAN/RSSOrigin-CelestialsPack-TransNeptunianObjects.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-TransNeptunianObjects.netkan
@@ -2,7 +2,7 @@ spec_version: v1.27
 identifier: RSSOrigin-CelestialsPack-TransNeptunianObjects
 name: RSS-Origin CelestialsPack TransNeptunianObjects
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.CelestialsPack.TransNeptunianObjects.zip'
-$vref: '#/ckan/ksp-avc'
+ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack

--- a/NetKAN/RSSOrigin-CelestialsPack-UranusMoons.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-UranusMoons.netkan
@@ -7,6 +7,7 @@ license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack
 depends:
+  - name: ModuleManager
   - name: RSSOrigin
 install:
   - find: RSSOrigin

--- a/NetKAN/RSSOrigin-CelestialsPack-UranusMoons.netkan
+++ b/NetKAN/RSSOrigin-CelestialsPack-UranusMoons.netkan
@@ -2,7 +2,7 @@ spec_version: v1.27
 identifier: RSSOrigin-CelestialsPack-UranusMoons
 name: RSS-Origin CelestialsPack UranusMoons
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.CelestialsPack.UranusMoons.zip'
-$vref: '#/ckan/ksp-avc'
+ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack

--- a/NetKAN/RSSOrigin-GalaxyTex-16k.netkan
+++ b/NetKAN/RSSOrigin-GalaxyTex-16k.netkan
@@ -12,6 +12,7 @@ tags:
 provides:
   - RSSOrigin-GalaxyTex
 depends:
+  - name: ModuleManager
   - name: TextureReplacer
 recommends:
   - name: RSSOrigin

--- a/NetKAN/RSSOrigin-GalaxyTex-16k.netkan
+++ b/NetKAN/RSSOrigin-GalaxyTex-16k.netkan
@@ -5,7 +5,7 @@ abstract: >-
   A part of RSS-Origin, which replaces your skybox with a high-quality Milky Way
   background. This is the 16k res version
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.GalaxyTex16k.zip'
-$vref: '#/ckan/ksp-avc'
+ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
   - graphics

--- a/NetKAN/RSSOrigin-GalaxyTex-32k.netkan
+++ b/NetKAN/RSSOrigin-GalaxyTex-32k.netkan
@@ -5,7 +5,7 @@ abstract: >-
   A part of RSS-Origin, which replaces your skybox with a high-quality Milky Way
   background. This is the 32k res version
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.GalaxyTex32k.zip'
-$vref: '#/ckan/ksp-avc'
+ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
   - graphics

--- a/NetKAN/RSSOrigin-GalaxyTex-32k.netkan
+++ b/NetKAN/RSSOrigin-GalaxyTex-32k.netkan
@@ -12,6 +12,7 @@ tags:
 provides:
   - RSSOrigin-GalaxyTex
 depends:
+  - name: ModuleManager
   - name: TextureReplacer
 recommends:
   - name: RSSOrigin

--- a/NetKAN/RSSOrigin-GalaxyTex-64k.netkan
+++ b/NetKAN/RSSOrigin-GalaxyTex-64k.netkan
@@ -5,7 +5,7 @@ abstract: >-
   A part of RSS-Origin, which replaces your skybox with a high-quality Milky Way
   background. This is the 64k res version
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.GalaxyTex64k.zip'
-$vref: '#/ckan/ksp-avc'
+ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
   - graphics

--- a/NetKAN/RSSOrigin-GalaxyTex-64k.netkan
+++ b/NetKAN/RSSOrigin-GalaxyTex-64k.netkan
@@ -12,6 +12,7 @@ tags:
 provides:
   - RSSOrigin-GalaxyTex
 depends:
+  - name: ModuleManager
   - name: TextureReplacer
 recommends:
   - name: RSSOrigin

--- a/NetKAN/RSSOrigin-GalaxyTex-8k.netkan
+++ b/NetKAN/RSSOrigin-GalaxyTex-8k.netkan
@@ -5,7 +5,7 @@ abstract: >-
   A part of RSS-Origin, which replaces your skybox with a high-quality Milky Way
   background. This is the 8k res version
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.GalaxyTex8k.zip'
-$vref: '#/ckan/ksp-avc'
+ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
   - graphics

--- a/NetKAN/RSSOrigin-GalaxyTex-8k.netkan
+++ b/NetKAN/RSSOrigin-GalaxyTex-8k.netkan
@@ -12,6 +12,7 @@ tags:
 provides:
   - RSSOrigin-GalaxyTex
 depends:
+  - name: ModuleManager
   - name: TextureReplacer
 recommends:
   - name: RSSOrigin

--- a/NetKAN/RSSOrigin-JSUNrings.netkan
+++ b/NetKAN/RSSOrigin-JSUNrings.netkan
@@ -5,7 +5,7 @@ abstract: >-
   A part of RSS-Origin, which adds accurate and realistic rings to the 4 gas
   giants in our solar system.
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.JSUNrings.zip'
-$vref: '#/ckan/ksp-avc'
+ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack

--- a/NetKAN/RSSOrigin.netkan
+++ b/NetKAN/RSSOrigin.netkan
@@ -7,7 +7,7 @@ abstract: >-
   interstellar objects into real solar system, currently 198 in total. (dozens
   more in the future). This is the core pack
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.CelestialsPack.Core.zip'
-$vref: '#/ckan/ksp-avc'
+ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
   - planet-pack


### PR DESCRIPTION
These modules were added with a `$vref`, but they don't have version files.

![image](https://github.com/user-attachments/assets/89f37859-f2a2-4dba-80b3-b604bd946d2e)

Now they have `ksp_version: 1.12` as specified in #10126.
And MM deps are added to the ones that use MM syntax.
