### PR TITLE
Add GitHub krefs to SpaceDock mods

### DIFF
--- a/NetKAN/4kSPExpanded.netkan
+++ b/NetKAN/4kSPExpanded.netkan
@@ -1,22 +1,25 @@
-{
-  "license": "MIT",
-  "identifier": "4kSPExpanded",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "$kref": "#/ckan/spacedock/2554",
-  "$vref": "#/ckan/ksp-avc",
-  "conflicts": [ { "name": "4kSP" } ],
-  "depends": [
-    { "name": "ToolbarController" },
-    { "name": "ClickThroughBlocker" }
-  ],
-  "tags": [
-    "plugin",
-    "convenience",
-    "information",
-    "graphics"
-  ],
-  "install": [ {
-        "find":"4ksp",
-        "install_to": "GameData"
-    } ]
-}
+identifier: 4kSPExpanded
+$kref: '#/ckan/github/linuxgurugamer/4ksp_Expanded'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: 4ksp
+    install_to: GameData
+---
+license: MIT
+identifier: 4kSPExpanded
+x_via: Automated Linuxgurugamer CKAN script
+$kref: '#/ckan/spacedock/2554'
+$vref: '#/ckan/ksp-avc'
+conflicts:
+  - name: 4kSP
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+tags:
+  - plugin
+  - convenience
+  - information
+  - graphics
+install:
+  - find: 4ksp
+    install_to: GameData

--- a/NetKAN/ALCOR.netkan
+++ b/NetKAN/ALCOR.netkan
@@ -1,4 +1,8 @@
 identifier: ALCOR
+$kref: '#/ckan/github/FirstPersonKSP/KSP-ALCOR'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: ALCOR
 author:
   - alexustas
   - JonnyOThan

--- a/NetKAN/AQSS.netkan
+++ b/NetKAN/AQSS.netkan
@@ -1,28 +1,22 @@
-{
-  "license": "GPL-3.0",
-  "identifier": "AQSS",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "$kref": "#/ckan/spacedock/2475",
-  "$vref": "#/ckan/ksp-avc",
-  "depends": [
-    {
-      "name": "ToolbarController"
-    },
-    {
-      "name": "ClickThroughBlocker"
-    },
-    {
-      "name": "SpaceTuxLibrary"
-    }
-  ],
-  "tags": [
-    "plugin",
-    "convenience"
-  ],
-  "install": [
-    {
-      "find": "AutoQuickSaveSystem",
-      "install_to": "GameData"
-    }
-  ]
-}
+identifier: AQSS
+$kref: '#/ckan/github/linuxgurugamer/AutoQuickSaveSystem'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: AutoQuickSaveSystem
+    install_to: GameData
+---
+license: GPL-3.0
+identifier: AQSS
+x_via: Automated Linuxgurugamer CKAN script
+$kref: '#/ckan/spacedock/2475'
+$vref: '#/ckan/ksp-avc'
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+tags:
+  - plugin
+  - convenience
+install:
+  - find: AutoQuickSaveSystem
+    install_to: GameData

--- a/NetKAN/ASETAvionics.netkan
+++ b/NetKAN/ASETAvionics.netkan
@@ -1,4 +1,11 @@
 identifier: ASETAvionics
+$kref: '#/ckan/github/StoneBlue/ASET-Consolidated-Avionics'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ASET
+    install_to: GameData
+---
+identifier: ASETAvionics
 author:
   - alexustas
   - StoneBlue
@@ -11,13 +18,13 @@ tags:
   - library
   - crewed
   - first-person
-install:
-  - find: ASET
-    install_to: GameData
 depends:
   - name: ModuleManager
   - name: ASETAgency
   - name: ASETProps
-    min_version: '2.0.0'
+    min_version: 2.0.0
   - name: RasterPropMonitor-Core
     min_version: 1:v0.30.2
+install:
+  - find: ASET
+    install_to: GameData

--- a/NetKAN/ASETProps.netkan
+++ b/NetKAN/ASETProps.netkan
@@ -1,4 +1,11 @@
 identifier: ASETProps
+$kref: '#/ckan/github/StoneBlue/ASET-Consolidated-Props'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ASET/ASET_Props
+    install_to: GameData/ASET
+---
+identifier: ASETProps
 author:
   - alexustas
   - Stone Blue

--- a/NetKAN/Achievements.netkan
+++ b/NetKAN/Achievements.netkan
@@ -1,22 +1,19 @@
-{
-    "identifier"   : "Achievements",
-    "name"         : "KSP Achievements",
-    "abstract"     : "145 Achievements you can get playing Kerbal Space Program.",
-    "$kref"        : "#/ckan/spacedock/2422",
-    "$vref"        : "#/ckan/ksp-avc",
-    "license"      : "GPL-3.0",
-    "tags"         : [
-        "plugin"
-    ],
-    "install"      : [
-        {
-            "find": "Achievements",
-            "install_to": "GameData"
-        }
-    ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" },
-        { "name": "SpaceTuxLibrary" }
-    ]
-}
+identifier: Achievements
+$kref: '#/ckan/github/linuxgurugamer/Achievements'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: Achievements
+name: KSP Achievements
+abstract: 145 Achievements you can get playing Kerbal Space Program.
+$kref: '#/ckan/spacedock/2422'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+install:
+  - find: Achievements
+    install_to: GameData
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary

--- a/NetKAN/AdvancedFlyByWire.netkan
+++ b/NetKAN/AdvancedFlyByWire.netkan
@@ -1,41 +1,44 @@
-{
-    "identifier":   "AdvancedFlyByWire",
-    "name":         "Advanced Fly-By-Wire (Windows)",
-    "$kref":        "#/ckan/spacedock/1869",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "release_status": "stable",
-    "tags": [
-        "plugin",
-        "control"
-    ],
-    "install": [ {
-        "file":       "SDL2.dll",
-        "install_to": "GameRoot"
-    }, {
-        "file":       "SDL_LICENSE",
-        "install_to": "GameRoot"
-    }, {
-        "file":       "XINPUTDOTNET_LICENSE",
-        "install_to": "GameRoot"
-    }, {
-        "file":       "XInputInterface.dll",
-        "install_to": "GameRoot"
-    }, {
-        "file":       "GameData/ksp-advanced-flybywire",
-        "install_to": "GameData"
-    } ],
-    "provides": [
-        "AdvancedFlyByWireRevived"
-    ],
-    "conflicts": [
-        { "name": "AdvancedFlyByWireRevived" }
-    ],
-    "depends": [
-        { "name": "ToolbarController"   },
-        { "name": "ClickThroughBlocker" }
-    ],
-    "recommends": [
-        { "name": "KSP-AVC" }
-    ]
-}
+identifier: AdvancedFlyByWire
+$kref: '#/ckan/github/linuxgurugamer/ksp-advanced-flybywire/asset_match/win'
+$vref: '#/ckan/ksp-avc'
+install:
+  - file: SDL2.dll
+    install_to: GameRoot
+  - file: SDL_LICENSE
+    install_to: GameRoot
+  - file: XINPUTDOTNET_LICENSE
+    install_to: GameRoot
+  - file: XInputInterface.dll
+    install_to: GameRoot
+  - file: GameData/ksp-advanced-flybywire
+    install_to: GameData
+---
+identifier: AdvancedFlyByWire
+name: Advanced Fly-By-Wire (Windows)
+$kref: '#/ckan/spacedock/1869'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+release_status: stable
+tags:
+  - plugin
+  - control
+provides:
+  - AdvancedFlyByWireRevived
+conflicts:
+  - name: AdvancedFlyByWireRevived
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+recommends:
+  - name: KSP-AVC
+install:
+  - file: SDL2.dll
+    install_to: GameRoot
+  - file: SDL_LICENSE
+    install_to: GameRoot
+  - file: XINPUTDOTNET_LICENSE
+    install_to: GameRoot
+  - file: XInputInterface.dll
+    install_to: GameRoot
+  - file: GameData/ksp-advanced-flybywire
+    install_to: GameData

--- a/NetKAN/AirParkContinued.netkan
+++ b/NetKAN/AirParkContinued.netkan
@@ -1,21 +1,23 @@
-{
-    "identifier":   "AirParkContinued",
-    "$kref":        "#/ckan/spacedock/2661",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-2.0",
-    "x_netkan_epoch": 1,
-    "tags": [
-        "plugin",
-        "physics"
-    ],
-    "install": [ {
-        "find":       "AirPark",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name" : "ModuleManager" },
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" },
-        { "name": "SpaceTuxLibrary" }
-    ]
-}
+identifier: AirParkContinued
+$kref: '#/ckan/github/linuxgurugamer/AirPark'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: AirPark
+    install_to: GameData
+---
+identifier: AirParkContinued
+$kref: '#/ckan/spacedock/2661'
+$vref: '#/ckan/ksp-avc'
+license: GPL-2.0
+x_netkan_epoch: 1
+tags:
+  - plugin
+  - physics
+depends:
+  - name: ModuleManager
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+install:
+  - find: AirPark
+    install_to: GameData

--- a/NetKAN/ArtemisConstructionKit.netkan
+++ b/NetKAN/ArtemisConstructionKit.netkan
@@ -1,4 +1,18 @@
 identifier: ArtemisConstructionKit
+$kref: '#/ckan/github/benjee10/Benjee10_Orion'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: Benjee10_Orion
+    install_to: GameData
+  - find: Craft Files
+    install_to: Ships
+    as: VAB
+---
+identifier: ArtemisConstructionKit
 $kref: '#/ckan/spacedock/3098'
 license: restricted
 tags:

--- a/NetKAN/AtmosphericBeatsKSRSSconfigforEVEVolumetrics.netkan
+++ b/NetKAN/AtmosphericBeatsKSRSSconfigforEVEVolumetrics.netkan
@@ -1,4 +1,14 @@
 identifier: AtmosphericBeatsKSRSSconfigforEVEVolumetrics
+$kref: '#/ckan/github/atmosphericbeats/atmosphericbeats_eveconfig_ksrss'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+install:
+  - find: AtmosphericBeats
+    install_to: GameData
+---
+identifier: AtmosphericBeatsKSRSSconfigforEVEVolumetrics
 $kref: '#/ckan/spacedock/3343'
 license: MIT
 tags:
@@ -9,4 +19,3 @@ depends:
 install:
   - find: AtmosphericBeats
     install_to: GameData
-x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/AutoLoadGame.netkan
+++ b/NetKAN/AutoLoadGame.netkan
@@ -1,10 +1,15 @@
-{
-    "identifier":   "AutoLoadGame",
-    "$kref":        "#/ckan/spacedock/832",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "convenience"
-    ]
-}
+identifier: AutoLoadGame
+$kref: '#/ckan/github/allista/AutoLoadGame'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc'
+---
+identifier: AutoLoadGame
+$kref: '#/ckan/spacedock/832'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - convenience

--- a/NetKAN/AutoRCS.netkan
+++ b/NetKAN/AutoRCS.netkan
@@ -1,4 +1,12 @@
 identifier: AutoRCS
+$kref: '#/ckan/github/todi/AutoRCS'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc'
+---
+identifier: AutoRCS
 $kref: '#/ckan/spacedock/3134'
 license: MIT
 $vref: '#/ckan/ksp-avc'

--- a/NetKAN/AviationLights.netkan
+++ b/NetKAN/AviationLights.netkan
@@ -1,4 +1,14 @@
 identifier: AviationLights
+$kref: '#/ckan/github/net-lisias-ksp/AviationLights/asset_match/^(?!.*CurseForge)'
+x_netkan_version_edit:
+  find: ^RELEASE/
+  replace: ''
+  strict: false
+x_netkan_force_v: true
+x_netkan_epoch: 1
+$vref: '#/ckan/ksp-avc'
+---
+identifier: AviationLights
 name: Aviation Lights
 author:
   - LisiasT

--- a/NetKAN/B9StockPatches.netkan
+++ b/NetKAN/B9StockPatches.netkan
@@ -1,17 +1,16 @@
-{
-    "identifier":   "B9StockPatches",
-    "$kref":        "#/ckan/spacedock/2374",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "config"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "B9PartSwitch"  }
-    ],
-    "recommends": [
-        { "name": "CommunityResourcePack" },
-        { "name": "KGEx"                  }
-    ]
-}
+identifier: B9StockPatches
+$kref: '#/ckan/github/zer0Kerbal/B9StockPatches'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: B9StockPatches
+$kref: '#/ckan/spacedock/2374'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - config
+depends:
+  - name: ModuleManager
+  - name: B9PartSwitch
+recommends:
+  - name: CommunityResourcePack
+  - name: KGEx

--- a/NetKAN/BDArmoryForRunwayProject.netkan
+++ b/NetKAN/BDArmoryForRunwayProject.netkan
@@ -1,4 +1,19 @@
 identifier: BDArmoryForRunwayProject
+$kref: '#/ckan/github/BrettRyland/BDArmory'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+install:
+  - find: BDArmory
+    install_to: GameData
+  - find: craft
+    install_to: Ships
+    as: SPH
+---
+identifier: BDArmoryForRunwayProject
 author:
   - BahamutoD
   - Papa_Joe

--- a/NetKAN/BenjisHardwiredLogic.netkan
+++ b/NetKAN/BenjisHardwiredLogic.netkan
@@ -1,4 +1,8 @@
 identifier: BenjisHardwiredLogic
+$kref: '#/ckan/github/ErinaceusLinnaeus/BenjisHardwiredLogic'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: BenjisHardwiredLogic
 $kref: '#/ckan/spacedock/2759'
 $vref: '#/ckan/ksp-avc'
 license: GPL-3.0

--- a/NetKAN/BetterKerbol.netkan
+++ b/NetKAN/BetterKerbol.netkan
@@ -1,4 +1,7 @@
 identifier: BetterKerbol
+$kref: '#/ckan/github/jamespglaze/BetterKerbol'
+---
+identifier: BetterKerbol
 $kref: '#/ckan/spacedock/3118'
 license: CC-BY-NC-ND-3.0
 tags:

--- a/NetKAN/BonVoyage.netkan
+++ b/NetKAN/BonVoyage.netkan
@@ -1,14 +1,14 @@
-{
-    "identifier":   "BonVoyage",
-    "$kref":        "#/ckan/spacedock/950",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_epoch": 1,
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "convenience"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ]
-}
+identifier: BonVoyage
+$kref: '#/ckan/github/jarosm/KSP-BonVoyage'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: BonVoyage
+$kref: '#/ckan/spacedock/950'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: 1
+license: GPL-3.0
+tags:
+  - plugin
+  - convenience
+depends:
+  - name: ModuleManager

--- a/NetKAN/BoosterGuidance.netkan
+++ b/NetKAN/BoosterGuidance.netkan
@@ -1,4 +1,8 @@
 identifier: BoosterGuidance
+$kref: '#/ckan/github/linuxgurugamer/BoosterGuidance'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: BoosterGuidance
 $kref: '#/ckan/spacedock/3018'
 $vref: '#/ckan/ksp-avc'
 license: GPL-3.0

--- a/NetKAN/Bumblebee.netkan
+++ b/NetKAN/Bumblebee.netkan
@@ -1,4 +1,7 @@
 identifier: Bumblebee
+$kref: '#/ckan/github/Rodg88/BumbleBee'
+---
+identifier: Bumblebee
 $kref: '#/ckan/spacedock/2428'
 ksp_version_min: 1.8.1
 ksp_version_max: '1.12'

--- a/NetKAN/BuranEnergia.netkan
+++ b/NetKAN/BuranEnergia.netkan
@@ -1,4 +1,14 @@
 identifier: BuranEnergia
+$kref: '#/ckan/github/MyNameIsBorat/KspBuran'
+x_netkan_github:
+  use_source_archive: true
+install:
+  - find: DECQ_ENERGIA
+    install_to: GameData
+  - find: Alcentar_Add-ons
+    install_to: GameData
+---
+identifier: BuranEnergia
 $kref: '#/ckan/spacedock/2966'
 license: GPL-3.0
 tags:

--- a/NetKAN/CactEyeCommunityRefocused.netkan
+++ b/NetKAN/CactEyeCommunityRefocused.netkan
@@ -1,4 +1,11 @@
 identifier: CactEyeCommunityRefocused
+$kref: '#/ckan/github/linuxgurugamer/CactEye-2'
+$vref: '#/ckan/ksp-avc'
+install:
+  - file: GameData/CactEye
+    install_to: GameData
+---
+identifier: CactEyeCommunityRefocused
 $kref: '#/ckan/spacedock/2930'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-4.0
@@ -13,9 +20,6 @@ depends:
   - name: ClickThroughBlocker
   - name: SpaceTuxLibrary
   - name: DistantObject
-#recommends:
-#  - name: CactEyeCommunityDOEPatch
-#  - name: DistantObject
 install:
   - file: GameData/CactEye
     install_to: GameData

--- a/NetKAN/CameraFocusChanger.netkan
+++ b/NetKAN/CameraFocusChanger.netkan
@@ -1,15 +1,17 @@
-{
-    "identifier"   : "CameraFocusChanger",
-    "name"         : "Camera Focus Changer",
-    "abstract"     : "A plugin that lets you change the focus of the camera by pressing 'o' when hovering a part.",
-    "$kref"        : "#/ckan/spacedock/1625",
-    "$vref"        : "#/ckan/ksp-avc",
-    "x_netkan_epoch": 1,
-    "license"      : "MIT",
-    "tags": [
-        "plugin"
-    ],
-    "suggests": [
-        { "name": "KerbalChangelog"         }
-    ]
-}
+identifier: CameraFocusChanger
+$kref: '#/ckan/github/linuxgurugamer/camerafocuschanger'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: CameraFocusChanger
+name: Camera Focus Changer
+abstract: >-
+  A plugin that lets you change the focus of the camera by pressing 'o' when
+  hovering a part.
+$kref: '#/ckan/spacedock/1625'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: 1
+license: MIT
+tags:
+  - plugin
+suggests:
+  - name: KerbalChangelog

--- a/NetKAN/CameraTools.netkan
+++ b/NetKAN/CameraTools.netkan
@@ -1,11 +1,15 @@
-{
-    "identifier":   "CameraTools",
-    "author":       [ "BahamutoD", "jrodrigv", "Brett_Ryland" ],
-    "$kref":        "#/ckan/spacedock/2657",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_force_v": true,
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin"
-    ]
-}
+identifier: CameraTools
+$kref: '#/ckan/github/BrettRyland/CameraTools'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: CameraTools
+author:
+  - BahamutoD
+  - jrodrigv
+  - Brett_Ryland
+$kref: '#/ckan/spacedock/2657'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+license: GPL-3.0
+tags:
+  - plugin

--- a/NetKAN/CareerManagerContinued.netkan
+++ b/NetKAN/CareerManagerContinued.netkan
@@ -1,21 +1,22 @@
-{
-    "identifier":   "CareerManagerContinued",
-    "$kref":        "#/ckan/spacedock/1221",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "career"
-    ],
-    "install": [ {
-        "find": "CareerManager",
-        "install_to": "GameData"
-    } ],
-    "conflicts" : [
-        { "name": "CareerManager" }
-    ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ]
-}
+identifier: CareerManagerContinued
+$kref: '#/ckan/github/linuxgurugamer/CareerManagerContinued'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: CareerManager
+    install_to: GameData
+---
+identifier: CareerManagerContinued
+$kref: '#/ckan/spacedock/1221'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - career
+conflicts:
+  - name: CareerManager
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: CareerManager
+    install_to: GameData

--- a/NetKAN/CarnationREDFlexibleParts.netkan
+++ b/NetKAN/CarnationREDFlexibleParts.netkan
@@ -1,4 +1,11 @@
 identifier: CarnationREDFlexibleParts
+$kref: '#/ckan/github/linuxgurugamer/CarnationREDFlexibleParts'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: CarnationREDFlexiblePart
+    install_to: GameData
+---
+identifier: CarnationREDFlexibleParts
 $kref: '#/ckan/spacedock/2380'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-SA-4.0

--- a/NetKAN/ChampagneBottleRedux.netkan
+++ b/NetKAN/ChampagneBottleRedux.netkan
@@ -1,24 +1,23 @@
-{
-    "identifier"    : "ChampagneBottleRedux",
-    "$kref"         : "#/ckan/spacedock/613",
-    "$vref"         : "#/ckan/ksp-avc",
-    "license"       : "CC-BY-NC-SA",
-    "tags": [
-        "plugin",
-        "editor"
-    ],
-    "depends": [
-        { "name": "ToolbarController"   },
-        { "name": "ClickThroughBlocker" }
-    ],
-    "recommends": [
-        { "name": "Toolbar" },
-        { "name": "JanitorsCloset" }
-    ],
-    "install": [
-        {
-            "find": "Champagne",
-            "install_to": "GameData"
-        }
-    ]
-}
+identifier: ChampagneBottleRedux
+$kref: '#/ckan/github/linuxgurugamer/ChampagneBottleRedux'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: Champagne
+    install_to: GameData
+---
+identifier: ChampagneBottleRedux
+$kref: '#/ckan/spacedock/613'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA
+tags:
+  - plugin
+  - editor
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+recommends:
+  - name: Toolbar
+  - name: JanitorsCloset
+install:
+  - find: Champagne
+    install_to: GameData

--- a/NetKAN/ChayrolDesignOrg.netkan
+++ b/NetKAN/ChayrolDesignOrg.netkan
@@ -1,25 +1,31 @@
-{
-    "identifier"  : "ChayrolDesignOrg",
-    "abstract"    : "Add ISRO rockets and spacecraft. Eventually the plan is to add SLV, GSLV MK1-3, RLV, along with a couple of probes (Ex. Chandrayaan, Mangalyaan etc).",
-    "$kref"       : "#/ckan/spacedock/2337",
-    "$vref"       : "#/ckan/ksp-avc/ChrayolDesignOrg.version",
-    "license"     : "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "B9PartSwitch"  }
-    ],
-    "suggests": [
-        { "name": "JNSQ"                   },
-        { "name": "RealPlume-StockConfigs" },
-        { "name": "BluedogDB"              },
-        { "name": "ModularLaunchPads"      }
-    ],
-    "install": [ {
-        "find":       "GameData/Chrayol_Design_Org",
-        "install_to": "GameData",
-        "filter":     [ ".gitignore" ]
-    } ]
-}
+identifier: ChayrolDesignOrg
+$kref: '#/ckan/github/DylanSemrau/Chrayol-Design-Org'
+$vref: '#/ckan/ksp-avc/ChrayolDesignOrg.version'
+install:
+  - find: GameData/Chrayol_Design_Org
+    install_to: GameData
+    filter:
+      - .gitignore
+---
+identifier: ChayrolDesignOrg
+abstract: >-
+  Add ISRO rockets and spacecraft. Eventually the plan is to add SLV, GSLV
+  MK1-3, RLV, along with a couple of probes (Ex. Chandrayaan, Mangalyaan etc).
+$kref: '#/ckan/spacedock/2337'
+$vref: '#/ckan/ksp-avc/ChrayolDesignOrg.version'
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+  - name: B9PartSwitch
+suggests:
+  - name: JNSQ
+  - name: RealPlume-StockConfigs
+  - name: BluedogDB
+  - name: ModularLaunchPads
+install:
+  - find: GameData/Chrayol_Design_Org
+    install_to: GameData
+    filter:
+      - .gitignore

--- a/NetKAN/ClickThroughBlocker.netkan
+++ b/NetKAN/ClickThroughBlocker.netkan
@@ -1,4 +1,11 @@
 identifier: ClickThroughBlocker
+$kref: '#/ckan/github/linuxgurugamer/ClickThroughBlocker'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: 000_ClickThroughBlocker
+    install_to: GameData
+---
+identifier: ClickThroughBlocker
 name: ClickThrough Blocker
 abstract: Helps eliminate the clickthrough problem with mods
 $kref: '#/ckan/spacedock/1689'

--- a/NetKAN/CollisionFXReUpdated.netkan
+++ b/NetKAN/CollisionFXReUpdated.netkan
@@ -1,4 +1,8 @@
 identifier: CollisionFXReUpdated
+$kref: '#/ckan/github/VoidCosmo/CollisionFX-ReUpdated'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: CollisionFXReUpdated
 $kref: '#/ckan/spacedock/2426'
 $vref: '#/ckan/ksp-avc'
 author:

--- a/NetKAN/ConformalDecals.netkan
+++ b/NetKAN/ConformalDecals.netkan
@@ -1,4 +1,11 @@
 identifier: ConformalDecals
+$kref: '#/ckan/github/drewcassidy/KSP-Conformal-Decals'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: GameData/ConformalDecals
+    install_to: GameData
+---
+identifier: ConformalDecals
 $kref: '#/ckan/spacedock/2451'
 $vref: '#/ckan/ksp-avc'
 license: GPL-3.0

--- a/NetKAN/ConstantTWR.netkan
+++ b/NetKAN/ConstantTWR.netkan
@@ -1,17 +1,16 @@
-{
-    "identifier":   "ConstantTWR",
-    "$kref":        "#/ckan/spacedock/1429",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "LGPL-3.0",
-    "tags": [
-        "plugin",
-        "control"
-    ],
-    "depends": [
-        { "name" : "ClickThroughBlocker" }
-    ],
-    "install": [ {
-        "find": "ConstantTWR",
-        "install_to": "GameData"
-    } ]
-}
+identifier: ConstantTWR
+$kref: '#/ckan/github/linuxgurugamer/ConstantTWR'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: ConstantTWR
+$kref: '#/ckan/spacedock/1429'
+$vref: '#/ckan/ksp-avc'
+license: LGPL-3.0
+tags:
+  - plugin
+  - control
+depends:
+  - name: ClickThroughBlocker
+install:
+  - find: ConstantTWR
+    install_to: GameData

--- a/NetKAN/ContinuousCollisions.netkan
+++ b/NetKAN/ContinuousCollisions.netkan
@@ -1,4 +1,7 @@
 identifier: ContinuousCollisions
+$kref: '#/ckan/github/Holoday/ContinuousCollision'
+---
+identifier: ContinuousCollisions
 $kref: '#/ckan/spacedock/3067'
 license: MIT
 tags:

--- a/NetKAN/ContractConfigurator-HistoryofSpaceflight-PocketEdition.netkan
+++ b/NetKAN/ContractConfigurator-HistoryofSpaceflight-PocketEdition.netkan
@@ -1,29 +1,28 @@
-{
-    "identifier":   "ContractConfigurator-HistoryofSpaceflight-PocketEdition",
-    "$kref":        "#/ckan/spacedock/2387",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "config",
-        "career"
-    ],
-    "provides": [
-        "ContractConfigurator-HistoryofSpaceflight"
-    ],
-    "conflicts": [
-        { "name": "ContractConfigurator-HistoryofSpaceflight" }
-    ],
-    "depends": [
-        { "name": "ModuleManager"        },
-        { "name": "ContractConfigurator" }
-    ],
-    "recommends": [
-        { "name": "BluedogDB"   },
-        { "name": "NewTantares" },
-        { "name": "ProbesPlus"  }
-    ],
-    "install": [ {
-        "find":       "ContractPacks",
-        "install_to": "GameData"
-    } ]
-}
+identifier: ContractConfigurator-HistoryofSpaceflight-PocketEdition
+$kref: '#/ckan/github/Frylovespi/History-of-Spaceflight/asset_match/PE'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ContractPacks
+    install_to: GameData
+---
+identifier: ContractConfigurator-HistoryofSpaceflight-PocketEdition
+$kref: '#/ckan/spacedock/2387'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - config
+  - career
+provides:
+  - ContractConfigurator-HistoryofSpaceflight
+conflicts:
+  - name: ContractConfigurator-HistoryofSpaceflight
+depends:
+  - name: ModuleManager
+  - name: ContractConfigurator
+recommends:
+  - name: BluedogDB
+  - name: NewTantares
+  - name: ProbesPlus
+install:
+  - find: ContractPacks
+    install_to: GameData

--- a/NetKAN/ContractConfigurator-HistoryofSpaceflight-RSS.netkan
+++ b/NetKAN/ContractConfigurator-HistoryofSpaceflight-RSS.netkan
@@ -1,36 +1,37 @@
-{
-    "identifier":   "ContractConfigurator-HistoryofSpaceflight-RSS",
-    "$kref":        "#/ckan/spacedock/2385",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "config",
-        "career"
-    ],
-    "provides": [
-        "ContractConfigurator-HistoryofSpaceflight"
-    ],
-    "conflicts": [
-        { "name": "ContractConfigurator-HistoryofSpaceflight" }
-    ],
-    "depends": [
-        { "name": "ModuleManager"        },
-        { "name": "ContractConfigurator" },
-        { "name": "RealSolarSystem"      }
-    ],
-    "recommends": [
-        { "name": "BluedogDB"   },
-        { "name": "NewTantares" },
-        { "name": "ProbesPlus"  }
-    ],
-    "install": [ {
-        "find":       "ContractPacks",
-        "install_to": "GameData"
-    }, {
-        "find":       "GenericEngines",
-        "install_to": "GameData"
-    }, {
-        "find":       "GenericPlumes",
-        "install_to": "GameData"
-    } ]
-}
+identifier: ContractConfigurator-HistoryofSpaceflight-RSS
+$kref: '#/ckan/github/Frylovespi/History-of-Spaceflight/asset_match/RSS'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ContractPacks
+    install_to: GameData
+  - find: GenericEngines
+    install_to: GameData
+  - find: GenericPlumes
+    install_to: GameData
+---
+identifier: ContractConfigurator-HistoryofSpaceflight-RSS
+$kref: '#/ckan/spacedock/2385'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - config
+  - career
+provides:
+  - ContractConfigurator-HistoryofSpaceflight
+conflicts:
+  - name: ContractConfigurator-HistoryofSpaceflight
+depends:
+  - name: ModuleManager
+  - name: ContractConfigurator
+  - name: RealSolarSystem
+recommends:
+  - name: BluedogDB
+  - name: NewTantares
+  - name: ProbesPlus
+install:
+  - find: ContractPacks
+    install_to: GameData
+  - find: GenericEngines
+    install_to: GameData
+  - find: GenericPlumes
+    install_to: GameData

--- a/NetKAN/ContractConfigurator-HistoryofSpaceflight-Stock.netkan
+++ b/NetKAN/ContractConfigurator-HistoryofSpaceflight-Stock.netkan
@@ -1,29 +1,28 @@
-{
-    "identifier":   "ContractConfigurator-HistoryofSpaceflight-Stock",
-    "$kref":        "#/ckan/spacedock/2386",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "config",
-        "career"
-    ],
-    "provides": [
-        "ContractConfigurator-HistoryofSpaceflight"
-    ],
-    "conflicts": [
-        { "name": "ContractConfigurator-HistoryofSpaceflight" }
-    ],
-    "depends": [
-        { "name": "ModuleManager"        },
-        { "name": "ContractConfigurator" }
-    ],
-    "recommends": [
-        { "name": "BluedogDB"   },
-        { "name": "NewTantares" },
-        { "name": "ProbesPlus"  }
-    ],
-    "install": [ {
-        "find":       "ContractPacks",
-        "install_to": "GameData"
-    } ]
-}
+identifier: ContractConfigurator-HistoryofSpaceflight-Stock
+$kref: '#/ckan/github/Frylovespi/History-of-Spaceflight/asset_match/Stock'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ContractPacks
+    install_to: GameData
+---
+identifier: ContractConfigurator-HistoryofSpaceflight-Stock
+$kref: '#/ckan/spacedock/2386'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - config
+  - career
+provides:
+  - ContractConfigurator-HistoryofSpaceflight
+conflicts:
+  - name: ContractConfigurator-HistoryofSpaceflight
+depends:
+  - name: ModuleManager
+  - name: ContractConfigurator
+recommends:
+  - name: BluedogDB
+  - name: NewTantares
+  - name: ProbesPlus
+install:
+  - find: ContractPacks
+    install_to: GameData

--- a/NetKAN/CoriolisSpaceSystems.netkan
+++ b/NetKAN/CoriolisSpaceSystems.netkan
@@ -1,4 +1,15 @@
 identifier: CoriolisSpaceSystems
+$kref: '#/ckan/github/benjee10/Benjee10_stowaway'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: Benjee10_stowaway
+    install_to: GameData
+---
+identifier: CoriolisSpaceSystems
 $kref: '#/ckan/spacedock/2706'
 $vref: '#/ckan/ksp-avc'
 license: restricted

--- a/NetKAN/CorrectCoL.netkan
+++ b/NetKAN/CorrectCoL.netkan
@@ -1,22 +1,20 @@
-{
-    "identifier":   "CorrectCoL",
-    "$kref":        "#/ckan/spacedock/789",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "information",
-        "editor"
-    ],
-    "conflicts": [
-        { "name": "FerramAerospaceResearch" }
-    ],
-    "install": [ {
-        "find":       "CorrectCoL",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name" : "ToolbarController"   },
-        { "name" : "ClickThroughBlocker" }
-    ]
-}
+identifier: CorrectCoL
+$kref: '#/ckan/github/linuxgurugamer/CorrectCoL'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: CorrectCoL
+$kref: '#/ckan/spacedock/789'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - information
+  - editor
+conflicts:
+  - name: FerramAerospaceResearch
+install:
+  - find: CorrectCoL
+    install_to: GameData
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker

--- a/NetKAN/CorrectifTraductionFrancaise.netkan
+++ b/NetKAN/CorrectifTraductionFrancaise.netkan
@@ -1,4 +1,7 @@
 identifier: CorrectifTraductionFrancaise
+$kref: '#/ckan/github/KSP-FrTranslation/CorrectifTraductionFrancaise'
+---
+identifier: CorrectifTraductionFrancaise
 $kref: '#/ckan/spacedock/3443'
 license: MIT
 tags:

--- a/NetKAN/Corvus125mTwoKerbalPod.netkan
+++ b/NetKAN/Corvus125mTwoKerbalPod.netkan
@@ -1,40 +1,41 @@
-{
-    "identifier": "Corvus125mTwoKerbalPod",
-    "author": [
-        "OrionKermin",
-        "Micha"
-    ],
-    "$kref": "#/ckan/spacedock/1405",
-    "$vref": "#/ckan/ksp-avc",
-    "x_netkan_epoch": 1,
-    "license": "CC-BY-SA",
-    "tags": [
-        "parts",
-        "crewed"
-    ],
-    "install": [
-        {
-            "find": "HGR",
-            "install_to": "GameData"
-        },
-        {
-            "find": "Corvus",
-            "install_to": "GameData"
-        }
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "AnimatedDecouplers" }
-    ],
-    "supports": [
-        { "name": "ConnectedLivingSpace" },
-        { "name": "DeadlyReentry" },
-        { "name": "RasterPropMonitor" },
-        { "name": "RealChute" },
-        { "name": "Snacks" },
-        { "name": "TACLS" },
-        { "name": "TweakScale" }
-    ]
-}
+identifier: Corvus125mTwoKerbalPod
+$kref: '#/ckan/github/mwerle/Corvus_CF'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: HGR
+    install_to: GameData
+  - find: Corvus
+    install_to: GameData
+---
+identifier: Corvus125mTwoKerbalPod
+author:
+  - OrionKermin
+  - Micha
+$kref: '#/ckan/spacedock/1405'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: 1
+license: CC-BY-SA
+tags:
+  - parts
+  - crewed
+depends:
+  - name: ModuleManager
+recommends:
+  - name: AnimatedDecouplers
+supports:
+  - name: ConnectedLivingSpace
+  - name: DeadlyReentry
+  - name: RasterPropMonitor
+  - name: RealChute
+  - name: Snacks
+  - name: TACLS
+  - name: TweakScale
+install:
+  - find: HGR
+    install_to: GameData
+  - find: Corvus
+    install_to: GameData

--- a/NetKAN/CraftImport.netkan
+++ b/NetKAN/CraftImport.netkan
@@ -1,23 +1,21 @@
-{
-    "identifier"     : "CraftImport",
-    "$kref"          : "#/ckan/spacedock/47",
-    "$vref"          : "#/ckan/ksp-avc",
-    "x_netkan_epoch" : 1,
-    "license"        : "GPL-3.0",
-    "tags": [
-        "plugin",
-        "editor",
-        "convenience"
-    ],
-    "recommends": [
-        { "name": "JanitorsCloset" }
-    ],
-    "depends": [
-        { "name": "ToolbarController" },
-        { "name": "ClickThroughBlocker" }
-    ],
-    "install": [ {
-        "find"       : "CraftImport",
-        "install_to" : "GameData"
-    } ]
-}
+identifier: CraftImport
+$kref: '#/ckan/github/linuxgurugamer/CraftImport'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: CraftImport
+$kref: '#/ckan/spacedock/47'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: 1
+license: GPL-3.0
+tags:
+  - plugin
+  - editor
+  - convenience
+recommends:
+  - name: JanitorsCloset
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: CraftImport
+    install_to: GameData

--- a/NetKAN/CrewLight.netkan
+++ b/NetKAN/CrewLight.netkan
@@ -1,19 +1,21 @@
-{
-    "identifier":   "CrewLight",
-    "name":         "Crew Light",
-    "abstract":     "An automatic light manager",
-    "author":       [ "Li0n", "linuxgurugamer" ],
-    "$kref":        "#/ckan/spacedock/2236",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_epoch": 1,
-    "license" :     "MIT",
-    "tags": [
-        "plugin",
-        "crewed",
-        "information"
-    ],
-    "depends" : [
-        { "name" : "ModuleManager" },
-        { "name" : "ClickThroughBlocker" }
-    ]
-}
+identifier: CrewLight
+$kref: '#/ckan/github/linuxgurugamer/CrewLight'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: CrewLight
+name: Crew Light
+abstract: An automatic light manager
+author:
+  - Li0n
+  - linuxgurugamer
+$kref: '#/ckan/spacedock/2236'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: 1
+license: MIT
+tags:
+  - plugin
+  - crewed
+  - information
+depends:
+  - name: ModuleManager
+  - name: ClickThroughBlocker

