### PR TITLE
InterstellarFuelSwitch-Core only depends on tweakscale-redist

### DIFF
--- a/NetKAN/InterstellarFuelSwitch-Core.netkan
+++ b/NetKAN/InterstellarFuelSwitch-Core.netkan
@@ -19,7 +19,7 @@
     ],
     "depends": [
         { "name": "ModuleManager" },
-        { "name": "TweakScale"    }
+        { "name": "TweakScale-Redist"    }
     ],
     "recommends": [
         { "name" : "CommunityResourcePack", "min_version" : "0.7.1" }


### PR DESCRIPTION
per forum post: https://forum.kerbalspaceprogram.com/topic/106243-181-1125-interstellar-fuel-switch-ifs-3295/

> Dependancies
Tweakscale ( 999_Scale_Redist.dll  only)
Module Manager

