### PR TITLE
Add conflicts with WildBlue play modes' provided names

### DIFF
--- a/NetKAN/Buffalo-PlayMode-CRP.netkan
+++ b/NetKAN/Buffalo-PlayMode-CRP.netkan
@@ -1,33 +1,27 @@
-{
-    "identifier":   "Buffalo-PlayMode-CRP",
-    "name":         "Buffalo CRP Play Mode",
-    "author":       "Angel-125",
-    "$kref":        "#/ckan/github/Angel-125/Buffalo",
-    "$vref":        "#/ckan/ksp-avc/Buffalo.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "GPL-3.0",
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/122617-*"
-    },
-    "tags": [
-        "config"
-    ],
-    "provides": [
-        "Buffalo-PlayMode"
-    ],
-    "depends": [
-        { "name": "WildBlue-PlayMode-CRP" },
-        { "name": "Buffalo"               }
-    ],
-    "install": [ {
-        "find":       "Buffalo/Templates/CRP.cfg",
-        "install_to": "GameData/WildBlueIndustries/Buffalo/Templates",
-        "find_matches_files": true
-    }, {
-        "find":       "Buffalo/Templates/CRP/BuffaloISRU.txt",
-        "install_to": "GameData/WildBlueIndustries/Buffalo/Templates/CRP",
-        "as":         "BuffaloISRU.cfg",
-        "find_matches_files": true
-    } ]
-}
+identifier: Buffalo-PlayMode-CRP
+name: Buffalo CRP Play Mode
+author: Angel-125
+$kref: '#/ckan/github/Angel-125/Buffalo'
+$vref: '#/ckan/ksp-avc/Buffalo.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: GPL-3.0
+resources:
+  homepage: http://forum.kerbalspaceprogram.com/index.php?/topic/122617-*
+tags:
+  - config
+provides:
+  - Buffalo-PlayMode
+conflicts:
+  - name: Buffalo-PlayMode
+depends:
+  - name: WildBlue-PlayMode-CRP
+  - name: Buffalo
+install:
+  - find: Buffalo/Templates/CRP.cfg
+    install_to: GameData/WildBlueIndustries/Buffalo/Templates
+    find_matches_files: true
+  - find: Buffalo/Templates/CRP/BuffaloISRU.txt
+    install_to: GameData/WildBlueIndustries/Buffalo/Templates/CRP
+    as: BuffaloISRU.cfg
+    find_matches_files: true

--- a/NetKAN/Buffalo-PlayMode-ClassicStock.netkan
+++ b/NetKAN/Buffalo-PlayMode-ClassicStock.netkan
@@ -1,31 +1,25 @@
-{
-    "identifier":   "Buffalo-PlayMode-ClassicStock",
-    "name":         "Buffalo Classic Stock Play Mode",
-    "author":       "Angel-125",
-    "$kref":        "#/ckan/github/Angel-125/Buffalo",
-    "$vref":        "#/ckan/ksp-avc/Buffalo.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "GPL-3.0",
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/122617-*"
-    },
-    "tags": [
-        "config"
-    ],
-    "provides": [
-        "Buffalo-PlayMode"
-    ],
-    "depends": [
-        { "name": "WildBlue-PlayMode-ClassicStock" },
-        { "name": "Buffalo"                        }
-    ],
-    "install": [ {
-        "find":       "Buffalo/Templates/ClassicStock",
-        "install_to": "GameData/WildBlueIndustries/Buffalo/Templates"
-    }, {
-        "find":       "Buffalo/Templates/ClassicStock.cfg",
-        "install_to": "GameData/WildBlueIndustries/Buffalo/Templates",
-        "find_matches_files": true
-    } ]
-}
+identifier: Buffalo-PlayMode-ClassicStock
+name: Buffalo Classic Stock Play Mode
+author: Angel-125
+$kref: '#/ckan/github/Angel-125/Buffalo'
+$vref: '#/ckan/ksp-avc/Buffalo.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: GPL-3.0
+resources:
+  homepage: http://forum.kerbalspaceprogram.com/index.php?/topic/122617-*
+tags:
+  - config
+provides:
+  - Buffalo-PlayMode
+conflicts:
+  - name: Buffalo-PlayMode
+depends:
+  - name: WildBlue-PlayMode-ClassicStock
+  - name: Buffalo
+install:
+  - find: Buffalo/Templates/ClassicStock
+    install_to: GameData/WildBlueIndustries/Buffalo/Templates
+  - find: Buffalo/Templates/ClassicStock.cfg
+    install_to: GameData/WildBlueIndustries/Buffalo/Templates
+    find_matches_files: true

