### PR TITLE
Advertise install filters in ZeroMiniAVC, fix BetterSRBs name

### DIFF
--- a/NetKAN/BetterSRBs.netkan
+++ b/NetKAN/BetterSRBs.netkan
@@ -1,24 +1,14 @@
-{
-    "identifier":   "BetterSRBs",
-    "$kref":        "#/ckan/github/OhioBob/BetterSRBs",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "CC-BY-NC-ND",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/175316-*",
-        "repository": "https://github.com/OhioBob/BetterSRBs"
-    },
-    "tags": [
-        "plugin",
-        "parts"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "SmartParts" }
-    ],
-    "install": [ {
-        "find": "BetterSRBs",
-        "install_to": "GameData"
-    } ]
-}
+identifier: BetterSRBs
+name: Better SRBs
+$kref: '#/ckan/github/OhioBob/BetterSRBs'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-ND
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/175316-*
+tags:
+  - plugin
+  - parts
+depends:
+  - name: ModuleManager
+recommends:
+  - name: SmartParts

--- a/NetKAN/ZeroMiniAVC.netkan
+++ b/NetKAN/ZeroMiniAVC.netkan
@@ -1,7 +1,7 @@
 identifier: ZeroMiniAVC
 name: Zero MiniAVC
 abstract: >-
-  CKAN users do not need this.
+  If you only install mods with CKAN, you do not need this.
   To prevent MiniAVC from being installed, go to Settings→Installation filters
   and click the Add MiniAVC button
 author:

--- a/NetKAN/ZeroMiniAVC.netkan
+++ b/NetKAN/ZeroMiniAVC.netkan
@@ -1,6 +1,9 @@
 identifier: ZeroMiniAVC
 name: Zero MiniAVC
-abstract: Delete/Prune/Disable all MiniAVC
+abstract: >-
+  CKAN users do not need this.
+  To prevent MiniAVC from being installed, go to Settings→Installation filters
+  and click the Add MiniAVC button
 author:
   - malah
   - linuxgurugamer


### PR DESCRIPTION
## Problems

- The name of BetterSRBs looks weird, with a space between the R and the B
  ![image](https://github.com/user-attachments/assets/fc78610a-9ca4-40c9-8110-97159b4266a8)
- Discord user `dan` reported frequent prompts from the dev build to reinstall mods after running the game, which said "metadata changed" even though the metadata for those mods had either never changed or changed over two years previously

## Causes

- When no `name` is defined in the netkan of a mod hosted on GitHub, some automatic logic is applied to compute a name from the repository title, which makes some assumptions about capitalization and word boundaries that do not hold for the string `BetterSRBs` (it interprets `Bs` as a word):
  https://github.com/KSP-CKAN/CKAN/blob/228c887a0f281123ae482566479e928cc5d91886/Netkan/Transformers/GithubTransformer.cs#L200-L210
- When ZeroMiniAVC deletes files that CKAN installed, the feature from KSP-CKAN/CKAN#4067 will detect that as a mod with missing files and prompt the user to reinstall that mod, which completes the circuit of uselessness for ZeroMiniAVC since KSP-CKAN/CKAN#3458 added up-front install filters that do what it is supposed to do in a better way

## Changes

- Now BetterSRBs has a hard coded `name` of `Better SRBs`
- Now the `abstract` of ZeroMiniAVC instructs users how to access the settings from KSP-CKAN/CKAN#3458, so users who wish to banish MiniAVC can discover the optimal way of doing that:
  ![image](https://github.com/user-attachments/assets/f33c7e29-e25a-4185-9037-369a1a03ca94)
  (A subsequent pull request in the CKAN repo will improve other aspects of usability for users who encounter this ZeroMiniAVC reinstallation cycle.)

I'm going to attempt to clear the second part of this with @linuxgurugamer before merging (reached out via Discord PM and forum PM).
