### PR TITLE
OPX-SarnusPlus depends on VertexHeightOblateAdvanced

### DIFF
--- a/NetKAN/OPX-SarnusPlus.netkan
+++ b/NetKAN/OPX-SarnusPlus.netkan
@@ -9,6 +9,7 @@ depends:
   - name: Kopernicus
   - name: VertexMitchellNetravaliHeightMap
   - name: OuterPlanetsMod
+  - name: VertexHeightOblateAdvanced
 suggests:
   - name: ResearchBodies
   - name: KopernicusExpansionContinueder


### PR DESCRIPTION
this was added in the zip file in the latest release, and the game fails to load without it