### PR TITLE
Set Mk-33's name to contain a dash

### DIFF
--- a/NetKAN/Mk-33.netkan
+++ b/NetKAN/Mk-33.netkan
@@ -1,4 +1,5 @@
 identifier: Mk-33
+name: Mk-33
 $kref: '#/ckan/github/Angel-125/Mk-33'
 $vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Mk-33/Mk33.version'
 license: restricted


### PR DESCRIPTION
This mod's intended name is `Mk-33`.
Since it's not set in the netkan, the inflator derives it from the repo name, and in the process it converts the dash to a space, so the name in the metadata is `Mk 33`.

Now we override the name to retain the dash.