--- a/NetKAN/DSEV-PlayMode-CRP.netkan
+++ b/NetKAN/DSEV-PlayMode-CRP.netkan
@@ -1,64 +1,48 @@
-{
-    "identifier":   "DSEV-PlayMode-CRP",
-    "name":         "DSEV CRP Play Mode",
-    "$kref":        "#/ckan/github/Angel-125/DSEV",
-    "$vref":        "#/ckan/ksp-avc/GameData/WildBlueIndustries/DSEV/DSEV.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "restricted",
-    "resources": {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/122162-*",
-        "repository": "https://github.com/Angel-125/DSEV"
-    },
-    "tags": [
-        "config"
-    ],
-    "provides": [
-        "DSEV-PlayMode"
-    ],
-    "depends": [
-        { "name": "WildBlue-PlayMode-CRP" },
-        { "name": "ModuleManager"         },
-        { "name": "DSEV"                  }
-    ],
-    "install": [ {
-        "find":       "WildBlueIndustries/DSEV/Templates/CRP.cfg",
-        "install_to": "GameData/WildBlueIndustries/DSEV/Templates",
-        "find_matches_files": true
-    }, {
-        "find":       "DSEV/Templates/CRP/D2Templates.txt",
-        "install_to": "GameData/WildBlueIndustries/DSEV/Templates/CRP",
-        "as":         "D2Templates.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "DSEV/Templates/CRP/MM_CompactISRU.txt",
-        "install_to": "GameData/WildBlueIndustries/DSEV/Templates/CRP",
-        "as":         "MM_CompactISRU.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "DSEV/Templates/CRP/MM_Snacks.txt",
-        "install_to": "GameData/WildBlueIndustries/DSEV/Templates/CRP",
-        "as":         "MM_Snacks.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "DSEV/Templates/CRP/MM_Trinity.txt",
-        "install_to": "GameData/WildBlueIndustries/DSEV/Templates/CRP",
-        "as":         "MM_Trinity.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "DSEV/Templates/CRP/PathfinderTemplates.txt",
-        "install_to": "GameData/WildBlueIndustries/DSEV/Templates/CRP",
-        "as":         "PathfinderTemplates.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "DSEV/Templates/CRP/Scanners.txt",
-        "install_to": "GameData/WildBlueIndustries/DSEV/Templates/CRP",
-        "as":         "Scanners.cfg",
-        "find_matches_files": true
-    } ]
-}
+identifier: DSEV-PlayMode-CRP
+name: DSEV CRP Play Mode
+$kref: '#/ckan/github/Angel-125/DSEV'
+$vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/DSEV/DSEV.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: restricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/122162-*
+  repository: https://github.com/Angel-125/DSEV
+tags:
+  - config
+provides:
+  - DSEV-PlayMode
+conflicts:
+  - name: DSEV-PlayMode
+depends:
+  - name: WildBlue-PlayMode-CRP
+  - name: ModuleManager
+  - name: DSEV
+install:
+  - find: WildBlueIndustries/DSEV/Templates/CRP.cfg
+    install_to: GameData/WildBlueIndustries/DSEV/Templates
+    find_matches_files: true
+  - find: DSEV/Templates/CRP/D2Templates.txt
+    install_to: GameData/WildBlueIndustries/DSEV/Templates/CRP
+    as: D2Templates.cfg
+    find_matches_files: true
+  - find: DSEV/Templates/CRP/MM_CompactISRU.txt
+    install_to: GameData/WildBlueIndustries/DSEV/Templates/CRP
+    as: MM_CompactISRU.cfg
+    find_matches_files: true
+  - find: DSEV/Templates/CRP/MM_Snacks.txt
+    install_to: GameData/WildBlueIndustries/DSEV/Templates/CRP
+    as: MM_Snacks.cfg
+    find_matches_files: true
+  - find: DSEV/Templates/CRP/MM_Trinity.txt
+    install_to: GameData/WildBlueIndustries/DSEV/Templates/CRP
+    as: MM_Trinity.cfg
+    find_matches_files: true
+  - find: DSEV/Templates/CRP/PathfinderTemplates.txt
+    install_to: GameData/WildBlueIndustries/DSEV/Templates/CRP
+    as: PathfinderTemplates.cfg
+    find_matches_files: true
+  - find: DSEV/Templates/CRP/Scanners.txt
+    install_to: GameData/WildBlueIndustries/DSEV/Templates/CRP
+    as: Scanners.cfg
+    find_matches_files: true