--- a/NetKAN/CrewManifest.netkan
+++ b/NetKAN/CrewManifest.netkan
@@ -1,27 +1,30 @@
-{
-    "identifier":   "CrewManifest",
-    "name":         "Crew Manifest",
-    "abstract":     "This plugin will allow you to add or remove crew from parts while on the launch pad or transfer crew between parts in the same vessel. You can also edit/add custom crew members in your available crew roster provided that they are not part of an active flight (or dead).",
-    "author":       [ "vXSovereignXv", "Sarbian", "linuxgurugamer" ],
-    "$kref"          : "#/ckan/spacedock/3097",
-    "$vref"          : "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/209418-112x-kerbal-crew-manifest/",
-        "repository": "https://github.com/linuxgurugamer/CrewManifest"
-    },
-    "depends": [
-            { "name": "ToolbarController" },
-            { "name": "ClickThroughBlocker" },
-            { "name": "SpaceTuxLibrary" }
-    ],
-    "tags": [
-        "plugin",
-        "crewed",
-        "convenience"
-    ],
-    "install": [ {
-        "find": "CrewManifest",
-        "install_to": "GameData"
-    } ]
-}
+identifier: CrewManifest
+$kref: '#/ckan/github/linuxgurugamer/CrewManifest'
+---
+identifier: CrewManifest
+name: Crew Manifest
+abstract: >-
+  This plugin will allow you to add or remove crew from parts while on the
+  launch pad or transfer crew between parts in the same vessel.
+  You can also edit/add custom crew members in your available crew roster
+  provided that they are not part of an active flight (or dead).
+author:
+  - vXSovereignXv
+  - Sarbian
+  - linuxgurugamer
+$kref: '#/ckan/spacedock/3097'
+license: MIT
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/209418-112x-kerbal-crew-manifest/
+  repository: https://github.com/linuxgurugamer/CrewManifest
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+tags:
+  - plugin
+  - crewed
+  - convenience
+install:
+  - find: CrewManifest
+    install_to: GameData

--- a/NetKAN/CrewQueueTwo.netkan
+++ b/NetKAN/CrewQueueTwo.netkan
@@ -1,22 +1,23 @@
-{
-    "identifier":   "CrewQueueTwo",
-    "$vref":        "#/ckan/ksp-avc",
-    "$kref":        "#/ckan/spacedock/1324",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "crewed"
-    ],
-    "install": [ {
-        "install_to": "GameData",
-        "find": "CrewRandR"
-    } ],
-    "depends": [
-        { "name" : "ClickThroughBlocker" },
-        { "name": "ModuleManager" }
-    ],
-    "conflicts": [
-        { "name" : "BetterCrewAssignment" },
-        { "name" : "CrewQueue" }
-    ]
-}
+identifier: CrewQueueTwo
+$kref: '#/ckan/github/linuxgurugamer/CrewRandR'
+$vref: '#/ckan/ksp-avc'
+install:
+  - install_to: GameData
+    find: CrewRandR
+---
+identifier: CrewQueueTwo
+$vref: '#/ckan/ksp-avc'
+$kref: '#/ckan/spacedock/1324'
+license: MIT
+tags:
+  - plugin
+  - crewed
+depends:
+  - name: ClickThroughBlocker
+  - name: ModuleManager
+conflicts:
+  - name: BetterCrewAssignment
+  - name: CrewQueue
+install:
+  - install_to: GameData
+    find: CrewRandR

--- a/NetKAN/DE-IVAExtension.netkan
+++ b/NetKAN/DE-IVAExtension.netkan
@@ -1,4 +1,11 @@
 identifier: DE-IVAExtension
+$kref: '#/ckan/github/FirstPersonKSP/DE_IVAExtension'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: DE_IVAExtension
+    install_to: GameData
+---
+identifier: DE-IVAExtension
 author:
   - DemonEin
   - HonkHogan

--- a/NetKAN/DTV2.netkan
+++ b/NetKAN/DTV2.netkan
@@ -1,20 +1,22 @@
-{
-    "identifier":   "DTV2",
-    "abstract":     "Draft, tour with, or rescue your twitch viewers as in-game Kerbals!",
-    "$kref":        "#/ckan/spacedock/1985",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "crewed",
-        "app"
-    ],
-    "install": [ {
-        "find": "DraftTwitchViewers",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ]
-}
+identifier: DTV2
+$kref: '#/ckan/github/linuxgurugamer/DraftTwitchViewers'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: DraftTwitchViewers
+    install_to: GameData
+---
+identifier: DTV2
+abstract: Draft, tour with, or rescue your twitch viewers as in-game Kerbals!
+$kref: '#/ckan/spacedock/1985'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - crewed
+  - app
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: DraftTwitchViewers
+    install_to: GameData

--- a/NetKAN/DangItContinued.netkan
+++ b/NetKAN/DangItContinued.netkan
@@ -1,22 +1,23 @@
-{
-    "identifier":   "DangItContinued",
-    "$kref":        "#/ckan/spacedock/1055",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin"
-    ],
-    "install": [ {
-        "find":       "DangIt",
-        "install_to": "GameData"
-    } ],
-    "recommends": [
-        { "name": "KerbalChangelog" }
-    ],
-    "depends": [
-        { "name": "ModuleManager"       },
-        { "name": "ToolbarController"   },
-        { "name": "ClickThroughBlocker" },
-        { "name": "SpaceTuxLibrary" }
-    ]
-}
+identifier: DangItContinued
+$kref: '#/ckan/github/linuxgurugamer/DangIt'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: DangIt
+    install_to: GameData
+---
+identifier: DangItContinued
+$kref: '#/ckan/spacedock/1055'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+recommends:
+  - name: KerbalChangelog
+depends:
+  - name: ModuleManager
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+install:
+  - find: DangIt
+    install_to: GameData

--- a/NetKAN/DangerAlertsContinued.netkan
+++ b/NetKAN/DangerAlertsContinued.netkan
@@ -1,18 +1,20 @@
-{
-    "identifier":   "DangerAlertsContinued",
-    "$kref":        "#/ckan/spacedock/1260",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "install": [ {
-      "find": "DangerAlerts",
-      "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ]
-}
+identifier: DangerAlertsContinued
+$kref: '#/ckan/github/linuxgurugamer/DangerAlerts'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: DangerAlerts
+    install_to: GameData
+---
+identifier: DangerAlertsContinued
+$kref: '#/ckan/spacedock/1260'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - information
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: DangerAlerts
+    install_to: GameData

--- a/NetKAN/DavonTCsystemsMod.netkan
+++ b/NetKAN/DavonTCsystemsMod.netkan
@@ -1,20 +1,19 @@
-{
-    "identifier"   : "DavonTCsystemsMod",
-    "$kref"        : "#/ckan/spacedock/2516",
-    "$vref":        "#/ckan/ksp-avc",
-    "license"      : "GPL-2.0",
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" },
-        { "name" : "SpaceTuxLibrary" }
-    ],
-    "tags": [
-        "plugin",
-        "control"
-    ],
-    "install": [ {
-        "find"          : "DavonTCsystemsMod",
-        "install_to"    : "GameData"
-    } ],
-    "x_netkan_epoch": 1
-}
+identifier: DavonTCsystemsMod
+$kref: '#/ckan/github/linuxgurugamer/DavonTCsystemsMod'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: DavonTCsystemsMod
+$kref: '#/ckan/spacedock/2516'
+$vref: '#/ckan/ksp-avc'
+license: GPL-2.0
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+tags:
+  - plugin
+  - control
+install:
+  - find: DavonTCsystemsMod
+    install_to: GameData
+x_netkan_epoch: 1

--- a/NetKAN/DecouplerShroud.netkan
+++ b/NetKAN/DecouplerShroud.netkan
@@ -1,4 +1,8 @@
 identifier: DecouplerShroud
+$kref: '#/ckan/github/linuxgurugamer/DecouplerShroud'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: DecouplerShroud
 $kref: '#/ckan/spacedock/1692'
 $vref: '#/ckan/ksp-avc'
 license: MIT

--- a/NetKAN/DeepFreeze.netkan
+++ b/NetKAN/DeepFreeze.netkan
@@ -1,4 +1,12 @@
 identifier: DeepFreeze
+$kref: '#/ckan/github/JPLRepo/DeepFreeze'
+$vref: '#/ckan/ksp-avc'
+x_netkan_version_edit:
+  find: ^v
+  replace: V
+  strict: false
+---
+identifier: DeepFreeze
 $kref: '#/ckan/spacedock/142'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-4.0

--- a/NetKAN/DeployableBatteries.netkan
+++ b/NetKAN/DeployableBatteries.netkan
@@ -1,18 +1,17 @@
-{
-    "identifier":   "DeployableBatteries",
-    "$kref":        "#/ckan/spacedock/2268",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_allow_out_of_order": true,
-    "license":      "GPL-3.0",
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "SpaceTuxLibrary" }
-    ],
-    "install": [ {
-        "find":       "DeployableBatteries",
-        "install_to": "GameData"
-    } ],
-    "x_via": "Automated Linuxgurugamer CKAN script"
-}
+identifier: DeployableBatteries
+$kref: '#/ckan/github/linuxgurugamer/DeployableBatteries'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: DeployableBatteries
+$kref: '#/ckan/spacedock/2268'
+$vref: '#/ckan/ksp-avc'
+x_netkan_allow_out_of_order: true
+license: GPL-3.0
+tags:
+  - parts
+depends:
+  - name: SpaceTuxLibrary
+install:
+  - find: DeployableBatteries
+    install_to: GameData
+x_via: Automated Linuxgurugamer CKAN script

--- a/NetKAN/DepthMask.netkan
+++ b/NetKAN/DepthMask.netkan
@@ -1,4 +1,8 @@
 identifier: DepthMask
+$kref: '#/ckan/github/drewcassidy/KSP-DepthMask'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: DepthMask
 $kref: '#/ckan/spacedock/2943'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-SA

--- a/NetKAN/DistantObject-default.netkan
+++ b/NetKAN/DistantObject-default.netkan
@@ -1,30 +1,35 @@
-{
-    "identifier":   "DistantObject-default",
-    "name":         "Distant Object Enhancement /L default config",
-    "abstract":     "Default planets colors",
-    "$kref":        "#/ckan/spacedock/2274",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_force_v": true,
-    "license":      "CC-BY-4.0",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/205063-*"
-    },
-    "tags": [
-        "config",
-        "graphics"
-    ],
-    "install": [ {
-        "find":       "PlanetColors.cfg",
-        "install_to": "GameData/DistantObject",
-        "find_matches_files": true
-    } ],
-    "depends": [
-        { "name": "DistantObject" }
-    ],
-    "provides": [
-        "DistantObject-config"
-    ],
-    "conflicts": [
-        { "name": "DistantObject-config" }
-    ]
-}
+identifier: DistantObject-default
+$kref: '#/ckan/github/net-lisias-ksp/DistantObject/asset_match/^(?!.*CurseForge)'
+x_netkan_version_edit:
+  find: ^RELEASE/
+  replace: ''
+  strict: false
+x_netkan_force_v: true
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: PlanetColors.cfg
+    install_to: GameData/DistantObject
+    find_matches_files: true
+---
+identifier: DistantObject-default
+name: Distant Object Enhancement /L default config
+abstract: Default planets colors
+$kref: '#/ckan/spacedock/2274'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+license: CC-BY-4.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/205063-*
+tags:
+  - config
+  - graphics
+depends:
+  - name: DistantObject
+provides:
+  - DistantObject-config
+conflicts:
+  - name: DistantObject-config
+install:
+  - find: PlanetColors.cfg
+    install_to: GameData/DistantObject
+    find_matches_files: true

--- a/NetKAN/DistantObject.netkan
+++ b/NetKAN/DistantObject.netkan
@@ -1,4 +1,13 @@
 identifier: DistantObject
+$kref: '#/ckan/github/net-lisias-ksp/DistantObject/asset_match/^(?!.*CurseForge)'
+x_netkan_version_edit:
+  find: ^RELEASE/
+  replace: ''
+  strict: false
+x_netkan_force_v: true
+$vref: '#/ckan/ksp-avc'
+---
+identifier: DistantObject
 name: Distant Object Enhancement /L
 abstract: >-
   Visual enhancement mod that makes objects realistically visible over large

--- a/NetKAN/DraggableControls.netkan
+++ b/NetKAN/DraggableControls.netkan
@@ -1,4 +1,7 @@
 identifier: DraggableControls
+$kref: '#/ckan/github/andrew-vant/dragctrl'
+---
+identifier: DraggableControls
 $kref: '#/ckan/spacedock/3073'
 $vref: '#/ckan/ksp-avc'
 license: MIT

--- a/NetKAN/EVAEnhancementsContinued.netkan
+++ b/NetKAN/EVAEnhancementsContinued.netkan
@@ -1,24 +1,22 @@
-{
-    "identifier":   "EVAEnhancementsContinued",
-    "$kref":        "#/ckan/spacedock/994",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "crewed",
-        "information",
-        "control"
-    ],
-    "depends": [
-        { "name": "ModuleManager"       },
-        { "name": "ToolbarController"   },
-        { "name": "ClickThroughBlocker" }
-    ],
-    "suggests": [
-        { "name": "EvaFuelCont" }
-    ],
-    "install": [ {
-        "find":       "EVAEnhancementsContinued",
-        "install_to": "GameData"
-    } ]
-}
+identifier: EVAEnhancementsContinued
+$kref: '#/ckan/github/linuxgurugamer/EVAEnhancementsContinued'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: EVAEnhancementsContinued
+$kref: '#/ckan/spacedock/994'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - crewed
+  - information
+  - control
+depends:
+  - name: ModuleManager
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+suggests:
+  - name: EvaFuelCont
+install:
+  - find: EVAEnhancementsContinued
+    install_to: GameData

--- a/NetKAN/EcoRocket.netkan
+++ b/NetKAN/EcoRocket.netkan
@@ -1,4 +1,7 @@
 identifier: EcoRocket
+$kref: '#/ckan/github/cmdrads/kspEcoRocket'
+---
+identifier: EcoRocket
 $kref: '#/ckan/spacedock/3050'
 license: GPL-3.0
 tags:

--- a/NetKAN/EditorExtensionsRedux.netkan
+++ b/NetKAN/EditorExtensionsRedux.netkan
@@ -1,17 +1,18 @@
-{
-    "identifier"          : "EditorExtensionsRedux",
-    "abstract"            : "Tweaks and features for the in-game vessel editor, e.g. alignment and symmetry aids. Now includes SelectRoot mod",
-    "$kref"               : "#/ckan/spacedock/48",
-    "$vref"               : "#/ckan/ksp-avc",
-    "license"             : "MIT",
-    "tags": [
-        "plugin",
-        "convenience"
-    ],
-    "depends": [
-        { "name": "ClickThroughBlocker" }
-    ],
-    "recommends": [
-        { "name": "JanitorsCloset" }
-    ]
-}
+identifier: EditorExtensionsRedux
+$kref: '#/ckan/github/linuxgurugamer/EditorExtensionsRedux'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: EditorExtensionsRedux
+abstract: >-
+  Tweaks and features for the in-game vessel editor, e.g. alignment and symmetry
+  aids. Now includes SelectRoot mod
+$kref: '#/ckan/spacedock/48'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - convenience
+depends:
+  - name: ClickThroughBlocker
+recommends:
+  - name: JanitorsCloset

--- a/NetKAN/EngineIgnitorReignited.netkan
+++ b/NetKAN/EngineIgnitorReignited.netkan
@@ -1,23 +1,24 @@
-{
-    "identifier"   : "EngineIgnitorReignited",
-    "name"         : "Engine Ignitor (standalone)",
-    "abstract"     : "Adding ignitors service to engines",
-    "author"       : "linuxgurugamer",
-    "$kref"        : "#/ckan/spacedock/1639",
-    "$vref"        : "#/ckan/ksp-avc",
-    "license"      : "CC-BY-SA",
-    "tags": [
-        "plugin"
-    ],
-    "install": [
-        {
-            "find"       : "EngineIgnitor",
-            "install_to" : "GameData",
-            "filter"     : "Thumbs.db"
-        }
-    ],
-    "depends": [
-        { "name" : "ModuleManager" },
-        { "name" : "ToolbarController" }
-    ]
-}
+identifier: EngineIgnitorReignited
+$kref: '#/ckan/github/linuxgurugamer/EngineIgnitor'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: EngineIgnitor
+    install_to: GameData
+    filter: Thumbs.db
+---
+identifier: EngineIgnitorReignited
+name: Engine Ignitor (standalone)
+abstract: Adding ignitors service to engines
+author: linuxgurugamer
+$kref: '#/ckan/spacedock/1639'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-SA
+tags:
+  - plugin
+depends:
+  - name: ModuleManager
+  - name: ToolbarController
+install:
+  - find: EngineIgnitor
+    install_to: GameData
+    filter: Thumbs.db

--- a/NetKAN/EngineLightRelit.netkan
+++ b/NetKAN/EngineLightRelit.netkan
@@ -1,28 +1,23 @@
-{
-    "identifier":   "EngineLightRelit",
-    "$kref":        "#/ckan/spacedock/2111",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "graphics"
-    ],
-    "depends": [
-        {
-            "name": "ModuleManager",
-            "min_version": "2.6.3"
-        },
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ],
-    "suggests": [
-        { "name": "HotRockets" }
-    ],
-    "conflicts": [
-        { "name": "EngineLighting" }
-    ],
-    "install": [ {
-        "find"      : "EngineLightRelit",
-        "install_to": "GameData"
-    } ]
-}
+identifier: EngineLightRelit
+$kref: '#/ckan/github/linuxgurugamer/EngineLightRelit'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: EngineLightRelit
+$kref: '#/ckan/spacedock/2111'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - graphics
+depends:
+  - name: ModuleManager
+    min_version: 2.6.3
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+suggests:
+  - name: HotRockets
+conflicts:
+  - name: EngineLighting
+install:
+  - find: EngineLightRelit
+    install_to: GameData

--- a/NetKAN/EnvironmentalVisualEnhancements.netkan
+++ b/NetKAN/EnvironmentalVisualEnhancements.netkan
@@ -1,4 +1,8 @@
 identifier: EnvironmentalVisualEnhancements
+$kref: '#/ckan/github/LGhassen/EnvironmentalVisualEnhancements'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: EnvironmentalVisualEnhancements
 author:
   - rbray89
   - WazWaz

--- a/NetKAN/EstrelaDobre.netkan
+++ b/NetKAN/EstrelaDobre.netkan
@@ -1,4 +1,8 @@
 identifier: EstrelaDobre
+$kref: '#/ckan/github/JcoolTheShipBuilder/Estrela-Dobre'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: EstrelaDobre
 $kref: '#/ckan/spacedock/3192'
 license: CC-BY-NC-SA
 tags:

--- a/NetKAN/EvaFollower.netkan
+++ b/NetKAN/EvaFollower.netkan
@@ -1,16 +1,16 @@
-{
-    "identifier"  : "EvaFollower",
-    "$kref"       : "#/ckan/spacedock/1582",
-    "$vref"       : "#/ckan/ksp-avc",
-    "x_netkan_epoch": 1,
-    "license"     : "CC-BY-NC-SA-3.0",
-    "tags": [
-        "plugin",
-        "crewed",
-        "control"
-    ],
-    "install": [ {
-        "find":       "EvaFollower",
-        "install_to": "GameData"
-    } ]
-}
+identifier: EvaFollower
+$kref: '#/ckan/github/linuxgurugamer/EvaFollower'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: EvaFollower
+$kref: '#/ckan/spacedock/1582'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: 1
+license: CC-BY-NC-SA-3.0
+tags:
+  - plugin
+  - crewed
+  - control
+install:
+  - find: EvaFollower
+    install_to: GameData

--- a/NetKAN/EvaFuelCont.netkan
+++ b/NetKAN/EvaFuelCont.netkan
@@ -1,21 +1,22 @@
-{
-    "identifier":   "EvaFuelCont",
-    "$kref":        "#/ckan/spacedock/1274",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "crewed"
-    ],
-    "install": [ {
-        "find": "EvaFuel",
-        "install_to": "GameData"
-    } ],
-    "conflicts" : [
-        { "name" : "EvaFuel" },
-        { "name" : "Kerbalism" }
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ]
-}
+identifier: EvaFuelCont
+$kref: '#/ckan/github/linuxgurugamer/EvaFuel'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: EvaFuel
+    install_to: GameData
+---
+identifier: EvaFuelCont
+$kref: '#/ckan/spacedock/1274'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - crewed
+conflicts:
+  - name: EvaFuel
+  - name: Kerbalism
+depends:
+  - name: ModuleManager
+install:
+  - find: EvaFuel
+    install_to: GameData

--- a/NetKAN/ExperimentTracker.netkan
+++ b/NetKAN/ExperimentTracker.netkan
@@ -1,25 +1,26 @@
-{
-    "identifier"   : "ExperimentTracker",
-    "$kref"        : "#/ckan/spacedock/1858",
-    "$vref"        : "#/ckan/ksp-avc",
-    "x_netkan_force_v": true,
-    "x_netkan_epoch": "1",
-    "license"      : "Apache-2.0",
-    "abstract"     : "This mod lists all science experiments and helps to deploy them fast and easy.",
-    "tags": [
-        "plugin",
-        "science",
-        "convenience"
-    ],
-    "depends": [
-        { "name": "ModuleManager"       },
-        { "name": "ToolbarController"   },
-        { "name": "ClickThroughBlocker" }
-    ],
-    "install": [
-        {
-            "find"       : "ExperimentTracker",
-            "install_to" : "GameData"
-        }
-    ]
-}
+identifier: ExperimentTracker
+$kref: '#/ckan/github/linuxgurugamer/ExperimentTracker'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+x_netkan_epoch: '1'
+---
+identifier: ExperimentTracker
+$kref: '#/ckan/spacedock/1858'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+x_netkan_epoch: '1'
+license: Apache-2.0
+abstract: >-
+  This mod lists all science experiments and helps to deploy them fast and
+  easy.
+tags:
+  - plugin
+  - science
+  - convenience
+depends:
+  - name: ModuleManager
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: ExperimentTracker
+    install_to: GameData

--- a/NetKAN/ExperimentsTakeTime.netkan
+++ b/NetKAN/ExperimentsTakeTime.netkan
@@ -1,4 +1,8 @@
 identifier: ExperimentsTakeTime
+$kref: '#/ckan/github/linuxgurugamer/ExperimentsTakeTime'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: ExperimentsTakeTime
 $kref: '#/ckan/spacedock/3033'
 license: GPL-3.0
 $vref: '#/ckan/ksp-avc'

