### PR TITLE
Bump CelestialHarmony epoch

### DIFF
--- a/NetKAN/CelestialHarmony.netkan
+++ b/NetKAN/CelestialHarmony.netkan
@@ -3,6 +3,7 @@ abstract: >-
   A brand new star system set in the far future where Kerbals
   have migrated towards a luxurious binary habitable worlds
 $kref: '#/ckan/github/ProximaCentauri-star/Celestial-Harmony'
+x_netkan_epoch: 1
 license: restricted
 tags:
   - planet-pack


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d3ffee2c-d339-4c9f-8199-301a4132b1f4)

This mod previously had an `Alpha-` prefix on its versions, which is now removed.

- <https://github.com/ProximaCentauri-star/Celestial-Harmony/releases>

![image](https://github.com/user-attachments/assets/2ec89026-0d43-4170-9e1f-9ba93446b0ed)