--- a/NetKAN/DSEV-PlayMode-ClassicStock.netkan
+++ b/NetKAN/DSEV-PlayMode-ClassicStock.netkan
@@ -1,32 +1,26 @@
-{
-    "identifier":   "DSEV-PlayMode-ClassicStock",
-    "name":         "DSEV Classic Stock Play Mode",
-    "$kref":        "#/ckan/github/Angel-125/DSEV",
-    "$vref":        "#/ckan/ksp-avc/GameData/WildBlueIndustries/DSEV/DSEV.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "restricted",
-    "resources": {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/122162-*",
-        "repository": "https://github.com/Angel-125/DSEV"
-    },
-    "tags": [
-        "config"
-    ],
-    "provides": [
-        "DSEV-PlayMode"
-    ],
-    "depends": [
-        { "name": "WildBlue-PlayMode-ClassicStock" },
-        { "name": "ModuleManager"                  },
-        { "name": "DSEV"                           }
-    ],
-    "install": [ {
-        "find":       "WildBlueIndustries/DSEV/Templates/ClassicStock",
-        "install_to": "GameData/WildBlueIndustries/DSEV/Templates"
-    }, {
-        "find":       "WildBlueIndustries/DSEV/Templates/ClassicStock.cfg",
-        "install_to": "GameData/WildBlueIndustries/DSEV/Templates",
-        "find_matches_files": true
-    } ]
-}
+identifier: DSEV-PlayMode-ClassicStock
+name: DSEV Classic Stock Play Mode
+$kref: '#/ckan/github/Angel-125/DSEV'
+$vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/DSEV/DSEV.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: restricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/122162-*
+  repository: https://github.com/Angel-125/DSEV
+tags:
+  - config
+provides:
+  - DSEV-PlayMode
+conflicts:
+  - name: DSEV-PlayMode
+depends:
+  - name: WildBlue-PlayMode-ClassicStock
+  - name: ModuleManager
+  - name: DSEV
+install:
+  - find: WildBlueIndustries/DSEV/Templates/ClassicStock
+    install_to: GameData/WildBlueIndustries/DSEV/Templates
+  - find: WildBlueIndustries/DSEV/Templates/ClassicStock.cfg
+    install_to: GameData/WildBlueIndustries/DSEV/Templates
+    find_matches_files: true

--- a/NetKAN/DSEV-PlayMode-Pristine.netkan
+++ b/NetKAN/DSEV-PlayMode-Pristine.netkan
@@ -1,34 +1,28 @@
-{
-    "identifier":   "DSEV-PlayMode-Pristine",
-    "name":         "DSEV Pristine Play Mode",
-    "$kref":        "#/ckan/github/Angel-125/DSEV",
-    "$vref":        "#/ckan/ksp-avc/GameData/WildBlueIndustries/DSEV/DSEV.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "restricted",
-    "resources": {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/122162-*",
-        "repository": "https://github.com/Angel-125/DSEV"
-    },
-    "tags": [
-        "config"
-    ],
-    "provides": [
-        "DSEV-PlayMode"
-    ],
-    "depends": [
-        { "name": "WildBlue-PlayMode-Pristine" },
-        { "name": "ModuleManager"              },
-        { "name": "DSEV"                       }
-    ],
-    "install": [ {
-        "find":       "WildBlueIndustries/DSEV/Templates/Pristine.cfg",
-        "install_to": "GameData/WildBlueIndustries/DSEV/Templates",
-        "find_matches_files": true
-    }, {
-        "find":       "DSEV/Templates/Pristine/MM_Pristine.txt",
-        "install_to": "GameData/WildBlueIndustries/DSEV/Templates/Pristine",
-        "as":         "MM_Pristine.cfg",
-        "find_matches_files": true
-    } ]
-}
+identifier: DSEV-PlayMode-Pristine
+name: DSEV Pristine Play Mode
+$kref: '#/ckan/github/Angel-125/DSEV'
+$vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/DSEV/DSEV.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: restricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/122162-*
+  repository: https://github.com/Angel-125/DSEV
+tags:
+  - config
+provides:
+  - DSEV-PlayMode
+conflicts:
+  - name: DSEV-PlayMode
+depends:
+  - name: WildBlue-PlayMode-Pristine
+  - name: ModuleManager
+  - name: DSEV
+install:
+  - find: WildBlueIndustries/DSEV/Templates/Pristine.cfg
+    install_to: GameData/WildBlueIndustries/DSEV/Templates
+    find_matches_files: true
+  - find: DSEV/Templates/Pristine/MM_Pristine.txt
+    install_to: GameData/WildBlueIndustries/DSEV/Templates/Pristine
+    as: MM_Pristine.cfg
+    find_matches_files: true

--- a/NetKAN/Heisenberg-PlayMode-CRP.netkan
+++ b/NetKAN/Heisenberg-PlayMode-CRP.netkan
@@ -1,5 +1,5 @@
 identifier: Heisenberg-PlayMode-CRP
-name: Heisenberg CRP Play Mode
+name: Airships CRP Play Mode
 $kref: '#/ckan/github/Angel-125/Airships'
 $vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version'
 x_netkan_staging: true

--- a/NetKAN/Heisenberg-PlayMode-ClassicStock.netkan
+++ b/NetKAN/Heisenberg-PlayMode-ClassicStock.netkan
@@ -1,5 +1,5 @@
 identifier: Heisenberg-PlayMode-ClassicStock
-name: Heisenberg Classic Stock Play Mode
+name: Airships Classic Stock Play Mode
 $kref: '#/ckan/github/Angel-125/Airships'
 $vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version'
 x_netkan_staging: true

--- a/NetKAN/Heisenberg-PlayMode-Pristine.netkan
+++ b/NetKAN/Heisenberg-PlayMode-Pristine.netkan
@@ -1,5 +1,5 @@
 identifier: Heisenberg-PlayMode-Pristine
