### PR TITLE
Update SillyPhotonDrives.netkan

### DIFF
--- a/NetKAN/SillyPhotonDrives.netkan
+++ b/NetKAN/SillyPhotonDrives.netkan
@@ -6,16 +6,15 @@ tags:
 depends:
   - name: ModuleManager
   - name: B9PartSwitch
-  - name: CommunityResourcePack
 recommends:
-  - name: NearFutureElectrical
   - name: Waterfall
-  - name: PersistentThrust
 suggests:
-  - name: CommunityTechTree
-  - name: NearFutureSolar
+  - name: CommunityResourcePack
   - name: FarFutureTechnologies
   - name: CryoTanks
+  - name: NearFutureElectrical
+  - name: PersistentThrust
 supports:
   - name: CommunityTechTree
+  - name: VABOrganizer
 x_via: Automated SpaceDock CKAN submission


### PR DESCRIPTION
Moved CommunityResourcePack to suggests, moved PersistentThrust & NearFutureElectrical to suggests, moved CommunityTechTree to supports, removed NearFutureSolar from suggests, added VABOrganizer to supports.

___

ckan compat add 1.12