--- a/NetKAN/ExplodiumBreathingEngines.netkan
+++ b/NetKAN/ExplodiumBreathingEngines.netkan
@@ -1,16 +1,18 @@
-{
-    "identifier":   "ExplodiumBreathingEngines",
-    "$kref":        "#/ckan/spacedock/1362",
-    "x_netkan_epoch": 1,
-    "license":      "MIT",
-    "tags": [
-        "parts"
-    ],
-    "install": [ {
-        "find":       "ExplodiumBreathingEngines",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ]
-}
+identifier: ExplodiumBreathingEngines
+$kref: '#/ckan/github/gordonfpanam/ExplodiumBreathingEngines'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+---
+identifier: ExplodiumBreathingEngines
+$kref: '#/ckan/spacedock/1362'
+x_netkan_epoch: 1
+license: MIT
+tags:
+  - parts
+install:
+  - find: ExplodiumBreathingEngines
+    install_to: GameData
+depends:
+  - name: ModuleManager

--- a/NetKAN/ExplorationRoverSystembyASET.netkan
+++ b/NetKAN/ExplorationRoverSystembyASET.netkan
@@ -1,4 +1,11 @@
 identifier: ExplorationRoverSystembyASET
+$kref: '#/ckan/github/linuxgurugamer/ASET_ERS_Rover'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ASET
+    install_to: GameData
+---
+identifier: ExplorationRoverSystembyASET
 $kref: '#/ckan/spacedock/2979'
 license: CC-BY-NC-SA
 $vref: '#/ckan/ksp-avc'
@@ -19,4 +26,3 @@ recommends:
 install:
   - find: ASET
     install_to: GameData
-

--- a/NetKAN/FMRSContinued.netkan
+++ b/NetKAN/FMRSContinued.netkan
@@ -1,4 +1,11 @@
 identifier: FMRSContinued
+$kref: '#/ckan/github/linuxgurugamer/FMRS'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: FMRS
+    install_to: GameData
+---
+identifier: FMRSContinued
 $vref: '#/ckan/ksp-avc'
 $kref: '#/ckan/spacedock/1251'
 license: MIT
@@ -8,11 +15,11 @@ provides:
   - FMRS
 conflicts:
   - name: FMRS
-install:
-  - find: FMRS
-    install_to: GameData
 depends:
   - name: ModuleManager
   - name: RecoveryController
   - name: ToolbarController
   - name: ClickThroughBlocker
+install:
+  - find: FMRS
+    install_to: GameData

--- a/NetKAN/FRS.netkan
+++ b/NetKAN/FRS.netkan
@@ -1,4 +1,8 @@
 identifier: FRS
+$kref: '#/ckan/github/linuxgurugamer/FRS'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: FRS
 $kref: '#/ckan/spacedock/3293'
 license: CC-BY-SA
 $vref: '#/ckan/ksp-avc'

--- a/NetKAN/FTLDriveContinued.netkan
+++ b/NetKAN/FTLDriveContinued.netkan
@@ -1,26 +1,27 @@
-{
-    "identifier":   "FTLDriveContinued",
-    "abstract":     "Ever wished you were somewhere else instantly. With the Kerbin Science Foundry faster than light (FTL) drive you can! Just spin it up to create an instant reality dysfunction that might, just might transport you instantly to another point in space.",
-    "$kref":        "#/ckan/spacedock/835",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-3.0",
-    "tags": [
-        "plugin",
-        "parts"
-    ],
-    "depends": [
-        { "name": "ModuleManager"       },
-        { "name": "ToolbarController"   },
-        { "name": "ClickThroughBlocker" }
-    ],
-    "recommends": [
-        { "name": "JanitorsCloset" }
-    ],
-    "conflicts": [
-        { "name": "FTLDrive" }
-    ],
-    "install": [ {
-        "find":       "FTLDriveContinued",
-        "install_to": "GameData"
-    } ]
-}
+identifier: FTLDriveContinued
+$kref: '#/ckan/github/linuxgurugamer/FTLDriveContinued'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: FTLDriveContinued
+abstract: >-
+  Ever wished you were somewhere else instantly.
+  With the Kerbin Science Foundry faster than light (FTL) drive you can!
+  Just spin it up to create an instant reality dysfunction that might,
+  just might transport you instantly to another point in space.
+$kref: '#/ckan/spacedock/835'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-3.0
+tags:
+  - plugin
+  - parts
+depends:
+  - name: ModuleManager
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+recommends:
+  - name: JanitorsCloset
+conflicts:
+  - name: FTLDrive
+install:
+  - find: FTLDriveContinued
+    install_to: GameData

--- a/NetKAN/FillitUp.netkan
+++ b/NetKAN/FillitUp.netkan
@@ -1,20 +1,19 @@
-{
-    "identifier":   "FillitUp",
-    "$kref":        "#/ckan/spacedock/2051",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "editor",
-        "convenience"
-    ],
-    "install": [ {
-        "find": "FillItUp",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" },
-        { "name" : "ButtonManager" }
-    ]
-}
+identifier: FillitUp
+$kref: '#/ckan/github/linuxgurugamer/FillItUp'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: FillitUp
+$kref: '#/ckan/spacedock/2051'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - editor
+  - convenience
+install:
+  - find: FillItUp
+    install_to: GameData
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: ButtonManager

--- a/NetKAN/FilterExtensions.netkan
+++ b/NetKAN/FilterExtensions.netkan
@@ -1,32 +1,37 @@
-{
-    "identifier"     : "FilterExtensions",
-    "name"           : "Filter Extensions - Plugin",
-    "abstract"       : "Plugin allowing for configurable filters for the VAB/SPH using .cfg files.",
-    "$kref"          : "#/ckan/spacedock/1972",
-    "$vref"          : "#/ckan/ksp-avc",
-    "license"        : "CC-BY-NC-SA-4.0",
-    "release_status" : "stable",
-    "tags": [
-        "plugin",
-        "convenience",
-        "editor"
-    ],
-    "depends": [
-        { "name" : "ModuleManager" }
-    ],
-    "recommends" : [
-        { "name" : "FilterExtensionsDefaultConfig" },
-        { "name" : "MoarFEConfigs" }
-    ],
-    "install" : [
-        {
-            "file"       : "GameData/000_FilterExtensions",
-            "install_to" : "GameData"
-        },
-        {
-            "file"       : "GameData/000_FilterExtensions_Configs",
-            "install_to" : "GameData",
-            "filter"     : [ "Default", "StockRework" ]
-        }
-    ]
-}
+identifier: FilterExtensions
+$kref: '#/ckan/github/linuxgurugamer/FilterExtension'
+$vref: '#/ckan/ksp-avc'
+install:
+  - file: GameData/000_FilterExtensions
+    install_to: GameData
+  - file: GameData/000_FilterExtensions_Configs
+    install_to: GameData
+    filter:
+      - Default
+      - StockRework
+---
+identifier: FilterExtensions
+name: Filter Extensions - Plugin
+abstract: >-
+  Plugin allowing for configurable filters for the VAB/SPH using .cfg files.
+$kref: '#/ckan/spacedock/1972'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+release_status: stable
+tags:
+  - plugin
+  - convenience
+  - editor
+depends:
+  - name: ModuleManager
+recommends:
+  - name: FilterExtensionsDefaultConfig
+  - name: MoarFEConfigs
+install:
+  - file: GameData/000_FilterExtensions
+    install_to: GameData
+  - file: GameData/000_FilterExtensions_Configs
+    install_to: GameData
+    filter:
+      - Default
+      - StockRework

--- a/NetKAN/FilterExtensionsDefaultConfig.netkan
+++ b/NetKAN/FilterExtensionsDefaultConfig.netkan
@@ -1,28 +1,30 @@
-{
-    "name"           : "Filter Extensions - Default Configuration",
-    "identifier"     : "FilterExtensionsDefaultConfig",
-    "abstract"       : "Configuration files using Filter Extensions to create a large array of new part categories in the Editor",
-    "$kref"          : "#/ckan/spacedock/1972",
-    "$vref"          : "#/ckan/ksp-avc",
-    "license"        : "CC-BY-NC-SA-4.0",
-    "release_status" : "stable",
-    "tags": [
-        "config",
-        "convenience",
-        "editor"
-    ],
-    "depends" : [
-        { "name": "ModuleManager"    },
-        { "name": "FilterExtensions" }
-    ],
-    "install" : [
-        {
-            "file"       : "GameData/000_FilterExtensions_Configs/Default",
-            "install_to" : "GameData/000_FilterExtensions_Configs"
-        },
-        {
-            "file"       : "GameData/zFinal_FilterExtensions",
-            "install_to" : "GameData"
-        }
-    ]
-}
+identifier: FilterExtensionsDefaultConfig
+$kref: '#/ckan/github/linuxgurugamer/FilterExtension'
+$vref: '#/ckan/ksp-avc'
+install:
+  - file: GameData/000_FilterExtensions_Configs/Default
+    install_to: GameData/000_FilterExtensions_Configs
+  - file: GameData/zFinal_FilterExtensions
+    install_to: GameData
+---
+name: Filter Extensions - Default Configuration
+identifier: FilterExtensionsDefaultConfig
+abstract: >-
+  Configuration files using Filter Extensions to create a large array of new
+  part categories in the Editor
+$kref: '#/ckan/spacedock/1972'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+release_status: stable
+tags:
+  - config
+  - convenience
+  - editor
+depends:
+  - name: ModuleManager
+  - name: FilterExtensions
+install:
+  - file: GameData/000_FilterExtensions_Configs/Default
+    install_to: GameData/000_FilterExtensions_Configs
+  - file: GameData/zFinal_FilterExtensions
+    install_to: GameData

--- a/NetKAN/FoxDefenseContracts.netkan
+++ b/NetKAN/FoxDefenseContracts.netkan
@@ -1,4 +1,7 @@
 identifier: FoxDefenseContracts
+$kref: '#/ckan/github/lancefoxcia/FoxDefenseContracts'
+---
+identifier: FoxDefenseContracts
 $kref: '#/ckan/spacedock/1455'
 license: CC-BY-SA-4.0
 tags:

--- a/NetKAN/FreeIva.netkan
+++ b/NetKAN/FreeIva.netkan
@@ -1,4 +1,8 @@
 identifier: FreeIva
+$kref: '#/ckan/github/FirstPersonKSP/FreeIva'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: FreeIva
 author:
   - pizzaoverhead
   - Icecovery

--- a/NetKAN/FuelVent-RP.netkan
+++ b/NetKAN/FuelVent-RP.netkan
@@ -1,4 +1,11 @@
 identifier: FuelVent-RP
+$kref: '#/ckan/github/1Kion/FuelVent-RP'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+---
+identifier: FuelVent-RP
 $kref: '#/ckan/spacedock/3520'
 license: MIT
 tags:

--- a/NetKAN/FuseBoxContinued.netkan
+++ b/NetKAN/FuseBoxContinued.netkan
@@ -1,22 +1,20 @@
-{
-    "identifier":   "FuseBoxContinued",
-    "$kref":        "#/ckan/spacedock/1263",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-2.0",
-    "tags": [
-        "plugin",
-        "uncrewed"
-    ],
-    "install": [ {
-        "find": "FuseboxContinued",
-        "install_to": "GameData"
-    } ],
-    "conflicts" : [
-        { "name" : "AmpYearPowerManager" }
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ]
-}
+identifier: FuseBoxContinued
+$kref: '#/ckan/github/linuxgurugamer/FuseBoxContinued'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: FuseBoxContinued
+$kref: '#/ckan/spacedock/1263'
+$vref: '#/ckan/ksp-avc'
+license: GPL-2.0
+tags:
+  - plugin
+  - uncrewed
+install:
+  - find: FuseboxContinued
+    install_to: GameData
+conflicts:
+  - name: AmpYearPowerManager
+depends:
+  - name: ModuleManager
+  - name: ToolbarController
+  - name: ClickThroughBlocker

--- a/NetKAN/GPOSpeedPump.netkan
+++ b/NetKAN/GPOSpeedPump.netkan
@@ -1,4 +1,13 @@
 identifier: GPOSpeedPump
+$kref: '#/ckan/github/net-lisias-ksp/GPOSpeedPump/asset_match/^(?!.*CurseForge)'
+x_netkan_version_edit:
+  find: ^RELEASE/
+  replace: ''
+  strict: false
+x_netkan_force_v: true
+$vref: '#/ckan/ksp-avc'
+---
+identifier: GPOSpeedPump
 name: Goo Pumps & Oils' Speed Pump
 abstract: Allows you to automatically transfer or balance fuel.
 author:

--- a/NetKAN/GPWS.netkan
+++ b/NetKAN/GPWS.netkan
@@ -1,25 +1,22 @@
-{
-    "identifier"   : "GPWS",
-    "name"         : "Ground Proximity Warning System",
-    "abstract"     : "Add warning sounds for planes.",
-    "$kref"        : "#/ckan/spacedock/2659",
-    "$vref"        : "#/ckan/ksp-avc",
-    "license"      : "CC-BY-NC-SA-4.0",
-    "tags"         : [
-        "plugin",
-        "information",
-        "sound"
-    ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" },
-        { "name": "SpaceTuxLibrary" },
-        { "name": "ModuleManager" }
-    ],
-    "install": [
-        {
-            "file"          : "GameData/GPWS",
-            "install_to"    : "GameData"
-        }
-    ]
-}
+identifier: GPWS
+$kref: '#/ckan/github/linuxgurugamer/KSP_GPWS'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: GPWS
+name: Ground Proximity Warning System
+abstract: Add warning sounds for planes.
+$kref: '#/ckan/spacedock/2659'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - plugin
+  - information
+  - sound
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+  - name: ModuleManager
+install:
+  - file: GameData/GPWS
+    install_to: GameData

--- a/NetKAN/GenesStarRemaster.netkan
+++ b/NetKAN/GenesStarRemaster.netkan
@@ -1,30 +1,28 @@
-{
-    "identifier":   "GenesStarRemaster",
-    "$kref":        "#/ckan/spacedock/2411",
-    "license":      "CC-BY-NC-3.0",
-    "tags": [
-        "config",
-        "planet-pack"
-    ],
-    "depends": [
-        { "name": "ModuleManager"    },
-        { "name": "Kopernicus"       },
-        { "name": "Scatterer-config" }
-    ],
-    "provides": [
-        "EnvironmentalVisualEnhancements-Config",
-        "Scatterer-sunflare"
-    ],
-    "conflicts": [
-        { "name": "EnvironmentalVisualEnhancements-Config" },
-        { "name": "Scatterer-sunflare"                     }
-    ],
-    "recommends": [
-        { "name": "EnvironmentalVisualEnhancements" },
-        { "name": "Scatterer"                       }
-    ],
-    "install": [ {
-        "find":       "GenesStar",
-        "install_to": "GameData"
-    } ]
-}
+identifier: GenesStarRemaster
+$kref: '#/ckan/github/AR3S-Vega/GenesStar'
+install:
+  - find: GenesStar
+    install_to: GameData
+---
+identifier: GenesStarRemaster
+$kref: '#/ckan/spacedock/2411'
+license: CC-BY-NC-3.0
+tags:
+  - config
+  - planet-pack
+depends:
+  - name: ModuleManager
+  - name: Kopernicus
+  - name: Scatterer-config
+provides:
+  - EnvironmentalVisualEnhancements-Config
+  - Scatterer-sunflare
+conflicts:
+  - name: EnvironmentalVisualEnhancements-Config
+  - name: Scatterer-sunflare
+recommends:
+  - name: EnvironmentalVisualEnhancements
+  - name: Scatterer
+install:
+  - find: GenesStar
+    install_to: GameData

--- a/NetKAN/GroundProximity.netkan
+++ b/NetKAN/GroundProximity.netkan
@@ -1,19 +1,21 @@
-{
-    "identifier":   "GroundProximity",
-    "$kref":        "#/ckan/spacedock/2056",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "depends": [
-        { "name": "ModuleManager"       },
-        { "name": "ToolbarController"   },
-        { "name": "ClickThroughBlocker" }
-    ],
-    "install": [ {
-        "find":       "KSP_Proximity",
-        "install_to": "GameData"
-    } ]
-}
+identifier: GroundProximity
+$kref: '#/ckan/github/linuxgurugamer/KSP_Proximity'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: KSP_Proximity
+    install_to: GameData
+---
+identifier: GroundProximity
+$kref: '#/ckan/spacedock/2056'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - information
+depends:
+  - name: ModuleManager
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: KSP_Proximity
+    install_to: GameData

--- a/NetKAN/H-II-H3-TransferVehicle.netkan
+++ b/NetKAN/H-II-H3-TransferVehicle.netkan
@@ -1,4 +1,18 @@
 identifier: H-II-H3-TransferVehicle
+$kref: '#/ckan/github/HakariMatt/Matveich_HTV'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+install:
+  - find: Matveich_HTV
+    install_to: GameData
+    filter_regexp: \.craft$
+  - find: Crafts
+    install_to: Ships
+    as: VAB
+---
+identifier: H-II-H3-TransferVehicle
 $kref: '#/ckan/spacedock/3156'
 license: CC-BY
 tags:

--- a/NetKAN/HabTech2.netkan
+++ b/NetKAN/HabTech2.netkan
@@ -1,4 +1,13 @@
 identifier: HabTech2
+$kref: '#/ckan/github/benjee10/HabTech2'
+install:
+  - find: GameData/HabTech2
+    install_to: GameData
+  - find: Craft Files
+    install_to: Ships
+    as: SPH
+---
+identifier: HabTech2
 $kref: '#/ckan/spacedock/2078'
 license: restricted
 tags:

--- a/NetKAN/HangarGrid.netkan
+++ b/NetKAN/HangarGrid.netkan
@@ -1,4 +1,8 @@
 identifier: HangarGrid
+$kref: '#/ckan/github/linuxgurugamer/HangarGrid'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: HangarGrid
 $kref: '#/ckan/spacedock/2872'
 $vref: '#/ckan/ksp-avc'
 license: GPL-3.0

--- a/NetKAN/HangerExtenderExtended.netkan
+++ b/NetKAN/HangerExtenderExtended.netkan
@@ -1,21 +1,22 @@
-{
-    "identifier":   "HangerExtenderExtended",
-    "name":         "Hangar Extender",
-    "$kref":        "#/ckan/spacedock/1428",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-SA-4.0",
-    "tags": [
-        "plugin",
-        "convenience"
-    ],
-    "provides": [
-        "HangarExtender"
-    ],
-    "install": [ {
-        "find":       "FShangarExtender",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ToolbarController" }
-    ]
-}
+identifier: HangerExtenderExtended
+$kref: '#/ckan/github/linuxgurugamer/FShangarExtender'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: FShangarExtender
+    install_to: GameData
+---
+identifier: HangerExtenderExtended
+name: Hangar Extender
+$kref: '#/ckan/spacedock/1428'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-SA-4.0
+tags:
+  - plugin
+  - convenience
+provides:
+  - HangarExtender
+depends:
+  - name: ToolbarController
+install:
+  - find: FShangarExtender
+    install_to: GameData

--- a/NetKAN/HaystackReContinued.netkan
+++ b/NetKAN/HaystackReContinued.netkan
@@ -1,19 +1,21 @@
-{
-    "identifier":   "HaystackReContinued",
-    "$kref":        "#/ckan/spacedock/1680",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "information",
-        "convenience"
-    ],
-    "install": [ {
-        "find": "HaystackContinued",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ]
-}
+identifier: HaystackReContinued
+$kref: '#/ckan/github/linuxgurugamer/HaystackContinued'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: HaystackContinued
+    install_to: GameData
+---
+identifier: HaystackReContinued
+$kref: '#/ckan/spacedock/1680'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - information
+  - convenience
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: HaystackContinued
+    install_to: GameData

--- a/NetKAN/HeapPadder.netkan
+++ b/NetKAN/HeapPadder.netkan
@@ -1,11 +1,14 @@
-{
-    "identifier"   : "HeapPadder",
-    "name"         : "HeapPadder",
-    "abstract"     : "This is a simple plugin to allocate extra space on the heap to help minimize the frequency of garbage collection.",
-    "$kref"        : "#/ckan/spacedock/2190",
-    "$vref"        : "#/ckan/ksp-avc",
-    "license"      : "MIT",
-    "tags"         : [
-        "plugin"
-    ]
-}
+identifier: HeapPadder
+$kref: '#/ckan/github/linuxgurugamer/HeapPadder'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: HeapPadder
+name: HeapPadder
+abstract: >-
+  This is a simple plugin to allocate extra space on the heap to help minimize
+  the frequency of garbage collection.
+$kref: '#/ckan/spacedock/2190'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin

--- a/NetKAN/HideEmptyTechNodes.netkan
+++ b/NetKAN/HideEmptyTechNodes.netkan
@@ -1,18 +1,24 @@
-{
-    "identifier":   "HideEmptyTechNodes",
-    "$kref":        "#/ckan/spacedock/577",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-4.0",
-    "tags": [
-        "plugin",
-        "tech-tree",
-        "convenience"
-    ],
-    "suggests": [
-        { "name": "CommunityTechTree" }
-    ],
-    "install": [ {
-        "file":       "GameData/HideEmptyTechTreeNodes",
-        "install_to": "GameData"
-    } ]
-}
+identifier: HideEmptyTechNodes
+$kref: '#/ckan/github/Orthethac/HideEmptyTechTreeNodes'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc'
+install:
+  - file: GameData/HideEmptyTechTreeNodes
+    install_to: GameData
+---
+identifier: HideEmptyTechNodes
+$kref: '#/ckan/spacedock/577'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-4.0
+tags:
+  - plugin
+  - tech-tree
+  - convenience
+suggests:
+  - name: CommunityTechTree
+install:
+  - file: GameData/HideEmptyTechTreeNodes
+    install_to: GameData

--- a/NetKAN/HooliganLabsAirships.netkan
+++ b/NetKAN/HooliganLabsAirships.netkan
@@ -1,4 +1,17 @@
 identifier: HooliganLabsAirships
+$kref: '#/ckan/github/net-lisias-ksp/HLAirshipsCore/asset_match/^(?!.*CurseForge)'
+x_netkan_version_edit:
+  find: ^RELEASE/
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: HLAirshipsCore
+    install_to: GameData
+  - find: Ships/SPH
+    install_to: Ships
+---
+identifier: HooliganLabsAirships
 $kref: '#/ckan/spacedock/3040'
 $vref: '#/ckan/ksp-avc'
 license: MIT

--- a/NetKAN/HullcamVDSContinued.netkan
+++ b/NetKAN/HullcamVDSContinued.netkan
@@ -1,24 +1,24 @@
-{
-    "identifier":   "HullcamVDSContinued",
-    "$kref":        "#/ckan/spacedock/885",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "parts",
-        "crewed"
-    ],
-    "conflicts" : [
-        { "name": "HullcamVDS" }
-    ],
-    "provides": [
-        "HullcamVDS"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "install": [ {
-      "find": "HullCameraVDS",
-      "install_to": "GameData"
-    } ]
-}
+identifier: HullcamVDSContinued
+$kref: '#/ckan/github/linuxgurugamer/HullcamVDSContinued'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: HullCameraVDS
+    install_to: GameData
+---
+identifier: HullcamVDSContinued
+$kref: '#/ckan/spacedock/885'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - parts
+  - crewed
+conflicts:
+  - name: HullcamVDS
+provides:
+  - HullcamVDS
+depends:
+  - name: ModuleManager
+install:
+  - find: HullCameraVDS
+    install_to: GameData

--- a/NetKAN/IFILS.netkan
+++ b/NetKAN/IFILS.netkan
@@ -1,4 +1,8 @@
 identifier: IFILS
+$kref: '#/ckan/github/linuxgurugamer/IFI-Life-Support'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: IFILS
 $kref: '#/ckan/spacedock/3145'
 $vref: '#/ckan/ksp-avc'
 license: GPL-3.0

--- a/NetKAN/IXSWarpshipOS.netkan
+++ b/NetKAN/IXSWarpshipOS.netkan
@@ -1,4 +1,8 @@
 identifier: IXSWarpshipOS
+$kref: '#/ckan/github/linuxgurugamer/warpship'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: IXSWarpshipOS
 $kref: '#/ckan/spacedock/589'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-4.0

--- a/NetKAN/ImprovedUpdatedChaseCam.netkan
+++ b/NetKAN/ImprovedUpdatedChaseCam.netkan
@@ -1,16 +1,18 @@
-{
-    "identifier":   "ImprovedUpdatedChaseCam",
-    "$kref":        "#/ckan/spacedock/2249",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin"
-    ],
-    "conflicts": [
-        { "name": "ImprovedChaseCamera" }
-    ],
-    "install": [ {
-        "find": "ImprovedChaseCamera",
-        "install_to": "GameData"
-    } ]
-}
+identifier: ImprovedUpdatedChaseCam
+$kref: '#/ckan/github/linuxgurugamer/ImprovedChaseCamera'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ImprovedChaseCamera
+    install_to: GameData
+---
+identifier: ImprovedUpdatedChaseCam
+$kref: '#/ckan/spacedock/2249'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+conflicts:
+  - name: ImprovedChaseCamera
+install:
+  - find: ImprovedChaseCamera
+    install_to: GameData

--- a/NetKAN/ImpulseParty.netkan
+++ b/NetKAN/ImpulseParty.netkan
@@ -1,4 +1,8 @@
 identifier: ImpulseParty
+$kref: '#/ckan/github/JadeOfMaar/ImpulseParty'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: ImpulseParty
 $kref: '#/ckan/spacedock/3424'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-ND

--- a/NetKAN/IntegratedStackDecouplers.netkan
+++ b/NetKAN/IntegratedStackDecouplers.netkan
@@ -1,16 +1,15 @@
-{
-    "identifier":   "IntegratedStackDecouplers",
-    "$kref":        "#/ckan/spacedock/1538",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin"
-    ],
-    "install": [ {
-        "find": "IntegratedStackDecouplers",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ]
-}
+identifier: IntegratedStackDecouplers
+$kref: '#/ckan/github/linuxgurugamer/IntegratedStackDecouplers'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: IntegratedStackDecouplers
+$kref: '#/ckan/spacedock/1538'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+install:
+  - find: IntegratedStackDecouplers
+    install_to: GameData
+depends:
+  - name: ModuleManager

--- a/NetKAN/IsaQuestsBlueMoon.netkan
+++ b/NetKAN/IsaQuestsBlueMoon.netkan
@@ -1,4 +1,10 @@
 identifier: IsaQuestsBlueMoon
+$kref: '#/ckan/github/IsaQuest/BlueMoonKSP'
+install:
+  - find: IQ_BlueMoon
+    install_to: GameData
+---
+identifier: IsaQuestsBlueMoon
 $kref: '#/ckan/spacedock/3403'
 license: restricted
 tags:

--- a/NetKAN/JDiminishingRTG.netkan
+++ b/NetKAN/JDiminishingRTG.netkan
@@ -1,4 +1,8 @@
 identifier: JDiminishingRTG
+$kref: '#/ckan/github/linuxgurugamer/JDiminishingRTG'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: JDiminishingRTG
 $kref: '#/ckan/spacedock/2096'
 $vref: '#/ckan/ksp-avc'
 author:

--- a/NetKAN/JanitorsCloset.netkan
+++ b/NetKAN/JanitorsCloset.netkan
@@ -1,22 +1,20 @@
-{
-    "identifier":   "JanitorsCloset",
-    "$kref":        "#/ckan/spacedock/944",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-4.0",
-    "tags": [
-        "plugin",
-        "convenience"
-    ],
-    "recommends": [
-        { "name": "FilterExtensions" }
-    ],
-    "depends": [
-        { "name": "ModuleManager"       },
-        { "name": "ClickThroughBlocker" },
-        { "name": "SpaceTuxLibrary" }
-    ],
-    "install": [ {
-        "find":       "JanitorsCloset",
-        "install_to": "GameData"
-    } ]
-}
+identifier: JanitorsCloset
+$kref: '#/ckan/github/linuxgurugamer/JanitorsCloset'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: JanitorsCloset
+$kref: '#/ckan/spacedock/944'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-4.0
+tags:
+  - plugin
+  - convenience
+recommends:
+  - name: FilterExtensions
+depends:
+  - name: ModuleManager
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+install:
+  - find: JanitorsCloset
+    install_to: GameData

--- a/NetKAN/JxFabUtilitySystems.netkan
+++ b/NetKAN/JxFabUtilitySystems.netkan
@@ -1,4 +1,11 @@
 identifier: JxFabUtilitySystems
+$kref: '#/ckan/github/JackATac98/JxFab_Utility_Systems'
+license: CC-BY-NC-SA
+install:
+  - find: JxFab_UtilitySystems
+    install_to: GameData
+---
+identifier: JxFabUtilitySystems
 $kref: '#/ckan/spacedock/2911'
 license: CC-BY-NC-SA
 tags:

--- a/NetKAN/K2CommandPodCont.netkan
+++ b/NetKAN/K2CommandPodCont.netkan
@@ -1,24 +1,24 @@
-{
-    "identifier":   "K2CommandPodCont",
-    "$kref":        "#/ckan/spacedock/1163",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts",
-        "crewed"
-    ],
-    "install": [ {
-        "file":       "GameData/JFJohnny5",
-        "install_to": "GameData"
-    } ],
-    "conflicts": [
-        { "name": "K2CommandPod" }
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "supports": [
-        { "name": "ConnectedLivingSpace" },
-        { "name": "TacLifeSupport"       }
-    ]
-}
+identifier: K2CommandPodCont
+$kref: '#/ckan/github/linuxgurugamer/K2_Command_Pod'
+$vref: '#/ckan/ksp-avc'
+install:
+  - file: GameData/JFJohnny5
+    install_to: GameData
+---
+identifier: K2CommandPodCont
+$kref: '#/ckan/spacedock/1163'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+  - crewed
+conflicts:
+  - name: K2CommandPod
+depends:
+  - name: ModuleManager
+supports:
+  - name: ConnectedLivingSpace
+  - name: TacLifeSupport
+install:
+  - file: GameData/JFJohnny5
+    install_to: GameData

--- a/NetKAN/KARE.netkan
+++ b/NetKAN/KARE.netkan
@@ -1,4 +1,8 @@
 identifier: KARE
+$kref: '#/ckan/github/JadeOfMaar/KARE'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: KARE
 $kref: '#/ckan/spacedock/2906'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA

--- a/NetKAN/KRASH.netkan
+++ b/NetKAN/KRASH.netkan
@@ -1,23 +1,19 @@
-{
-    "identifier"     : "KRASH",
-    "$kref"          : "#/ckan/spacedock/302",
-    "$vref"          : "#/ckan/ksp-avc",
-    "license"        : "MIT",
-    "tags": [
-        "plugin",
-        "career"
-    ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ],
-    "recommends": [
-        { "name": "JanitorsCloset" }
-    ],
-    "install" :  [
-        {
-            "find"       : "KRASH",
-            "install_to" : "GameData"
-        }
-    ]
-}
+identifier: KRASH
+$kref: '#/ckan/github/linuxgurugamer/KRASH'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: KRASH
+$kref: '#/ckan/spacedock/302'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - career
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+recommends:
+  - name: JanitorsCloset
+install:
+  - find: KRASH
+    install_to: GameData

--- a/NetKAN/KRnD.netkan
+++ b/NetKAN/KRnD.netkan
@@ -1,20 +1,19 @@
-{
-    "identifier":   "KRnD",
-    "$kref":        "#/ckan/spacedock/2311",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "plugin",
-        "science"
-    ],
-    "depends": [
-        { "name": "ModuleManager"       },
-        { "name": "SpaceTuxLibrary"     },
-        { "name": "ToolbarController"   },
-        { "name": "ClickThroughBlocker" }
-    ],
-    "install": [ {
-        "find":       "KRnD",
-        "install_to": "GameData"
-    } ]
-}
+identifier: KRnD
+$kref: '#/ckan/github/linuxgurugamer/KRnD'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: KRnD
+$kref: '#/ckan/spacedock/2311'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - plugin
+  - science
+depends:
+  - name: ModuleManager
+  - name: SpaceTuxLibrary
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: KRnD
+    install_to: GameData

--- a/NetKAN/KSCExtended.netkan
+++ b/NetKAN/KSCExtended.netkan
@@ -1,4 +1,8 @@
 identifier: KSCExtended
+$kref: '#/ckan/github/JadeOfMaar/KSC_Extended'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: KSCExtended
 $kref: '#/ckan/spacedock/2062'
 $vref: '#/ckan/ksp-avc'
 license: MIT

--- a/NetKAN/KSCFloodlightsMk2.netkan
+++ b/NetKAN/KSCFloodlightsMk2.netkan
@@ -1,4 +1,14 @@
 identifier: KSCFloodlightsMk2
+$kref: '#/ckan/github/TedThompson/KSC-Floodlights-02'
+x_netkan_version_edit:
+  find: ^FLT02-v
+  replace: ''
+  strict: false
+install:
+  - find: KSCFloodlight2
+    install_to: GameData
+---
+identifier: KSCFloodlightsMk2
 $kref: '#/ckan/spacedock/3238'
 license: CC-BY-NC-SA
 tags:
@@ -9,4 +19,3 @@ depends:
 install:
   - find: KSCFloodlight2
     install_to: GameData
-x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/KSP-AVC.netkan
+++ b/NetKAN/KSP-AVC.netkan
@@ -1,12 +1,15 @@
-{
-    "identifier"  : "KSP-AVC",
-    "name"        : "KSP AVC",
-    "abstract"    : "In-Game GUI for KSP Addon Version Checker",
-    "author"      : [ "cybutek", "linuxgurugamer" ],
-    "$kref"       : "#/ckan/spacedock/2092",
-    "$vref"       : "#/ckan/ksp-avc",
-    "license"     : "GPL-3.0",
-    "tags": [
-        "plugin"
-    ]
-}
+identifier: KSP-AVC
+$kref: '#/ckan/github/linuxgurugamer/KSPAddonVersionChecker'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: KSP-AVC
+name: KSP AVC
+abstract: In-Game GUI for KSP Addon Version Checker
+author:
+  - cybutek
+  - linuxgurugamer
+$kref: '#/ckan/spacedock/2092'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin

--- a/NetKAN/KSP-Data-Export.netkan
+++ b/NetKAN/KSP-Data-Export.netkan
@@ -1,20 +1,24 @@
-{
-    "identifier":   "KSP-Data-Export",
-    "$kref":        "#/ckan/spacedock/2711",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "app",
-        "information"
-    ],
-    "install": [ {
-        "find":       "DataExport",
-        "install_to": "GameData"
-    } ],
-    "x_netkan_override": [ {
-        "version": "0.6",
-        "override": {
-            "ksp_version_min": "1.12.0"
-        }
-    } ]
-}
+identifier: KSP-Data-Export
+$kref: '#/ckan/github/kna27/ksp-data-export'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+install:
+  - find: DataExport
+    install_to: GameData
+---
+identifier: KSP-Data-Export
+$kref: '#/ckan/spacedock/2711'
+license: MIT
+tags:
+  - plugin
+  - app
+  - information
+x_netkan_override:
+  - version: '0.6'
+    override:
+      ksp_version_min: 1.12.0
+install:
+  - find: DataExport
+    install_to: GameData

--- a/NetKAN/KSP-PartVolume.netkan
+++ b/NetKAN/KSP-PartVolume.netkan
@@ -1,4 +1,14 @@
 identifier: KSP-PartVolume
+$kref: '#/ckan/github/linuxgurugamer/KSP_PartVolume'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: KSP_PartVolume
+    install_to: GameData
+    filter_regexp:
+      - .*~$
+      - .*\.pdb$
+---
+identifier: KSP-PartVolume
 $kref: '#/ckan/spacedock/2672'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-4.0

--- a/NetKAN/KSP-Recall.netkan
+++ b/NetKAN/KSP-Recall.netkan
@@ -1,4 +1,15 @@
 identifier: KSP-Recall
+$kref: '#/ckan/github/net-lisias-ksp/KSP-Recall/asset_match/^(?!.*CurseForge)'
+x_netkan_version_edit:
+  find: ^RELEASE/
+  replace: v
+  strict: false
+$vref: '#/ckan/ksp-avc'
+install:
+  - file: GameData/999_KSP-Recall
+    install_to: GameData
+---
+identifier: KSP-Recall
 name: KSP Recall
 abstract: >-
   KSP Recall - Solves the resource resetting on KSP 1.9.x, the heading drift on

--- a/NetKAN/KSPCasherCont.netkan
+++ b/NetKAN/KSPCasherCont.netkan
@@ -1,38 +1,36 @@
-{
-    "identifier":   "KSPCasherCont",
-    "$kref":        "#/ckan/spacedock/1267",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "career"
-    ],
-    "install": [ {
-        "find": "KSPCasher",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ],
-    "recommends": [
-        { "name" : "Karbonite" },
-        { "name" : "KerbinSide" }
-    ],
-    "suggests": [
-        { "name" : "ContractConfigurator-AnomalySurveyor" },
-        { "name" : "ContractConfigurator-KerbinSpaceStation" },
-        { "name" : "ContractConfigurator-CleverSats" },
-        { "name" : "ContractConfigurator-FieldResearch" },
-        { "name" : "ContractConfigurator-KerbalAcademy" },
-        { "name" : "ContractConfigurator-RemoteTech" },
-        { "name" : "ContractConfigurator-Tourism" }
-    ],
-    "supports": [
-        { "name" : "Strategia" },
-        { "name" : "RealSolarSystem" }
-    ],
-    "conflicts": [
-        { "name" : "KerbalConstructionTime" }
-    ]
-}
+identifier: KSPCasherCont
+$kref: '#/ckan/github/linuxgurugamer/kspcasher'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: KSPCasher
+    install_to: GameData
+---
+identifier: KSPCasherCont
+$kref: '#/ckan/spacedock/1267'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - career
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+recommends:
+  - name: Karbonite
+  - name: KerbinSide
+suggests:
+  - name: ContractConfigurator-AnomalySurveyor
+  - name: ContractConfigurator-KerbinSpaceStation
+  - name: ContractConfigurator-CleverSats
+  - name: ContractConfigurator-FieldResearch
+  - name: ContractConfigurator-KerbalAcademy
+  - name: ContractConfigurator-RemoteTech
+  - name: ContractConfigurator-Tourism
+supports:
+  - name: Strategia
+  - name: RealSolarSystem
+conflicts:
+  - name: KerbalConstructionTime
+install:
+  - find: KSPCasher
+    install_to: GameData

--- a/NetKAN/KSTS.netkan
+++ b/NetKAN/KSTS.netkan
@@ -1,18 +1,17 @@
-{
-    "identifier":   "KSTS",
-    "$kref":        "#/ckan/spacedock/2303",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "plugin"
-    ],
-    "depends": [
-        { "name": "ToolbarController"   },
-        { "name": "ClickThroughBlocker" },
-        { "name": "SpaceTuxLibrary" }
-    ],
-    "install": [ {
-        "find":       "KSTS",
-        "install_to": "GameData"
-    } ]
-}
+identifier: KSTS
+$kref: '#/ckan/github/linuxgurugamer/KSTS'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: KSTS
+$kref: '#/ckan/spacedock/2303'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - plugin
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+install:
+  - find: KSTS
+    install_to: GameData

--- a/NetKAN/KaptainsLog.netkan
+++ b/NetKAN/KaptainsLog.netkan
@@ -1,4 +1,8 @@
 identifier: KaptainsLog
+$kref: '#/ckan/github/linuxgurugamer/KaptainsLog'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: KaptainsLog
 $kref: '#/ckan/spacedock/1523'
 $vref: '#/ckan/ksp-avc/GameData/KaptainsLog/KaptainsLog.version'
 license: GPL-3.0

--- a/NetKAN/Kartographer.netkan
+++ b/NetKAN/Kartographer.netkan
@@ -1,15 +1,18 @@
-{
-    "identifier"   : "Kartographer",
-    "author"       : [ "satnet", "RealGecko", "linuxgurugamer" ],
-    "$kref"        : "#/ckan/spacedock/1575",
-    "$vref"        : "#/ckan/ksp-avc",
-    "license"      : "CC-BY-NC-SA-3.0",
-    "tags"         : [
-        "plugin",
-        "convenience"
-    ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ]
-}
+identifier: Kartographer
+$kref: '#/ckan/github/linuxgurugamer/Kartographer'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: Kartographer
+author:
+  - satnet
+  - RealGecko
+  - linuxgurugamer
+$kref: '#/ckan/spacedock/1575'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-3.0
+tags:
+  - plugin
+  - convenience
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker

--- a/NetKAN/KeepItStraight.netkan
+++ b/NetKAN/KeepItStraight.netkan
@@ -1,10 +1,11 @@
-{
-    "identifier":   "KeepItStraight",
-    "$kref":        "#/ckan/spacedock/824",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "convenience"
-    ]
-}
+identifier: KeepItStraight
+$kref: '#/ckan/github/jarosm/KSP-KeepItStraight'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: KeepItStraight
+$kref: '#/ckan/spacedock/824'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - convenience

--- a/NetKAN/KerBalloons.netkan
+++ b/NetKAN/KerBalloons.netkan
@@ -1,4 +1,8 @@
 identifier: KerBalloons
+$kref: '#/ckan/github/linuxgurugamer/KerballoonsReinflated'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: KerBalloons
 $kref: '#/ckan/spacedock/2662'
 $vref: '#/ckan/ksp-avc'
 license: MIT

--- a/NetKAN/KerbCam-Continued.netkan
+++ b/NetKAN/KerbCam-Continued.netkan
@@ -1,17 +1,19 @@
-{
-    "identifier":   "KerbCam-Continued",
-    "$kref":        "#/ckan/spacedock/2135",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "BSD-2-clause",
-    "tags": [
-        "plugin"
-    ],
-    "depends": [
-        { "name": "ToolbarController" },
-        { "name": "ClickThroughBlocker" }
-    ],
-    "install": [ {
-        "find": "KerbCam",
-        "install_to": "GameData"
-    } ]
-}
+identifier: KerbCam-Continued
+$kref: '#/ckan/github/linuxgurugamer/kerbcam'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: KerbCam
+    install_to: GameData
+---
+identifier: KerbCam-Continued
+$kref: '#/ckan/spacedock/2135'
+$vref: '#/ckan/ksp-avc'
+license: BSD-2-clause
+tags:
+  - plugin
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: KerbCam
+    install_to: GameData

--- a/NetKAN/KerbalAircraftExpansion.netkan
+++ b/NetKAN/KerbalAircraftExpansion.netkan
@@ -1,28 +1,35 @@
-{
-    "identifier":   "KerbalAircraftExpansion",
-    "name":         "Kerbal Aircraft Expansion",
-    "abstract":     "A pack of select vanilla-inspired parts for your aircrafting needs.",
-    "author":       [ "keptin", "SpannerMonkey", "LisiasT" ],
-    "$kref":        "#/ckan/spacedock/2150",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_epoch": 4,
-    "license":      "restricted",
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name" : "FirespitterCore" },
-        { "name" : "FirespitterResourcesConfig" },
-        { "name" : "ModuleManager" }
-    ],
-    "install" : [
-        {
-            "file": "GameData/KAX",
-            "install_to": "GameData"
-        },
-        {
-            "file": "Ships/SPH",
-            "install_to": "Ships"
-        }
-    ]
-}
+identifier: KerbalAircraftExpansion
+$kref: '#/ckan/github/net-lisias-ksp/KAX/asset_match/^(?!.*CurseForge)'
+x_netkan_version_edit:
+  find: ^RELEASE/
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc'
+install:
+  - file: GameData/KAX
+    install_to: GameData
+  - file: Ships/SPH
+    install_to: Ships
+---
+identifier: KerbalAircraftExpansion
+name: Kerbal Aircraft Expansion
+abstract: A pack of select vanilla-inspired parts for your aircrafting needs.
+author:
+  - keptin
+  - SpannerMonkey
+  - LisiasT
+$kref: '#/ckan/spacedock/2150'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: 4
+license: restricted
+tags:
+  - parts
+depends:
+  - name: FirespitterCore
+  - name: FirespitterResourcesConfig
+  - name: ModuleManager
+install:
+  - file: GameData/KAX
+    install_to: GameData
+  - file: Ships/SPH
+    install_to: Ships

--- a/NetKAN/KerbalConstructionTime.netkan
+++ b/NetKAN/KerbalConstructionTime.netkan
@@ -1,35 +1,31 @@
-{
-    "identifier"     : "KerbalConstructionTime",
-    "$kref"          : "#/ckan/spacedock/222",
-    "$vref"          : "#/ckan/ksp-avc",
-    "x_netkan_epoch" : 1,
-    "license"        : "GPL-3.0",
-    "tags": [
-        "plugin",
-        "career"
-    ],
-    "install": [ {
-        "file":       "GameData/KerbalConstructionTime",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ModuleManager"       },
-        { "name": "MagiCore"            },
-        { "name": "ClickThroughBlocker" },
-        { "name": "ToolbarController"   },
-        { "name": "SpaceTuxLibrary"     }
-    ],
-    "recommends": [
-        { "name": "ScrapYard"     },
-        { "name": "KRASH"         },
-        { "name": "StageRecovery" },
-        { "name": "CrewQueueTwo"  },
-        { "name": "OhScrap"       }
-    ],
-    "suggests": [
-        { "name": "KerbalAlarmClock" }
-    ],
-    "conflicts": [
-        { "name": "KerbalConstructionTime-173" }
-    ]
-}
+identifier: KerbalConstructionTime
+$kref: '#/ckan/github/linuxgurugamer/KCT'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: KerbalConstructionTime
+$kref: '#/ckan/spacedock/222'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: 1
+license: GPL-3.0
+tags:
+  - plugin
+  - career
+install:
+  - file: GameData/KerbalConstructionTime
+    install_to: GameData
+depends:
+  - name: ModuleManager
+  - name: MagiCore
+  - name: ClickThroughBlocker
+  - name: ToolbarController
+  - name: SpaceTuxLibrary
+recommends:
+  - name: ScrapYard
+  - name: KRASH
+  - name: StageRecovery
+  - name: CrewQueueTwo
+  - name: OhScrap
+suggests:
+  - name: KerbalAlarmClock
+conflicts:
+  - name: KerbalConstructionTime-173

--- a/NetKAN/KerbalGPSRevived.netkan
+++ b/NetKAN/KerbalGPSRevived.netkan
@@ -1,26 +1,27 @@
-{
-    "identifier":   "KerbalGPSRevived",
-    "name":         "Kerbal GPS",
-    "abstract":     "Adds support for GPS satelites",
-    "author":       "linuxgurugamer",
-    "$kref":        "#/ckan/spacedock/1949",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-3.0",
-    "tags": [
-        "plugin",
-        "parts",
-        "uncrewed"
-    ],
-    "recommends": [
-        { "name": "ContractConfigurator" }
-    ],
-    "depends": [
-        { "name": "ModuleManager"       },
-        { "name": "ToolbarController"   },
-        { "name": "ClickThroughBlocker" }
-    ],
-    "install": [ {
-        "find":       "KerbalGPS",
-        "install_to": "GameData"
-    } ]
-}
+identifier: KerbalGPSRevived
+$kref: '#/ckan/github/linuxgurugamer/KerbalGPS'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: KerbalGPS
+    install_to: GameData
+---
+identifier: KerbalGPSRevived
+name: Kerbal GPS
+abstract: Adds support for GPS satelites
+author: linuxgurugamer
+$kref: '#/ckan/spacedock/1949'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-3.0
+tags:
+  - plugin
+  - parts
+  - uncrewed
+recommends:
+  - name: ContractConfigurator
+depends:
+  - name: ModuleManager
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: KerbalGPS
+    install_to: GameData

--- a/NetKAN/KerbalHotSeatCont.netkan
+++ b/NetKAN/KerbalHotSeatCont.netkan
@@ -1,17 +1,19 @@
-{
-    "identifier":   "KerbalHotSeatCont",
-    "$kref":        "#/ckan/spacedock/1272",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "plugin",
-        "crewed"
-    ],
-    "install": [ {
-        "find":       "KerbalHotSeat",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ConnectedLivingSpace" }
-    ]
-}
+identifier: KerbalHotSeatCont
+$kref: '#/ckan/github/linuxgurugamer/KerbalHotSeat'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: KerbalHotSeat
+    install_to: GameData
+---
+identifier: KerbalHotSeatCont
+$kref: '#/ckan/spacedock/1272'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - plugin
+  - crewed
+depends:
+  - name: ConnectedLivingSpace
+install:
+  - find: KerbalHotSeat
+    install_to: GameData

--- a/NetKAN/KerbalImprovedSaveSystem.netkan
+++ b/NetKAN/KerbalImprovedSaveSystem.netkan
@@ -1,4 +1,8 @@
 identifier: KerbalImprovedSaveSystem
+$kref: '#/ckan/github/KerbalSpike/KerbalImprovedSaveSystem'
+x_netkan_force_v: true
+---
+identifier: KerbalImprovedSaveSystem
 $kref: '#/ckan/spacedock/583'
 x_netkan_force_v: true
 license: MIT

--- a/NetKAN/KerbalLaunchFailure.netkan
+++ b/NetKAN/KerbalLaunchFailure.netkan
@@ -1,17 +1,16 @@
-{
-    "identifier":   "KerbalLaunchFailure",
-    "$kref":        "#/ckan/spacedock/989",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-2.0",
-    "tags": [
-        "plugin"
-    ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ],
-    "install": [ {
-        "find": "KerbalLaunchFailure",
-        "install_to": "GameData"
-    } ]
-}
+identifier: KerbalLaunchFailure
+$kref: '#/ckan/github/linuxgurugamer/ksp-KerbalLaunchFailure'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: KerbalLaunchFailure
+$kref: '#/ckan/spacedock/989'
+$vref: '#/ckan/ksp-avc'
+license: GPL-2.0
+tags:
+  - plugin
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: KerbalLaunchFailure
+    install_to: GameData

--- a/NetKAN/KerbalMostlyHarmless.netkan
+++ b/NetKAN/KerbalMostlyHarmless.netkan
@@ -1,4 +1,11 @@
 identifier: KerbalMostlyHarmless
+$kref: '#/ckan/github/kaerospace/KerbalMostlyHarmless'
+x_netkan_version_edit: ^v(?<version>[^-]+)-.*$
+install:
+  - find: kAerospace
+    install_to: GameData
+---
+identifier: KerbalMostlyHarmless
 $kref: '#/ckan/spacedock/3423'
 ksp_version: 1.12
 license: restricted

--- a/NetKAN/KerbalNRAP.netkan
+++ b/NetKAN/KerbalNRAP.netkan
@@ -1,21 +1,24 @@
-{
-    "identifier":   "KerbalNRAP",
-    "author":       [ "linuxgurugamer", "stupid_chris", "kotysoft" ],
-    "$kref":        "#/ckan/spacedock/386",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-SA",
-    "tags": [
-        "plugin",
-        "parts"
-    ],
-    "depends" : [
-        { "name" : "ClickThroughBlocker" },
-        { "name" : "SpaceTuxLibrary" }
-    ],
-    "install": [
-        {
-            "file": "GameData/NRAP",
-            "install_to": "GameData"
-        }
-    ]
-}
+identifier: KerbalNRAP
+$kref: '#/ckan/github/linuxgurugamer/NRAP'
+$vref: '#/ckan/ksp-avc'
+install:
+  - file: GameData/NRAP
+    install_to: GameData
+---
+identifier: KerbalNRAP
+author:
+  - linuxgurugamer
+  - stupid_chris
+  - kotysoft
+$kref: '#/ckan/spacedock/386'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-SA
+tags:
+  - plugin
+  - parts
+depends:
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+install:
+  - file: GameData/NRAP
+    install_to: GameData

--- a/NetKAN/KerbalObjectInspectorCont.netkan
+++ b/NetKAN/KerbalObjectInspectorCont.netkan
@@ -1,17 +1,19 @@
-{
-    "identifier":   "KerbalObjectInspectorCont",
-    "$kref":        "#/ckan/spacedock/1040",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin"
-    ],
-    "install": [ {
-        "find": "KerbalObjectInspector",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ]
-}
+identifier: KerbalObjectInspectorCont
+$kref: '#/ckan/github/linuxgurugamer/KerbalObjectInspector'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: KerbalObjectInspector
+    install_to: GameData
+---
+identifier: KerbalObjectInspectorCont
+$kref: '#/ckan/spacedock/1040'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: KerbalObjectInspector
+    install_to: GameData

--- a/NetKAN/KerbalPlanetaryBaseSystems.netkan
+++ b/NetKAN/KerbalPlanetaryBaseSystems.netkan
@@ -1,23 +1,25 @@
-{
-    "identifier":   "KerbalPlanetaryBaseSystems",
-    "$kref":        "#/ckan/spacedock/173",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-4.0",
-    "tags": [
-        "parts",
-        "crewed"
-    ],
-    "install": [
-        {
-            "find"       : "PlanetaryBaseInc",
-            "install_to" : "GameData",
-            "filter"     : "_src.zip"
-        }
-    ],
-    "depends" : [
-        { "name": "ModuleManager"         },
-        { "name": "CommunityCategoryKit"  },
-        { "name": "CommunityResourcePack" }
-    ],
-    "x_netkan_force_v": true
-}
+identifier: KerbalPlanetaryBaseSystems
+$kref: '#/ckan/github/Nils277/KerbalPlanetaryBaseSystems'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+install:
+  - find: PlanetaryBaseInc
+    install_to: GameData
+    filter: _src.zip
+---
+identifier: KerbalPlanetaryBaseSystems
+$kref: '#/ckan/spacedock/173'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+license: CC-BY-NC-4.0
+tags:
+  - parts
+  - crewed
+depends:
+  - name: ModuleManager
+  - name: CommunityCategoryKit
+  - name: CommunityResourcePack
+install:
+  - find: PlanetaryBaseInc
+    install_to: GameData
+    filter: _src.zip

--- a/NetKAN/KerbalPublicRadioServiceKPRS.netkan
+++ b/NetKAN/KerbalPublicRadioServiceKPRS.netkan
@@ -1,4 +1,12 @@
 identifier: KerbalPublicRadioServiceKPRS
+$kref: '#/ckan/github/linuxgurugamer/K.P.R.S'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: KPRS
+    install_to: GameData
+    filter_regexp: \.mdb$
+---
+identifier: KerbalPublicRadioServiceKPRS
 $kref: '#/ckan/spacedock/3504'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-SA
@@ -14,4 +22,3 @@ install:
   - find: KPRS
     install_to: GameData
     filter_regexp: \.mdb$
-x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/KerbalSports.netkan
+++ b/NetKAN/KerbalSports.netkan
@@ -1,4 +1,8 @@
 identifier: KerbalSports
+$kref: '#/ckan/github/KSPModStewards/KerbalSports'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: KerbalSports
 author:
   - nightingale
   - JonnyOThan

--- a/NetKAN/KerbalWeatherProject-Lite.netkan
+++ b/NetKAN/KerbalWeatherProject-Lite.netkan
@@ -1,26 +1,24 @@
-{
-    "identifier":   "KerbalWeatherProject-Lite",
-    "$kref":        "#/ckan/spacedock/2611",
-    "license":      "MIT",
-    "tags": [
-        "plugin"
-    ],
-    "provides": [
-        "KerbalWeatherProject"
-    ],
-    "conflicts": [
-        { "name": "KerbalWeatherProject" }
-    ],
-    "depends": [
-        { "name": "ToolbarController"       },
-        { "name": "ModularFlightIntegrator" }
-    ],
-    "recommends": [
-        { "name": "KerBalloons"          },
-        { "name": "AtmosphereAutopilot"  }
-    ],
-    "install": [ {
-        "find":       "KerbalWeatherProject_Lite",
-        "install_to": "GameData"
-    } ]
-}
+identifier: KerbalWeatherProject-Lite
+$kref: '#/ckan/github/cmac994/KerbalWeatherProject/asset_match/Lite'
+install:
+  - find: KerbalWeatherProject_Lite
+    install_to: GameData
+---
+identifier: KerbalWeatherProject-Lite
+$kref: '#/ckan/spacedock/2611'
+license: MIT
+tags:
+  - plugin
+provides:
+  - KerbalWeatherProject
+conflicts:
+  - name: KerbalWeatherProject
+depends:
+  - name: ToolbarController
+  - name: ModularFlightIntegrator
+recommends:
+  - name: KerBalloons
+  - name: AtmosphereAutopilot
+install:
+  - find: KerbalWeatherProject_Lite
+    install_to: GameData

--- a/NetKAN/KerbalWeatherProject.netkan
+++ b/NetKAN/KerbalWeatherProject.netkan
@@ -1,17 +1,15 @@
-{
-    "identifier":   "KerbalWeatherProject",
-    "$kref":        "#/ckan/spacedock/2607",
-    "license":      "MIT",
-    "tags": [
-        "plugin"
-    ],
-    "depends": [
-        { "name": "ToolbarController"       },
-        { "name": "ModularFlightIntegrator" }
-    ],
-    "recommends": [
-        { "name": "KerbinSideRemastered" },
-        { "name": "KerBalloons"          },
-        { "name": "AtmosphereAutopilot"  }
-    ]
-}
+identifier: KerbalWeatherProject
+$kref: '#/ckan/github/cmac994/KerbalWeatherProject/asset_match/^(?!.*Lite)'
+---
+identifier: KerbalWeatherProject
+$kref: '#/ckan/spacedock/2607'
+license: MIT
+tags:
+  - plugin
+depends:
+  - name: ToolbarController
+  - name: ModularFlightIntegrator
+recommends:
+  - name: KerbinSideRemastered
+  - name: KerBalloons
+  - name: AtmosphereAutopilot

--- a/NetKAN/KerbealisticDocking.netkan
+++ b/NetKAN/KerbealisticDocking.netkan
@@ -1,4 +1,8 @@
 identifier: KerbealisticDocking
+$kref: '#/ckan/github/kurgut/KerbealisticDocking'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: KerbealisticDocking
 $kref: '#/ckan/spacedock/3392'
 $vref: '#/ckan/ksp-avc'
 license: MIT

--- a/NetKAN/KipardSkylon.netkan
+++ b/NetKAN/KipardSkylon.netkan
@@ -1,15 +1,15 @@
-{
-    "identifier":   "KipardSkylon",
-    "$kref":        "#/ckan/spacedock/2309",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA",
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "ModuleManager"         },
-        { "name": "B9PartSwitch"          },
-        { "name": "B9AnimationModules"    },
-        { "name": "CommunityResourcePack" }
-    ]
-}
+identifier: KipardSkylon
+$kref: '#/ckan/github/JadeOfMaar/KipardSkylon'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: KipardSkylon
+$kref: '#/ckan/spacedock/2309'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+  - name: B9PartSwitch
+  - name: B9AnimationModules
+  - name: CommunityResourcePack

