### PR TITLE
Add RSSOrigin TopoRevamp

### DIFF
--- a/NetKAN/RSSOrigin-TopoRevampConfigs.netkan
+++ b/NetKAN/RSSOrigin-TopoRevampConfigs.netkan
@@ -2,6 +2,7 @@ identifier: RSSOrigin-TopoRevampConfigs
 name: RSS-Origin RSS Texture & Topo Revamp Configs
 abstract: A part of RSS-Origin, which overhauls some RSS celestials with more accurate, more realistic and higher res textures and topography, since some of original RSS textures are unrealistic in color, topo and other stuff. This is the configs pack.
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/TopoRevamp.Configs'
+license: CC-BY-NC-SA-4.0
 tags:
   - config
   - planet-pack

--- a/NetKAN/RSSOrigin-TopoRevampConfigs.netkan
+++ b/NetKAN/RSSOrigin-TopoRevampConfigs.netkan
@@ -1,0 +1,22 @@
+identifier: RSSOrigin-TopoRevampConfigs
+name: RSS-Origin RSS Texture & Topo Revamp Configs
+abstract: A part of RSS-Origin, which overhauls some RSS celestials with more accurate, more realistic and higher res textures and topography, since some of original RSS textures are unrealistic in color, topo and other stuff. This is the configs pack.
+$kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/TopoRevamp.Configs'
+tags:
+  - config
+  - planet-pack
+depends:
+  - name: ModuleManager
+  - name: Kopernicus
+  - name: KSPCommunityFixes
+  - name: RSSOrigin-TopoRevampTextures
+recommends:
+  - name: RSSOrigin
+suggests:
+  - name: Parallax
+  - name: TUFX
+  - name: PlanetShine
+  - name: DistantObject
+install:
+  - find: RSSOrigin
+    install_to: GameData

--- a/NetKAN/RSSOrigin-TopoRevampConfigs.netkan
+++ b/NetKAN/RSSOrigin-TopoRevampConfigs.netkan
@@ -1,6 +1,11 @@
 identifier: RSSOrigin-TopoRevampConfigs
 name: RSS-Origin RSS Texture & Topo Revamp Configs
-abstract: A part of RSS-Origin, which overhauls some RSS celestials with more accurate, more realistic and higher res textures and topography, since some of original RSS textures are unrealistic in color, topo and other stuff. This is the configs pack.
+abstract: >-
+  A part of RSS-Origin, which overhauls some RSS celestials with
+  more accurate, more realistic and higher res textures and topography,
+  since some of original RSS textures are unrealistic in
+  color, topo and other stuff.
+  This is the configs pack.
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/TopoRevamp.Configs'
 license: CC-BY-NC-SA-4.0
 tags:

--- a/NetKAN/RSSOrigin-TopoRevampTextures16k.netkan
+++ b/NetKAN/RSSOrigin-TopoRevampTextures16k.netkan
@@ -2,6 +2,7 @@ identifier: RSSOrigin-TopoRevampTextures16k
 name: RSS-Origin RSS Texture & Topo Revamp Textures 16k
 abstract: The texture pack of RSS-Origin RSSTexture&TopoRevamp. This is the 16k version.
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/TopoRevamp.Textures16k'
+license: CC-BY-NC-SA-4.0
 tags:
   - config
   - planet-pack

--- a/NetKAN/RSSOrigin-TopoRevampTextures16k.netkan
+++ b/NetKAN/RSSOrigin-TopoRevampTextures16k.netkan
@@ -1,6 +1,8 @@
 identifier: RSSOrigin-TopoRevampTextures16k
 name: RSS-Origin RSS Texture & Topo Revamp Textures 16k
-abstract: The texture pack of RSS-Origin RSSTexture&TopoRevamp. This is the 16k version.
+abstract: >-
+  The texture pack of RSS-Origin RSSTexture&TopoRevamp.
+  This is the 16k version.
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/TopoRevamp.Textures16k'
 license: CC-BY-NC-SA-4.0
 tags:

--- a/NetKAN/RSSOrigin-TopoRevampTextures16k.netkan
+++ b/NetKAN/RSSOrigin-TopoRevampTextures16k.netkan
@@ -1,0 +1,16 @@
+identifier: RSSOrigin-TopoRevampTextures16k
+name: RSS-Origin RSS Texture & Topo Revamp Textures 16k
+abstract: The texture pack of RSS-Origin RSSTexture&TopoRevamp. This is the 16k version.
+$kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/TopoRevamp.Textures16k'
+tags:
+  - config
+  - planet-pack
+provides:
+  - RSSOrigin-TopoRevampTextures
+conflicts:
+  - name: RSSOrigin-TopoRevampTextures
+depends:
+  - name: RSSOrigin-TopoRevampConfigs
+install:
+  - find: RSSOrigin
+    install_to: GameData

