### PR TITLE
Remove WaterfallExtensions GitHub kref

### DIFF
--- a/NetKAN/WaterfallExtensions.netkan
+++ b/NetKAN/WaterfallExtensions.netkan
@@ -1,22 +1,4 @@
 identifier: WaterfallExtensions
-$kref: '#/ckan/github/rbeap/WaterfallExtensions'
-license: CC0
-tags:
-  - config
-  - graphics
-  - sound
-depends:
-  - name: ModuleManager
-  - name: B9PartSwitch
-  - name: Waterfall
-recommends:
-  - name: KWRocketryRebalanced
-  - name: NewTantaresLV
-  - name: ReStock
-  - name: ShuttleLiftingBodyCormorantAeronology
-  - name: KWRocketry-LegacyFairings
----
-identifier: WaterfallExtensions
 $kref: '#/ckan/spacedock/3604'
 license: CC0
 tags:


### PR DESCRIPTION
This mod seems to have been removed from GitHub (in an incident contrary to the author's intentions):

- <https://github.com/rbeap/WaterfallExtensions>

And hasn't been a new upload to what appears to be the author's new account:

- <https://github.com/rbeap0>

Now the GitHub kref is removed, and only the SpaceDock kref remains.

___

ckan compat add 1.11 1.12