--- a/NetKAN/KourageousTourists.netkan
+++ b/NetKAN/KourageousTourists.netkan
@@ -1,4 +1,12 @@
 identifier: KourageousTourists
+$kref: '#/ckan/github/net-lisias-ksp/KourageousTourists/asset_match/^(?!.*CurseForge)'
+x_netkan_version_edit:
+  find: ^RELEASE/
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc'
+---
+identifier: KourageousTourists
 author:
   - whale_2
   - Lisias

--- a/NetKAN/KramaxAutopilotContinued.netkan
+++ b/NetKAN/KramaxAutopilotContinued.netkan
@@ -1,18 +1,20 @@
-{
-    "identifier":   "KramaxAutopilotContinued",
-    "$kref":        "#/ckan/spacedock/1019",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "plugin",
-        "control"
-    ],
-    "install": [ {
-        "find":       "KramaxAutoPilot",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ToolbarController"   },
-        { "name": "ClickThroughBlocker" }
-    ]
-}
+identifier: KramaxAutopilotContinued
+$kref: '#/ckan/github/linuxgurugamer/KramaxAutoPilot'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: KramaxAutoPilot
+    install_to: GameData
+---
+identifier: KramaxAutopilotContinued
+$kref: '#/ckan/spacedock/1019'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - plugin
+  - control
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: KramaxAutoPilot
+    install_to: GameData

--- a/NetKAN/KspCraftOrganizer.netkan
+++ b/NetKAN/KspCraftOrganizer.netkan
@@ -1,21 +1,18 @@
-{
-    "identifier"   : "KspCraftOrganizer",
-    "$kref"        : "#/ckan/spacedock/2901",
-    "$vref"        : "#/ckan/ksp-avc",
-    "license"      : "MIT",
-    "tags": [
-        "plugin",
-        "convenience"
-    ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" },
-        { "name" : "SpaceTuxLibrary" }
-    ],
-    "install": [
-        {
-            "find"       : "KspCraftOrganizer",
-            "install_to" : "GameData"
-        }
-    ]
-}
+identifier: KspCraftOrganizer
+$kref: '#/ckan/github/linuxgurugamer/ksp-craft-organizer'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: KspCraftOrganizer
+$kref: '#/ckan/spacedock/2901'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - convenience
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+install:
+  - find: KspCraftOrganizer
+    install_to: GameData

--- a/NetKAN/LLL-Extras.netkan
+++ b/NetKAN/LLL-Extras.netkan
@@ -1,18 +1,21 @@
-{
-    "identifier":   "LLL-Extras",
-    "name":         "LLL Extra Parts",
-    "$kref":        "#/ckan/spacedock/856",
-    "x_netkan_epoch" : 1,
-    "$vref":        "#/ckan/ksp-avc/LLL.version",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "LLL" }
-    ],
-    "install": [ {
-        "find"       : "GameData/LLL-Extra/Parts",
-        "install_to" : "GameData/LLL-Extra"
-    } ]
-}
+identifier: LLL-Extras
+$kref: '#/ckan/github/linuxgurugamer/LLL-Continued'
+x_netkan_epoch: 1
+$vref: '#/ckan/ksp-avc/LLL.version'
+install:
+  - find: GameData/LLL-Extra/Parts
+    install_to: GameData/LLL-Extra
+---
+identifier: LLL-Extras
+name: LLL Extra Parts
+$kref: '#/ckan/spacedock/856'
+x_netkan_epoch: 1
+$vref: '#/ckan/ksp-avc/LLL.version'
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+depends:
+  - name: LLL
+install:
+  - find: GameData/LLL-Extra/Parts
+    install_to: GameData/LLL-Extra

--- a/NetKAN/LLL.netkan
+++ b/NetKAN/LLL.netkan
@@ -1,29 +1,23 @@
-{
-    "identifier"     : "LLL",
-    "$kref"          : "#/ckan/spacedock/856",
-    "$vref"          : "#/ckan/ksp-avc",
-    "x_netkan_epoch" : 1,
-    "license"        : "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "InterstellarFuelSwitch-Core"}
-    ],
-    "recommends": [
-        { "name": "TweakScale" },
-        { "name": "CrewManifest"}
-    ],
-    "install": [
-        {
-            "find"       : "GameData/LLL",
-            "install_to" : "GameData"
-        },
-        {
-            "find"       : "GameData/LLL-Extra",
-            "install_to" : "GameData/LLL",
-            "filter"     : "Parts"
-        }
-    ]
-}
+identifier: LLL
+$kref: '#/ckan/github/linuxgurugamer/LLL-Continued'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: LLL
+$kref: '#/ckan/spacedock/856'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: 1
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+  - name: InterstellarFuelSwitch-Core
+recommends:
+  - name: TweakScale
+  - name: CrewManifest
+install:
+  - find: GameData/LLL
+    install_to: GameData
+  - find: GameData/LLL-Extra
+    install_to: GameData/LLL
+    filter: Parts

--- a/NetKAN/LTechContinued.netkan
+++ b/NetKAN/LTechContinued.netkan
@@ -1,30 +1,29 @@
-{
-    "identifier": "LTechContinued",
-    "$kref":        "#/ckan/spacedock/227",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "parts",
-        "science"
-    ],
-    "depends": [
-        { "name" : "ModuleManager"       },
-        { "name" : "ToolbarController"   },
-        { "name" : "SpaceTuxLibrary"     },
-        { "name" : "ClickThroughBlocker" }
-    ],
-    "x_netkan_override": [
-        {
-            "version": "v4.1",
-            "override": {
-                "conflicts": [ { "name": "KEI" } ]
-            }
-        }
-    ],
-    "install": [ {
-        "find": "LTech",
-        "install_to": "GameData"
-    } ],
-    "x_netkan_epoch": 1
-}
+identifier: LTechContinued
+$kref: '#/ckan/github/linuxgurugamer/L-Tech'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: LTech
+    install_to: GameData
+---
+identifier: LTechContinued
+$kref: '#/ckan/spacedock/227'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: 1
+license: MIT
+tags:
+  - plugin
+  - parts
+  - science
+depends:
+  - name: ModuleManager
+  - name: ToolbarController
+  - name: SpaceTuxLibrary
+  - name: ClickThroughBlocker
+x_netkan_override:
+  - version: v4.1
+    override:
+      conflicts:
+        - name: KEI
+install:
+  - find: LTech
+    install_to: GameData

--- a/NetKAN/LaunchNumbering.netkan
+++ b/NetKAN/LaunchNumbering.netkan
@@ -1,19 +1,16 @@
-{
-    "identifier":   "LaunchNumbering",
-    "$kref":        "#/ckan/spacedock/201",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin"
-    ],
-    "depends": [
-        { "name": "ToolbarController" },
-        { "name": "ClickThroughBlocker" }
-    ],
-    "install": [
-        {
-            "find": "LaunchNumbering",
-            "install_to": "GameData"
-        }
-    ]
-}
+identifier: LaunchNumbering
+$kref: '#/ckan/github/linuxgurugamer/KSPLaunchNumbering'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: LaunchNumbering
+$kref: '#/ckan/spacedock/201'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: LaunchNumbering
+    install_to: GameData

--- a/NetKAN/LaunchSitesAppended.netkan
+++ b/NetKAN/LaunchSitesAppended.netkan
@@ -1,4 +1,10 @@
 identifier: LaunchSitesAppended
+$kref: '#/ckan/github/TedThompson/Launch-Sites-Appended'
+install:
+  - find: FP_LaunchSitesAppended
+    install_to: GameData
+---
+identifier: LaunchSitesAppended
 $kref: '#/ckan/spacedock/3361'
 license: CC-BY-NC-SA
 tags:

--- a/NetKAN/LoadingScreenManager.netkan
+++ b/NetKAN/LoadingScreenManager.netkan
@@ -1,13 +1,13 @@
-{
-    "identifier":   "LoadingScreenManager",
-    "$kref":        "#/ckan/spacedock/1422",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA",
-    "tags": [
-        "plugin"
-    ],
-    "install": [ {
-        "find": "LoadingScreenManager",
-        "install_to": "GameData"
-    } ]
-}
+identifier: LoadingScreenManager
+$kref: '#/ckan/github/linuxgurugamer/KSPLoadingScreenManager'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: LoadingScreenManager
+$kref: '#/ckan/spacedock/1422'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA
+tags:
+  - plugin
+install:
+  - find: LoadingScreenManager
+    install_to: GameData

--- a/NetKAN/MK12PodIVAReplacementbyASET.netkan
+++ b/NetKAN/MK12PodIVAReplacementbyASET.netkan
@@ -1,4 +1,17 @@
 identifier: MK12PodIVAReplacementbyASET
+$kref: '#/ckan/github/StoneBlue/ASET-Consolidated-IVAs'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ASET
+    install_to: GameData
+    include_only:
+      - Assets
+      - FreeIVA_ASET_SRI_Mk1-2.3_Pod.cfg
+      - RevIVA_ASET_SRI_Mk1-2.3_Pod.cfg
+      - RPM_ASET_SRI_Mk1-2.3_Pod.cfg
+      - ASET_SRI_Mk1-2.3_Pod.cfg
+---
+identifier: MK12PodIVAReplacementbyASET
 name: MK1-2 IVA Replacement by ASET
 author:
   - alexustas
@@ -25,7 +38,7 @@ recommends:
   - name: DockingPortAlignmentIndicator
   - name: Astrogator
 x_netkan_override:
-  - version: '1:0.3'
+  - version: 1:0.3
     delete:
       - ksp_version
     override:

--- a/NetKAN/MOARStationScience.netkan
+++ b/NetKAN/MOARStationScience.netkan
@@ -1,32 +1,45 @@
-{
-    "identifier":   "MOARStationScience",
-    "name":         "MOAR Station Science",
-    "abstract":     "Station Science mod adds several large parts designed to be integrated into a permanent space station.",
-    "description":  "This mod adds several large parts designed to be integrated into a permanent space station: the Science Lab, the Zoology Bay, the Cyclotron, and the Spectrometron. These heavy parts provide facilities for performing experiments. Experiments are held in small, light pods that you can dock with your space station, execute, and bring back to the surface for Science points. The Spectrometron uses the Cyclotron to analyze Surface Samples that you've brought into orbit, and allows you to transmit the data home for full value. In addition, there are tanks for storing Kibbal for the Zoology Bay.",
-    "author":       [ "linuxgurugamer", "tomf"],
-    "$kref":        "#/ckan/spacedock/2670",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_force_v": true,
-    "release_status": "stable",
-    "license":      "restricted",
-    "resources": {
-        "x_screenshot": "http://i.imgur.com/63DTlDLl.png"
-    },
-    "tags": [
-        "parts",
-        "crewed",
-        "science"
-    ],
-    "conflicts": [
-        { "name": "StationScience" },
-        { "name": "StationScienceContinued" }
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "SpaceTuxLibrary"     }
-    ],
-    "install": [ {
-        "find":       "StationScience",
-        "install_to": "GameData"
-    } ]
-}
+identifier: MOARStationScience
+$kref: '#/ckan/github/linuxgurugamer/StationScience'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+install:
+  - find: StationScience
+    install_to: GameData
+---
+identifier: MOARStationScience
+name: MOAR Station Science
+abstract: >-
+  Station Science mod adds several large parts designed to be integrated into
+  a permanent space station.
+description: >-
+  This mod adds several large parts designed to be integrated into a permanent
+  space station: the Science Lab, the Zoology Bay, the Cyclotron, and the
+  Spectrometron. These heavy parts provide facilities for performing
+  experiments. Experiments are held in small, light pods that you can dock
+  with your space station, execute, and bring back to the surface for Science
+  points. The Spectrometron uses the Cyclotron to analyze Surface Samples that
+  you've brought into orbit, and allows you to transmit the data home for full
+  value. In addition, there are tanks for storing Kibbal for the Zoology Bay.
+author:
+  - linuxgurugamer
+  - tomf
+$kref: '#/ckan/spacedock/2670'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+release_status: stable
+license: restricted
+resources:
+  x_screenshot: http://i.imgur.com/63DTlDLl.png
+tags:
+  - parts
+  - crewed
+  - science
+conflicts:
+  - name: StationScience
+  - name: StationScienceContinued
+depends:
+  - name: ModuleManager
+  - name: SpaceTuxLibrary
+install:
+  - find: StationScience
+    install_to: GameData

--- a/NetKAN/MS-SRBs.netkan
+++ b/NetKAN/MS-SRBs.netkan
@@ -1,22 +1,28 @@
-{
-    "identifier":   "MS-SRBs",
-    "$kref":        "#/ckan/spacedock/2297",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts",
-        "plugin"
-    ],
-    "depends": [
-        { "name": "ModuleManager"   },
-        { "name": "SpaceTuxLibrary" }
-    ],
-    "install": [ {
-        "find":       "ModularSegmentedSRBs",
-        "install_to": "GameData",
-        "filter":     [ "Ships" ]
-    }, {
-        "find":       "VAB",
-        "install_to": "Ships"
-    } ]
-}
+identifier: MS-SRBs
+$kref: '#/ckan/github/linuxgurugamer/ModularSegmentedSRBs'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ModularSegmentedSRBs
+    install_to: GameData
+    filter:
+      - Ships
+  - find: VAB
+    install_to: Ships
+---
+identifier: MS-SRBs
+$kref: '#/ckan/spacedock/2297'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+  - plugin
+depends:
+  - name: ModuleManager
+  - name: SpaceTuxLibrary
+install:
+  - find: ModularSegmentedSRBs
+    install_to: GameData
+    filter:
+      - Ships
+  - find: VAB
+    install_to: Ships

--- a/NetKAN/ManeuverQueue.netkan
+++ b/NetKAN/ManeuverQueue.netkan
@@ -1,14 +1,14 @@
-{
-    "identifier":   "ManeuverQueue",
-    "$kref":        "#/ckan/spacedock/1541",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "install": [ {
-        "find": "ManeuverQueue",
-        "install_to": "GameData"
-    } ]
-}
+identifier: ManeuverQueue
+$kref: '#/ckan/github/linuxgurugamer/ManeuverQueue'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: ManeuverQueue
+$kref: '#/ckan/spacedock/1541'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - information
+install:
+  - find: ManeuverQueue
+    install_to: GameData

--- a/NetKAN/Measurizer.netkan
+++ b/NetKAN/Measurizer.netkan
@@ -1,4 +1,7 @@
 identifier: Measurizer
+$kref: '#/ckan/github/JadeOfMaar/Measurizer'
+---
+identifier: Measurizer
 $kref: '#/ckan/spacedock/2889'
 license: MIT
 tags:

--- a/NetKAN/MicroSatRevived.netkan
+++ b/NetKAN/MicroSatRevived.netkan
@@ -1,27 +1,27 @@
-{
-    "identifier":   "MicroSatRevived",
-    "$kref":        "#/ckan/spacedock/1795",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts",
-        "uncrewed"
-    ],
-    "install"   :   [ {
-        "find" : "SquiggsySpaceResearch",
-        "install_to" : "GameData"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends" : [
-        { "name" : "FMRSContinued" },
-        { "name" : "KerbalJointReinforcement" },
-        { "name" : "AntennaRange" },
-        { "name" : "ProceduralFairings" },
-        { "name" : "SimpleAdjustableFairings-KWRocketry" }
-    ],
-    "suggests" : [
-        { "name" : "RemoteTech" }
-    ]
-}
+identifier: MicroSatRevived
+$kref: '#/ckan/github/linuxgurugamer/MicroSat_0.35m_Probe_Parts'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: SquiggsySpaceResearch
+    install_to: GameData
+---
+identifier: MicroSatRevived
+$kref: '#/ckan/spacedock/1795'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+  - uncrewed
+depends:
+  - name: ModuleManager
+recommends:
+  - name: FMRSContinued
+  - name: KerbalJointReinforcement
+  - name: AntennaRange
+  - name: ProceduralFairings
+  - name: SimpleAdjustableFairings-KWRocketry
+suggests:
+  - name: RemoteTech
+install:
+  - find: SquiggsySpaceResearch
+    install_to: GameData

--- a/NetKAN/MinAmbLightUpd.netkan
+++ b/NetKAN/MinAmbLightUpd.netkan
@@ -1,18 +1,20 @@
-{
-    "identifier":   "MinAmbLightUpd",
-    "$kref":        "#/ckan/spacedock/2279",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "BSD-2-clause",
-    "tags": [
-        "plugin",
-        "graphics"
-    ],
-    "depends": [
-        { "name": "ToolbarController"   },
-        { "name": "ClickThroughBlocker" }
-    ],
-    "install": [ {
-        "find":       "MinimumAmbientLightingUpdated",
-        "install_to": "GameData"
-    } ]
-}
+identifier: MinAmbLightUpd
+$kref: '#/ckan/github/linuxgurugamer/MinimumAmbientLightingUpdated'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: MinimumAmbientLightingUpdated
+    install_to: GameData
+---
+identifier: MinAmbLightUpd
+$kref: '#/ckan/spacedock/2279'
+$vref: '#/ckan/ksp-avc'
+license: BSD-2-clause
+tags:
+  - plugin
+  - graphics
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: MinimumAmbientLightingUpdated
+    install_to: GameData

--- a/NetKAN/Mk-X.netkan
+++ b/NetKAN/Mk-X.netkan
@@ -1,4 +1,11 @@
 identifier: Mk-X
+$kref: '#/ckan/github/linuxgurugamer/Mk-X'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: Benjee10_X-37B
+    install_to: GameData
+---
+identifier: Mk-X
 $kref: '#/ckan/spacedock/2165'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-4.0

--- a/NetKAN/Mk1CockpitIVAReplbyASET.netkan
+++ b/NetKAN/Mk1CockpitIVAReplbyASET.netkan
@@ -1,4 +1,15 @@
 identifier: Mk1CockpitIVAReplbyASET
+$kref: '#/ckan/github/StoneBlue/ASET-Consolidated-IVAs'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ASET
+    install_to: GameData
+    include_only:
+      - RevIVA_ASET_SRI_Mk1_Cockpit.cfg
+      - RPM_ASET_SRI_Mk1_Cockpit.cfg
+      - ASET_SRI_Mk1_Cockpit.cfg
+---
+identifier: Mk1CockpitIVAReplbyASET
 name: Mk1 Cockpit IVA Replacement by ASET
 author:
   - alexustas

--- a/NetKAN/Mk1LanderCanIVAReplbyASET.netkan
+++ b/NetKAN/Mk1LanderCanIVAReplbyASET.netkan
@@ -1,4 +1,15 @@
 identifier: Mk1LanderCanIVAReplbyASET
+$kref: '#/ckan/github/StoneBlue/ASET-Consolidated-IVAs'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ASET
+    install_to: GameData
+    include_only:
+      - RevIVA_ASET_SRI_Mk1_LCan.cfg
+      - RPM_ASET_SRI_Mk1_LCan.cfg
+      - ASET_SRI_Mk1_LCan.cfg
+---
+identifier: Mk1LanderCanIVAReplbyASET
 name: Mk1 Lander Can IVA Replacement by ASET
 author:
   - alexustas

--- a/NetKAN/Mk2Expansion.netkan
+++ b/NetKAN/Mk2Expansion.netkan
@@ -1,28 +1,27 @@
-{
-    "identifier":   "Mk2Expansion",
-    "$kref":        "#/ckan/spacedock/473",
-    "x_netkan_epoch": 2,
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "CommunityResourcePack" },
-        { "name": "B9PartSwitch" }
-    ],
-    "install": [
-        {
-            "find"       : "GameData/Mk2Expansion",
-            "install_to" : "GameData"
-        },
-        {
-            "find"        : "VAB",
-            "install_to"  : "Ships"
-        },
-        {
-            "find"        : "SPH",
-            "install_to"  : "Ships"
-        }
-    ]
-}
+identifier: Mk2Expansion
+$kref: '#/ckan/github/SuicidalInsanity/Mk2Expansion'
+install:
+  - find: GameData/Mk2Expansion
+    install_to: GameData
+  - find: VAB
+    install_to: Ships
+  - find: SPH
+    install_to: Ships
+---
+identifier: Mk2Expansion
+$kref: '#/ckan/spacedock/473'
+x_netkan_epoch: 2
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+  - name: CommunityResourcePack
+  - name: B9PartSwitch
+install:
+  - find: GameData/Mk2Expansion
+    install_to: GameData
+  - find: VAB
+    install_to: Ships
+  - find: SPH
+    install_to: Ships

--- a/NetKAN/Mk3Expansion.netkan
+++ b/NetKAN/Mk3Expansion.netkan
@@ -1,28 +1,27 @@
-{
-    "identifier":   "Mk3Expansion",
-    "$kref":        "#/ckan/spacedock/663",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts",
-        "crewed"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "CommunityResourcePack" },
-        { "name": "B9PartSwitch" }
-    ],
-    "install" : [
-        {
-            "find"       : "GameData/Mk3Expansion",
-            "install_to" : "GameData"
-        },
-        {
-            "find"        : "VAB",
-            "install_to"  : "Ships"
-        },
-        {
-            "find"        : "SPH",
-            "install_to"  : "Ships"
-        }
-    ]
-}
+identifier: Mk3Expansion
+$kref: '#/ckan/github/SuicidalInsanity/Mk3Expansion'
+install:
+  - find: GameData/Mk3Expansion
+    install_to: GameData
+  - find: VAB
+    install_to: Ships
+  - find: SPH
+    install_to: Ships
+---
+identifier: Mk3Expansion
+$kref: '#/ckan/spacedock/663'
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+  - crewed
+depends:
+  - name: ModuleManager
+  - name: CommunityResourcePack
+  - name: B9PartSwitch
+install:
+  - find: GameData/Mk3Expansion
+    install_to: GameData
+  - find: VAB
+    install_to: Ships
+  - find: SPH
+    install_to: Ships

--- a/NetKAN/ModularComputerPackageRevived.netkan
+++ b/NetKAN/ModularComputerPackageRevived.netkan
@@ -1,4 +1,11 @@
 identifier: ModularComputerPackageRevived
+$kref: '#/ckan/github/linuxgurugamer/ChromaWorks'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ChromaWorks
+    install_to: GameData
+---
+identifier: ModularComputerPackageRevived
 author:
   - CSVoltage
   - micha030201

--- a/NetKAN/ModularLaunchPads.netkan
+++ b/NetKAN/ModularLaunchPads.netkan
@@ -1,4 +1,13 @@
 identifier: ModularLaunchPads
+$kref: '#/ckan/github/AlphaMensae/Modular-Launch-Pads'
+install:
+  - find: ModularLaunchPads
+    install_to: GameData
+  - find: Bare Assemblies
+    install_to: Ships
+    as: VAB
+---
+identifier: ModularLaunchPads
 $kref: '#/ckan/spacedock/1767'
 license: CC-BY-NC-SA-4.0
 tags:
@@ -11,12 +20,6 @@ depends:
 recommends:
   - name: KSCExtended
   - name: BluedogDB
-install:
-  - find: ModularLaunchPads
-    install_to: GameData
-  - find: Bare Assemblies
-    install_to: Ships
-    as: VAB
 x_netkan_override:
   - version: 2.1.2
     override:
@@ -27,3 +30,9 @@ x_netkan_override:
   - version: 2.2.0.b
     override:
       ksp_version_min: 1.8.1
+install:
+  - find: ModularLaunchPads
+    install_to: GameData
+  - find: Bare Assemblies
+    install_to: Ships
+    as: VAB

--- a/NetKAN/ModularPods.netkan
+++ b/NetKAN/ModularPods.netkan
@@ -1,4 +1,11 @@
 identifier: ModularPods
+$kref: '#/ckan/github/linuxgurugamer/ModPods'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ModPods
+    install_to: GameData
+---
+identifier: ModularPods
 $kref: '#/ckan/spacedock/1017'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-SA-4.0

--- a/NetKAN/MoldaviteMachines.netkan
+++ b/NetKAN/MoldaviteMachines.netkan
@@ -1,4 +1,8 @@
 identifier: MoldaviteMachines
+$kref: '#/ckan/github/JadeOfMaar/MoldaviteMachines'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: MoldaviteMachines
 $kref: '#/ckan/spacedock/3060'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA

--- a/NetKAN/MoldaviteMachinesKerbalism.netkan
+++ b/NetKAN/MoldaviteMachinesKerbalism.netkan
@@ -1,4 +1,8 @@
 identifier: MoldaviteMachinesKerbalism
+$kref: '#/ckan/github/JadeOfMaar/MoldaviteMachines'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: MoldaviteMachinesKerbalism
 name: Moldavite Machines - Kerbalism
 $kref: '#/ckan/spacedock/3060'
 $vref: '#/ckan/ksp-avc'

--- a/NetKAN/MunarIndustriesFTX.netkan
+++ b/NetKAN/MunarIndustriesFTX.netkan
@@ -1,22 +1,22 @@
-{
-    "identifier":   "MunarIndustriesFTX",
-    "$kref":        "#/ckan/spacedock/1396",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts"
-    ],
-    "install": [ {
-        "find": "MunarIndustries",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "InterstellarFuelSwitch-Core" }
-    ],
-    "suggests": [
-        { "name": "PatchManager" }
-    ]
-}
+identifier: MunarIndustriesFTX
+$kref: '#/ckan/github/linuxgurugamer/ModularFuelTankExpansion'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: MunarIndustries
+    install_to: GameData
+---
+identifier: MunarIndustriesFTX
+$kref: '#/ckan/spacedock/1396'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+recommends:
+  - name: InterstellarFuelSwitch-Core
+suggests:
+  - name: PatchManager
+install:
+  - find: MunarIndustries
+    install_to: GameData

--- a/NetKAN/NASA-CountDown.netkan
+++ b/NetKAN/NASA-CountDown.netkan
@@ -1,19 +1,21 @@
-{
-    "identifier":   "NASA-CountDown",
-    "$kref":        "#/ckan/spacedock/1462",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA",
-    "tags": [
-        "plugin",
-        "sound"
-    ],
-    "install": [ {
-        "find": "NASA_CountDown",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name" : "ModuleManager" },
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ]
-}
+identifier: NASA-CountDown
+$kref: '#/ckan/github/linuxgurugamer/LaunchCountdownEx'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: NASA_CountDown
+    install_to: GameData
+---
+identifier: NASA-CountDown
+$kref: '#/ckan/spacedock/1462'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA
+tags:
+  - plugin
+  - sound
+depends:
+  - name: ModuleManager
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: NASA_CountDown
+    install_to: GameData

--- a/NetKAN/NavBallTextureChangerUpdated.netkan
+++ b/NetKAN/NavBallTextureChangerUpdated.netkan
@@ -1,4 +1,13 @@
 identifier: NavBallTextureChangerUpdated
+$kref: '#/ckan/github/linuxgurugamer/NavBallTextureChanger'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: NavBallTextureChanger
+    install_to: GameData
+    filter_regexp:
+      - .*\.pdb$
+---
+identifier: NavBallTextureChangerUpdated
 $kref: '#/ckan/spacedock/2654'
 $vref: '#/ckan/ksp-avc'
 license: MIT

--- a/NetKAN/NavUtilitiesContinued.netkan
+++ b/NetKAN/NavUtilitiesContinued.netkan
@@ -1,4 +1,14 @@
 identifier: NavUtilitiesContinued
+$kref: '#/ckan/github/SerTheGreat/NavInstruments'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+install:
+  - find: NavUtilities continued
+    install_to: GameData
+---
+identifier: NavUtilitiesContinued
 $kref: '#/ckan/spacedock/1432'
 license: CC-BY-NC-SA-4.0
 tags:

--- a/NetKAN/NavUtilitiesUpdated.netkan
+++ b/NetKAN/NavUtilitiesUpdated.netkan
@@ -1,4 +1,11 @@
 identifier: NavUtilitiesUpdated
+$kref: '#/ckan/github/linuxgurugamer/NavInstruments'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: NavInstruments
+    install_to: GameData
+---
+identifier: NavUtilitiesUpdated
 $kref: '#/ckan/spacedock/2879'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-4.0

--- a/NetKAN/NavballDockAlignIndCE.netkan
+++ b/NetKAN/NavballDockAlignIndCE.netkan
@@ -1,21 +1,21 @@
-{
-    "identifier":   "NavballDockAlignIndCE",
-    "$kref":        "#/ckan/spacedock/1098",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "install": [
-        {
-            "find":       "NavBallDockingAlignmentIndicatorCE",
-            "install_to": "GameData"
-        }
-    ],
-    "conflicts": [
-        { "name": "NavballDockingIndicator"}
-    ],
-    "provides": [ "NavballDockingIndicator" ],
-    "x_via":    "Automated Linuxgurugamer CKAN script"
-}
+identifier: NavballDockAlignIndCE
+$kref: '#/ckan/github/linuxgurugamer/NavBallDockingAlignmentIndicatorCE'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: NavBallDockingAlignmentIndicatorCE
+    install_to: GameData
+---
+identifier: NavballDockAlignIndCE
+$kref: '#/ckan/spacedock/1098'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - information
+conflicts:
+  - name: NavballDockingIndicator
+provides:
+  - NavballDockingIndicator
+install:
+  - find: NavBallDockingAlignmentIndicatorCE
+    install_to: GameData

--- a/NetKAN/NearFutureSolar-Core.netkan
+++ b/NetKAN/NearFutureSolar-Core.netkan
@@ -1,4 +1,11 @@
 identifier: NearFutureSolar-Core
+$kref: '#/ckan/github/post-kerbin-mining-corporation/NearFutureSolar'
+$vref: '#/ckan/ksp-avc/NearFutureSolar.version'
+install:
+  - file: GameData/NearFutureSolar/Plugins/NearFutureSolar.dll
+    install_to: GameData/NearFutureSolar/Plugins
+---
+identifier: NearFutureSolar-Core
 name: Near Future Solar Core
 abstract: >-
   Near Future Solar plugin stand-alone, for adding functionality to other mods.

--- a/NetKAN/NearFutureSolar.netkan
+++ b/NetKAN/NearFutureSolar.netkan
@@ -1,4 +1,8 @@
 identifier: NearFutureSolar
+$kref: '#/ckan/github/post-kerbin-mining-corporation/NearFutureSolar'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: NearFutureSolar
 abstract: New solar panels in a variety of sizes and types
 author: Nertea (Chris Adderley)
 $kref: '#/ckan/spacedock/559'

--- a/NetKAN/NetherdyneMassDriver.netkan
+++ b/NetKAN/NetherdyneMassDriver.netkan
@@ -1,30 +1,24 @@
-{
-  "license": "CDDL",
-  "identifier": "NetherdyneMassDriver",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "$kref": "#/ckan/spacedock/2542",
-  "$vref": "#/ckan/ksp-avc",
-  "depends": [
-    {
-      "name": "ToolbarController"
-    },
-    {
-      "name": "ClickThroughBlocker"
-    },
-    {
-      "name": "SpaceTuxLibrary"
-    }
-  ],
-  "tags": [
-    "parts",
-    "plugin",
-    "crewed",
-    "uncrewed"
-  ],
-  "install": [
-    {
-      "find": "NeatherdyneMassDriver",
-      "install_to": "GameData"
-    }
-  ]
-}
+identifier: NetherdyneMassDriver
+$kref: '#/ckan/github/linuxgurugamer/NeatherdyneMassDriver'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: NeatherdyneMassDriver
+    install_to: GameData
+---
+license: CDDL
+identifier: NetherdyneMassDriver
+x_via: Automated Linuxgurugamer CKAN script
+$kref: '#/ckan/spacedock/2542'
+$vref: '#/ckan/ksp-avc'
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+tags:
+  - parts
+  - plugin
+  - crewed
+  - uncrewed
+install:
+  - find: NeatherdyneMassDriver
+    install_to: GameData

--- a/NetKAN/NoIntakeOcclusion.netkan
+++ b/NetKAN/NoIntakeOcclusion.netkan
@@ -1,4 +1,12 @@
 identifier: NoIntakeOcclusion
+$kref: '#/ckan/github/kaerospace/KerbalNoOcclusion'
+install:
+  - file: NoIntakeOcclusion.cfg
+    install_to: GameData/NoIntakeOcclusion
+  - file: NoIntakeOcclusion.dll
+    install_to: GameData/NoIntakeOcclusion
+---
+identifier: NoIntakeOcclusion
 $kref: '#/ckan/spacedock/3435'
 license: MIT
 tags:

--- a/NetKAN/NodeSplitter.netkan
+++ b/NetKAN/NodeSplitter.netkan
@@ -1,19 +1,21 @@
-{
-    "identifier":   "NodeSplitter",
-    "$kref":        "#/ckan/spacedock/2453",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "convenience"
-    ],
-    "depends": [
-        { "name": "ToolbarController"   },
-        { "name": "ClickThroughBlocker" },
-        { "name": "SpaceTuxLibrary"     }
-    ],
-    "install": [ {
-        "find":       "ManeuverNodeSplitter",
-        "install_to": "GameData"
-    } ]
-}
+identifier: NodeSplitter
+$kref: '#/ckan/github/linuxgurugamer/ManeuverNodeSplitter'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ManeuverNodeSplitter
+    install_to: GameData
+---
+identifier: NodeSplitter
+$kref: '#/ckan/spacedock/2453'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - convenience
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+install:
+  - find: ManeuverNodeSplitter
+    install_to: GameData

