### PR TITLE
add InterstellarFuelSwitch recommendation for TweakScale

### DIFF
--- a/NetKAN/InterstellarFuelSwitch.netkan
+++ b/NetKAN/InterstellarFuelSwitch.netkan
@@ -17,6 +17,7 @@ depends:
   - name: PatchManager
 recommends:
   - name: KSPInterstellarExtended
+  - name: TweakScale
 install:
   - find: InterstellarFuelSwitch
     install_to: GameData


### PR DESCRIPTION
Previously this was a dependency via InterstellarFuelSwitch-Core, which was incorrect.  But this mod does have extensive tweakscale support, so softening that to a recommendation in this module makes sense.

history:
https://github.com/KSP-CKAN/NetKAN/pull/7883
https://github.com/KSP-CKAN/NetKAN/pull/9114