### PR TITLE
Add SunkWorks

### DIFF
--- a/NetKAN/SunkWorks.netkan
+++ b/NetKAN/SunkWorks.netkan
@@ -1,0 +1,18 @@
+identifier: SunkWorks
+$kref: '#/ckan/github/Angel-125/SunkWorks'
+$vref: '#/ckan/ksp-avc/SunkWorks.version'
+license: restricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/topic/202746-*
+tags:
+  - plugin
+  - parts
+  - agency
+  - suits
+  - crewed
+depends:
+  - name: ModuleManager
+  - name: WildBlueCore
+install:
+  - find: SunkWorks
+    install_to: GameData/WildBlueIndustries


### PR DESCRIPTION
Discord user Teusdv asked about this mod. Earlier this year, @Angel-125 described its absence from CKAN as "an oversight."

[![image](https://github.com/user-attachments/assets/04b2a914-926d-4ac4-a4ef-f1c03e7bdb94)](https://forum.kerbalspaceprogram.com/topic/202746-min-ksp-111-wip-sunkworks-maritime-technologies/?do=findComment&comment=4400332)

- <https://github.com/Angel-125/SunkWorks>
- <https://forum.kerbalspaceprogram.com/topic/202746-min-ksp-111-wip-sunkworks-maritime-technologies/>

Send a forum PM to make sure it's not a surprise.