--- a/NetKAN/NovaPunchRebalanced-Freyja.netkan
+++ b/NetKAN/NovaPunchRebalanced-Freyja.netkan
@@ -1,17 +1,19 @@
-{
-    "identifier":   "NovaPunchRebalanced-Freyja",
-    "name":         "NovaPunchRebalanced Freyja",
-    "$kref":        "#/ckan/spacedock/2003",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-SA-4.0",
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "NovaPunchRebalanced" }
-    ],
-    "install": [ {
-        "find":       "NovaPunch/Freyja",
-        "install_to": "GameData/NovaPunch"
-    } ]
-}
+identifier: NovaPunchRebalanced-Freyja
+$kref: '#/ckan/github/linuxgurugamer/NovaPunch'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: NovaPunch/Freyja
+    install_to: GameData/NovaPunch
+---
+identifier: NovaPunchRebalanced-Freyja
+name: NovaPunchRebalanced Freyja
+$kref: '#/ckan/spacedock/2003'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-SA-4.0
+tags:
+  - parts
+depends:
+  - name: NovaPunchRebalanced
+install:
+  - find: NovaPunch/Freyja
+    install_to: GameData/NovaPunch

--- a/NetKAN/NovaPunchRebalanced-Odin.netkan
+++ b/NetKAN/NovaPunchRebalanced-Odin.netkan
@@ -1,17 +1,19 @@
-{
-    "identifier":   "NovaPunchRebalanced-Odin",
-    "name":         "NovaPunchRebalanced Odin",
-    "$kref":        "#/ckan/spacedock/2003",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-SA-4.0",
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "NovaPunchRebalanced" }
-    ],
-    "install": [ {
-        "find":       "NovaPunch/Odin",
-        "install_to": "GameData/NovaPunch"
-    } ]
-}
+identifier: NovaPunchRebalanced-Odin
+$kref: '#/ckan/github/linuxgurugamer/NovaPunch'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: NovaPunch/Odin
+    install_to: GameData/NovaPunch
+---
+identifier: NovaPunchRebalanced-Odin
+name: NovaPunchRebalanced Odin
+$kref: '#/ckan/spacedock/2003'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-SA-4.0
+tags:
+  - parts
+depends:
+  - name: NovaPunchRebalanced
+install:
+  - find: NovaPunch/Odin
+    install_to: GameData/NovaPunch

--- a/NetKAN/NovaPunchRebalanced-Thor.netkan
+++ b/NetKAN/NovaPunchRebalanced-Thor.netkan
@@ -1,17 +1,19 @@
-{
-    "identifier":   "NovaPunchRebalanced-Thor",
-    "name":         "NovaPunchRebalanced Thor",
-    "$kref":        "#/ckan/spacedock/2003",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-SA-4.0",
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "NovaPunchRebalanced" }
-    ],
-    "install": [ {
-        "find":       "NovaPunch/Thor",
-        "install_to": "GameData/NovaPunch"
-    } ]
-}
+identifier: NovaPunchRebalanced-Thor
+$kref: '#/ckan/github/linuxgurugamer/NovaPunch'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: NovaPunch/Thor
+    install_to: GameData/NovaPunch
+---
+identifier: NovaPunchRebalanced-Thor
+name: NovaPunchRebalanced Thor
+$kref: '#/ckan/spacedock/2003'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-SA-4.0
+tags:
+  - parts
+depends:
+  - name: NovaPunchRebalanced
+install:
+  - find: NovaPunch/Thor
+    install_to: GameData/NovaPunch

--- a/NetKAN/NovaPunchRebalanced.netkan
+++ b/NetKAN/NovaPunchRebalanced.netkan
@@ -1,22 +1,30 @@
-{
-    "identifier":   "NovaPunchRebalanced",
-    "$kref":        "#/ckan/spacedock/2003",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-SA-4.0",
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "NovaPunchRebalanced-Freyja" },
-        { "name": "NovaPunchRebalanced-Odin"   },
-        { "name": "NovaPunchRebalanced-Thor"   }
-    ],
-    "install": [ {
-        "find":       "NovaPunch",
-        "install_to": "GameData",
-        "filter":     [ "Freyja", "Odin", "Thor" ]
-    } ]
-}
+identifier: NovaPunchRebalanced
+$kref: '#/ckan/github/linuxgurugamer/NovaPunch'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: NovaPunch
+    install_to: GameData
+    filter:
+      - Freyja
+      - Odin
+      - Thor
+---
+identifier: NovaPunchRebalanced
+$kref: '#/ckan/spacedock/2003'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-SA-4.0
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+recommends:
+  - name: NovaPunchRebalanced-Freyja
+  - name: NovaPunchRebalanced-Odin
+  - name: NovaPunchRebalanced-Thor
+install:
+  - find: NovaPunch
+    install_to: GameData
+    filter:
+      - Freyja
+      - Odin
+      - Thor

--- a/NetKAN/OrbitalTug.netkan
+++ b/NetKAN/OrbitalTug.netkan
@@ -1,24 +1,22 @@
-{
-    "identifier"  : "OrbitalTug",
-    "$kref"       : "#/ckan/spacedock/2198",
-    "$vref"       : "#/ckan/ksp-avc",
-    "license"     : "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "BurstAtomicThrust" },
-        { "name": "B9PartSwitch" }
-    ],
-    "recommends": [
-        { "name": "AllYAll" },
-        { "name": "DockingCamKURS" },
-        { "name": "TacSelfDestructContinued" },
-        { "name": "JSIAdvancedTransparentPods" }
-    ],
-    "install" : [ {
-        "find"       : "OrbitalTug",
-        "install_to" : "GameData"
-    } ]
-}
+identifier: OrbitalTug
+$kref: '#/ckan/github/linuxgurugamer/OrbitalTug'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: OrbitalTug
+$kref: '#/ckan/spacedock/2198'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+  - name: BurstAtomicThrust
+  - name: B9PartSwitch
+recommends:
+  - name: AllYAll
+  - name: DockingCamKURS
+  - name: TacSelfDestructContinued
+  - name: JSIAdvancedTransparentPods
+install:
+  - find: OrbitalTug
+    install_to: GameData

--- a/NetKAN/PADContinued.netkan
+++ b/NetKAN/PADContinued.netkan
@@ -1,22 +1,24 @@
-{
-    "identifier":   "PADContinued",
-    "$kref":        "#/ckan/spacedock/1679",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "editor",
-        "information"
-    ],
-    "install": [ {
-        "find": "PartAngleDisplay",
-        "install_to": "GameData"
-    } ],
-    "conflicts": [
-        { "name": "PartAngleDisplay" }
-    ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name": "ClickThroughBlocker" }
-    ]
-}
+identifier: PADContinued
+$kref: '#/ckan/github/linuxgurugamer/PartAngleDisplay'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+install:
+  - find: PartAngleDisplay
+    install_to: GameData
+---
+identifier: PADContinued
+$kref: '#/ckan/spacedock/1679'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - editor
+  - information
+conflicts:
+  - name: PartAngleDisplay
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: PartAngleDisplay
+    install_to: GameData

--- a/NetKAN/Parallax-OuterPlanetsMod.netkan
+++ b/NetKAN/Parallax-OuterPlanetsMod.netkan
@@ -1,4 +1,12 @@
 identifier: Parallax-OuterPlanetsMod
+$kref: '#/ckan/github/OneSaltyPringle/OPM-Parallax'
+x_netkan_force_v: true
+license: MIT
+install:
+  - find: OPM_Parallax
+    install_to: GameData
+---
+identifier: Parallax-OuterPlanetsMod
 $kref: '#/ckan/spacedock/3501'
 x_netkan_force_v: true
 license: MIT

--- a/NetKAN/ParkingBrake.netkan
+++ b/NetKAN/ParkingBrake.netkan
@@ -1,12 +1,12 @@
-{
-    "identifier":   "ParkingBrake",
-    "$kref":        "#/ckan/spacedock/2018",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "config"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ]
-}
+identifier: ParkingBrake
+$kref: '#/ckan/github/jarosm/KSP-ParkingBrake'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: ParkingBrake
+$kref: '#/ckan/spacedock/2018'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - config
+depends:
+  - name: ModuleManager

--- a/NetKAN/PartCommanderCont.netkan
+++ b/NetKAN/PartCommanderCont.netkan
@@ -1,18 +1,20 @@
-{
-    "identifier":   "PartCommanderCont",
-    "$kref":        "#/ckan/spacedock/1004",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "convenience"
-    ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ],
-    "install": [ {
-        "find": "PartCommanderContinued",
-        "install_to": "GameData"
-    } ]
-}
+identifier: PartCommanderCont
+$kref: '#/ckan/github/linuxgurugamer/PartCommander'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: PartCommanderContinued
+    install_to: GameData
+---
+identifier: PartCommanderCont
+$kref: '#/ckan/spacedock/1004'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - convenience
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: PartCommanderContinued
+    install_to: GameData

--- a/NetKAN/PartInfo.netkan
+++ b/NetKAN/PartInfo.netkan
@@ -1,20 +1,21 @@
-{
-    "identifier":   "PartInfo",
-    "abstract":     "PartInfo is a simple mod to expose the internal part name and path to the part file.",
-    "$kref":        "#/ckan/spacedock/2091",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "plugin",
-        "editor",
-        "information"
-    ],
-    "depends": [
-        { "name": "ClickThroughBlocker" },
-        { "name": "ModuleManager" }
-    ],
-    "install": [ {
-        "find": "PartInfo",
-        "install_to": "GameData"
-    } ]
-}
+identifier: PartInfo
+$kref: '#/ckan/github/linuxgurugamer/PartInfo'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: PartInfo
+abstract: >-
+  PartInfo is a simple mod to expose the internal part name and path to the
+  part file.
+$kref: '#/ckan/spacedock/2091'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - plugin
+  - editor
+  - information
+depends:
+  - name: ClickThroughBlocker
+  - name: ModuleManager
+install:
+  - find: PartInfo
+    install_to: GameData

--- a/NetKAN/PartInfoInPAW.netkan
+++ b/NetKAN/PartInfoInPAW.netkan
@@ -1,4 +1,8 @@
 identifier: PartInfoInPAW
+$kref: '#/ckan/github/judicator/PartInfoInPAW'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: PartInfoInPAW
 name: Part info in PAW
 author: Alexander Rogov
 $kref: '#/ckan/spacedock/3148'

--- a/NetKAN/PartWizardContinued.netkan
+++ b/NetKAN/PartWizardContinued.netkan
@@ -1,27 +1,36 @@
-{
-    "identifier":   "PartWizardContinued",
-    "abstract":     "Part Wizard is a vehicle design utility plugin that adds a few conveniences when building your next strut/booster carrier.  It provides a list of parts with part highlighting for easier identification, allows deleting of parts from the list on eligible parts, allows complete control of symmetry on eligible parts, allows selecting parts for Action Group assignment, shows either all parts or only those that are hidden from the editor's Parts List. (Helpful in finding obsolete parts when mod authors make updates.) and shows unavailable parts in career modes with options to buy one or all necessary parts for launch.",
-    "$kref":        "#/ckan/spacedock/1148",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "BSD-3-clause",
-    "tags": [
-        "plugin",
-        "editor",
-        "convenience"
-    ],
-    "install": [ {
-        "find":       "PartWizard",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name" : "ToolbarController"   },
-        { "name" : "ClickThroughBlocker" }
-    ],
-    "suggests": [
-        { "name": "JanitorsCloset" },
-        { "name": "Toolbar"        }
-    ],
-    "conflicts": [
-        { "name": "PartWizard" }
-    ]
-}
+identifier: PartWizardContinued
+$kref: '#/ckan/github/linuxgurugamer/PartWizard'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: PartWizard
+    install_to: GameData
+---
+identifier: PartWizardContinued
+abstract: >-
+  Part Wizard is a vehicle design utility plugin that adds a few conveniences
+  when building your next strut/booster carrier.  It provides a list of parts
+  with part highlighting for easier identification, allows deleting of parts
+  from the list on eligible parts, allows complete control of symmetry on
+  eligible parts, allows selecting parts for Action Group assignment, shows
+  either all parts or only those that are hidden from the editor's Parts List.
+  (Helpful in finding obsolete parts when mod authors make updates.) and shows
+  unavailable parts in career modes with options to buy one or all necessary
+  parts for launch.
+$kref: '#/ckan/spacedock/1148'
+$vref: '#/ckan/ksp-avc'
+license: BSD-3-clause
+tags:
+  - plugin
+  - editor
+  - convenience
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+suggests:
+  - name: JanitorsCloset
+  - name: Toolbar
+conflicts:
+  - name: PartWizard
+install:
+  - find: PartWizard
+    install_to: GameData

--- a/NetKAN/PersistentRotation.netkan
+++ b/NetKAN/PersistentRotation.netkan
@@ -1,37 +1,26 @@
-{
-    "identifier":   "PersistentRotation",
-    "$kref":        "#/ckan/spacedock/447",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "physics"
-    ],
-    "suggests": [
-        { "name": "Toolbar" }
-    ],
-    "install": [ {
-        "file":       "GameData/PersistentRotation",
-        "install_to": "GameData"
-    } ],
-    "x_netkan_override": [
-        {
-            "version": "1.8.5",
-            "override": {
-                "ksp_version": "1.4"
-            }
-        },
-        {
-            "version": "1.8.1",
-            "override": {
-                "ksp_version": "1.2"
-            }
-        },
-        {
-            "version": "1.8.4",
-            "override": {
-                "ksp_version": "1.2.2"
-            }
-        }
-    ]
-}
+identifier: PersistentRotation
+$kref: '#/ckan/github/markusa380/PersistentRotation'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: PersistentRotation
+$kref: '#/ckan/spacedock/447'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - physics
+suggests:
+  - name: Toolbar
+install:
+  - file: GameData/PersistentRotation
+    install_to: GameData
+x_netkan_override:
+  - version: 1.8.5
+    override:
+      ksp_version: '1.4'
+  - version: 1.8.1
+    override:
+      ksp_version: '1.2'
+  - version: 1.8.4
+    override:
+      ksp_version: 1.2.2

--- a/NetKAN/PersistentRotationUpgraded.netkan
+++ b/NetKAN/PersistentRotationUpgraded.netkan
@@ -1,25 +1,25 @@
-{
-    "identifier":   "PersistentRotationUpgraded",
-    "$kref":        "#/ckan/spacedock/2660",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "physics"
-    ],
-    "provides": [
-        "PersistentRotation"
-    ],
-    "conflicts": [
-        { "name": "PersistentRotation" }
-    ],
-    "depends": [
-        { "name": "ToolbarController"   },
-        { "name": "ClickThroughBlocker" },
-        { "name": "SpaceTuxLibrary"     }
-    ],
-    "install": [ {
-        "file":       "GameData/PersistentRotation",
-        "install_to": "GameData"
-    } ]
-}
+identifier: PersistentRotationUpgraded
+$kref: '#/ckan/github/linuxgurugamer/PersistentRotation'
+$vref: '#/ckan/ksp-avc'
+install:
+  - file: GameData/PersistentRotation
+    install_to: GameData
+---
+identifier: PersistentRotationUpgraded
+$kref: '#/ckan/spacedock/2660'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - physics
+provides:
+  - PersistentRotation
+conflicts:
+  - name: PersistentRotation
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+install:
+  - file: GameData/PersistentRotation
+    install_to: GameData

--- a/NetKAN/PicoPort.netkan
+++ b/NetKAN/PicoPort.netkan
@@ -1,20 +1,20 @@
-{
-    "identifier":   "PicoPort",
-    "$kref":        "#/ckan/spacedock/1165",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts"
-    ],
-    "install": [ {
-        "find":       "SHED",
-        "install_to": "GameData",
-        "filter":     [ "Agencies", "License" ]
-    } ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "IndicatorLights" }
-    ]
-}
+identifier: PicoPort
+$kref: '#/ckan/github/linuxgurugamer/PicoPort'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: PicoPort
+$kref: '#/ckan/spacedock/1165'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+install:
+  - find: SHED
+    install_to: GameData
+    filter:
+      - Agencies
+      - License
+depends:
+  - name: ModuleManager
+recommends:
+  - name: IndicatorLights

--- a/NetKAN/PlanetaryDiversity.netkan
+++ b/NetKAN/PlanetaryDiversity.netkan
@@ -1,19 +1,21 @@
-{
-    "identifier":   "PlanetaryDiversity",
-    "name":         "Planetary Diversity",
-    "abstract":     "Creates some diversity on the otherwise static planets.",
-    "author":       [ "Thomas P.", "linuxgurugamer" ],
-    "$kref":        "#/ckan/spacedock/2243",
-    "x_netkan_epoch":  "1",
-    "$vref":        "#/ckan/ksp-avc",
-    "release_status": "development",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "planet-pack"
-    ],
-    "install": [ {
-        "find":       "PlanetaryDiversity",
-        "install_to": "GameData"
-    } ]
-}
+identifier: PlanetaryDiversity
+$kref: '#/ckan/github/linuxgurugamer/Planetary-Diversity'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: PlanetaryDiversity
+name: Planetary Diversity
+abstract: Creates some diversity on the otherwise static planets.
+author:
+  - Thomas P.
+  - linuxgurugamer
+$kref: '#/ckan/spacedock/2243'
+x_netkan_epoch: '1'
+$vref: '#/ckan/ksp-avc'
+release_status: development
+license: MIT
+tags:
+  - plugin
+  - planet-pack
+install:
+  - find: PlanetaryDiversity
+    install_to: GameData

--- a/NetKAN/PlanetsideExplorationTechnologies.netkan
+++ b/NetKAN/PlanetsideExplorationTechnologies.netkan
@@ -1,4 +1,15 @@
 identifier: PlanetsideExplorationTechnologies
+$kref: '#/ckan/github/benjee10/Benjee10_MMSEV'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: Benjee10_MMSEV
+    install_to: GameData
+---
+identifier: PlanetsideExplorationTechnologies
 $kref: '#/ckan/spacedock/2681'
 $vref: '#/ckan/ksp-avc'
 license: restricted

--- a/NetKAN/PlayYourWay.netkan
+++ b/NetKAN/PlayYourWay.netkan
@@ -1,14 +1,16 @@
-{
-    "identifier":   "PlayYourWay",
-    "abstract":     "Earn funds for doing science! Remember to download Contract Configurator and disable all contracts to truly play your way!",
-    "$kref":        "#/ckan/spacedock/2280",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "public-domain",
-    "tags": [
-        "config",
-        "career"
-    ],
-    "recommends": [
-        { "name": "ContractConfigurator" }
-    ]
-}
+identifier: PlayYourWay
+$kref: '#/ckan/github/linuxgurugamer/PlayYourWay'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: PlayYourWay
+abstract: >-
+  Earn funds for doing science! Remember to download Contract Configurator
+  and disable all contracts to truly play your way!
+$kref: '#/ckan/spacedock/2280'
+$vref: '#/ckan/ksp-avc'
+license: public-domain
+tags:
+  - config
+  - career
+recommends:
+  - name: ContractConfigurator

--- a/NetKAN/PolishTranslationByReMakee.netkan
+++ b/NetKAN/PolishTranslationByReMakee.netkan
@@ -1,4 +1,10 @@
 identifier: PolishTranslationByReMakee
+$kref: '#/ckan/github/MarcinZboralski/PolishTranslation'
+install:
+  - find: PolishTranslation
+    install_to: GameData
+---
+identifier: PolishTranslationByReMakee
 $kref: '#/ckan/spacedock/3251'
 license: MIT
 tags:

--- a/NetKAN/PrakasaAeroworks.netkan
+++ b/NetKAN/PrakasaAeroworks.netkan
@@ -1,4 +1,8 @@
 identifier: PrakasaAeroworks
+$kref: '#/ckan/github/linuxgurugamer/PrakasaAeroworks'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: PrakasaAeroworks
 $kref: '#/ckan/spacedock/443'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-4.0

--- a/NetKAN/PreciseEditor.netkan
+++ b/NetKAN/PreciseEditor.netkan
@@ -1,4 +1,8 @@
 identifier: PreciseEditor
+$kref: '#/ckan/github/linuxgurugamer/PreciseEditor'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: PreciseEditor
 author:
   - jfrouleau
   - zolotiyeruki

--- a/NetKAN/PreciseNode.netkan
+++ b/NetKAN/PreciseNode.netkan
@@ -1,22 +1,24 @@
-{
-    "identifier"     : "PreciseNode",
-    "name"           : "Precise Node",
-    "abstract"       : "Provides a more precise widget for maneuver node editing",
-    "author"         : ["blizzy78", "linuxgurugamer"],
-    "$kref"          : "#/ckan/spacedock/1691",
-    "$vref"          : "#/ckan/ksp-avc",
-    "license"        : "BSD-2-clause",
-    "release_status" : "stable",
-    "tags": [
-        "plugin",
-        "information",
-        "convenience"
-    ],
-    "depends" : [
-        { "name" : "ClickThroughBlocker" }
-    ],
-    "install" : [ {
-        "find"       : "GameData/PreciseNode",
-        "install_to" : "GameData"
-    } ]
-}
+identifier: PreciseNode
+$kref: '#/ckan/github/linuxgurugamer/ksp-precisenode'
+$vref: '#/ckan/ksp-avc'
+license: BSD-2-clause
+---
+identifier: PreciseNode
+name: Precise Node
+abstract: Provides a more precise widget for maneuver node editing
+author:
+  - blizzy78
+  - linuxgurugamer
+$kref: '#/ckan/spacedock/1691'
+$vref: '#/ckan/ksp-avc'
+license: BSD-2-clause
+release_status: stable
+tags:
+  - plugin
+  - information
+  - convenience
+depends:
+  - name: ClickThroughBlocker
+install:
+  - find: GameData/PreciseNode
+    install_to: GameData

--- a/NetKAN/ProbeControlRoomRecontrolled.netkan
+++ b/NetKAN/ProbeControlRoomRecontrolled.netkan
@@ -1,4 +1,15 @@
 identifier: ProbeControlRoomRecontrolled
+$kref: '#/ckan/github/FirstPersonKSP/KSP-ProbeControlRoom'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ProbeControlRoom
+    install_to: GameData
+---
+identifier: ProbeControlRoomRecontrolled
 $kref: '#/ckan/spacedock/1558'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-3.0
@@ -6,9 +17,6 @@ tags:
   - plugin
   - uncrewed
   - first-person
-install:
-  - find: ProbeControlRoom
-    install_to: GameData
 depends:
   - name: ModuleManager
   - name: ToolbarController
@@ -22,3 +30,6 @@ suggests:
   - name: DockingPortAlignment
   - name: kOS
   - name: KPS-AVC
+install:
+  - find: ProbeControlRoom
+    install_to: GameData

--- a/NetKAN/QuackPack.netkan
+++ b/NetKAN/QuackPack.netkan
@@ -1,4 +1,11 @@
 identifier: QuackPack
+$kref: '#/ckan/github/jamespglaze/QuackPack'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+---
+identifier: QuackPack
 $kref: '#/ckan/spacedock/3136'
 license: CC-BY-NC-ND-3.0
 tags:

--- a/NetKAN/QuantumStrutsContinued.netkan
+++ b/NetKAN/QuantumStrutsContinued.netkan
@@ -1,18 +1,17 @@
-{
-    "identifier":   "QuantumStrutsContinued",
-    "$kref":        "#/ckan/spacedock/301",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "BSD-3-clause",
-    "tags": [
-        "plugin",
-        "physics"
-    ],
-    "install": [ {
-        "file":       "GameData/QuantumStrutsContinued",
-        "install_to": "GameData"
-    } ],
-    "suggests": [
-        { "name": "ModuleManager" },
-        { "name": "KAS"           }
-    ]
-}
+identifier: QuantumStrutsContinued
+$kref: '#/ckan/github/linuxgurugamer/QuantumStrutsContinued'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: QuantumStrutsContinued
+$kref: '#/ckan/spacedock/301'
+$vref: '#/ckan/ksp-avc'
+license: BSD-3-clause
+tags:
+  - plugin
+  - physics
+install:
+  - file: GameData/QuantumStrutsContinued
+    install_to: GameData
+suggests:
+  - name: ModuleManager
+  - name: KAS

--- a/NetKAN/QuizTechAeroPackContinued.netkan
+++ b/NetKAN/QuizTechAeroPackContinued.netkan
@@ -1,35 +1,32 @@
-{
-    "identifier":   "QuizTechAeroPackContinued",
-    "name" :        "QuizTech Aero Pack",
-    "$kref":        "#/ckan/spacedock/836",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-4.0",
-    "tags": [
-        "parts"
-    ],
-    "conflicts" : [
-        { "name" : "QuizTechAeroPack-internals" },
-        { "name" : "QuizTechAeroPack" }
-    ],
-    "depends" : [
-        { "name": "ModuleManager" },
-        { "name": "FirespitterCore" },
-        { "name": "BDAnimationModules" }
-    ],
-    "recommends": [
-        { "name": "RasterPropMonitor-Core" }
-    ],
-    "suggests"     : [
-        { "name": "RasterPropMonitor" },
-        { "name": "ThrottleControlledAvionics" },
-        { "name": "B9AerospaceProceduralParts" },
-        { "name": "AdjustableLandingGear" },
-        { "name": "Mk2Essentials" }
-    ],
-    "install": [
-        {
-            "find"       : "QuizTechAeroContinued",
-            "install_to" : "GameData"
-        }
-    ]
-}
+identifier: QuizTechAeroPackContinued
+$kref: '#/ckan/github/linuxgurugamer/QuizTechAeroPackContinued'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: QuizTechAeroContinued
+    install_to: GameData
+---
+identifier: QuizTechAeroPackContinued
+name: QuizTech Aero Pack
+$kref: '#/ckan/spacedock/836'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-4.0
+tags:
+  - parts
+conflicts:
+  - name: QuizTechAeroPack-internals
+  - name: QuizTechAeroPack
+depends:
+  - name: ModuleManager
+  - name: FirespitterCore
+  - name: BDAnimationModules
+recommends:
+  - name: RasterPropMonitor-Core
+suggests:
+  - name: RasterPropMonitor
+  - name: ThrottleControlledAvionics
+  - name: B9AerospaceProceduralParts
+  - name: AdjustableLandingGear
+  - name: Mk2Essentials
+install:
+  - find: QuizTechAeroContinued
+    install_to: GameData

--- a/NetKAN/RCSBuildAidCont.netkan
+++ b/NetKAN/RCSBuildAidCont.netkan
@@ -1,33 +1,37 @@
-{
-    "identifier": "RCSBuildAidCont",
-    "abstract": "This is something I made for placing RCS thrusters in the right positions in the first try without having to go back and forth between the VAB and the hacked gravity launchpad.  Features: Display thrust and torque forces caused by RCS or engines. Delta V readout for RCS. Dry center of mass marker. Average center of mass marker. Ability to resize editor's overlay markers. Display total mass of resources.",
-    "author": "linuxgurugamer",
-    "$kref":  "#/ckan/spacedock/1547",
-    "$vref": "#/ckan/ksp-avc",
-    "x_netkan_epoch": 1,
-    "license": "LGPL-3.0",
-    "resources": {
-        "manual": "https://github.com/linuxgurugamer/RCSBuildAid/blob/master/README.asciidoc"
-    },
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "supports": [
-        { "name": "KSP-AVC" }
-    ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ],
-    "conflicts": [
-        { "name" : "RCSBuildAid" }
-    ],
-    "install": [
-        {
-            "find": "RCSBuildAid",
-            "install_to": "GameData",
-            "filter": "Sources"
-        }
-    ]
-}
+identifier: RCSBuildAidCont
+$kref: '#/ckan/github/linuxgurugamer/RCSBuildAid'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: RCSBuildAid
+    install_to: GameData
+    filter: Sources
+---
+identifier: RCSBuildAidCont
+abstract: >-
+  This is something I made for placing RCS thrusters in the right positions
+  in the first try without having to go back and forth between the VAB and
+  the hacked gravity launchpad.  Features: Display thrust and torque forces
+  caused by RCS or engines. Delta V readout for RCS. Dry center of mass
+  marker. Average center of mass marker. Ability to resize editor's overlay
+  markers. Display total mass of resources.
+author: linuxgurugamer
+$kref: '#/ckan/spacedock/1547'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: 1
+license: LGPL-3.0
+resources:
+  manual: https://github.com/linuxgurugamer/RCSBuildAid/blob/master/README.asciidoc
+tags:
+  - plugin
+  - information
+supports:
+  - name: KSP-AVC
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+conflicts:
+  - name: RCSBuildAid
+install:
+  - find: RCSBuildAid
+    install_to: GameData
+    filter: Sources

--- a/NetKAN/REKT.netkan
+++ b/NetKAN/REKT.netkan
@@ -1,25 +1,26 @@
-{
-    "identifier":   "REKT",
-    "$kref":        "#/ckan/spacedock/1021",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts",
-        "crewed"
-    ],
-    "install": [ {
-        "find":       "SHED",
-        "install_to": "GameData",
-        "filter":     [ "Agencies", "License", "RetractableLiftingSurface" ]
-    } ],
-    "depends": [
-        { "name": "ModuleManager"             },
-        { "name": "RetractableLiftingSurface" },
-        { "name": "KSPWheel"                  }
-    ],
-    "recommends": [
-        { "name": "IndicatorLights"   },
-        { "name": "Landertron"        },
-        { "name": "RasterPropMonitor" }
-    ]
-}
+identifier: REKT
+$kref: '#/ckan/github/linuxgurugamer/REKT'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: REKT
+$kref: '#/ckan/spacedock/1021'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+  - crewed
+install:
+  - find: SHED
+    install_to: GameData
+    filter:
+      - Agencies
+      - License
+      - RetractableLiftingSurface
+depends:
+  - name: ModuleManager
+  - name: RetractableLiftingSurface
+  - name: KSPWheel
+recommends:
+  - name: IndicatorLights
+  - name: Landertron
+  - name: RasterPropMonitor

--- a/NetKAN/RFA-One.netkan
+++ b/NetKAN/RFA-One.netkan
@@ -1,4 +1,20 @@
 identifier: RFA-One
+$kref: '#/ckan/github/RFA-One/RFA-One'
+install:
+  - file: Kerbal Space Program/GameData/RFA
+    install_to: GameData
+  - file: Kerbal Space Program/Ships/VAB
+    install_to: Ships
+  - file: Kerbal Space Program/Ships/@thumbs
+    install_to: Ships
+  - find_regexp: saves/scenarios/.*\.sfs$
+    find_matches_files: true
+    install_to: Scenarios
+  - find_regexp: Missions/.*\.zip$
+    find_matches_files: true
+    install_to: Missions
+---
+identifier: RFA-One
 author: Rocket Factory Augsburg
 $kref: '#/ckan/spacedock/3044'
 license: CC-BY-NC-SA-4.0

--- a/NetKAN/RasterPropMonitor-Core.netkan
+++ b/NetKAN/RasterPropMonitor-Core.netkan
@@ -1,4 +1,16 @@
 identifier: RasterPropMonitor-Core
+$kref: '#/ckan/github/FirstPersonKSP/RasterPropMonitor'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: JSI/RasterPropMonitor
+    install_to: GameData/JSI
+  - find: JSI/RPMPodPatches/BasicMFD
+    install_to: GameData/JSI/RPMPodPatches
+    comment: >-
+      This folder contains the multi-function display props, which belong in
+      this module along with the other props
+---
+identifier: RasterPropMonitor-Core
 name: RasterPropMonitor Core
 abstract: Plugin and props for use in IVAs
 comment: This package contains the plugin, and the standard parts library.

--- a/NetKAN/RasterPropMonitor.netkan
+++ b/NetKAN/RasterPropMonitor.netkan
@@ -1,4 +1,19 @@
 identifier: RasterPropMonitor
+$kref: '#/ckan/github/FirstPersonKSP/RasterPropMonitor'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: '1'
+x_netkan_force_v: true
+install:
+  - find: JSI
+    filter:
+      - RasterPropMonitor
+      - BasicMFD
+      - README.md
+      - LICENSE.md
+      - Agencies
+    install_to: GameData
+---
+identifier: RasterPropMonitor
 name: RasterPropMonitor
 abstract: Modifies stock and some modded IVAs with functional props
 author:

--- a/NetKAN/RationalResources.netkan
+++ b/NetKAN/RationalResources.netkan
@@ -1,5 +1,11 @@
 identifier: RationalResources
-abstract: Makes resource placement no longer random but fit to composition templates. Promotes cryofuel mods and planet pack to life support compatibility.
+$kref: '#/ckan/github/JadeOfMaar/RationalResources'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: RationalResources
+abstract: >-
+  Makes resource placement no longer random but fit to composition templates.
+  Promotes cryofuel mods and planet pack to life support compatibility.
 $kref: '#/ckan/spacedock/2201'
 $vref: '#/ckan/ksp-avc'
 license: MIT

--- a/NetKAN/RationalResourcesAluminium.netkan
+++ b/NetKAN/RationalResourcesAluminium.netkan
@@ -1,4 +1,8 @@
 identifier: RationalResourcesAluminium
+$kref: '#/ckan/github/JadeOfMaar/RationalResources'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: RationalResourcesAluminium
 name: Rational Resources Aluminium
 abstract: >-
   Enables Aluminium in RR's Ore tanks, instead of Metal in RR's converters,

--- a/NetKAN/RationalResourcesBlacksmith.netkan
+++ b/NetKAN/RationalResourcesBlacksmith.netkan
@@ -1,4 +1,8 @@
 identifier: RationalResourcesBlacksmith
+$kref: '#/ckan/github/JadeOfMaar/RationalResources'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: RationalResourcesBlacksmith
 name: Rational Resources Blacksmith
 abstract: >-
   Enables the stock science lab (with engineers) to refill or transfer

--- a/NetKAN/RationalResourcesCompanion.netkan
+++ b/NetKAN/RationalResourcesCompanion.netkan
@@ -1,6 +1,12 @@
 identifier: RationalResourcesCompanion
+$kref: '#/ckan/github/JadeOfMaar/RationalResources'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: RationalResourcesCompanion
 name: Rational Resources Companion
-abstract: Diverse resource chains and easy opt-in systems to make ISRU parts compatible
+abstract: >-
+  Diverse resource chains and easy opt-in systems
+  to make ISRU parts compatible
 $kref: '#/ckan/spacedock/2201'
 $vref: '#/ckan/ksp-avc'
 license: MIT

--- a/NetKAN/RationalResourcesELUtilities.netkan
+++ b/NetKAN/RationalResourcesELUtilities.netkan
@@ -1,4 +1,8 @@
 identifier: RationalResourcesELUtilities
+$kref: '#/ckan/github/JadeOfMaar/RationalResources'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: RationalResourcesELUtilities
 name: Rational Resources EL Utilities
 abstract: Provides integrations for Extraplanetary Launchpads
 $kref: '#/ckan/spacedock/2201'

--- a/NetKAN/RationalResourcesJetFamily.netkan
+++ b/NetKAN/RationalResourcesJetFamily.netkan
@@ -1,4 +1,8 @@
 identifier: RationalResourcesJetFamily
+$kref: '#/ckan/github/JadeOfMaar/RationalResources'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: RationalResourcesJetFamily
 name: Rational Resources Jet Family
 abstract: >-
   Enables fuel switching in air-breathing engines.

--- a/NetKAN/RationalResourcesKerbalism.netkan
+++ b/NetKAN/RationalResourcesKerbalism.netkan
@@ -1,4 +1,8 @@
 identifier: RationalResourcesKerbalism
+$kref: '#/ckan/github/JadeOfMaar/RationalResources'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: RationalResourcesKerbalism
 name: Rational Resources Kerbalism
 abstract: Kerbalism integration
 $kref: '#/ckan/spacedock/2201'

--- a/NetKAN/RationalResourcesKerbalismRF.netkan
+++ b/NetKAN/RationalResourcesKerbalismRF.netkan
@@ -1,4 +1,8 @@
 identifier: RationalResourcesKerbalismRF
+$kref: '#/ckan/github/JadeOfMaar/RationalResources'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: RationalResourcesKerbalismRF
 name: Rational Resources Kerbalism + RealFuels
 abstract: Kerbalism & RealFuels integration
 $kref: '#/ckan/spacedock/2201'

--- a/NetKAN/RationalResourcesNuclearFamily.netkan
+++ b/NetKAN/RationalResourcesNuclearFamily.netkan
@@ -1,4 +1,8 @@
 identifier: RationalResourcesNuclearFamily
+$kref: '#/ckan/github/JadeOfMaar/RationalResources'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: RationalResourcesNuclearFamily
 name: Rational Resources Nuclear Family
 abstract: >-
   Enables fuel switching and Kerbalism radioactivity in supported NTRs.

--- a/NetKAN/RationalResourcesParts.netkan
+++ b/NetKAN/RationalResourcesParts.netkan
@@ -1,6 +1,12 @@
 identifier: RationalResourcesParts
+$kref: '#/ckan/github/JadeOfMaar/RationalResources'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: RationalResourcesParts
 name: Rational Resources Parts
-abstract: Provides dedicated parts. Some are demos for concept tech. Some are niche ISRU parts.
+abstract: >-
+  Provides dedicated parts. Some are demos for concept tech. Some are niche
+  ISRU parts.
 $kref: '#/ckan/spacedock/2201'
 $vref: '#/ckan/ksp-avc'
 license: MIT