-name: Heisenberg Pristine Play Mode
+name: Airships Pristine Play Mode
 $kref: '#/ckan/github/Angel-125/Airships'
 $vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version'
 x_netkan_staging: true

--- a/NetKAN/Heisenberg-PlayMode-Simplified.netkan
+++ b/NetKAN/Heisenberg-PlayMode-Simplified.netkan
@@ -1,5 +1,5 @@
 identifier: Heisenberg-PlayMode-Simplified
-name: Heisenberg Simplified Play Mode
+name: Airships Simplified Play Mode
 $kref: '#/ckan/github/Angel-125/Airships'
 $vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/Heisenberg/Airships.version'
 x_netkan_staging: true

--- a/NetKAN/MOLE-PlayMode-CRP.netkan
+++ b/NetKAN/MOLE-PlayMode-CRP.netkan
@@ -1,59 +1,48 @@
-{
-    "identifier":   "MOLE-PlayMode-CRP",
-    "name":         "MOLE CRP Play Mode",
-    "$kref":        "#/ckan/github/Angel-125/MOLE",
-    "$vref":        "#/ckan/ksp-avc/GameData/WildBlueIndustries/MOLE/MOLE.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "restricted",
-    "resources": {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/154893-*",
-        "repository": "https://github.com/Angel-125/MOLE"
-    },
-    "tags": [
-        "config"
-    ],
-    "provides": [
-        "MOLE-PlayMode"
-    ],
-    "depends": [
-        { "name": "WildBlue-PlayMode-CRP" },
-        { "name": "ModuleManager"         },
-        { "name": "MOLE"                  }
-    ],
-    "install": [ {
-        "find":       "WildBlueIndustries/MOLE/Templates/CRP.cfg",
-        "install_to": "GameData/WildBlueIndustries/MOLE/Templates",
-        "find_matches_files": true
-    }, {
-        "find":       "MOLE/Templates/CRP/BOW.txt",
-        "install_to": "GameData/WildBlueIndustries/MOLE/Templates/CRP",
-        "as":         "BOW.cfg",
-        "find_matches_files": true
-    }, {
-        "find":       "MOLE/Templates/CRP/Experiments.txt",
-        "install_to": "GameData/WildBlueIndustries/MOLE/Templates/CRP",
-        "as":         "Experiments.cfg",
-        "find_matches_files": true
-    }, {
-        "find":       "MOLE/Templates/CRP/MM_Snacks.txt",
-        "install_to": "GameData/WildBlueIndustries/MOLE/Templates/CRP",
-        "as":         "MM_Snacks.cfg",
-        "find_matches_files": true
-    }, {
-        "find":       "MOLE/Templates/CRP/MOBL18.txt",
-        "install_to": "GameData/WildBlueIndustries/MOLE/Templates/CRP",
-        "as":         "MOBL18.cfg",
-        "find_matches_files": true
-    }, {
-        "find":       "MOLE/Templates/CRP/MOH18.txt",
-        "install_to": "GameData/WildBlueIndustries/MOLE/Templates/CRP",
-        "as":         "MOH18.cfg",
-        "find_matches_files": true
-    }, {
-        "find":       "MOLE/Templates/CRP/MOLE18.txt",
-        "install_to": "GameData/WildBlueIndustries/MOLE/Templates/CRP",
-        "as":         "MOLE18.cfg",
-        "find_matches_files": true
-    } ]
-}
+identifier: MOLE-PlayMode-CRP
+name: MOLE CRP Play Mode
+$kref: '#/ckan/github/Angel-125/MOLE'
+$vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/MOLE/MOLE.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: restricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/154893-*
+  repository: https://github.com/Angel-125/MOLE
+tags:
+  - config
+provides:
+  - MOLE-PlayMode
+conflicts:
+  - name: MOLE-PlayMode
+depends:
+  - name: WildBlue-PlayMode-CRP
+  - name: ModuleManager
+  - name: MOLE
+install:
+  - find: WildBlueIndustries/MOLE/Templates/CRP.cfg
+    install_to: GameData/WildBlueIndustries/MOLE/Templates
+    find_matches_files: true
+  - find: MOLE/Templates/CRP/BOW.txt
+    install_to: GameData/WildBlueIndustries/MOLE/Templates/CRP
+    as: BOW.cfg
+    find_matches_files: true
+  - find: MOLE/Templates/CRP/Experiments.txt
+    install_to: GameData/WildBlueIndustries/MOLE/Templates/CRP
+    as: Experiments.cfg
+    find_matches_files: true
+  - find: MOLE/Templates/CRP/MM_Snacks.txt
+    install_to: GameData/WildBlueIndustries/MOLE/Templates/CRP
+    as: MM_Snacks.cfg
+    find_matches_files: true
+  - find: MOLE/Templates/CRP/MOBL18.txt
+    install_to: GameData/WildBlueIndustries/MOLE/Templates/CRP
+    as: MOBL18.cfg
+    find_matches_files: true
+  - find: MOLE/Templates/CRP/MOH18.txt
+    install_to: GameData/WildBlueIndustries/MOLE/Templates/CRP
+    as: MOH18.cfg
+    find_matches_files: true
+  - find: MOLE/Templates/CRP/MOLE18.txt
+    install_to: GameData/WildBlueIndustries/MOLE/Templates/CRP
+    as: MOLE18.cfg
+    find_matches_files: true