--- a/NetKAN/RSSOrigin-TopoRevampTextures4k.netkan
+++ b/NetKAN/RSSOrigin-TopoRevampTextures4k.netkan
@@ -1,0 +1,16 @@
+identifier: RSSOrigin-TopoRevampTextures4k
+name: RSS-Origin RSS Texture & Topo Revamp Textures 4k
+abstract: The texture pack of RSS-Origin RSSTexture&TopoRevamp. This is the 4k version.
+$kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/TopoRevamp.Textures4k'
+tags:
+  - config
+  - planet-pack
+provides:
+  - RSSOrigin-TopoRevampTextures
+conflicts:
+  - name: RSSOrigin-TopoRevampTextures
+depends:
+  - name: RSSOrigin-TopoRevampConfigs
+install:
+  - find: RSSOrigin
+    install_to: GameData

--- a/NetKAN/RSSOrigin-TopoRevampTextures4k.netkan
+++ b/NetKAN/RSSOrigin-TopoRevampTextures4k.netkan
@@ -2,6 +2,7 @@ identifier: RSSOrigin-TopoRevampTextures4k
 name: RSS-Origin RSS Texture & Topo Revamp Textures 4k
 abstract: The texture pack of RSS-Origin RSSTexture&TopoRevamp. This is the 4k version.
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/TopoRevamp.Textures4k'
+license: CC-BY-NC-SA-4.0
 tags:
   - config
   - planet-pack

--- a/NetKAN/RSSOrigin-TopoRevampTextures4k.netkan
+++ b/NetKAN/RSSOrigin-TopoRevampTextures4k.netkan
@@ -1,6 +1,8 @@
 identifier: RSSOrigin-TopoRevampTextures4k
 name: RSS-Origin RSS Texture & Topo Revamp Textures 4k
-abstract: The texture pack of RSS-Origin RSSTexture&TopoRevamp. This is the 4k version.
+abstract: >-
+  The texture pack of RSS-Origin RSSTexture&TopoRevamp.
+  This is the 4k version.
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/TopoRevamp.Textures4k'
 license: CC-BY-NC-SA-4.0
 tags:

--- a/NetKAN/RSSOrigin-TopoRevampTextures8k.netkan
+++ b/NetKAN/RSSOrigin-TopoRevampTextures8k.netkan
@@ -1,6 +1,8 @@
 identifier: RSSOrigin-TopoRevampTextures8k
 name: RSS-Origin RSS Texture & Topo Revamp Textures 8k
-abstract: The texture pack of RSS-Origin RSSTexture&TopoRevamp. This is the 8k version.
+abstract: >-
+  The texture pack of RSS-Origin RSSTexture&TopoRevamp.
+  This is the 8k version.
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/TopoRevamp.Textures8k'
 license: CC-BY-NC-SA-4.0
 tags:

--- a/NetKAN/RSSOrigin-TopoRevampTextures8k.netkan
+++ b/NetKAN/RSSOrigin-TopoRevampTextures8k.netkan
@@ -2,6 +2,7 @@ identifier: RSSOrigin-TopoRevampTextures8k
 name: RSS-Origin RSS Texture & Topo Revamp Textures 8k
 abstract: The texture pack of RSS-Origin RSSTexture&TopoRevamp. This is the 8k version.
 $kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/TopoRevamp.Textures8k'
+license: CC-BY-NC-SA-4.0
 tags:
   - config
   - planet-pack

--- a/NetKAN/RSSOrigin-TopoRevampTextures8k.netkan
+++ b/NetKAN/RSSOrigin-TopoRevampTextures8k.netkan
@@ -1,0 +1,16 @@
+identifier: RSSOrigin-TopoRevampTextures8k
+name: RSS-Origin RSS Texture & Topo Revamp Textures 8k
+abstract: The texture pack of RSS-Origin RSSTexture&TopoRevamp. This is the 8k version.
+$kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/TopoRevamp.Textures8k'
+tags:
+  - config
+  - planet-pack
+provides:
+  - RSSOrigin-TopoRevampTextures
+conflicts:
+  - name: RSSOrigin-TopoRevampTextures
+depends:
+  - name: RSSOrigin-TopoRevampConfigs
+install:
+  - find: RSSOrigin
+    install_to: GameData


### PR DESCRIPTION
- <https://github.com/CharonSSS/RSS-Origin>

From [the mod's readme](https://github.com/CharonSSS/RSS-Origin?tab=readme-ov-file#rss-origin-rsstexturetoporevamp):

> RSS-Origin RSSTexture&TopoRevamp is an overhaul to some of the RSS celestials. I've done a widely search for information and figure out some of the RSS celestials are using wrong and misaligned surface textures ,topograhy maps, false or enhanced color images. So this mod's purpose is to fix those issues, fixing texture alignment flip or rotation, and make them displayed in natural color. Different texture resolutions are provided (4k, 8k and 16k).

Fixes #10140.