--- a/NetKAN/RationalResourcesRCSFamily.netkan
+++ b/NetKAN/RationalResourcesRCSFamily.netkan
@@ -1,4 +1,8 @@
 identifier: RationalResourcesRCSFamily
+$kref: '#/ckan/github/JadeOfMaar/RationalResources'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: RationalResourcesRCSFamily
 name: Rational Resources RCS Family
 abstract: Enables fuel switching in supported MonoPropellant or LFO RCS
 $kref: '#/ckan/spacedock/2201'

--- a/NetKAN/RationalResourcesSSPXRTanks.netkan
+++ b/NetKAN/RationalResourcesSSPXRTanks.netkan
@@ -1,4 +1,8 @@
 identifier: RationalResourcesSSPXRTanks
+$kref: '#/ckan/github/JadeOfMaar/RationalResources'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: RationalResourcesSSPXRTanks
 name: Rational Resources SSPXR Tanks
 abstract: Adds RR Ore tank options to SSPXR's payload tanks
 $kref: '#/ckan/spacedock/2201'

--- a/NetKAN/RationalResourcesSquad.netkan
+++ b/NetKAN/RationalResourcesSquad.netkan
@@ -1,4 +1,8 @@
 identifier: RationalResourcesSquad
+$kref: '#/ckan/github/JadeOfMaar/RationalResources'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: RationalResourcesSquad
 name: Rational Resources Squad
 abstract: >-
   Provides fuel switching in the stock tanks, the stock jet engines, and

--- a/NetKAN/RationalResourcesTACLS.netkan
+++ b/NetKAN/RationalResourcesTACLS.netkan
@@ -1,4 +1,8 @@
 identifier: RationalResourcesTACLS
+$kref: '#/ckan/github/JadeOfMaar/RationalResources'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: RationalResourcesTACLS
 name: Rational Resources TAC LS
 abstract: >-
   Changes TAC converters in supported mods to produce less abstract Waste

--- a/NetKAN/ReCoupler.netkan
+++ b/NetKAN/ReCoupler.netkan
@@ -1,18 +1,21 @@
-{
-    "identifier":   "ReCoupler",
-    "$kref":        "#/ckan/spacedock/1250",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "physics"
-    ],
-    "x_netkan_epoch": 1,
-    "x_netkan_override": [ {
-        "version": "1:1.3.1",
-        "delete":  [ "ksp_version" ],
-        "override": {
-            "ksp_version_min": "1.3",
-            "ksp_version_max": "1.4"
-        }
-    } ]
-}
+identifier: ReCoupler
+$kref: '#/ckan/github/DBooots/ReCoupler'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+---
+identifier: ReCoupler
+$kref: '#/ckan/spacedock/1250'
+license: MIT
+tags:
+  - plugin
+  - physics
+x_netkan_epoch: 1
+x_netkan_override:
+  - version: 1:1.3.1
+    delete:
+      - ksp_version
+    override:
+      ksp_version_min: '1.3'
+      ksp_version_max: '1.4'

--- a/NetKAN/RealTimeClock2.netkan
+++ b/NetKAN/RealTimeClock2.netkan
@@ -1,17 +1,20 @@
-{
-    "identifier":   "RealTimeClock2",
-    "name":         "Real Time Clock 2",
-    "abstract":     "In-game clock",
-    "author":       [ "Li0n", "linuxgurugamer" ],
-    "$kref":        "#/ckan/spacedock/2237",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_force_v": true,
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "depends": [
-        { "name": "ClickThroughBlocker" }
-    ]
-}
+identifier: RealTimeClock2
+$kref: '#/ckan/github/linuxgurugamer/Real-Time-Clock-2'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+---
+identifier: RealTimeClock2
+name: Real Time Clock 2
+abstract: In-game clock
+author:
+  - Li0n
+  - linuxgurugamer
+$kref: '#/ckan/spacedock/2237'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+license: GPL-3.0
+tags:
+  - plugin
+  - information
+depends:
+  - name: ClickThroughBlocker

--- a/NetKAN/ReasonableScienceReturn.netkan
+++ b/NetKAN/ReasonableScienceReturn.netkan
@@ -1,4 +1,7 @@
 identifier: ReasonableScienceReturn
+$kref: '#/ckan/github/Michionlion/ReasonableScienceReturn'
+---
+identifier: ReasonableScienceReturn
 $kref: '#/ckan/spacedock/3171'
 license: MIT
 tags:

--- a/NetKAN/RecoveryController.netkan
+++ b/NetKAN/RecoveryController.netkan
@@ -1,17 +1,19 @@
-{
-    "identifier":   "RecoveryController",
-    "$kref":        "#/ckan/spacedock/1311",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "career"
-    ],
-    "install": [ {
-        "find":       "RecoveryController",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ]
-}
+identifier: RecoveryController
+$kref: '#/ckan/github/linuxgurugamer/RecoveryController'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: RecoveryController
+    install_to: GameData
+---
+identifier: RecoveryController
+$kref: '#/ckan/spacedock/1311'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - career
+depends:
+  - name: ModuleManager
+install:
+  - find: RecoveryController
+    install_to: GameData

--- a/NetKAN/RecycledParts.netkan
+++ b/NetKAN/RecycledParts.netkan
@@ -1,4 +1,8 @@
 identifier: RecycledParts
+$kref: '#/ckan/github/linuxgurugamer/RecycledParts'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: RecycledParts
 name: Recycled Parts
 $kref: '#/ckan/spacedock/1507'
 $vref: '#/ckan/ksp-avc'

--- a/NetKAN/RecycledPartsAtomicAge.netkan
+++ b/NetKAN/RecycledPartsAtomicAge.netkan
@@ -1,31 +1,32 @@
-{
-    "identifier":   "RecycledPartsAtomicAge",
-    "name":         "Recycled Parts Atomic Age",
-    "$kref":        "#/ckan/spacedock/1507",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "restricted",
-    "tags": [
-        "parts"
-    ],
-    "install": [ {
-        "find":       "SpaceTuxIndustries/RecycledParts/AtomicAge",
-        "install_to": "GameData/SpaceTuxIndustries/RecycledParts"
-    }, {
-        "find":       "SPH/A Nuke Cruiser-Skalou-03.craft",
-        "install_to": "Ships/SPH",
-        "find_matches_files": true
-    } ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "CommunityTechTree" }
-    ],
-    "suggests": [
-        { "name": "JanitorsCloset" }
-    ],
-    "conflicts": [
-        { "name" : "AtomicAge" },
-        { "name" : "RecycledPartsAtomicAge" }
-    ]
-}
+identifier: RecycledPartsAtomicAge
+$kref: '#/ckan/github/linuxgurugamer/RecycledParts'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: SpaceTuxIndustries/RecycledParts/AtomicAge
+    install_to: GameData/SpaceTuxIndustries/RecycledParts
+  - find: SPH/A Nuke Cruiser-Skalou-03.craft
+    install_to: Ships/SPH
+    find_matches_files: true
+---
+identifier: RecycledPartsAtomicAge
+name: Recycled Parts Atomic Age
+$kref: '#/ckan/spacedock/1507'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+recommends:
+  - name: CommunityTechTree
+suggests:
+  - name: JanitorsCloset
+conflicts:
+  - name: AtomicAge
+  - name: RecycledPartsAtomicAge
+install:
+  - find: SpaceTuxIndustries/RecycledParts/AtomicAge
+    install_to: GameData/SpaceTuxIndustries/RecycledParts
+  - find: SPH/A Nuke Cruiser-Skalou-03.craft
+    install_to: Ships/SPH
+    find_matches_files: true

--- a/NetKAN/RecycledPartsBDMk22Lightning.netkan
+++ b/NetKAN/RecycledPartsBDMk22Lightning.netkan
@@ -1,32 +1,30 @@
-{
-    "identifier":   "RecycledPartsBDMk22Lightning",
-    "name":         "Recycled Parts BDM Mk22 Lightning",
-    "$kref":        "#/ckan/spacedock/1507",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "restricted",
-    "tags": [
-        "parts"
-    ],
-    "install": [
-        {
-            "find": "BDMk22",
-            "install_to": "GameData/SpaceTuxIndustries/RecycledParts"
-        },
-        {
-            "find": "Plugins",
-            "install_to": "GameData/SpaceTuxIndustries"
-        }
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "ASETProps" },
-        { "name": "RasterPropMonitor-Core" }
-    ],
-    "suggests": [
-        { "name": "JanitorsCloset" }
-    ],
-    "conflicts": [
-        { "name" : "RecycledPartsBDMk22Lightning" },
-        { "name" : "BDynamicsMk22Cockpits" }
-    ]
-}
+identifier: RecycledPartsBDMk22Lightning
+$kref: '#/ckan/github/linuxgurugamer/RecycledParts'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: BDMk22
+    install_to: GameData/SpaceTuxIndustries/RecycledParts
+  - find: Plugins
+    install_to: GameData/SpaceTuxIndustries
+---
+identifier: RecycledPartsBDMk22Lightning
+name: Recycled Parts BDM Mk22 Lightning
+$kref: '#/ckan/spacedock/1507'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+  - name: ASETProps
+  - name: RasterPropMonitor-Core
+suggests:
+  - name: JanitorsCloset
+conflicts:
+  - name: RecycledPartsBDMk22Lightning
+  - name: BDynamicsMk22Cockpits
+install:
+  - find: BDMk22
+    install_to: GameData/SpaceTuxIndustries/RecycledParts
+  - find: Plugins
+    install_to: GameData/SpaceTuxIndustries

--- a/NetKAN/RecycledPartsFTmNAtomicRockets.netkan
+++ b/NetKAN/RecycledPartsFTmNAtomicRockets.netkan
@@ -1,13 +1,17 @@
 identifier: RecycledPartsFTmNAtomicRockets
+$kref: '#/ckan/github/linuxgurugamer/RecycledParts'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ftmn
+    install_to: GameData/SpaceTuxIndustries/RecycledParts
+---
+identifier: RecycledPartsFTmNAtomicRockets
 name: Recycled Parts FTmN Atomic Rockets
 $kref: '#/ckan/spacedock/1507'
 $vref: '#/ckan/ksp-avc'
 license: restricted
 tags:
   - parts
-install:
-  - find: ftmn
-    install_to: GameData/SpaceTuxIndustries/RecycledParts
 depends:
   - name: ModuleManager
   - name: BDAnimationModules
@@ -19,3 +23,6 @@ suggests:
   - name: JanitorsCloset
 conflicts:
   - name: RecycledPartsFTmNAtomicRockets
+install:
+  - find: ftmn
+    install_to: GameData/SpaceTuxIndustries/RecycledParts

--- a/NetKAN/RecycledPartsFTmNImprovedAtomicRockets.netkan
+++ b/NetKAN/RecycledPartsFTmNImprovedAtomicRockets.netkan
@@ -1,13 +1,17 @@
 identifier: RecycledPartsFTmNImprovedAtomicRockets
+$kref: '#/ckan/github/linuxgurugamer/RecycledParts'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ftmn_new
+    install_to: GameData/SpaceTuxIndustries/RecycledParts
+---
+identifier: RecycledPartsFTmNImprovedAtomicRockets
 name: Recycled Parts FTmN Improved Atomic Rockets
 $kref: '#/ckan/spacedock/1507'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-3.0
 tags:
   - parts
-install:
-  - find: ftmn_new
-    install_to: GameData/SpaceTuxIndustries/RecycledParts
 depends:
   - name: ModuleManager
   - name: BDAnimationModules
@@ -19,3 +23,6 @@ suggests:
   - name: JanitorsCloset
 conflicts:
   - name: RecycledPartsFTmNImprovedAtomicRockets
+install:
+  - find: ftmn_new
+    install_to: GameData/SpaceTuxIndustries/RecycledParts

--- a/NetKAN/RecycledPartsFarscape.netkan
+++ b/NetKAN/RecycledPartsFarscape.netkan
@@ -1,32 +1,35 @@
-{
-    "identifier":   "RecycledPartsFarscape",
-    "name":         "Recycled Parts Farscape",
-    "$kref":        "#/ckan/spacedock/1507",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "restricted",
-    "tags": [
-        "parts"
-    ],
-    "install": [ {
-        "find":       "Mike_NZ_Crafts",
-        "install_to": "GameData/SpaceTuxIndustries/RecycledParts"
-    }, {
-        "find":       "SPH",
-        "install_to": "Ships",
-        "filter":     [ "A Nuke Cruiser-Skalou-03.craft" ]
-    } ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "KSPWheel"      },
-        { "name": "PatchManager"  }
-    ],
-    "recommends": [
-        { "name": "CommunityTechTree" }
-    ],
-    "suggests": [
-        { "name": "JanitorsCloset" }
-    ],
-    "conflicts": [
-        { "name" : "RecycledPartsFarscape" }
-    ]
-}
+identifier: RecycledPartsFarscape
+$kref: '#/ckan/github/linuxgurugamer/RecycledParts'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: Mike_NZ_Crafts
+    install_to: GameData/SpaceTuxIndustries/RecycledParts
+  - find: SPH
+    install_to: Ships
+    filter:
+      - A Nuke Cruiser-Skalou-03.craft
+---
+identifier: RecycledPartsFarscape
+name: Recycled Parts Farscape
+$kref: '#/ckan/spacedock/1507'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+  - name: KSPWheel
+  - name: PatchManager
+recommends:
+  - name: CommunityTechTree
+suggests:
+  - name: JanitorsCloset
+conflicts:
+  - name: RecycledPartsFarscape
+install:
+  - find: Mike_NZ_Crafts
+    install_to: GameData/SpaceTuxIndustries/RecycledParts
+  - find: SPH
+    install_to: Ships
+    filter:
+      - A Nuke Cruiser-Skalou-03.craft

--- a/NetKAN/RecycledPartsLVNClusters.netkan
+++ b/NetKAN/RecycledPartsLVNClusters.netkan
@@ -1,13 +1,17 @@
 identifier: RecycledPartsLVNClusters
+$kref: '#/ckan/github/linuxgurugamer/RecycledParts'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: LVN_Clusters
+    install_to: GameData/SpaceTuxIndustries/RecycledParts
+---
+identifier: RecycledPartsLVNClusters
 name: Recycled Parts LVN Clusters
 $kref: '#/ckan/spacedock/1507'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-3.0
 tags:
   - parts
-install:
-  - find: LVN_Clusters
-    install_to: GameData/SpaceTuxIndustries/RecycledParts
 depends:
   - name: ModuleManager
   - name: BDAnimationModules
@@ -20,3 +24,6 @@ suggests:
 conflicts:
   - name: RecycledPartsLVNClusters
   - name: LVNNuclearEngineClusters
+install:
+  - find: LVN_Clusters
+    install_to: GameData/SpaceTuxIndustries/RecycledParts

--- a/NetKAN/RecycledPartsMk2Essentials.netkan
+++ b/NetKAN/RecycledPartsMk2Essentials.netkan
@@ -1,24 +1,24 @@
-{
-    "identifier":   "RecycledPartsMk2Essentials",
-    "name":         "Recycled Parts Mk2 Essentials",
-    "$kref":        "#/ckan/spacedock/1507",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "restricted",
-    "tags": [
-        "parts"
-    ],
-    "install": [ {
-        "find": "Mk2Essentials",
-        "install_to": "GameData/SpaceTuxIndustries/RecycledParts"
-    } ],
-    "recommends": [
-        { "name": "CommunityTechTree" }
-    ],
-    "suggests": [
-        { "name": "JanitorsCloset" }
-    ],
-    "conflicts": [
-        { "name" : "Mk2Essentials" },
-        { "name" : "RecycledPartsMk2Essentials" }
-    ]
-}
+identifier: RecycledPartsMk2Essentials
+$kref: '#/ckan/github/linuxgurugamer/RecycledParts'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: Mk2Essentials
+    install_to: GameData/SpaceTuxIndustries/RecycledParts
+---
+identifier: RecycledPartsMk2Essentials
+name: Recycled Parts Mk2 Essentials
+$kref: '#/ckan/spacedock/1507'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+tags:
+  - parts
+recommends:
+  - name: CommunityTechTree
+suggests:
+  - name: JanitorsCloset
+conflicts:
+  - name: Mk2Essentials
+  - name: RecycledPartsMk2Essentials
+install:
+  - find: Mk2Essentials
+    install_to: GameData/SpaceTuxIndustries/RecycledParts

--- a/NetKAN/RecycledPartsMk2KISContainers.netkan
+++ b/NetKAN/RecycledPartsMk2KISContainers.netkan
@@ -1,20 +1,21 @@
-{
-    "identifier":   "RecycledPartsMk2KISContainers",
-    "name":         "Recycled Parts Mk2 KIS Containers",
-    "$kref":        "#/ckan/spacedock/1507",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "restricted",
-    "tags": [
-        "parts"
-    ],
-    "install": [ {
-        "find": "Mk2Containers",
-        "install_to": "GameData/SpaceTuxIndustries/RecycledParts"
-    } ],
-    "suggests": [
-        { "name": "JanitorsCloset" }
-    ],
-    "conflicts": [
-        { "name" : "RecycledPartsMk2KISContainers" }
-    ]
-}
+identifier: RecycledPartsMk2KISContainers
+$kref: '#/ckan/github/linuxgurugamer/RecycledParts'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: Mk2Containers
+    install_to: GameData/SpaceTuxIndustries/RecycledParts
+---
+identifier: RecycledPartsMk2KISContainers
+name: Recycled Parts Mk2 KIS Containers
+$kref: '#/ckan/spacedock/1507'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+tags:
+  - parts
+suggests:
+  - name: JanitorsCloset
+conflicts:
+  - name: RecycledPartsMk2KISContainers
+install:
+  - find: Mk2Containers
+    install_to: GameData/SpaceTuxIndustries/RecycledParts

--- a/NetKAN/RecycledPartsMk2Lightning.netkan
+++ b/NetKAN/RecycledPartsMk2Lightning.netkan
@@ -1,28 +1,26 @@
-{
-    "identifier":   "RecycledPartsMk2Lightning",
-    "name":         "Recycled Parts Mk2 Lightning",
-    "$kref":        "#/ckan/spacedock/1507",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "restricted",
-    "tags": [
-        "parts"
-    ],
-    "install": [
-        {
-            "find": "BahaSP",
-            "install_to": "GameData/SpaceTuxIndustries/RecycledParts"
-        }
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "ASETProps" },
-        { "name": "RasterPropMonitor-Core" }
-    ],
-    "suggests": [
-        { "name": "JanitorsCloset" }
-    ],
-    "conflicts": [
-        { "name" : "RecycledPartsMk2Lightning" },
-        { "name" : "BDynamicsMk22Cockpits" }
-    ]
-}
+identifier: RecycledPartsMk2Lightning
+$kref: '#/ckan/github/linuxgurugamer/RecycledParts'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: BahaSP
+    install_to: GameData/SpaceTuxIndustries/RecycledParts
+---
+identifier: RecycledPartsMk2Lightning
+name: Recycled Parts Mk2 Lightning
+$kref: '#/ckan/spacedock/1507'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+  - name: ASETProps
+  - name: RasterPropMonitor-Core
+suggests:
+  - name: JanitorsCloset
+conflicts:
+  - name: RecycledPartsMk2Lightning
+  - name: BDynamicsMk22Cockpits
+install:
+  - find: BahaSP
+    install_to: GameData/SpaceTuxIndustries/RecycledParts

--- a/NetKAN/RecycledPartsMk2SolarBatteries.netkan
+++ b/NetKAN/RecycledPartsMk2SolarBatteries.netkan
@@ -1,20 +1,21 @@
-{
-    "identifier":   "RecycledPartsMk2SolarBatteries",
-    "name":         "Recycled Parts Mk2 Solar Batteries",
-    "$kref":        "#/ckan/spacedock/1507",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "restricted",
-    "tags": [
-        "parts"
-    ],
-    "install": [ {
-        "find": "Mk2SolarBatteries",
-        "install_to": "GameData/SpaceTuxIndustries/RecycledParts"
-    } ],
-    "suggests": [
-        { "name": "JanitorsCloset" }
-    ],
-    "conflicts": [
-        { "name" : "RecycledPartsMk2SolarBatteries" }
-    ]
-}
+identifier: RecycledPartsMk2SolarBatteries
+$kref: '#/ckan/github/linuxgurugamer/RecycledParts'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: Mk2SolarBatteries
+    install_to: GameData/SpaceTuxIndustries/RecycledParts
+---
+identifier: RecycledPartsMk2SolarBatteries
+name: Recycled Parts Mk2 Solar Batteries
+$kref: '#/ckan/spacedock/1507'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+tags:
+  - parts
+suggests:
+  - name: JanitorsCloset
+conflicts:
+  - name: RecycledPartsMk2SolarBatteries
+install:
+  - find: Mk2SolarBatteries
+    install_to: GameData/SpaceTuxIndustries/RecycledParts

--- a/NetKAN/RecycledPartsOrgamiFoldableAssets.netkan
+++ b/NetKAN/RecycledPartsOrgamiFoldableAssets.netkan
@@ -1,20 +1,21 @@
-{
-    "identifier":   "RecycledPartsOrgamiFoldableAssets",
-    "name":         "Recycled Parts Orgami Foldable Assets",
-    "$kref":        "#/ckan/spacedock/1507",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "restricted",
-    "tags": [
-        "parts"
-    ],
-    "install": [ {
-        "find":       "NAU",
-        "install_to": "GameData/SpaceTuxIndustries/RecycledParts"
-    } ],
-    "conflicts": [
-        { "name" : "RecycledPartsOrgamiFoldableAssets" }
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ]
-}
+identifier: RecycledPartsOrgamiFoldableAssets
+$kref: '#/ckan/github/linuxgurugamer/RecycledParts'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: NAU
+    install_to: GameData/SpaceTuxIndustries/RecycledParts
+---
+identifier: RecycledPartsOrgamiFoldableAssets
+name: Recycled Parts Orgami Foldable Assets
+$kref: '#/ckan/spacedock/1507'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+tags:
+  - parts
+conflicts:
+  - name: RecycledPartsOrgamiFoldableAssets
+depends:
+  - name: ModuleManager
+install:
+  - find: NAU
+    install_to: GameData/SpaceTuxIndustries/RecycledParts

--- a/NetKAN/RecycledPartsRSCapsuledyne.netkan
+++ b/NetKAN/RecycledPartsRSCapsuledyne.netkan
@@ -1,28 +1,27 @@
-{
-    "identifier":   "RecycledPartsRSCapsuledyne",
-    "name":         "Recycled Parts RSCapsuledyne",
-    "$kref":        "#/ckan/spacedock/1507",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "restricted",
-    "tags": [
-        "parts"
-    ],
-    "install": [ {
-        "find": "RSCapsuledyne",
-        "install_to": "GameData/SpaceTuxIndustries/RecycledParts"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "BDAnimationModules" }
-    ],
-    "recommends": [
-        { "name": "CommunityTechTree" }
-    ],
-    "suggests": [
-        { "name": "JanitorsCloset" }
-    ],
-    "conflicts": [
-        { "name" : "RandSCapsuledyne" },
-        { "name" : "RecycledPartsRSCapsuledyne" }
-    ]
-}
+identifier: RecycledPartsRSCapsuledyne
+$kref: '#/ckan/github/linuxgurugamer/RecycledParts'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: RSCapsuledyne
+    install_to: GameData/SpaceTuxIndustries/RecycledParts
+---
+identifier: RecycledPartsRSCapsuledyne
+name: Recycled Parts RSCapsuledyne
+$kref: '#/ckan/spacedock/1507'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+  - name: BDAnimationModules
+recommends:
+  - name: CommunityTechTree
+suggests:
+  - name: JanitorsCloset
+conflicts:
+  - name: RandSCapsuledyne
+  - name: RecycledPartsRSCapsuledyne
+install:
+  - find: RSCapsuledyne
+    install_to: GameData/SpaceTuxIndustries/RecycledParts

--- a/NetKAN/RecycledPartsSpareParts.netkan
+++ b/NetKAN/RecycledPartsSpareParts.netkan
@@ -1,26 +1,25 @@
-{
-    "identifier":   "RecycledPartsSpareParts",
-    "name":         "Recycled Parts Spare Parts",
-    "$kref":        "#/ckan/spacedock/1507",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "restricted",
-    "tags": [
-        "parts"
-    ],
-    "install": [ {
-        "find":       "Clockwork_Industries",
-        "install_to": "GameData/SpaceTuxIndustries/RecycledParts"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "CommunityTechTree" }
-    ],
-    "suggests": [
-        { "name": "JanitorsCloset" }
-    ],
-    "conflicts": [
-        { "name" : "RecycledPartsSpareParts" }
-    ]
-}
+identifier: RecycledPartsSpareParts
+$kref: '#/ckan/github/linuxgurugamer/RecycledParts'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: Clockwork_Industries
+    install_to: GameData/SpaceTuxIndustries/RecycledParts
+---
+identifier: RecycledPartsSpareParts
+name: Recycled Parts Spare Parts
+$kref: '#/ckan/spacedock/1507'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+recommends:
+  - name: CommunityTechTree
+suggests:
+  - name: JanitorsCloset
+conflicts:
+  - name: RecycledPartsSpareParts
+install:
+  - find: Clockwork_Industries
+    install_to: GameData/SpaceTuxIndustries/RecycledParts

--- a/NetKAN/RecycledPartskal9000.netkan
+++ b/NetKAN/RecycledPartskal9000.netkan
@@ -1,20 +1,21 @@
-{
-    "identifier":   "RecycledPartskal9000",
-    "name":         "Recycled Parts KAL-9000",
-    "$kref":        "#/ckan/spacedock/1507",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "restricted",
-    "tags": [
-        "parts"
-    ],
-    "install": [ {
-        "find": "KAL9000",
-        "install_to": "GameData/SpaceTuxIndustries/RecycledParts"
-    } ],
-    "suggests": [
-        { "name": "JanitorsCloset" }
-    ],
-    "conflicts": [
-        { "name" : "RecycledPartskal9000" }
-    ]
-}
+identifier: RecycledPartskal9000
+$kref: '#/ckan/github/linuxgurugamer/RecycledParts'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: KAL9000
+    install_to: GameData/SpaceTuxIndustries/RecycledParts
+---
+identifier: RecycledPartskal9000
+name: Recycled Parts KAL-9000
+$kref: '#/ckan/spacedock/1507'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+tags:
+  - parts
+suggests:
+  - name: JanitorsCloset
+conflicts:
+  - name: RecycledPartskal9000
+install:
+  - find: KAL9000
+    install_to: GameData/SpaceTuxIndustries/RecycledParts

--- a/NetKAN/ReentryParticleEffect.netkan
+++ b/NetKAN/ReentryParticleEffect.netkan
@@ -1,16 +1,21 @@
-{
-    "identifier":   "ReentryParticleEffect",
-    "$kref":        "#/ckan/spacedock/2373",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-2.0",
-    "tags": [
-        "plugin",
-        "graphics"
-    ],
-    "install": [
-        {
-            "find":       "GameData/ReentryParticleEffectRenewed",
-            "install_to": "GameData"
-        }
-    ]
-}
+identifier: ReentryParticleEffect
+$kref: '#/ckan/github/leatherneck6017/ReentryParticleEffectRenewed'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: GameData/ReentryParticleEffectRenewed
+    install_to: GameData
+---
+identifier: ReentryParticleEffect
+$kref: '#/ckan/spacedock/2373'
+$vref: '#/ckan/ksp-avc'
+license: GPL-2.0
+tags:
+  - plugin
+  - graphics
+install:
+  - find: GameData/ReentryParticleEffectRenewed
+    install_to: GameData

--- a/NetKAN/RemoteTech.netkan
+++ b/NetKAN/RemoteTech.netkan
@@ -1,26 +1,26 @@
-{
-    "identifier":   "RemoteTech",
-    "author":       "Remote Technologies Group",
-    "$kref":        "#/ckan/spacedock/520",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_force_v": true,
-    "release_status": "stable",
-    "license":      "GPL-2.0",
-    "tags": [
-        "plugin",
-        "control",
-        "uncrewed",
-        "comms"
-    ],
-    "depends": [
-        {
-            "name": "ModuleManager",
-            "min_version": "2.3.1",
-            "comment": "Earlier versions of MM have forward compatibility problems, according to the MM release notes."
-        }
-    ],
-    "install": [ {
-        "file": "GameData/RemoteTech",
-        "install_to": "GameData"
-    } ]
-}
+identifier: RemoteTech
+$kref: '#/ckan/github/RemoteTechnologiesGroup/RemoteTech'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+---
+identifier: RemoteTech
+author: Remote Technologies Group
+$kref: '#/ckan/spacedock/520'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+release_status: stable
+license: GPL-2.0
+tags:
+  - plugin
+  - control
+  - uncrewed
+  - comms
+depends:
+  - name: ModuleManager
+    min_version: 2.3.1
+    comment: >-
+      Earlier versions of MM have forward compatibility problems, according
+      to the MM release notes.
+install:
+  - file: GameData/RemoteTech
+    install_to: GameData

--- a/NetKAN/RemoteTechRedevAntennas.netkan
+++ b/NetKAN/RemoteTechRedevAntennas.netkan
@@ -1,32 +1,32 @@
-{
-    "identifier"   : "RemoteTechRedevAntennas",
-    "name"         : "RemoteTech Redev Antennas",
-    "abstract"     : "Standalone and optional antenna package of RemoteTech Redev for Kerbal Space Program's stock CommNet",
-    "$kref"        : "#/ckan/spacedock/1929",
-    "$vref"        : "#/ckan/ksp-avc",
-    "license"      : "GPL-3.0",
-    "tags": [
-        "parts",
-        "comms"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "install": [
-        {
-            "file": "GameData/RemoteTechRedev",
-            "install_to": "GameData"
-        }
-    ],
-    "conflicts": [
-        { "name": "RemoteTech" }
-    ],
-    "x_netkan_override": [ {
-        "version": "0.1",
-        "delete":  [ "ksp_version" ],
-        "override": {
-            "ksp_version_min": "1.3",
-            "ksp_version_max": "1.4"
-        }
-    } ]
-}
+identifier: RemoteTechRedevAntennas
+$kref: '#/ckan/github/RemoteTechnologiesGroup/RemoteTech-Antennas'
+$vref: '#/ckan/ksp-avc'
+install:
+  - file: GameData/RemoteTechRedev
+    install_to: GameData
+---
+identifier: RemoteTechRedevAntennas
+name: RemoteTech Redev Antennas
+abstract: >-
+  Standalone and optional antenna package of RemoteTech Redev for Kerbal Space
+  Program's stock CommNet
+$kref: '#/ckan/spacedock/1929'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - parts
+  - comms
+depends:
+  - name: ModuleManager
+conflicts:
+  - name: RemoteTech
+x_netkan_override:
+  - version: '0.1'
+    delete:
+      - ksp_version
+    override:
+      ksp_version_min: '1.3'
+      ksp_version_max: '1.4'
+install:
+  - file: GameData/RemoteTechRedev
+    install_to: GameData

--- a/NetKAN/ResearchAdvancementDivision.netkan
+++ b/NetKAN/ResearchAdvancementDivision.netkan
@@ -1,4 +1,15 @@
 identifier: ResearchAdvancementDivision
+$kref: '#/ckan/github/Morphisor244/Research-Advancement-Division'
+x_netkan_version_edit:
+  find: ^V
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ContractPacks
+    install_to: GameData
+---
+identifier: ResearchAdvancementDivision
 $kref: '#/ckan/spacedock/2929'
 license: CC-BY-NC-SA
 $vref: '#/ckan/ksp-avc'

--- a/NetKAN/ResearchBodies.netkan
+++ b/NetKAN/ResearchBodies.netkan
@@ -1,27 +1,29 @@
-{
-    "identifier":   "ResearchBodies",
-    "$kref":        "#/ckan/spacedock/684",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "x_netkan_epoch": 2,
-    "tags": [
-        "plugin",
-        "parts",
-        "career"
-    ],
-    "suggests": [
-        { "name": "AsteroidDay" }
-    ],
-    "depends": [
-        { "name": "ModuleManager"         },
-        { "name": "ContractConfigurator"  },
-        { "name": "REPOSoftTech-Agencies" }
-    ],
-    "install": [ {
-        "find":       "ResearchBodies",
-        "install_to": "GameData/REPOSoftTech"
-    }, {
-        "find":       "ProgressiveCBMaps",
-        "install_to": "GameData/REPOSoftTech"
-    } ]
-}
+identifier: ResearchBodies
+$kref: '#/ckan/github/JPLRepo/ResearchBodies'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ResearchBodies
+    install_to: GameData/REPOSoftTech
+  - find: ProgressiveCBMaps
+    install_to: GameData/REPOSoftTech
+---
+identifier: ResearchBodies
+$kref: '#/ckan/spacedock/684'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+x_netkan_epoch: 2
+tags:
+  - plugin
+  - parts
+  - career
+suggests:
+  - name: AsteroidDay
+depends:
+  - name: ModuleManager
+  - name: ContractConfigurator
+  - name: REPOSoftTech-Agencies
+install:
+  - find: ResearchBodies
+    install_to: GameData/REPOSoftTech
+  - find: ProgressiveCBMaps
+    install_to: GameData/REPOSoftTech

--- a/NetKAN/ResonantOrbitCalculator.netkan
+++ b/NetKAN/ResonantOrbitCalculator.netkan
@@ -1,18 +1,17 @@
-{
-    "identifier":   "ResonantOrbitCalculator",
-    "license":      "MIT",
-    "$kref":        "#/ckan/spacedock/1954",
-    "$vref":        "#/ckan/ksp-avc",
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "install": [ {
-        "find":       "ResonantOrbitCalculator",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ToolbarController"   },
-        { "name": "ClickThroughBlocker" }
-    ]
-}
+identifier: ResonantOrbitCalculator
+$kref: '#/ckan/github/linuxgurugamer/ResonantOrbitCalculator'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: ResonantOrbitCalculator
+license: MIT
+$kref: '#/ckan/spacedock/1954'
+$vref: '#/ckan/ksp-avc'
+tags:
+  - plugin
+  - information
+install:
+  - find: ResonantOrbitCalculator
+    install_to: GameData
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker

--- a/NetKAN/ResourceOverview.netkan
+++ b/NetKAN/ResourceOverview.netkan
@@ -1,4 +1,8 @@
 identifier: ResourceOverview
+$kref: '#/ckan/github/linuxgurugamer/ResourceOverview'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: ResourceOverview
 $kref: '#/ckan/spacedock/3021'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-SA-4.0

--- a/NetKAN/RetroFuture.netkan
+++ b/NetKAN/RetroFuture.netkan
@@ -1,38 +1,37 @@
-{
-    "identifier":   "RetroFuture",
-    "author":       [ "LinuxGuruGamer", "NohArk", "amankduffers" ],
-    "$kref":        "#/ckan/spacedock/2153",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_epoch": "2",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts",
-        "combat"
-    ],
-    "depends": [
-        { "name": "FirespitterCore" },
-        { "name": "KSPWheel" },
-        { "name": "B9-PWings-Fork" },
-        { "name": "ModuleManager"   }
-    ],
-    "recommends": [
-        { "name": "FerramAerospaceResearchContinued" },
-        { "name": "RasterPropMonitor"                },
-        { "name": "PatchManager"                     }
-    ],
-    "suggests": [
-        { "name": "SmokeScreen" },
-        { "name": "TweakScale"  }
-    ],
-    "supports": [
-        { "name": "BDArmory" }
-    ],
-    "install": [ {
-        "find":       "RetroFuture",
-        "install_to": "GameData",
-        "filter":     [ "Ships" ]
-    }, {
-        "find":       "Ships/SPH",
-        "install_to": "Ships"
-    } ]
-}
+identifier: RetroFuture
+$kref: '#/ckan/github/linuxgurugamer/RetroFuture'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: RetroFuture
+author:
+  - LinuxGuruGamer
+  - NohArk
+  - amankduffers
+$kref: '#/ckan/spacedock/2153'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: '2'
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+  - combat
+depends:
+  - name: FirespitterCore
+  - name: KSPWheel
+  - name: B9-PWings-Fork
+  - name: ModuleManager
+recommends:
+  - name: FerramAerospaceResearchContinued
+  - name: RasterPropMonitor
+  - name: PatchManager
+suggests:
+  - name: SmokeScreen
+  - name: TweakScale
+supports:
+  - name: BDArmory
+install:
+  - find: RetroFuture
+    install_to: GameData
+    filter:
+      - Ships
+  - find: Ships/SPH
+    install_to: Ships

--- a/NetKAN/RocketMotorMenagerie.netkan
+++ b/NetKAN/RocketMotorMenagerie.netkan
@@ -1,4 +1,7 @@
 identifier: RocketMotorMenagerie
+$kref: '#/ckan/github/EStreetRockets/RocketMotorMenagerie'
+---
+identifier: RocketMotorMenagerie
 $kref: '#/ckan/spacedock/2729'
 ksp_version: 1.12
 license: CC-BY-NC-SA-4.0

--- a/NetKAN/RosterManager.netkan
+++ b/NetKAN/RosterManager.netkan
@@ -1,4 +1,8 @@
 identifier: RosterManager
+$kref: '#/ckan/github/PapaJoesSoup/RosterManager'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: RosterManager
 $kref: '#/ckan/spacedock/191'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-4.0

--- a/NetKAN/RoverScienceCont.netkan
+++ b/NetKAN/RoverScienceCont.netkan
@@ -1,20 +1,22 @@
-{
-    "identifier":   "RoverScienceCont",
-    "$kref":        "#/ckan/spacedock/1437",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA",
-    "tags": [
-        "plugin",
-        "science"
-    ],
-    "install": [ {
-        "find": "RoverScience",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" },
-        { "name" : "SpaceTuxLibrary" },
-        { "name" : "ModuleManager" }
-    ]
-}
+identifier: RoverScienceCont
+$kref: '#/ckan/github/linuxgurugamer/RoverScience-Continued'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: RoverScience
+    install_to: GameData
+---
+identifier: RoverScienceCont
+$kref: '#/ckan/spacedock/1437'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA
+tags:
+  - plugin
+  - science
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+  - name: ModuleManager
+install:
+  - find: RoverScience
+    install_to: GameData

--- a/NetKAN/SASAG.netkan
+++ b/NetKAN/SASAG.netkan
@@ -1,16 +1,18 @@
-{
-    "identifier":   "SASAG",
-    "$kref":        "#/ckan/spacedock/1380",
-    "license":      "public-domain",
-    "tags": [
-        "plugin",
-        "convenience"
-    ],
-    "install": [ {
-        "find":       "XyphosAerospace",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ]
-}
+identifier: SASAG
+$kref: '#/ckan/github/Xyphos/KSP_SASAG'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+---
+identifier: SASAG
+$kref: '#/ckan/spacedock/1380'
+license: public-domain
+tags:
+  - plugin
+  - convenience
+install:
+  - find: XyphosAerospace
+    install_to: GameData
+depends:
+  - name: ModuleManager

--- a/NetKAN/SAVE.netkan
+++ b/NetKAN/SAVE.netkan
@@ -1,16 +1,18 @@
-{
-    "identifier":   "SAVE",
-    "$kref":        "#/ckan/spacedock/2822",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "LGPL-3.0",
-    "tags": [
-        "plugin"
-    ],
-    "install": [
-        {
-            "file": "GameData/Nereid",
-            "install_to": "GameData",
-            "filter": "source"
-        }
-    ]
-}
+identifier: SAVE
+$kref: '#/ckan/github/linuxgurugamer/S.A.V.E'
+$vref: '#/ckan/ksp-avc'
+install:
+  - file: GameData/Nereid
+    install_to: GameData
+    filter: source
+---
+identifier: SAVE
+$kref: '#/ckan/spacedock/2822'
+$vref: '#/ckan/ksp-avc'
+license: LGPL-3.0
+tags:
+  - plugin
+install:
+  - file: GameData/Nereid
+    install_to: GameData
+    filter: source

--- a/NetKAN/SOS.netkan
+++ b/NetKAN/SOS.netkan
@@ -1,19 +1,18 @@
-{
-    "identifier":   "SOS",
-    "$kref":        "#/ckan/spacedock/2325",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "plugin",
-        "convenience"
-    ],
-    "depends": [
-        { "name": "ToolbarController"   },
-        { "name": "ClickThroughBlocker" },
-        { "name": "SpaceTuxLibrary"     }
-    ],
-    "install": [ {
-        "find":       "SOS",
-        "install_to": "GameData"
-    } ]
-}
+identifier: SOS
+$kref: '#/ckan/github/linuxgurugamer/SOS'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: SOS
+$kref: '#/ckan/spacedock/2325'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - plugin
+  - convenience
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+install:
+  - find: SOS
+    install_to: GameData

--- a/NetKAN/SXTContinued.netkan
+++ b/NetKAN/SXTContinued.netkan
@@ -1,20 +1,22 @@
-{
-    "identifier":   "SXTContinued",
-    "$kref":        "#/ckan/spacedock/1030",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_epoch": 1,
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name" : "FirespitterCore" },
-        { "name" : "FirespitterResourcesConfig"},
-        { "name" : "ModuleManager"},
-        { "name" : "RetractableLiftingSurface" }
-    ],
-    "install" : [ {
-        "find" : "SXT",
-        "install_to" : "GameData"
-    } ]
-}
+identifier: SXTContinued
+$kref: '#/ckan/github/linuxgurugamer/SXTContinued'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: SXT
+    install_to: GameData
+---
+identifier: SXTContinued
+$kref: '#/ckan/spacedock/1030'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: 1
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+depends:
+  - name: FirespitterCore
+  - name: FirespitterResourcesConfig
+  - name: ModuleManager
+  - name: RetractableLiftingSurface
+install:
+  - find: SXT
+    install_to: GameData

--- a/NetKAN/SaveConfirmationSound.netkan
+++ b/NetKAN/SaveConfirmationSound.netkan
@@ -1,4 +1,8 @@
 identifier: SaveConfirmationSound
+$kref: '#/ckan/github/linuxgurugamer/SaveConfirmationSound'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: SaveConfirmationSound
 $kref: '#/ckan/spacedock/3526'
 $vref: '#/ckan/ksp-avc'
 license: public-domain

--- a/NetKAN/Scatterer-config.netkan
+++ b/NetKAN/Scatterer-config.netkan
@@ -1,4 +1,15 @@
 identifier: Scatterer-config
+$kref: '#/ckan/github/LGhassen/Scatterer'
+x_netkan_force_v: true
+x_netkan_epoch: '3'
+install:
+  - find: Scatterer/config
+    install_to: GameData/Scatterer
+  - find: StockScattererConfigs
+    install_to: GameData
+    filter: Sunflares
+---
+identifier: Scatterer-config
 name: Scatterer Default Config
 abstract: >-
   Scatterer's default configuration.
@@ -14,12 +25,6 @@ tags:
 comment: Does not depend on Scatterer to match Scatterer-sunflare
 conflicts:
   - name: Scatterer-config
-install:
-  - find: Scatterer/config
-    install_to: GameData/Scatterer
-  - find: StockScattererConfigs
-    install_to: GameData
-    filter: Sunflares
 x_netkan_override:
   - version:
       - '>=3:v0.0829'
@@ -39,3 +44,9 @@ x_netkan_override:
   - version: 2:v0.0329_for_1.4.2
     override:
       ksp_version: 1.4.2
+install:
+  - find: Scatterer/config
+    install_to: GameData/Scatterer
+  - find: StockScattererConfigs
+    install_to: GameData
+    filter: Sunflares

--- a/NetKAN/Scatterer-sunflare.netkan
+++ b/NetKAN/Scatterer-sunflare.netkan
@@ -1,4 +1,12 @@
 identifier: Scatterer-sunflare
+$kref: '#/ckan/github/LGhassen/Scatterer'
+x_netkan_force_v: true
+x_netkan_epoch: '3'
+install:
+  - find: Sunflares
+    install_to: GameData/StockScattererConfigs
+---
+identifier: Scatterer-sunflare
 name: Scatterer Sunflare
 abstract: >-
   Scatterer's default sunflare.
@@ -18,9 +26,6 @@ provides:
   - Scatterer-sunflare-default
 conflicts:
   - name: Scatterer-sunflare
-install:
-  - find: Sunflares
-    install_to: GameData/StockScattererConfigs
 x_netkan_override:
   - version:
       - '>=3:v0.0829'
@@ -40,3 +45,6 @@ x_netkan_override:
   - version: 2:v0.0329_for_1.4.2
     override:
       ksp_version: 1.4.2
+install:
+  - find: Sunflares
+    install_to: GameData/StockScattererConfigs

--- a/NetKAN/Scatterer.netkan
+++ b/NetKAN/Scatterer.netkan
@@ -1,4 +1,8 @@
 identifier: Scatterer
+$kref: '#/ckan/github/LGhassen/Scatterer'
+x_netkan_force_v: true
+---
+identifier: Scatterer
 $kref: '#/ckan/spacedock/141'
 x_netkan_force_v: true
 x_netkan_epoch: '3'

--- a/NetKAN/ScienceAlert.netkan
+++ b/NetKAN/ScienceAlert.netkan
@@ -1,15 +1,15 @@
-{
-    "identifier":   "ScienceAlert",
-    "$kref":        "#/ckan/spacedock/1886",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "science",
-        "information"
-    ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ]
-}
+identifier: ScienceAlert
+$kref: '#/ckan/github/linuxgurugamer/ScienceAlert'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: ScienceAlert
+$kref: '#/ckan/spacedock/1886'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - science
+  - information
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker

