### PR TITLE
VertexColorMapEmissive depends for KcalbelohSystem

### DIFF
--- a/NetKAN/KcalbelohSystem.netkan
+++ b/NetKAN/KcalbelohSystem.netkan
@@ -14,6 +14,7 @@ depends:
   - name: KopernicusExpansionContinueder
   - name: VertexMitchellNetravaliHeightMap
   - name: KcalbelohSystem-Textures
+  - name: VertexColorMapEmissive
 recommends:
   - name: EnvironmentalVisualEnhancements
   - name: Scatterer


### PR DESCRIPTION
- <https://github.com/jcyuan06/Kcalbeloh-System>

New relationship requested by author, applies to a future release.

Fixes #10197.