--- a/NetKAN/MOLE-PlayMode-ClassicStock.netkan
+++ b/NetKAN/MOLE-PlayMode-ClassicStock.netkan
@@ -1,32 +1,26 @@
-{
-    "identifier":   "MOLE-PlayMode-ClassicStock",
-    "name":         "MOLE Classic Stock Play Mode",
-    "$kref":        "#/ckan/github/Angel-125/MOLE",
-    "$vref":        "#/ckan/ksp-avc/GameData/WildBlueIndustries/MOLE/MOLE.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "restricted",
-    "resources": {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/154893-*",
-        "repository": "https://github.com/Angel-125/MOLE"
-    },
-    "tags": [
-        "config"
-    ],
-    "provides": [
-        "MOLE-PlayMode"
-    ],
-    "depends": [
-        { "name": "WildBlue-PlayMode-ClassicStock" },
-        { "name": "ModuleManager"                  },
-        { "name": "MOLE"                           }
-    ],
-    "install": [ {
-        "find":       "WildBlueIndustries/MOLE/Templates/ClassicStock",
-        "install_to": "GameData/WildBlueIndustries/MOLE/Templates"
-    }, {
-        "find":       "WildBlueIndustries/MOLE/Templates/ClassicStock.cfg",
-        "install_to": "GameData/WildBlueIndustries/MOLE/Templates",
-        "find_matches_files": true
-    } ]
-}
+identifier: MOLE-PlayMode-ClassicStock
+name: MOLE Classic Stock Play Mode
+$kref: '#/ckan/github/Angel-125/MOLE'
+$vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/MOLE/MOLE.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: restricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/154893-*
+  repository: https://github.com/Angel-125/MOLE
+tags:
+  - config
+provides:
+  - MOLE-PlayMode
+conflicts:
+  - name: MOLE-PlayMode
+depends:
+  - name: WildBlue-PlayMode-ClassicStock
+  - name: ModuleManager
+  - name: MOLE
+install:
+  - find: WildBlueIndustries/MOLE/Templates/ClassicStock
+    install_to: GameData/WildBlueIndustries/MOLE/Templates
+  - find: WildBlueIndustries/MOLE/Templates/ClassicStock.cfg
+    install_to: GameData/WildBlueIndustries/MOLE/Templates
+    find_matches_files: true

--- a/NetKAN/MOLE-PlayMode-Pristine.netkan
+++ b/NetKAN/MOLE-PlayMode-Pristine.netkan
@@ -1,34 +1,28 @@
-{
-    "identifier":   "MOLE-PlayMode-Pristine",
-    "name":         "MOLE Pristine Play Mode",
-    "$kref":        "#/ckan/github/Angel-125/MOLE",
-    "$vref":        "#/ckan/ksp-avc/GameData/WildBlueIndustries/MOLE/MOLE.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "restricted",
-    "resources": {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/154893-*",
-        "repository": "https://github.com/Angel-125/MOLE"
-    },
-    "tags": [
-        "config"
-    ],
-    "provides": [
-        "MOLE-PlayMode"
-    ],
-    "depends": [
-        { "name": "WildBlue-PlayMode-Pristine" },
-        { "name": "ModuleManager"              },
-        { "name": "MOLE"                       }
-    ],
-    "install": [ {
-        "find":       "WildBlueIndustries/MOLE/Templates/Pristine.cfg",
-        "install_to": "GameData/WildBlueIndustries/MOLE/Templates",
-        "find_matches_files": true
-    }, {
-        "find":       "MOLE/Templates/Pristine/MM_Pristine.txt",
-        "install_to": "GameData/WildBlueIndustries/MOLE/Templates/Pristine",
-        "as":         "MM_Pristine.cfg",
-        "find_matches_files": true
-    } ]
-}
+identifier: MOLE-PlayMode-Pristine
+name: MOLE Pristine Play Mode
+$kref: '#/ckan/github/Angel-125/MOLE'
+$vref: '#/ckan/ksp-avc/GameData/WildBlueIndustries/MOLE/MOLE.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: restricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/154893-*
+  repository: https://github.com/Angel-125/MOLE
+tags:
+  - config
+provides:
+  - MOLE-PlayMode
+conflicts:
+  - name: MOLE-PlayMode
+depends:
+  - name: WildBlue-PlayMode-Pristine
+  - name: ModuleManager
+  - name: MOLE
+install:
+  - find: WildBlueIndustries/MOLE/Templates/Pristine.cfg
+    install_to: GameData/WildBlueIndustries/MOLE/Templates
+    find_matches_files: true
+  - find: MOLE/Templates/Pristine/MM_Pristine.txt
+    install_to: GameData/WildBlueIndustries/MOLE/Templates/Pristine
+    as: MM_Pristine.cfg
+    find_matches_files: true