--- a/NetKAN/ScienceSituationInfo.netkan
+++ b/NetKAN/ScienceSituationInfo.netkan
@@ -1,18 +1,21 @@
-{
-    "identifier":   "ScienceSituationInfo",
-    "abstract":     "Extended information about Scientific Experiments in VAB/SPH",
-    "$kref":        "#/ckan/spacedock/2000",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_epoch": 1,
-    "license":      "CC-BY-SA",
-    "tags": [
-        "plugin",
-        "editor",
-        "information",
-        "science"
-    ],
-    "install": [ {
-        "find":       "SituationModuleInfo",
-        "install_to": "GameData"
-    } ]
-}
+identifier: ScienceSituationInfo
+$kref: '#/ckan/github/linuxgurugamer/SituationModuleInfo'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: SituationModuleInfo
+    install_to: GameData
+---
+identifier: ScienceSituationInfo
+abstract: Extended information about Scientific Experiments in VAB/SPH
+$kref: '#/ckan/spacedock/2000'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: 1
+license: CC-BY-SA
+tags:
+  - plugin
+  - editor
+  - information
+  - science
+install:
+  - find: SituationModuleInfo
+    install_to: GameData

--- a/NetKAN/SelfDestruct.netkan
+++ b/NetKAN/SelfDestruct.netkan
@@ -1,4 +1,18 @@
 identifier: SelfDestruct
+$kref: '#/ckan/github/jacobcargen/Self-Destruct-Mod'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+install:
+  - file: Self Destruct Mod.dll
+    install_to: GameData/SelfDestruct
+  - file: LICENSE.txt
+    install_to: GameData/SelfDestruct
+  - file: README.md
+    install_to: GameData/SelfDestruct
+---
+identifier: SelfDestruct
 $kref: '#/ckan/spacedock/3194'
 license: MIT
 tags:

--- a/NetKAN/ShangshengOrbital.netkan
+++ b/NetKAN/ShangshengOrbital.netkan
@@ -1,25 +1,22 @@
-{
-    "identifier":   "ShangshengOrbital",
-    "$kref":        "#/ckan/spacedock/2209",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_force_v": true,
-    "license":      "CC-BY-NC-ND-4.0",
-    "tags": [
-        "parts"
-    ],
-    "install": [ {
-        "find"      : "ShangshengOrbital",
-        "install_to": "GameData"
-    }, {
-        "find"      : "VAB",
-        "install_to": "Ships"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "SpaceXLegs"    }
-    ],
-    "recommends": [
-        { "name": "Smokescreen" },
-        { "name": "CommunityCategoryKit" }
-    ]
-}
+identifier: ShangshengOrbital
+$kref: '#/ckan/github/TundraMods/Shangsheng-Orbital'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: ShangshengOrbital
+$kref: '#/ckan/spacedock/2209'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+license: CC-BY-NC-ND-4.0
+tags:
+  - parts
+install:
+  - find: ShangshengOrbital
+    install_to: GameData
+  - find: VAB
+    install_to: Ships
+depends:
+  - name: ModuleManager
+  - name: SpaceXLegs
+recommends:
+  - name: Smokescreen
+  - name: CommunityCategoryKit

--- a/NetKAN/ShipEffectsContinued.netkan
+++ b/NetKAN/ShipEffectsContinued.netkan
@@ -1,14 +1,14 @@
-{
-    "identifier":   "ShipEffectsContinued",
-    "$kref":        "#/ckan/spacedock/2225",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "plugin",
-        "sound"
-    ],
-    "install": [ {
-        "find": "ShipEffectsContinued",
-        "install_to": "GameData"
-    } ]
-}
+identifier: ShipEffectsContinued
+$kref: '#/ckan/github/linuxgurugamer/ShipEffectsContinued'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: ShipEffectsContinued
+$kref: '#/ckan/spacedock/2225'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - plugin
+  - sound
+install:
+  - find: ShipEffectsContinued
+    install_to: GameData

--- a/NetKAN/ShowFPS.netkan
+++ b/NetKAN/ShowFPS.netkan
@@ -1,22 +1,23 @@
-{
-    "identifier":   "ShowFPS",
-    "name":         "Show FPS",
-    "abstract":     "Simple framerate counter, enable with F8.",
-    "author":       [ "linuxgurugamer", "m4v" ],
-    "$kref":        "#/ckan/spacedock/1757",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_epoch": 1,
-    "license":      "LGPL-3.0",
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ],
-    "install": [ {
-        "find": "ShowFPS",
-        "install_to": "GameData"
-    } ]
-}
+identifier: ShowFPS
+$kref: '#/ckan/github/linuxgurugamer/ShowFPS'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: ShowFPS
+name: Show FPS
+abstract: Simple framerate counter, enable with F8.
+author:
+  - linuxgurugamer
+  - m4v
+$kref: '#/ckan/spacedock/1757'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: 1
+license: LGPL-3.0
+tags:
+  - plugin
+  - information
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: ShowFPS
+    install_to: GameData

--- a/NetKAN/ShuttleOrbiterConstructionKit.netkan
+++ b/NetKAN/ShuttleOrbiterConstructionKit.netkan
@@ -1,4 +1,24 @@
 identifier: ShuttleOrbiterConstructionKit
+$kref: '#/ckan/github/benjee10/Shuttle-Orbiter-Construction-Kit'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+install:
+  - find: Benjee10_shuttleOrbiter
+    install_to: GameData
+  - find: Manual
+    install_to: GameData/Benjee10_shuttleOrbiter
+  - find: Extras/ColumbiaWings
+    install_to: GameData/Benjee10_shuttleOrbiter
+  - find: Extras/Custom Shuttle Names
+    install_to: GameData/Benjee10_shuttleOrbiter
+  - find: Craft Files/SPH
+    install_to: Ships
+  - find: Craft Files/VAB
+    install_to: Ships
+---
+identifier: ShuttleOrbiterConstructionKit
 $kref: '#/ckan/spacedock/2176'
 ksp_version_min: 1.11
 license: restricted

--- a/NetKAN/ShuttlePayloadDeliverySystems.netkan
+++ b/NetKAN/ShuttlePayloadDeliverySystems.netkan
@@ -1,4 +1,11 @@
 identifier: ShuttlePayloadDeliverySystems
+$kref: '#/ckan/github/HakariMatt/ShuttlePayloadDeliverySystems'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+---
+identifier: ShuttlePayloadDeliverySystems
 $kref: '#/ckan/spacedock/3056'
 license: CC-BY
 tags:

--- a/NetKAN/SimpleContractDisplay.netkan
+++ b/NetKAN/SimpleContractDisplay.netkan
@@ -1,4 +1,8 @@
 identifier: SimpleContractDisplay
+$kref: '#/ckan/github/linuxgurugamer/SimpleContractDisplay'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: SimpleContractDisplay
 $kref: '#/ckan/spacedock/2948'
 license: MIT
 $vref: '#/ckan/ksp-avc'

--- a/NetKAN/SimpleOrbitCalculator.netkan
+++ b/NetKAN/SimpleOrbitCalculator.netkan
@@ -1,4 +1,8 @@
 identifier: SimpleOrbitCalculator
+$kref: '#/ckan/github/linuxgurugamer/ksp-SimpleOrbitCalculator'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: SimpleOrbitCalculator
 $kref: '#/ckan/spacedock/2816'
 $vref: '#/ckan/ksp-avc'
 license: GPL-2.0

--- a/NetKAN/SimpleRepaint.netkan
+++ b/NetKAN/SimpleRepaint.netkan
@@ -1,4 +1,8 @@
 identifier: SimpleRepaint
+$kref: '#/ckan/github/judicator/SimpleRepaint'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: SimpleRepaint
 author: Alexander Rogov
 $kref: '#/ckan/spacedock/2820'
 $vref: '#/ckan/ksp-avc'

--- a/NetKAN/SlingShotterReslung.netkan
+++ b/NetKAN/SlingShotterReslung.netkan
@@ -1,18 +1,20 @@
-{
-    "identifier":   "SlingShotterReslung",
-    "$kref":        "#/ckan/spacedock/1304",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-2.0",
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "install": [ {
-        "find": "SlingShotter",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ]
-}
+identifier: SlingShotterReslung
+$kref: '#/ckan/github/linuxgurugamer/KerbalSlingshotter'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: SlingShotter
+    install_to: GameData
+---
+identifier: SlingShotterReslung
+$kref: '#/ckan/spacedock/1304'
+$vref: '#/ckan/ksp-avc'
+license: GPL-2.0
+tags:
+  - plugin
+  - information
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: SlingShotter
+    install_to: GameData

--- a/NetKAN/SmartParts.netkan
+++ b/NetKAN/SmartParts.netkan
@@ -1,25 +1,24 @@
-{
-    "identifier"      : "SmartParts",
-    "name"            : "Smart Parts",
-    "abstract"        : "Smart Parts can trigger all 10 action groups, as well as various other functionality such as SAS, lights, stage, or abort.",
-    "$kref"           : "#/ckan/spacedock/614",
-    "$vref"           : "#/ckan/ksp-avc",
-    "license"         : "CC-BY-NC-SA-3.0",
-    "tags": [
-        "plugin",
-        "parts",
-        "control"
-    ],
-    "depends" : [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "PatchManager" }
-    ],
-    "install" : [
-        {
-            "find"          : "SmartParts",
-            "install_to"    : "GameData"
-        }
-    ]
-}
+identifier: SmartParts
+$kref: '#/ckan/github/linuxgurugamer/KerbalSmartParts'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-3.0
+---
+identifier: SmartParts
+name: Smart Parts
+abstract: >-
+  Smart Parts can trigger all 10 action groups, as well as various other
+  functionality such as SAS, lights, stage, or abort.
+$kref: '#/ckan/spacedock/614'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-3.0
+tags:
+  - plugin
+  - parts
+  - control
+depends:
+  - name: ModuleManager
+recommends:
+  - name: PatchManager
+install:
+  - find: SmartParts
+    install_to: GameData

--- a/NetKAN/SmartStage.netkan
+++ b/NetKAN/SmartStage.netkan
@@ -1,19 +1,19 @@
-{
-    "identifier"   : "SmartStage",
-    "name"         : "SmartStage",
-    "abstract"     : "SmartStage attempts to find optimal staging in VAB",
-    "$kref"        : "#/ckan/spacedock/1423",
-    "$vref"        : "#/ckan/ksp-avc",
-    "x_netkan_epoch": 1,
-    "license"      : "GPL-3.0",
-    "tags": [
-        "plugin",
-        "editor",
-        "convenience"
-    ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" },
-        { "name" : "SpaceTuxLibrary" }
-    ]
-}
+identifier: SmartStage
+$kref: '#/ckan/github/linuxgurugamer/SmartStage'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: SmartStage
+name: SmartStage
+abstract: SmartStage attempts to find optimal staging in VAB
+$kref: '#/ckan/spacedock/1423'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: 1
+license: GPL-3.0
+tags:
+  - plugin
+  - editor
+  - convenience
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary

--- a/NetKAN/SpaceDustUnbound.netkan
+++ b/NetKAN/SpaceDustUnbound.netkan
@@ -1,4 +1,12 @@
 identifier: SpaceDustUnbound
+$kref: '#/ckan/github/Vexxel/SpaceDustUnbound'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc'
+---
+identifier: SpaceDustUnbound
 $kref: '#/ckan/spacedock/2970'
 $vref: '#/ckan/ksp-avc'
 license: MIT

--- a/NetKAN/SpaceFrontierTechnologies.netkan
+++ b/NetKAN/SpaceFrontierTechnologies.netkan
@@ -1,8 +1,8 @@
-{
-    "identifier":   "SpaceFrontierTechnologies",
-    "$kref":        "#/ckan/spacedock/2452",
-    "license":      "MIT",
-    "tags": [
-        "parts"
-    ]
-}
+identifier: SpaceFrontierTechnologies
+$kref: '#/ckan/github/Outsoldier/Space-Frontier-Technologies'
+---
+identifier: SpaceFrontierTechnologies
+$kref: '#/ckan/spacedock/2452'
+license: MIT
+tags:
+  - parts

--- a/NetKAN/SpaceTuxLibrary.netkan
+++ b/NetKAN/SpaceTuxLibrary.netkan
@@ -1,22 +1,21 @@
-{
-    "identifier":   "SpaceTuxLibrary",
-    "$kref":        "#/ckan/spacedock/2210",
-    "$vref":        "#/ckan/ksp-avc/SpaceTuxLibrary.version",
-    "license":      "GPL-3.0",
-    "provides": [
-        "ButtonManager",
-        "KSPColorPicker",
-        "KSPLog",
-        "KSPPartHighlighter",
-        "SpaceTuxUtility",
-        "VesselModuleSave"
-    ],
-    "tags": [
-        "plugin",
-        "library"
-    ],
-    "install": [ {
-        "find": "SpaceTuxLibrary",
-        "install_to": "GameData"
-    } ]
-}
+identifier: SpaceTuxLibrary
+$kref: '#/ckan/github/linuxgurugamer/SpaceTuxLibrary'
+$vref: '#/ckan/ksp-avc/SpaceTuxLibrary.version'
+---
+identifier: SpaceTuxLibrary
+$kref: '#/ckan/spacedock/2210'
+$vref: '#/ckan/ksp-avc/SpaceTuxLibrary.version'
+license: GPL-3.0
+provides:
+  - ButtonManager
+  - KSPColorPicker
+  - KSPLog
+  - KSPPartHighlighter
+  - SpaceTuxUtility
+  - VesselModuleSave
+tags:
+  - plugin
+  - library
+install:
+  - find: SpaceTuxLibrary
+    install_to: GameData

--- a/NetKAN/SpaceXLandingPads.netkan
+++ b/NetKAN/SpaceXLandingPads.netkan
@@ -1,4 +1,12 @@
 identifier: SpaceXLandingPads
+$kref: '#/ckan/github/Fossilized4/SpaceX-Landing-Pads'
+x_netkan_github:
+  use_source_archive: true
+install:
+  - find: Fossil Industries
+    install_to: GameData
+---
+identifier: SpaceXLandingPads
 $kref: '#/ckan/spacedock/2941'
 license: restricted
 tags:
@@ -7,10 +15,10 @@ tags:
 depends:
   - name: ModuleManager
   - name: KerbalKonstructs
-install:
-  - find: Fossil Industries
-    install_to: GameData
 x_netkan_override:
   - version: 1.0
     override:
-      ksp_version_min: 1.10
+      ksp_version_min: '1.10'
+install:
+  - find: Fossil Industries
+    install_to: GameData

--- a/NetKAN/SpaceXLegs.netkan
+++ b/NetKAN/SpaceXLegs.netkan
@@ -1,12 +1,16 @@
 identifier: SpaceXLegs
+$kref: '#/ckan/github/TundraMods/Kerbal-Reusability-Expansion'
+$vref: '#/ckan/ksp-avc'
+install:
+  - file: KerbalReusabilityExpansion
+    install_to: GameData
+---
+identifier: SpaceXLegs
 $kref: '#/ckan/spacedock/841'
 $vref: '#/ckan/ksp-avc'
 license: MIT
 tags:
   - parts
-install:
-  - file: KerbalReusabilityExpansion
-    install_to: GameData
 depends:
   - name: ModuleManager
 recommends:
@@ -16,3 +20,6 @@ supports:
   - name: TweakScale
   - name: RealPlume
   - name: FerramAerospaceResearch
+install:
+  - file: KerbalReusabilityExpansion
+    install_to: GameData

--- a/NetKAN/SpacedocksRedeployed.netkan
+++ b/NetKAN/SpacedocksRedeployed.netkan
@@ -1,16 +1,18 @@
-{
-    "identifier":   "SpacedocksRedeployed",
-    "$kref":        "#/ckan/spacedock/1585",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts"
-    ],
-    "install": [ {
-        "find":       "SpaceDockReBoxed",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ]
-}
+identifier: SpacedocksRedeployed
+$kref: '#/ckan/github/linuxgurugamer/SpaceDockReBoxed'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: SpaceDockReBoxed
+    install_to: GameData
+---
+identifier: SpacedocksRedeployed
+$kref: '#/ckan/spacedock/1585'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+install:
+  - find: SpaceDockReBoxed
+    install_to: GameData

--- a/NetKAN/StageRecovery.netkan
+++ b/NetKAN/StageRecovery.netkan
@@ -1,28 +1,23 @@
-{
-    "identifier"     : "StageRecovery",
-    "$kref"          : "#/ckan/spacedock/219",
-    "$vref"          : "#/ckan/ksp-avc",
-    "license"        : "GPL-3.0",
-    "tags": [
-        "plugin",
-        "career"
-    ],
-    "suggests" : [
-        { "name" : "KerbalConstructionTime" },
-        { "name" : "Toolbar" }
-    ],
-    "depends": [
-        { "name": "ToolbarController" },
-        { "name": "ClickThroughBlocker" },
-        { "name": "SpaceTuxLibrary" }
-    ],
-    "conflicts" : [
-        { "name" : "DebRefund" }
-    ],
-    "install" : [
-        {
-            "file"       : "GameData/StageRecovery",
-            "install_to" : "GameData"
-        }
-    ]
-}
+identifier: StageRecovery
+$kref: '#/ckan/github/linuxgurugamer/StageRecovery'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: StageRecovery
+$kref: '#/ckan/spacedock/219'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - career
+suggests:
+  - name: KerbalConstructionTime
+  - name: Toolbar
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+conflicts:
+  - name: DebRefund
+install:
+  - file: GameData/StageRecovery
+    install_to: GameData

--- a/NetKAN/StageableRCS.netkan
+++ b/NetKAN/StageableRCS.netkan
@@ -1,4 +1,11 @@
 identifier: StageableRCS
+$kref: '#/ckan/github/kurgut/SRCS-Stageable-RCS'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: SRCS
+    install_to: GameData
+---
+identifier: StageableRCS
 author:
   - KSP-RO
   - Kurgut

--- a/NetKAN/StarshipExpansionProject.netkan
+++ b/NetKAN/StarshipExpansionProject.netkan
@@ -1,4 +1,7 @@
 identifier: StarshipExpansionProject
+$kref: '#/ckan/github/Kari1407/Starship-Expansion-Project'
+---
+identifier: StarshipExpansionProject
 name: Starship Expansion Project
 author:
   - Kari

--- a/NetKAN/StarshipExpansionProjectIVA.netkan
+++ b/NetKAN/StarshipExpansionProjectIVA.netkan
@@ -1,4 +1,10 @@
 identifier: StarshipExpansionProjectIVA
+$kref: '#/ckan/github/Kari1407/Starship-Expansion-Project'
+install:
+  - find: Spaces
+    install_to: GameData/StarshipExpansionProject
+---
+identifier: StarshipExpansionProjectIVA
 name: Starship Expansion Project IVA
 abstract: IVA portion of Starship Expansion Project
 author:

--- a/NetKAN/StarstroSpaceSystems.netkan
+++ b/NetKAN/StarstroSpaceSystems.netkan
@@ -1,4 +1,7 @@
 identifier: StarstroSpaceSystems
+$kref: '#/ckan/github/LilBread402/StarstroSpaceSystems'
+---
+identifier: StarstroSpaceSystems
 $kref: '#/ckan/spacedock/3200'
 license: restricted
 tags:

--- a/NetKAN/StateFundingContinued.netkan
+++ b/NetKAN/StateFundingContinued.netkan
@@ -1,19 +1,21 @@
-{
-    "identifier":   "StateFundingContinued",
-    "$kref":        "#/ckan/spacedock/1231",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "career"
-    ],
-    "install": [ {
-        "find": "StateFunding",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "ToolbarController" },
-        { "name": "ClickThroughBlocker" }
-    ]
-}
+identifier: StateFundingContinued
+$kref: '#/ckan/github/linuxgurugamer/StateFundingContinued'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: StateFunding
+    install_to: GameData
+---
+identifier: StateFundingContinued
+$kref: '#/ckan/spacedock/1231'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - career
+depends:
+  - name: ModuleManager
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: StateFunding
+    install_to: GameData

--- a/NetKAN/SteamGaugesRecalibrated.netkan
+++ b/NetKAN/SteamGaugesRecalibrated.netkan
@@ -1,28 +1,22 @@
-{
-  "license": "unknown",
-  "identifier": "SteamGaugesRecalibrated",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "$kref": "#/ckan/spacedock/2550",
-  "$vref": "#/ckan/ksp-avc",
-  "depends": [
-    {
-      "name": "ToolbarController"
-    },
-    {
-      "name": "ClickThroughBlocker"
-    },
-    {
-      "name": "SpaceTuxLibrary"
-    }
-  ],
-  "tags": [
-    "plugin",
-    "information"
-  ],
-  "install": [
-    {
-      "find": "SteamGauges",
-      "install_to": "GameData"
-    }
-  ]
-}
+identifier: SteamGaugesRecalibrated
+$kref: '#/ckan/github/linuxgurugamer/SteamGaugesRecalibrated'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: SteamGauges
+    install_to: GameData
+---
+license: unknown
+identifier: SteamGaugesRecalibrated
+x_via: Automated Linuxgurugamer CKAN script
+$kref: '#/ckan/spacedock/2550'
+$vref: '#/ckan/ksp-avc'
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+tags:
+  - plugin
+  - information
+install:
+  - find: SteamGauges
+    install_to: GameData

--- a/NetKAN/StockDepthMaskConfig.netkan
+++ b/NetKAN/StockDepthMaskConfig.netkan
@@ -1,4 +1,11 @@
 identifier: StockDepthMaskConfig
+$kref: '#/ckan/github/kingnoob1377/Stock_DepthMask_Config'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+---
+identifier: StockDepthMaskConfig
 $kref: '#/ckan/spacedock/2963'
 license: MIT
 tags:

--- a/NetKAN/StockRealism.netkan
+++ b/NetKAN/StockRealism.netkan
@@ -1,4 +1,8 @@
 identifier: StockRealism
+$kref: '#/ckan/github/ZombieStriker/StockRealism'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: StockRealism
 $kref: '#/ckan/spacedock/3125'
 $vref: '#/ckan/ksp-avc'
 license: AGPL-3.0

--- a/NetKAN/StoreMyReports.netkan
+++ b/NetKAN/StoreMyReports.netkan
@@ -1,12 +1,15 @@
-{
-    "identifier":   "StoreMyReports",
-    "abstract":     "Fix the inability for Kerbals to find glove-boxes within their vessel or pockets on their EVA suits.",
-    "$kref":        "#/ckan/spacedock/2289",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "convenience",
-        "science"
-    ]
-}
+identifier: StoreMyReports
+$kref: '#/ckan/github/linuxgurugamer/StoreMyReports'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: StoreMyReports
+abstract: >-
+  Fix the inability for Kerbals to find glove-boxes within their vessel or
+  pockets on their EVA suits.
+$kref: '#/ckan/spacedock/2289'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - convenience
+  - science

--- a/NetKAN/StorkDeliverySystem.netkan
+++ b/NetKAN/StorkDeliverySystem.netkan
@@ -1,27 +1,26 @@
-{
-    "identifier"   : "StorkDeliverySystem",
-    "author"       : [ "riocrokite", "zer0Kerbal" ],
-    "$kref"        : "#/ckan/spacedock/2347",
-    "$vref"        : "#/ckan/ksp-avc",
-    "license"      : "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "suggests": [
-        { "name": "MoarKerbals"             },
-        { "name": "MFS"                     },
-        { "name": "SimpleLogistics"         },
-        { "name": "SimpleConstruction"      },
-        { "name": "NotSoSimpleConstruction" }
-    ],
-    "supports": [
-        { "name": "KerbalChangelog" }
-    ],
-    "install": [ {
-        "find"      : "KermangeddonIndustries",
-        "install_to": "GameData"
-    } ]
-}
+identifier: StorkDeliverySystem
+$kref: '#/ckan/github/zer0Kerbal/StorkDeliverySystem'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: StorkDeliverySystem
+author:
+  - riocrokite
+  - zer0Kerbal
+$kref: '#/ckan/spacedock/2347'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+suggests:
+  - name: MoarKerbals
+  - name: MFS
+  - name: SimpleLogistics
+  - name: SimpleConstruction
+  - name: NotSoSimpleConstruction
+supports:
+  - name: KerbalChangelog
+install:
+  - find: KermangeddonIndustries
+    install_to: GameData

--- a/NetKAN/StrangeNewWorlds.netkan
+++ b/NetKAN/StrangeNewWorlds.netkan
@@ -1,4 +1,8 @@
 identifier: StrangeNewWorlds
+$kref: '#/ckan/github/Zaffreaqua/StrangeNewWorlds'
+x_netkan_force_v: true
+---
+identifier: StrangeNewWorlds
 $kref: '#/ckan/spacedock/2777'
 license: CC-BY-NC-ND
 tags:

--- a/NetKAN/SushutsMainMenuMod.netkan
+++ b/NetKAN/SushutsMainMenuMod.netkan
@@ -1,4 +1,14 @@
 identifier: SushutsMainMenuMod
+$kref: '#/ckan/github/Sushutt/Sushuts-Main-Menu-Mod'
+x_netkan_version_edit:
+  find: ^Release-
+  replace: ''
+  strict: false
+install:
+  - find: SushutsMainMenu
+    install_to: GameData
+---
+identifier: SushutsMainMenuMod
 $kref: '#/ckan/spacedock/3507'
 license: MIT
 tags:
@@ -7,4 +17,3 @@ tags:
 install:
   - find: SushutsMainMenu
     install_to: GameData
-x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/TDProps.netkan
+++ b/NetKAN/TDProps.netkan
@@ -1,4 +1,8 @@
 identifier: TDProps
+$kref: '#/ckan/github/linuxgurugamer/TDProps'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: TDProps
 $kref: '#/ckan/spacedock/1546'
 $vref: '#/ckan/ksp-avc'
 license: MIT

--- a/NetKAN/TRPHire.netkan
+++ b/NetKAN/TRPHire.netkan
@@ -1,17 +1,19 @@
-{
-    "identifier":   "TRPHire",
-    "$kref":        "#/ckan/spacedock/777",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "crewed"
-    ],
-    "install": [ {
-        "find": "TRP-Hire",
-        "install_to": "GameData"
-    } ],
-    "recommends": [
-        { "name": "CommunityTraitIcons" }
-    ]
-}
+identifier: TRPHire
+$kref: '#/ckan/github/linuxgurugamer/PHS'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: TRP-Hire
+    install_to: GameData
+---
+identifier: TRPHire
+$kref: '#/ckan/spacedock/777'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - crewed
+recommends:
+  - name: CommunityTraitIcons
+install:
+  - find: TRP-Hire
+    install_to: GameData

--- a/NetKAN/TacFuelBalancer.netkan
+++ b/NetKAN/TacFuelBalancer.netkan
@@ -1,24 +1,24 @@
-{
-    "identifier"     : "TacFuelBalancer",
-    "name"           : "TAC Fuel Balancer",
-    "author"         : [ "Z-Key Aerospace", "Taranis Elsu" ],
-    "$kref"          : "#/ckan/spacedock/640",
-    "$vref"          : "#/ckan/ksp-avc",
-    "x_netkan_force_v": true,
-    "license"        : "CC-BY-NC-SA-3.0",
-    "release_status" : "stable",
-    "tags": [
-        "plugin",
-        "convenience"
-    ],
-    "install" : [
-        {
-            "file"          : "GameData/TacFuelBalancer",
-            "install_to"    : "GameData"
-        }
-    ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ]
-}
+identifier: TacFuelBalancer
+$kref: '#/ckan/github/linuxgurugamer/TacFuelBalancer'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+---
+identifier: TacFuelBalancer
+name: TAC Fuel Balancer
+author:
+  - Z-Key Aerospace
+  - Taranis Elsu
+$kref: '#/ckan/spacedock/640'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+license: CC-BY-NC-SA-3.0
+release_status: stable
+tags:
+  - plugin
+  - convenience
+install:
+  - file: GameData/TacFuelBalancer
+    install_to: GameData
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker

--- a/NetKAN/TacSelfDestructContinued.netkan
+++ b/NetKAN/TacSelfDestructContinued.netkan
@@ -1,14 +1,17 @@
-{
-    "identifier":   "TacSelfDestructContinued",
-    "$kref":        "#/ckan/spacedock/1135",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_epoch": "1",
-    "license":      "CC-BY-NC-SA-3.0",
-    "tags": [
-        "plugin"
-    ],
-    "install": [ {
-        "find": "TacSelfDestruct",
-        "install_to": "GameData"
-    } ]
-}
+identifier: TacSelfDestructContinued
+$kref: '#/ckan/github/linuxgurugamer/TacSelfDestruct'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: TacSelfDestruct
+    install_to: GameData
+---
+identifier: TacSelfDestructContinued
+$kref: '#/ckan/spacedock/1135'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: '1'
+license: CC-BY-NC-SA-3.0
+tags:
+  - plugin
+install:
+  - find: TacSelfDestruct
+    install_to: GameData

--- a/NetKAN/TankLockRedux.netkan
+++ b/NetKAN/TankLockRedux.netkan
@@ -1,17 +1,20 @@
-{
-    "identifier"     : "TankLockRedux",
-    "$kref"          : "#/ckan/spacedock/592",
-    "$vref"          : "#/ckan/ksp-avc",
-    "license"        : "BSD-2-clause",
-    "tags"           : [
-        "config",
-        "convenience"
-    ],
-    "depends"        :  [
-        { "name" : "ModuleManager" }
-    ],
-    "install" : [ {
-        "find"       : "TankLock",
-        "install_to" : "GameData"
-    } ]
-}
+identifier: TankLockRedux
+$kref: '#/ckan/github/linuxgurugamer/TankLock'
+$vref: '#/ckan/ksp-avc'
+license: BSD-2-clause
+install:
+  - find: TankLock
+    install_to: GameData
+---
+identifier: TankLockRedux
+$kref: '#/ckan/spacedock/592'
+$vref: '#/ckan/ksp-avc'
+license: BSD-2-clause
+tags:
+  - config
+  - convenience
+depends:
+  - name: ModuleManager
+install:
+  - find: TankLock
+    install_to: GameData

--- a/NetKAN/Targetron.netkan
+++ b/NetKAN/Targetron.netkan
@@ -1,4 +1,9 @@
 identifier: Targetron
+$kref: '#/ckan/github/linuxgurugamer/Targetron'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+---
+identifier: Targetron
 abstract: Target or command vessel from a list of active flights!
 $kref: '#/ckan/spacedock/3095'
 $vref: '#/ckan/ksp-avc'
