### PR TITLE
Fix SimpleRepaint version specific depends

### DIFF
--- a/NetKAN/SimpleRepaint.netkan
+++ b/NetKAN/SimpleRepaint.netkan
@@ -14,4 +14,4 @@ depends:
   - name: ModuleManager
     min_version: 3.1.3
   - name: B9PartSwitch
-    min_version: 2.16.0
+    min_version: v2.16.0


### PR DESCRIPTION
This mod depends on B9PartSwitch 2.16.0 or later.
Unfortunately, that matches _all_ versions of that mod because they all have a `v` prefix:

- <https://github.com/KSP-CKAN/CKAN-meta/tree/master/B9PartSwitch>

Should have been caught in #8720; maybe someday the inflator could warn if a version specific relationship fails to exclude any mods?

Now the relationship version has a `v` prefix as well.
