### PR TITLE
Remove multi-hosting for three mods with bad repo versions

### DIFF
--- a/NetKAN/BuranEnergia.netkan
+++ b/NetKAN/BuranEnergia.netkan
@@ -1,14 +1,4 @@
 identifier: BuranEnergia
-$kref: '#/ckan/github/MyNameIsBorat/KspBuran'
-x_netkan_github:
-  use_source_archive: true
-install:
-  - find: DECQ_ENERGIA
-    install_to: GameData
-  - find: Alcentar_Add-ons
-    install_to: GameData
----
-identifier: BuranEnergia
 $kref: '#/ckan/spacedock/2966'
 license: GPL-3.0
 tags:

--- a/NetKAN/NoIntakeOcclusion.netkan
+++ b/NetKAN/NoIntakeOcclusion.netkan
@@ -1,12 +1,4 @@
 identifier: NoIntakeOcclusion
-$kref: '#/ckan/github/kaerospace/KerbalNoOcclusion'
-install:
-  - file: NoIntakeOcclusion.cfg
-    install_to: GameData/NoIntakeOcclusion
-  - file: NoIntakeOcclusion.dll
-    install_to: GameData/NoIntakeOcclusion
----
-identifier: NoIntakeOcclusion
 $kref: '#/ckan/spacedock/3435'
 license: MIT
 tags:

--- a/NetKAN/ZeroMiniAVC.netkan
+++ b/NetKAN/ZeroMiniAVC.netkan
@@ -1,8 +1,4 @@
 identifier: ZeroMiniAVC
-$kref: '#/ckan/github/linuxgurugamer/QuickMods/asset_match/ZeroMiniAVC'
-$vref: '#/ckan/ksp-avc'
----
-identifier: ZeroMiniAVC
 name: Zero MiniAVC
 abstract: Delete/Prune/Disable all MiniAVC
 author:


### PR DESCRIPTION
#10202 added GitHub hosting for these mods, but they have bad version strings on GitHub:

![image](https://github.com/user-attachments/assets/d02cc6a5-ca3d-46ca-a150-a04f399629db)

Now they're back to SpaceDock-only. I'll remove those versions from CKAN-meta separately.