@@ -11,4 +16,3 @@ depends:
   - name: ClickThroughBlocker
   - name: ToolbarController
   - name: SpaceTuxLibrary
-

--- a/NetKAN/TeaKettleRCS.netkan
+++ b/NetKAN/TeaKettleRCS.netkan
@@ -1,4 +1,8 @@
 identifier: TeaKettleRCS
+$kref: '#/ckan/github/JadeOfMaar/TeaKettleRCS'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: TeaKettleRCS
 $kref: '#/ckan/spacedock/2842'
 $vref: '#/ckan/ksp-avc'
 license: MIT

--- a/NetKAN/TheRATPack.netkan
+++ b/NetKAN/TheRATPack.netkan
@@ -1,21 +1,24 @@
-{
-    "identifier":   "TheRATPack",
-    "$kref":        "#/ckan/spacedock/1963",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "plugin",
-        "parts"
-    ],
-    "install": [ {
-        "find"       : "RATPack",
-        "install_to" : "GameData"
-    }, {
-        "find"       : "Ships",
-        "install_to" : "Ships"
-    } ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ]
-}
+identifier: TheRATPack
+$kref: '#/ckan/github/linuxgurugamer/RATPack'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: RATPack
+    install_to: GameData
+  - find: Ships
+    install_to: Ships
+---
+identifier: TheRATPack
+$kref: '#/ckan/spacedock/1963'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - plugin
+  - parts
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+install:
+  - find: RATPack
+    install_to: GameData
+  - find: Ships
+    install_to: Ships

--- a/NetKAN/ThrottleLimitExtended.netkan
+++ b/NetKAN/ThrottleLimitExtended.netkan
@@ -1,17 +1,16 @@
-{
-    "identifier":   "ThrottleLimitExtended",
-    "$kref":        "#/ckan/spacedock/1640",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "convenience"
-    ],
-    "install": [ {
-        "find": "ThrottleLimitExtended",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ]
-}
+identifier: ThrottleLimitExtended
+$kref: '#/ckan/github/linuxgurugamer/ThrottleLimitExtended'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: ThrottleLimitExtended
+$kref: '#/ckan/spacedock/1640'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - convenience
+install:
+  - find: ThrottleLimitExtended
+    install_to: GameData
+depends:
+  - name: ModuleManager

--- a/NetKAN/ThroughTheEyesOfaKerbal.netkan
+++ b/NetKAN/ThroughTheEyesOfaKerbal.netkan
@@ -1,4 +1,11 @@
 identifier: ThroughTheEyesOfaKerbal
+$kref: '#/ckan/github/linuxgurugamer/Through-The-Eyes'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ThroughTheEyes
+    install_to: GameData
+---
+identifier: ThroughTheEyesOfaKerbal
 $kref: '#/ckan/spacedock/1560'
 $vref: '#/ckan/ksp-avc'
 license: GPL-3.0

--- a/NetKAN/ToadicusToolsContinued.netkan
+++ b/NetKAN/ToadicusToolsContinued.netkan
@@ -1,14 +1,17 @@
-{
-    "identifier":   "ToadicusToolsContinued",
-    "$kref":        "#/ckan/spacedock/1069",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "BSD-3-clause",
-    "tags": [
-        "plugin",
-        "library"
-    ],
-    "install": [ {
-        "find": "ToadicusTools",
-        "install_to": "GameData"
-    } ]
-}
+identifier: ToadicusToolsContinued
+$kref: '#/ckan/github/linuxgurugamer/ToadicusTools'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: ToadicusTools
+    install_to: GameData
+---
+identifier: ToadicusToolsContinued
+$kref: '#/ckan/spacedock/1069'
+$vref: '#/ckan/ksp-avc'
+license: BSD-3-clause
+tags:
+  - plugin
+  - library
+install:
+  - find: ToadicusTools
+    install_to: GameData

--- a/NetKAN/TokamakRefurbishedParts.netkan
+++ b/NetKAN/TokamakRefurbishedParts.netkan
@@ -1,24 +1,25 @@
-{
-    "identifier":   "TokamakRefurbishedParts",
-    "$kref":        "#/ckan/spacedock/1444",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY",
-    "tags": [
-        "parts",
-        "crewed"
-    ],
-    "install": [ {
-        "find": "TokamakIndustries",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "USITools" }
-    ],
-    "suggests": [
-        { "name": "USI-LS" },
-        { "name": "TACLS" },
-        { "name": "Snacks" },
-        { "name": "Kerbalism" }
-    ]
-}
+identifier: TokamakRefurbishedParts
+$kref: '#/ckan/github/linuxgurugamer/Tokamak-Refurbished-Parts'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: TokamakIndustries
+    install_to: GameData
+---
+identifier: TokamakRefurbishedParts
+$kref: '#/ckan/spacedock/1444'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY
+tags:
+  - parts
+  - crewed
+depends:
+  - name: ModuleManager
+  - name: USITools
+suggests:
+  - name: USI-LS
+  - name: TACLS
+  - name: Snacks
+  - name: Kerbalism
+install:
+  - find: TokamakIndustries
+    install_to: GameData

--- a/NetKAN/TooManyOrbits.netkan
+++ b/NetKAN/TooManyOrbits.netkan
@@ -1,16 +1,15 @@
-{
-    "identifier":   "TooManyOrbits",
-    "$kref":        "#/ckan/spacedock/1340",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "x_netkan_override": [
-        {
-            "version": "1.1.0",
-            "override": { "ksp_version": "1.2.2" }
-        }
-    ]
-}
+identifier: TooManyOrbits
+$kref: '#/ckan/github/linuxgurugamer/TooManyOrbits'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: TooManyOrbits
+$kref: '#/ckan/spacedock/1340'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - information
+x_netkan_override:
+  - version: 1.1.0
+    override:
+      ksp_version: 1.2.2

--- a/NetKAN/Toolbar.netkan
+++ b/NetKAN/Toolbar.netkan
@@ -1,22 +1,27 @@
-{
-    "identifier"    : "Toolbar",
-    "name"          : "Toolbar",
-    "abstract"      : "API for third-party plugins to provide toolbar buttons",
-    "author"        : ["blizzy78", "linuxgurugamer"],
-    "$kref"         : "#/ckan/spacedock/2090",
-    "$vref"         : "#/ckan/ksp-avc",
-    "x_netkan_epoch": "1",
-    "license"       : "BSD-2-clause",
-    "release_status": "stable",
-    "tags": [
-        "plugin",
-        "convenience"
-    ],
-    "install" : [ {
-        "find"       : "GameData/000_Toolbar",
-        "install_to" : "GameData"
-    } ],
-    "depends": [
-        { "name" : "ClickThroughBlocker" }
-    ]
-}
+identifier: Toolbar
+$kref: '#/ckan/github/linuxgurugamer/ksp_toolbar'
+$vref: '#/ckan/ksp-avc'
+license: BSD-2-clause
+install:
+  - find: GameData/000_Toolbar
+    install_to: GameData
+---
+identifier: Toolbar
+name: Toolbar
+abstract: API for third-party plugins to provide toolbar buttons
+author:
+  - blizzy78
+  - linuxgurugamer
+$kref: '#/ckan/spacedock/2090'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: '1'
+license: BSD-2-clause
+release_status: stable
+tags:
+  - plugin
+  - convenience
+depends:
+  - name: ClickThroughBlocker
+install:
+  - find: GameData/000_Toolbar
+    install_to: GameData

--- a/NetKAN/ToolbarController.netkan
+++ b/NetKAN/ToolbarController.netkan
@@ -1,4 +1,11 @@
 identifier: ToolbarController
+$kref: '#/ckan/github/linuxgurugamer/ToolbarControl'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: 001_ToolbarControl
+    install_to: GameData
+---
+identifier: ToolbarController
 name: Toolbar Controller
 abstract: Wrapper mod around the Blizzy and stock toolbars
 $kref: '#/ckan/spacedock/1931'
@@ -8,10 +15,10 @@ license: GPL-3.0
 tags:
   - plugin
   - library
-install:
-  - find: 001_ToolbarControl
-    install_to: GameData
 depends:
   - name: ClickThroughBlocker
 recommends:
   - name: Toolbar
+install:
+  - find: 001_ToolbarControl
+    install_to: GameData

--- a/NetKAN/TotalTime.netkan
+++ b/NetKAN/TotalTime.netkan
@@ -1,21 +1,19 @@
-{
-    "identifier"     : "TotalTime",
-    "$kref"          : "#/ckan/spacedock/54",
-    "$vref"          : "#/ckan/ksp-avc",
-    "license"        : "MIT",
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "depends": [
-        { "name" : "ToolbarController" },
-        { "name" : "ClickThroughBlocker" }
-    ],
-    "recommends": [
-        { "name": "JanitorsCloset" }
-    ],
-    "install": [ {
-        "find"       : "TotalTime",
-        "install_to" : "GameData"
-    } ]
-}
+identifier: TotalTime
+$kref: '#/ckan/github/linuxgurugamer/TotalTime'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: TotalTime
+$kref: '#/ckan/spacedock/54'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - information
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+recommends:
+  - name: JanitorsCloset
+install:
+  - find: TotalTime
+    install_to: GameData

--- a/NetKAN/TrackingStationEvolved.netkan
+++ b/NetKAN/TrackingStationEvolved.netkan
@@ -1,11 +1,16 @@
-{
-    "identifier":   "TrackingStationEvolved",
-    "$kref":        "#/ckan/spacedock/1738",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "information",
-        "convenience"
-    ]
-}
+identifier: TrackingStationEvolved
+$kref: '#/ckan/github/DMagic1/KSP_BetterTracking'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc'
+---
+identifier: TrackingStationEvolved
+$kref: '#/ckan/spacedock/1738'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+  - information
+  - convenience

--- a/NetKAN/Trajectories.netkan
+++ b/NetKAN/Trajectories.netkan
@@ -1,4 +1,9 @@
 identifier: Trajectories
+$kref: '#/ckan/github/linuxgurugamer/KSPTrajectories'
+$vref: '#/ckan/ksp-avc'
+x_netkan_force_v: true
+---
+identifier: Trajectories
 $kref: '#/ckan/spacedock/396'
 $vref: '#/ckan/ksp-avc'
 x_netkan_force_v: true

--- a/NetKAN/TrimIndicators.netkan
+++ b/NetKAN/TrimIndicators.netkan
@@ -1,14 +1,14 @@
-{
-    "identifier": "TrimIndicators",
-    "$kref": "#/ckan/spacedock/2179",
-    "$vref": "#/ckan/ksp-avc",
-    "license": "CC-BY-SA-3.0",
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "install": [ {
-        "find": "TrimIndicators",
-        "install_to": "GameData"
-    } ]
-}
+identifier: TrimIndicators
+$kref: '#/ckan/github/linuxgurugamer/TrimIndicators'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: TrimIndicators
+$kref: '#/ckan/spacedock/2179'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-SA-3.0
+tags:
+  - plugin
+  - information
+install:
+  - find: TrimIndicators
+    install_to: GameData

--- a/NetKAN/TrimPlus.netkan
+++ b/NetKAN/TrimPlus.netkan
@@ -1,4 +1,8 @@
 identifier: TrimPlus
+$kref: '#/ckan/github/linuxgurugamer/KSP_TrimPlus'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: TrimPlus
 $kref: '#/ckan/spacedock/3295'
 license: GPL-3.0
 $vref: '#/ckan/ksp-avc'

--- a/NetKAN/TundraTechnologies.netkan
+++ b/NetKAN/TundraTechnologies.netkan
@@ -1,6 +1,12 @@
 identifier: TundraTechnologies
+$kref: '#/ckan/github/TundraMods/TundraExploration'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: TundraTechnologies
 name: Tundra Techonologies
-abstract: This is a mod that adds satellite parts like New Horizons, Iridium and station parts like Haven-1!
+abstract: >-
+  This is a mod that adds satellite parts like New Horizons, Iridium and
+  station parts like Haven-1!
 $kref: '#/ckan/spacedock/223'
 $vref: '#/ckan/ksp-avc/TundraTechnologies.version'
 license: restricted

--- a/NetKAN/TutorialFixes.netkan
+++ b/NetKAN/TutorialFixes.netkan
@@ -1,4 +1,8 @@
 identifier: TutorialFixes
+$kref: '#/ckan/github/linuxgurugamer/TutorialFixes'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: TutorialFixes
 $kref: '#/ckan/spacedock/2940'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-SA

--- a/NetKAN/TweakScale-Redist.netkan
+++ b/NetKAN/TweakScale-Redist.netkan
@@ -1,6 +1,19 @@
 identifier: TweakScale-Redist
+$kref: '#/ckan/github/TweakScale/TweakScale/asset_match/^(?!.*CurseForge)'
+x_netkan_version_edit:
+  find: ^RELEASE/
+  replace: v
+  strict: false
+$vref: '#/ckan/ksp-avc/GameData/TweakScale/TweakScale.version'
+install:
+  - file: GameData/999_Scale_Redist.dll
+    install_to: GameData
+---
+identifier: TweakScale-Redist
 name: TweakScale Redistributable
-abstract: A library for other mods to integrate with TweakScale. Does not provide the actual TweakScale features.
+abstract: >-
+  A library for other mods to integrate with TweakScale. Does not provide
+  the actual TweakScale features.
 author:
   - Biotronic
   - pellinor

--- a/NetKAN/TweakScale.netkan
+++ b/NetKAN/TweakScale.netkan
@@ -1,4 +1,17 @@
 identifier: TweakScale
+$kref: '#/ckan/github/TweakScale/TweakScale/asset_match/^(?!.*CurseForge)'
+x_netkan_version_edit:
+  find: ^RELEASE/
+  replace: ''
+  strict: false
+x_netkan_force_v: true
+$vref: '#/ckan/ksp-avc'
+install:
+  - file: GameData/TweakScale
+    install_to: GameData
+    filter: Scale_Redist.dll
+---
+identifier: TweakScale
 name: TweakScale - Rescale Everything!
 abstract: >-
   TweakScale lets you change the size of a part. Not just that, but it will
@@ -19,15 +32,15 @@ release_status: stable
 tags:
   - plugin
   - convenience
-install:
-  - file: GameData/TweakScale
-    install_to: GameData
-    filter: Scale_Redist.dll
 depends:
   - name: TweakScale-Redist
   - name: ModuleManager
     min_version: 2.7.1
   - name: KSP-Recall
 conflicts:
-    - name: TweakscaleMakingHistoryConfigs
-    - name: TweakScaleRescaled-Redist
+  - name: TweakscaleMakingHistoryConfigs
+  - name: TweakScaleRescaled-Redist
+install:
+  - file: GameData/TweakScale
+    install_to: GameData
+    filter: Scale_Redist.dll

--- a/NetKAN/TweakScaleRescaled-Redist.netkan
+++ b/NetKAN/TweakScaleRescaled-Redist.netkan
@@ -1,4 +1,17 @@
 identifier: TweakScaleRescaled-Redist
+$kref: '#/ckan/github/JonnyOThan/TweakScale'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc/GameData/999_Scale_Redist.version'
+install:
+  - file: GameData/999_Scale_Redist.dll
+    install_to: GameData
+  - file: GameData/999_Scale_Redist.version
+    install_to: GameData
+---
+identifier: TweakScaleRescaled-Redist
 name: TweakScale Rescaled Redistributable
 abstract: >-
   Provides a mechanism for other mods to interact with TweakScaleRescaled.

--- a/NetKAN/TweakScaleRescaled-SafetyNet.netkan
+++ b/NetKAN/TweakScaleRescaled-SafetyNet.netkan
@@ -1,4 +1,15 @@
 identifier: TweakScaleRescaled-SafetyNet
+$kref: '#/ckan/github/JonnyOThan/TweakScale'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc/GameData/TSSafetyNet/TweakScaleSafetyNet.version'
+install:
+  - file: GameData/TSSafetyNet
+    install_to: GameData
+---
+identifier: TweakScaleRescaled-SafetyNet
 name: TweakScale Rescaled SafetyNet
 abstract: >-
   Attempts to prevent data loss when TweakScale

--- a/NetKAN/TweakScaleRescaled.netkan
+++ b/NetKAN/TweakScaleRescaled.netkan
@@ -1,4 +1,15 @@
 identifier: TweakScaleRescaled
+$kref: '#/ckan/github/JonnyOThan/TweakScale'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc/GameData/TweakScale/TweakScale.version'
+install:
+  - file: GameData/TweakScale
+    install_to: GameData
+---
+identifier: TweakScaleRescaled
 name: TweakScale Rescaled
 $kref: '#/ckan/spacedock/3514'
 $vref: '#/ckan/ksp-avc/GameData/TweakScale/TweakScale.version'

--- a/NetKAN/TweakableEverythingCont.netkan
+++ b/NetKAN/TweakableEverythingCont.netkan
@@ -1,23 +1,22 @@
-{
-    "identifier"   : "TweakableEverythingCont",
-    "$kref"        : "#/ckan/spacedock/1059",
-    "$vref"        : "#/ckan/ksp-avc",
-    "license"      : "BSD-3-clause",
-    "tags": [
-        "plugin",
-        "convenience"
-    ],
-    "install": [
-        {
-            "file": "GameData/TweakableEverything",
-            "install_to": "GameData"
-        }
-    ],
-    "depends": [
-        { "name": "ToadicusToolsContinued" },
-        { "name": "ModuleManager" }
-    ],
-    "conflicts": [
-        { "name": "ToadicusTools" }
-    ]
-}
+identifier: TweakableEverythingCont
+$kref: '#/ckan/github/linuxgurugamer/TweakableEverything'
+$vref: '#/ckan/ksp-avc'
+install:
+  - file: GameData/TweakableEverything
+    install_to: GameData
+---
+identifier: TweakableEverythingCont
+$kref: '#/ckan/spacedock/1059'
+$vref: '#/ckan/ksp-avc'
+license: BSD-3-clause
+tags:
+  - plugin
+  - convenience
+depends:
+  - name: ToadicusToolsContinued
+  - name: ModuleManager
+conflicts:
+  - name: ToadicusTools
+install:
+  - file: GameData/TweakableEverything
+    install_to: GameData

--- a/NetKAN/UniversalStorage2.netkan
+++ b/NetKAN/UniversalStorage2.netkan
@@ -1,29 +1,26 @@
-{
-    "identifier":   "UniversalStorage2",
-    "$kref":        "#/ckan/spacedock/2960",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "restricted",
-    "tags": [
-        "parts"
-    ],
-    "depends": [
-        { "name": "ModuleManager"         },
-        { "name": "CommunityResourcePack" }
-    ],
-    "recommends": [
-        { "name": "DockingCamKURS" },
-        { "name": "KIS" },
-        { "name": "DMagicOrbitalScience" },
-        { "name": "ConnectedLivingSpace" }
-    ],
-    "supports": [
-        { "name": "kOS"         },
-        { "name": "Kerbalism"         },
-        { "name": "TacLifeSupport"         },
-        { "name": "IFILS"         },
-        { "name": "USILifeSupport"         },
-        { "name": "SnacksUtils"         },
-        { "name": "CryoTanks"         }
-    ],
-
-}
+identifier: UniversalStorage2
+$kref: '#/ckan/github/linuxgurugamer/universal-storage-2'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: UniversalStorage2
+$kref: '#/ckan/spacedock/2960'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+tags:
+  - parts
+depends:
+  - name: ModuleManager
+  - name: CommunityResourcePack
+recommends:
+  - name: DockingCamKURS
+  - name: KIS
+  - name: DMagicOrbitalScience
+  - name: ConnectedLivingSpace
+supports:
+  - name: kOS
+  - name: Kerbalism
+  - name: TacLifeSupport
+  - name: IFILS
+  - name: USILifeSupport
+  - name: SnacksUtils
+  - name: CryoTanks

--- a/NetKAN/VOID.netkan
+++ b/NetKAN/VOID.netkan
@@ -1,22 +1,20 @@
-{
-    "identifier"    : "VOID",
-    "$kref"         : "#/ckan/spacedock/1413",
-    "$vref"         : "#/ckan/ksp-avc",
-    "license"       : "BSD-3-clause",
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "supports": [
-        { "name": "KSP-AVC" }
-    ],
-    "install": [ {
-        "find": "VOID",
-        "install_to": "GameData"
-    } ],
-    "depends": [
-        { "name": "ToadicusToolsContinued" },
-        { "name": "ToolbarController" },
-        { "name": "ClickThroughBlocker" }
-    ]
-}
+identifier: VOID
+$kref: '#/ckan/github/linuxgurugamer/VOID'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: VOID
+$kref: '#/ckan/spacedock/1413'
+$vref: '#/ckan/ksp-avc'
+license: BSD-3-clause
+tags:
+  - plugin
+  - information
+supports:
+  - name: KSP-AVC
+install:
+  - find: VOID
+    install_to: GameData
+depends:
+  - name: ToadicusToolsContinued
+  - name: ToolbarController
+  - name: ClickThroughBlocker

--- a/NetKAN/VaporVent.netkan
+++ b/NetKAN/VaporVent.netkan
@@ -1,4 +1,8 @@
 identifier: VaporVent
+$kref: '#/ckan/github/linuxgurugamer/VaporVent'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: VaporVent
 $kref: '#/ckan/spacedock/931'
 $vref: '#/ckan/ksp-avc'
 license: MIT

--- a/NetKAN/VertexHeightOblateAdvanced.netkan
+++ b/NetKAN/VertexHeightOblateAdvanced.netkan
@@ -1,4 +1,7 @@
 identifier: VertexHeightOblateAdvanced
+$kref: '#/ckan/github/jamespglaze/VertexHeightOblateAdvanced'
+---
+identifier: VertexHeightOblateAdvanced
 $kref: '#/ckan/spacedock/3543'
 license: MIT
 tags:

--- a/NetKAN/VesselNotes.netkan
+++ b/NetKAN/VesselNotes.netkan
@@ -1,22 +1,16 @@
-{
-  "identifier": "VesselNotes",
-  "$kref": "#/ckan/spacedock/2871",
-  "$vref": "#/ckan/ksp-avc",
-  "license": "CC-BY-NC-SA-4.0",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "depends": [
-    {
-      "name": "ToolbarController"
-    },
-    {
-      "name": "ClickThroughBlocker"
-    },
-    {
-      "name": "SpaceTuxLibrary"
-    }
-  ],
-  "tags": [
-    "plugin",
-    "convenience"
-  ]
-}
+identifier: VesselNotes
+$kref: '#/ckan/github/linuxgurugamer/VesselNotes'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: VesselNotes
+$kref: '#/ckan/spacedock/2871'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+x_via: Automated Linuxgurugamer CKAN script
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+tags:
+  - plugin
+  - convenience

--- a/NetKAN/VesselView-UI-RasterPropMonitor.netkan
+++ b/NetKAN/VesselView-UI-RasterPropMonitor.netkan
@@ -1,4 +1,12 @@
 identifier: VesselView-UI-RasterPropMonitor
+$kref: '#/ckan/github/linuxgurugamer/VesselViewer'
+$vref: '#/ckan/ksp-avc/VesselView.version'
+install:
+  - find: VesselViewRPM.dll
+    find_matches_files: true
+    install_to: GameData/VesselView/Plugins
+---
+identifier: VesselView-UI-RasterPropMonitor
 name: VesselView-UI-RasterPropMonitor
 $kref: '#/ckan/spacedock/923'
 $vref: '#/ckan/ksp-avc/VesselView.version'

--- a/NetKAN/VesselView-UI-Toolbar.netkan
+++ b/NetKAN/VesselView-UI-Toolbar.netkan
@@ -1,26 +1,30 @@
-{
-    "identifier":   "VesselView-UI-Toolbar",
-    "name":         "VesselView-UI-Toolbar",
-    "$kref":        "#/ckan/spacedock/923",
-    "x_netkan_epoch": 1,
-    "$vref":        "#/ckan/ksp-avc/VesselView.version",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "depends": [
-        { "name": "VesselView" },
-        { "name": "ToolbarController" },
-        { "name": "ClickThroughBlocker" }
-    ],
-    "provides": [
-        "VesselView-UI"
-    ],
-    "comment": "Providing but not conflicting is deliberate, as both UIs can be installed at the same time.",
-    "install": [ {
-        "find":       "VesselViewPlugin.dll",
-        "install_to": "GameData/VesselView/Plugins",
-        "find_matches_files": true
-    } ]
-}
+identifier: VesselView-UI-Toolbar
+$kref: '#/ckan/github/linuxgurugamer/VesselViewer'
+$vref: '#/ckan/ksp-avc/VesselView.version'
+install:
+  - find: VesselViewPlugin.dll
+    install_to: GameData/VesselView/Plugins
+    find_matches_files: true
+---
+identifier: VesselView-UI-Toolbar
+name: VesselView-UI-Toolbar
+$kref: '#/ckan/spacedock/923'
+x_netkan_epoch: 1
+$vref: '#/ckan/ksp-avc/VesselView.version'
+license: MIT
+tags:
+  - plugin
+  - information
+depends:
+  - name: VesselView
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+provides:
+  - VesselView-UI
+comment: >-
+  Providing but not conflicting is deliberate, as both UIs can be installed
+  at the same time.
+install:
+  - find: VesselViewPlugin.dll
+    install_to: GameData/VesselView/Plugins
+    find_matches_files: true

--- a/NetKAN/VesselView.netkan
+++ b/NetKAN/VesselView.netkan
@@ -1,4 +1,8 @@
 identifier: VesselView
+$kref: '#/ckan/github/linuxgurugamer/VesselViewer'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: VesselView
 $kref: '#/ckan/spacedock/923'
 $vref: '#/ckan/ksp-avc/VesselView.version'
 x_netkan_epoch: 2

--- a/NetKAN/WYGWatchYourGforces.netkan
+++ b/NetKAN/WYGWatchYourGforces.netkan
@@ -1,4 +1,11 @@
 identifier: WYGWatchYourGforces
+$kref: '#/ckan/github/kurgut/WYG-WatchYourG-Forces-'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: WYG
+    install_to: GameData
+---
+identifier: WYGWatchYourGforces
 $kref: '#/ckan/spacedock/3515'
 $vref: '#/ckan/ksp-avc'
 license: MIT
@@ -12,4 +19,3 @@ conflicts:
 install:
   - find: WYG
     install_to: GameData
-x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/WaypointManager.netkan
+++ b/NetKAN/WaypointManager.netkan
@@ -1,30 +1,20 @@
-{
-
-  "license": "MIT",
-  "identifier": "WaypointManager",
-  "x_via": "Automated Linuxgurugamer CKAN script",
-  "$kref": "#/ckan/spacedock/3107",
-  "$vref": "#/ckan/ksp-avc",
-  "resources": {
-    "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/194876-18x-19x-waypoint-manager/",
-    "repository": "https://github.com/linuxgurugamer/WaypointManager"
-  },
-"abstract": "Display waypoints while in flight, create custom waypoints.",
-  "depends": [
-    { "name": "ToolbarController" },
-    { "name": "ClickThroughBlocker" },
-    { "name": "SpaceTuxLibrary" }
-  ],
-  "tags": [
-    "plugin",
-    "information",
-    "convenience"
-  ],
-  "install": [
-    {
-      "find": "WaypointManager",
-      "install_to": "GameData"
-    }
-  ]
-}
-
+identifier: WaypointManager
+$kref: '#/ckan/github/linuxgurugamer/WaypointManager'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: WaypointManager
+abstract: Display waypoints while in flight, create custom waypoints.
+$kref: '#/ckan/spacedock/3107'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+tags:
+  - plugin
+  - information
+  - convenience
+install:
+  - find: WaypointManager
+    install_to: GameData

--- a/NetKAN/WeekWorldPlanetJam.netkan
+++ b/NetKAN/WeekWorldPlanetJam.netkan
@@ -1,4 +1,7 @@
 identifier: WeekWorldPlanetJam
+$kref: '#/ckan/github/WhirligigGirl/WeekWorldPlanetJam'
+---
+identifier: WeekWorldPlanetJam
 $kref: '#/ckan/spacedock/3124'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-4.0

--- a/NetKAN/WernherCheckerContinued.netkan
+++ b/NetKAN/WernherCheckerContinued.netkan
@@ -1,4 +1,13 @@
 identifier: WernherCheckerContinued
+$kref: '#/ckan/github/linuxgurugamer/WernherChecker'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: WernherChecker
+    filter_regexp:
+      - .*~$
+    install_to: GameData
+---
+identifier: WernherCheckerContinued
 $kref: '#/ckan/spacedock/1237'
 $vref: '#/ckan/ksp-avc'
 license: MIT
@@ -6,12 +15,12 @@ tags:
   - plugin
   - editor
   - information
-install:
-  - filter_regexp:
-      - .*~$
-    find: WernherChecker
-    install_to: GameData
 depends:
   - name: ToolbarController
   - name: ClickThroughBlocker
   - name: SpaceTuxLibrary
+install:
+  - find: WernherChecker
+    filter_regexp:
+      - .*~$
+    install_to: GameData

--- a/NetKAN/WhirligigWorld.netkan
+++ b/NetKAN/WhirligigWorld.netkan
@@ -1,34 +1,29 @@
-{
-    "identifier":   "WhirligigWorld",
-    "$kref":        "#/ckan/spacedock/1805",
-    "license":      "restricted",
-    "tags": [
-        "config",
-        "planet-pack",
-        "parts",
-        "plugin"
-    ],
-    "provides": [
-        "EnvironmentalVisualEnhancements-Config"
-    ],
-    "conflicts": [
-        { "name": "EnvironmentalVisualEnhancements-Config" }
-    ],
-    "depends": [
-        { "name": "ModuleManager"              },
-        { "name": "Kopernicus"                 },
-        { "name": "SciRev"                     },
-        { "name": "Scatterer-sunflare-default" }
-    ],
-    "recommends": [
-        { "name": "EnvironmentalVisualEnhancements" },
-        { "name": "DistantObject"                   },
-        { "name": "PlanetShine"                     },
-        { "name": "PoodsDeepStarMap"                }
-    ],
-    "suggests": [
-        { "name": "ResearchBodies"    },
-        { "name": "Kronometer"        },
-        { "name": "CommunityTechTree" }
-    ]
-}
+identifier: WhirligigWorld
+$kref: '#/ckan/github/WhirligigGirl/Whirligig-World/asset_match/WhirligigWorld'
+---
+identifier: WhirligigWorld
+$kref: '#/ckan/spacedock/1805'
+license: restricted
+tags:
+  - config
+  - planet-pack
+  - parts
+  - plugin
+provides:
+  - EnvironmentalVisualEnhancements-Config
+conflicts:
+  - name: EnvironmentalVisualEnhancements-Config
+depends:
+  - name: ModuleManager
+  - name: Kopernicus
+  - name: SciRev
+  - name: Scatterer-sunflare-default
+recommends:
+  - name: EnvironmentalVisualEnhancements
+  - name: DistantObject
+  - name: PlanetShine
+  - name: PoodsDeepStarMap
+suggests:
+  - name: ResearchBodies
+  - name: Kronometer
+  - name: CommunityTechTree

--- a/NetKAN/WhoAmI.netkan
+++ b/NetKAN/WhoAmI.netkan
@@ -1,11 +1,12 @@
-{
-    "identifier":   "WhoAmI",
-    "$kref":        "#/ckan/spacedock/825",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "information",
-        "crewed"
-    ]
-}
+identifier: WhoAmI
+$kref: '#/ckan/github/jarosm/KSP-WhoAmI'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: WhoAmI
+$kref: '#/ckan/spacedock/825'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - information
+  - crewed

--- a/NetKAN/WindTunnel.netkan
+++ b/NetKAN/WindTunnel.netkan
@@ -1,10 +1,10 @@
-{
-    "identifier":   "WindTunnel",
-    "$kref":        "#/ckan/spacedock/1927",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "information",
-        "editor"
-    ]
-}
+identifier: WindTunnel
+$kref: '#/ckan/github/DBooots/KerbalWindTunnel'
+---
+identifier: WindTunnel
+$kref: '#/ckan/spacedock/1927'
+license: MIT
+tags:
+  - plugin
+  - information
+  - editor

--- a/NetKAN/ZTheme.netkan
+++ b/NetKAN/ZTheme.netkan
@@ -1,4 +1,7 @@
 identifier: ZTheme
+$kref: '#/ckan/github/zapSNH/ZTheme'
+---
+identifier: ZTheme
 author:
   - zapsnh
   - UltraJohn

--- a/NetKAN/ZZZRadioTelescope.netkan
+++ b/NetKAN/ZZZRadioTelescope.netkan
@@ -1,21 +1,22 @@
-{
-    "identifier":   "ZZZRadioTelescope",
-    "$kref":        "#/ckan/spacedock/1358",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-SA-4.0",
-    "tags": [
-        "parts",
-        "science"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "SpacetuxSA"    }
-    ],
-    "suggests": [
-        { "name": "ContractConfigurator" }
-    ],
-    "install": [ {
-        "find":       "MunSeeker",
-        "install_to": "GameData"
-    } ]
-}
+identifier: ZZZRadioTelescope
+$kref: '#/ckan/github/linuxgurugamer/ZZZ-RadioTelescope'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: MunSeeker
+    install_to: GameData
+---
+identifier: ZZZRadioTelescope
+$kref: '#/ckan/spacedock/1358'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-4.0
+tags:
+  - parts
+  - science
+depends:
+  - name: ModuleManager
+  - name: SpacetuxSA
+suggests:
+  - name: ContractConfigurator
+install:
+  - find: MunSeeker
+    install_to: GameData

--- a/NetKAN/ZeroMiniAVC.netkan
+++ b/NetKAN/ZeroMiniAVC.netkan
@@ -1,17 +1,19 @@
-{
-    "identifier"   : "ZeroMiniAVC",
-    "name"         : "Zero MiniAVC",
-    "abstract"     : "Delete/Prune/Disable all MiniAVC",
-    "author"       : [ "malah", "linuxgurugamer" ],
-    "$kref"        : "#/ckan/spacedock/1614",
-    "$vref"        : "#/ckan/ksp-avc",
-    "x_netkan_epoch": "1",
-    "license"      : "GPL-3.0",
-    "tags": [
-        "plugin",
-        "convenience"
-    ],
-    "suggests"     : [
-        { "name": "KSP-AVC" }
-    ]
-}
+identifier: ZeroMiniAVC
+$kref: '#/ckan/github/linuxgurugamer/QuickMods/asset_match/ZeroMiniAVC'
+$vref: '#/ckan/ksp-avc'
+---
+identifier: ZeroMiniAVC
+name: Zero MiniAVC
+abstract: Delete/Prune/Disable all MiniAVC
+author:
+  - malah
+  - linuxgurugamer
+$kref: '#/ckan/spacedock/1614'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: '1'
+license: GPL-3.0
+tags:
+  - plugin
+  - convenience
+suggests:
+  - name: KSP-AVC

--- a/NetKAN/ZiveSystem.netkan
+++ b/NetKAN/ZiveSystem.netkan
@@ -1,4 +1,11 @@
 identifier: ZiveSystem
+$kref: '#/ckan/github/Sushutt/ZiveSystem'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+---
+identifier: ZiveSystem
 $kref: '#/ckan/spacedock/3191'
 license: MIT
 tags:

--- a/NetKAN/kOS-Career.netkan
+++ b/NetKAN/kOS-Career.netkan
@@ -1,4 +1,12 @@
 identifier: kOS-Career
+$kref: '#/ckan/github/KSP-KOS/kOS-Career'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc'
+---
+identifier: kOS-Career
 $kref: '#/ckan/spacedock/2530'
 $vref: '#/ckan/ksp-avc'
 license: GPL-3.0

--- a/NetKAN/kOS-EVA.netkan
+++ b/NetKAN/kOS-EVA.netkan
@@ -1,19 +1,22 @@
-{
-    "identifier":   "kOS-EVA",
-    "$kref":        "#/ckan/spacedock/2531",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "parts",
-        "crewed"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "kOS"           },
-        { "name": "Harmony2"      }
-    ],
-    "suggests": [
-        { "name": "KIS" }
-    ]
-}
+identifier: kOS-EVA
+$kref: '#/ckan/github/KSP-KOS/kOS-EVA'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc'
+---
+identifier: kOS-EVA
+$kref: '#/ckan/spacedock/2531'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - parts
+  - crewed
+depends:
+  - name: ModuleManager
+  - name: kOS
+  - name: Harmony2
+suggests:
+  - name: KIS

--- a/NetKAN/kOSPropMonitor.netkan
+++ b/NetKAN/kOSPropMonitor.netkan
@@ -1,4 +1,15 @@
 identifier: kOSPropMonitor
+$kref: '#/ckan/github/FirstPersonKSP/kOSPropMonitor'
+x_netkan_version_edit:
+  find: ^v
+  replace: ''
+  strict: false
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: kPM
+    install_to: GameData
+---
+identifier: kOSPropMonitor
 $kref: '#/ckan/spacedock/3473'
 $vref: '#/ckan/ksp-avc'
 license: GPL-3.0

--- a/NetKAN/xScienceContinued.netkan
+++ b/NetKAN/xScienceContinued.netkan
@@ -1,4 +1,11 @@
 identifier: xScienceContinued
+$kref: '#/ckan/github/linuxgurugamer/KSP-X-Science'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: '[x]_Science!'
+    install_to: GameData
+---
+identifier: xScienceContinued
 name: '[x] Science! Continued'
 abstract: >-
   The Science Report and Checklist for KSP.  [x] Science! keeps track of the


### PR DESCRIPTION
SpaceDock has been having a lot of downtime lately. Many mods on SpaceDock are also hosted on GitHub,  and we have the ability to list both hosts for one mod, but so far only KSP2 mods have been consistently set up for this.

Now the applicable KSP1 mods are multi-hosted.

Essentially I re-ran the SpaceDock Adder's multi-hosting logic for already indexed mods to generate the GitHub krefs, then made manual edits after noting a few patterns of bad data (especially re: `x_netkan_github.use_source_archive` for plugins).
