### PR TITLE
Update BluedogDB.netkan

### DIFF
--- a/NetKAN/BluedogDB.netkan
+++ b/NetKAN/BluedogDB.netkan
@@ -16,6 +16,7 @@ depends:
   - name: DeployableEngines
 recommends:
   - name: ContractConfigurator
+  - name: Resurfaced
 suggests:
   - name: NearFutureProps
   - name: SCANsat
@@ -37,6 +38,8 @@ supports:
   - name: USI-LS
   - name: TACLS
   - name: SpaceDust
+conflicts:
+  - MagpieMods
 install:
   - find: Bluedog_DB
     install_to: GameData

--- a/NetKAN/BluedogDB.netkan
+++ b/NetKAN/BluedogDB.netkan
@@ -39,7 +39,7 @@ supports:
   - name: TACLS
   - name: SpaceDust
 conflicts:
-  - MagpieMods
+  - name: MagpieMods
 install:
   - find: Bluedog_DB
     install_to: GameData


### PR DESCRIPTION
Update Bluedog Design Bureau Netkan to add Resurfaced to Reccomends and MagpieMods to conflicts. (note that Magpie considers itself compatible with BDB)