--- a/NetKAN/Pathfinder-PlayMode-CRP.netkan
+++ b/NetKAN/Pathfinder-PlayMode-CRP.netkan
@@ -1,118 +1,84 @@
-{
-    "identifier":   "Pathfinder-PlayMode-CRP",
-    "name":         "Pathfinder CRP Play Mode",
-    "author":       "Angel-125",
-    "$kref":        "#/ckan/github/Angel-125/Pathfinder",
-    "$vref":        "#/ckan/ksp-avc/Pathfinder.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "GPL-3.0",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/121397-*"
-    },
-    "tags": [
-        "config"
-    ],
-    "provides": [
-        "Pathfinder-PlayMode"
-    ],
-    "depends": [
-        { "name": "WildBlue-PlayMode-CRP" },
-        { "name": "ModuleManager"         },
-        { "name": "Pathfinder"            }
-    ],
-    "install": [ {
-        "find":       "Pathfinder/Templates/CRP.cfg",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates",
-        "find_matches_files": true
-    }, {
-        "find":       "Pathfinder/Templates/CRP/Blacksmith.txt",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates/CRP",
-        "as":         "Blacksmith.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "Pathfinder/Templates/CRP/BrewWorks.txt",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates/CRP",
-        "as":         "BrewWorks.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "Pathfinder/Templates/CRP/Claimjumper.txt",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates/CRP",
-        "as":         "Claimjumper.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "Pathfinder/Templates/CRP/Clockworks.txt",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates/CRP",
-        "as":         "Clockworks.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "Pathfinder/Templates/CRP/GeologyLab.txt",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates/CRP",
-        "as":         "GeologyLab.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "Pathfinder/Templates/CRP/GoldStrike.txt",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates/CRP",
-        "as":         "GoldStrike.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "Pathfinder/Templates/CRP/HotSprings.txt",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates/CRP",
-        "as":         "HotSprings.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "Pathfinder/Templates/CRP/Ironworks.txt",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates/CRP",
-        "as":         "Ironworks.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "Pathfinder/Templates/CRP/Lasso.txt",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates/CRP",
-        "as":         "Lasso.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "Pathfinder/Templates/CRP/MM_Snacks.txt",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates/CRP",
-        "as":         "MM_Snacks.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "Pathfinder/Templates/CRP/Nukeworks.txt",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates/CRP",
-        "as":         "Nukeworks.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "Pathfinder/Templates/CRP/OPAL.txt",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates/CRP",
-        "as":         "OPAL.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "Pathfinder/Templates/CRP/SolarFlare.txt",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates/CRP",
-        "as":         "SolarFlare.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "Pathfinder/Templates/CRP/SunburnLab.txt",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates/CRP",
-        "as":         "SunburnLab.cfg",
-        "find_matches_files": true
-    },
-    {
-        "find":       "Pathfinder/Templates/CRP/WatneyChemLab.txt",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates/CRP",
-        "as":         "WatneyChemLab.cfg",
-        "find_matches_files": true
-    } ]
-}
+identifier: Pathfinder-PlayMode-CRP
+name: Pathfinder CRP Play Mode
+author: Angel-125
+$kref: '#/ckan/github/Angel-125/Pathfinder'
+$vref: '#/ckan/ksp-avc/Pathfinder.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: GPL-3.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/121397-*
+tags:
+  - config
+provides:
+  - Pathfinder-PlayMode
+conflicts:
+  - name: Pathfinder-PlayMode
+depends:
+  - name: WildBlue-PlayMode-CRP
+  - name: ModuleManager
+  - name: Pathfinder
+install:
+  - find: Pathfinder/Templates/CRP.cfg
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates
+    find_matches_files: true
+  - find: Pathfinder/Templates/CRP/Blacksmith.txt
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates/CRP
+    as: Blacksmith.cfg
+    find_matches_files: true
+  - find: Pathfinder/Templates/CRP/BrewWorks.txt
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates/CRP
+    as: BrewWorks.cfg
+    find_matches_files: true
+  - find: Pathfinder/Templates/CRP/Claimjumper.txt
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates/CRP
+    as: Claimjumper.cfg
+    find_matches_files: true
+  - find: Pathfinder/Templates/CRP/Clockworks.txt
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates/CRP
+    as: Clockworks.cfg
+    find_matches_files: true
+  - find: Pathfinder/Templates/CRP/GeologyLab.txt
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates/CRP
+    as: GeologyLab.cfg
+    find_matches_files: true
+  - find: Pathfinder/Templates/CRP/GoldStrike.txt
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates/CRP
+    as: GoldStrike.cfg
+    find_matches_files: true
+  - find: Pathfinder/Templates/CRP/HotSprings.txt
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates/CRP
+    as: HotSprings.cfg
+    find_matches_files: true
+  - find: Pathfinder/Templates/CRP/Ironworks.txt
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates/CRP
+    as: Ironworks.cfg
+    find_matches_files: true
+  - find: Pathfinder/Templates/CRP/Lasso.txt
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates/CRP
+    as: Lasso.cfg
+    find_matches_files: true
+  - find: Pathfinder/Templates/CRP/MM_Snacks.txt
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates/CRP
+    as: MM_Snacks.cfg
+    find_matches_files: true
+  - find: Pathfinder/Templates/CRP/Nukeworks.txt
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates/CRP
+    as: Nukeworks.cfg
+    find_matches_files: true
+  - find: Pathfinder/Templates/CRP/OPAL.txt
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates/CRP
+    as: OPAL.cfg
+    find_matches_files: true
+  - find: Pathfinder/Templates/CRP/SolarFlare.txt
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates/CRP
+    as: SolarFlare.cfg
+    find_matches_files: true
+  - find: Pathfinder/Templates/CRP/SunburnLab.txt
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates/CRP
+    as: SunburnLab.cfg
+    find_matches_files: true
+  - find: Pathfinder/Templates/CRP/WatneyChemLab.txt
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates/CRP
+    as: WatneyChemLab.cfg
+    find_matches_files: true

