### PR TITLE
Split DKSalvage agency and flags into standalone module

### DIFF
--- a/NetKAN/DKSalvageAgencyAndFlag.netkan
+++ b/NetKAN/DKSalvageAgencyAndFlag.netkan
@@ -1,4 +1,6 @@
-identifier: DKSalvageAgencyAndFlag
+identifier: DKSalvageAgencyAndFlag\
+name: DKSalvage Agency and Flag
+abstract: The common agency and flag files used by DKSalvage mods
 $kref: '#/ckan/spacedock/3677'
 tags:
   - agency

--- a/NetKAN/DKSalvageAgencyAndFlag.netkan
+++ b/NetKAN/DKSalvageAgencyAndFlag.netkan
@@ -1,4 +1,4 @@
-identifier: DKSalvageAgencyAndFlag\
+identifier: DKSalvageAgencyAndFlag
 name: DKSalvage Agency and Flag
 abstract: The common agency and flag files used by DKSalvage mods
 $kref: '#/ckan/spacedock/3677'

--- a/NetKAN/DKSalvageAgencyAndFlag.netkan
+++ b/NetKAN/DKSalvageAgencyAndFlag.netkan
@@ -1,0 +1,10 @@
+identifier: DKSalvageAgencyAndFlag
+$kref: '#/ckan/spacedock/3677'
+tags:
+  - agency
+  - flags
+install:
+  - find: DKSalvage/Agencies
+    install_to: GameData/DKSalvage
+  - find: DKSalvage/Flags
+    install_to: GameData/DKSalvage

--- a/NetKAN/RoveMateClassicTuneUp.netkan
+++ b/NetKAN/RoveMateClassicTuneUp.netkan
@@ -4,8 +4,12 @@ tags:
   - parts
 depends:
   - name: ModuleManager
+  - name: DKSalvageAgencyAndFlag
 install:
   - find: DKSalvage
     install_to: GameData
+    filter:
+      - Agencies
+      - Flags
   - find: DKSalvageRMCTuneUp
     install_to: GameData

--- a/NetKAN/StructuralTubing.netkan
+++ b/NetKAN/StructuralTubing.netkan
@@ -1,19 +1,16 @@
-{
-    "identifier":   "StructuralTubing",
-    "$kref":        "#/ckan/spacedock/1753",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "suggests": [
-        { "name": "TweakScale" }
-    ],
-    "install": [ {
-        "find": "DKSalvage",
-        "install_to": "GameData"
-    } ]
-}
+identifier: StructuralTubing
+$kref: '#/ckan/spacedock/1753'
+$vref: '#/ckan/ksp-avc'
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+  - name: DKSalvageAgencyAndFlag
+suggests:
+  - name: TweakScale
+install:
+  - find: DKSalvage
+    install_to: GameData
+    filter:
+      - Agencies
+      - Flags


### PR DESCRIPTION
## Problem

If you try to install `StructuralTubing` and `RoveMateClassicTuneUp`, you get a file conflict at `GameData/DKSalvage/Agencies/agency.cfg`. If we fixed just this one file, the same thing would happen in the `GameData/DKSalvage/Flags` folder.

## Changes

- Now their common files are filtered out of `StructuralTubing` and `RoveMateClassicTuneUp`
- Now `GameData/DKSalvage/Agencies` and `GameData/DKSalvage/Flags` are installed by a new `DKSalvageAgencyAndFlag` module (from the `RoveMateClassicTuneUp ZIP)
- Now `StructuralTubing` and `RoveMateClassicTuneUp` depend on `DKSalvageAgencyAndFlag`

___

ckan compat add 1.12
ckan install StructuralTubing RoveMateClassicTuneUp
