### PR TITLE
force_v for RasterPropMonitor-Core

### DIFF
--- a/NetKAN/RasterPropMonitor-Core.netkan
+++ b/NetKAN/RasterPropMonitor-Core.netkan
@@ -1,6 +1,8 @@
 identifier: RasterPropMonitor-Core
 $kref: '#/ckan/github/FirstPersonKSP/RasterPropMonitor'
 $vref: '#/ckan/ksp-avc'
+x_netkan_epoch: '1'
+x_netkan_force_v: true
 install:
   - find: JSI/RasterPropMonitor
     install_to: GameData/JSI


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/86fb42ab-1b6a-4a92-b2e8-59f5453de9fa)

The `v` prefix has been dropped on GitHub:

![image](https://github.com/user-attachments/assets/2a9b5172-085d-4363-a352-eb92daf9c5b6)

![image](https://github.com/user-attachments/assets/100c55fa-df2c-4f8a-bdb2-59b8e6ac9fa5)

Now the bot will add it.