--- a/NetKAN/Pathfinder-PlayMode-ClassicStock.netkan
+++ b/NetKAN/Pathfinder-PlayMode-ClassicStock.netkan
@@ -1,32 +1,26 @@
-{
-    "identifier":   "Pathfinder-PlayMode-ClassicStock",
-    "name":         "Pathfinder Classic Stock Play Mode",
-    "author":       "Angel-125",
-    "$kref":        "#/ckan/github/Angel-125/Pathfinder",
-    "$vref":        "#/ckan/ksp-avc/Pathfinder.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "GPL-3.0",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/121397-*"
-    },
-    "tags": [
-        "config"
-    ],
-    "provides": [
-        "Pathfinder-PlayMode"
-    ],
-    "depends": [
-        { "name": "WildBlue-PlayMode-ClassicStock" },
-        { "name": "ModuleManager"                  },
-        { "name": "Pathfinder"                     }
-    ],
-    "install": [ {
-        "find":       "Pathfinder/Templates/ClassicStock",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates"
-    }, {
-        "find":       "Pathfinder/Templates/ClassicStock.cfg",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates",
-        "find_matches_files": true
-    } ]
-}
+identifier: Pathfinder-PlayMode-ClassicStock
+name: Pathfinder Classic Stock Play Mode
+author: Angel-125
+$kref: '#/ckan/github/Angel-125/Pathfinder'
+$vref: '#/ckan/ksp-avc/Pathfinder.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: GPL-3.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/121397-*
+tags:
+  - config
+provides:
+  - Pathfinder-PlayMode
+conflicts:
+  - name: Pathfinder-PlayMode
+depends:
+  - name: WildBlue-PlayMode-ClassicStock
+  - name: ModuleManager
+  - name: Pathfinder
+install:
+  - find: Pathfinder/Templates/ClassicStock
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates
+  - find: Pathfinder/Templates/ClassicStock.cfg
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates
+    find_matches_files: true

--- a/NetKAN/Pathfinder-PlayMode-Pristine.netkan
+++ b/NetKAN/Pathfinder-PlayMode-Pristine.netkan
@@ -1,34 +1,28 @@
-{
-    "identifier":   "Pathfinder-PlayMode-Pristine",
-    "name":         "Pathfinder Pristine Play Mode",
-    "author":       "Angel-125",
-    "$kref":        "#/ckan/github/Angel-125/Pathfinder",
-    "$vref":        "#/ckan/ksp-avc/Pathfinder.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "GPL-3.0",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/121397-*"
-    },
-    "tags": [
-        "config"
-    ],
-    "provides": [
-        "Pathfinder-PlayMode"
-    ],
-    "depends": [
-        { "name": "WildBlue-PlayMode-Pristine" },
-        { "name": "ModuleManager"              },
-        { "name": "Pathfinder"                 }
-    ],
-    "install": [ {
-        "find":       "Pathfinder/Templates/Pristine.cfg",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates",
-        "find_matches_files": true
-    }, {
-        "find":       "Pathfinder/Templates/Pristine/Pristine Mode.txt",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates/Pristine",
-        "as":         "Pristine Mode.cfg",
-        "find_matches_files": true
-    } ]
-}
+identifier: Pathfinder-PlayMode-Pristine
+name: Pathfinder Pristine Play Mode
+author: Angel-125
+$kref: '#/ckan/github/Angel-125/Pathfinder'
+$vref: '#/ckan/ksp-avc/Pathfinder.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: GPL-3.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/121397-*
+tags:
+  - config
+provides:
+  - Pathfinder-PlayMode
+conflicts:
+  - name: Pathfinder-PlayMode
+depends:
+  - name: WildBlue-PlayMode-Pristine
+  - name: ModuleManager
+  - name: Pathfinder
+install:
+  - find: Pathfinder/Templates/Pristine.cfg
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates
+    find_matches_files: true
+  - find: Pathfinder/Templates/Pristine/Pristine Mode.txt
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates/Pristine
+    as: Pristine Mode.cfg
+    find_matches_files: true

--- a/NetKAN/Pathfinder-PlayMode-Simplified.netkan
+++ b/NetKAN/Pathfinder-PlayMode-Simplified.netkan
@@ -1,34 +1,28 @@
-{
-    "identifier":   "Pathfinder-PlayMode-Simplified",
-    "name":         "Pathfinder Simplified Play Mode",
-    "author":       "Angel-125",
-    "$kref":        "#/ckan/github/Angel-125/Pathfinder",
-    "$vref":        "#/ckan/ksp-avc/Pathfinder.version",
-    "x_netkan_staging": true,
-    "x_netkan_staging_reason": "Make sure that all .txt files for this play mode are installed as .cfg",
-    "license":      "GPL-3.0",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/121397-*"
-    },
-    "tags": [
-        "config"
-    ],
-    "provides": [
-        "Pathfinder-PlayMode"
-    ],
-    "depends": [
-        { "name": "WildBlue-PlayMode-Simplified" },
-        { "name": "ModuleManager"                },
-        { "name": "Pathfinder"                   }
-    ],
-    "install": [ {
-        "find":       "Pathfinder/Templates/Simplified.cfg",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates",
-        "find_matches_files": true
-    }, {
-        "find":       "Pathfinder/Templates/Simplified/Simplified Mode.txt",
-        "install_to": "GameData/WildBlueIndustries/Pathfinder/Templates/Simplified",
-        "as":         "Simplified Mode.cfg",
-        "find_matches_files": true
-    } ]
-}
+identifier: Pathfinder-PlayMode-Simplified
+name: Pathfinder Simplified Play Mode
+author: Angel-125
+$kref: '#/ckan/github/Angel-125/Pathfinder'
+$vref: '#/ckan/ksp-avc/Pathfinder.version'
+x_netkan_staging: true
+x_netkan_staging_reason: Make sure that all .txt files for this play mode are installed as .cfg
+license: GPL-3.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/121397-*
+tags:
+  - config
+provides:
+  - Pathfinder-PlayMode
+conflicts:
+  - name: Pathfinder-PlayMode
+depends:
+  - name: WildBlue-PlayMode-Simplified
+  - name: ModuleManager
+  - name: Pathfinder
+install:
+  - find: Pathfinder/Templates/Simplified.cfg
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates
+    find_matches_files: true
+  - find: Pathfinder/Templates/Simplified/Simplified Mode.txt
+    install_to: GameData/WildBlueIndustries/Pathfinder/Templates/Simplified
+    as: Simplified Mode.cfg
+    find_matches_files: true

--- a/NetKAN/WildBlue-PlayMode-CRP.netkan
+++ b/NetKAN/WildBlue-PlayMode-CRP.netkan
@@ -20,6 +20,7 @@ provides:
   - ClassicStockResources-PlayMode
 conflicts:
   - name: WildBlue-PlayMode
+  - name: ClassicStockResources-PlayMode
 install:
   - find: 000WildBlueTools/Templates/CRP/Production/MM_SAFER.txt
     install_to: GameData/WildBlueIndustries/000WildBlueTools/Templates/CRP/Production

--- a/NetKAN/WildBlue-PlayMode-Pristine.netkan
+++ b/NetKAN/WildBlue-PlayMode-Pristine.netkan
@@ -21,6 +21,9 @@ provides:
   - ClassicStockResources-PlayMode
 conflicts:
   - name: WildBlue-PlayMode
+  - name: Buffalo-PlayMode
+  - name: KerbalKomets-PlayMode
+  - name: ClassicStockResources-PlayMode
   - name: CommunityResourcePack
 install:
   - find: 000WildBlueTools/Templates/Pristine/MM_Pristine.txt

--- a/NetKAN/WildBlue-PlayMode-Simplified.netkan
+++ b/NetKAN/WildBlue-PlayMode-Simplified.netkan
@@ -23,6 +23,11 @@ provides:
   - ClassicStockResources-PlayMode
 conflicts:
   - name: WildBlue-PlayMode
+  - name: Buffalo-PlayMode
+  - name: DSEV-PlayMode
+  - name: MOLE-PlayMode
+  - name: KerbalKomets-PlayMode
+  - name: ClassicStockResources-PlayMode
   - name: CommunityResourcePack
 install:
   - find: 000WildBlueTools/Templates/Simplified/Storage/OmniStorage.txt


### PR DESCRIPTION
While wokring on the relationship resolver refactor for KSP-CKAN/CKAN#4108, I noticed that the WildBlue play modes and Heisenberg play modes conflicted with the identifiers they provide, but the other mod-specific play modes don't. This is inconsistent and probably makes the resolver work a bit harder to figure these out.

Now all of the play modes conflict with the identifiers they provide.
In addition, "Heisenberg" is replaced by "Airships" in the play mode names for consistency with the main mod.
