### PR TITLE
KerbalismModularScienceScienceOnly provides Kerbalism-Config

### DIFF
--- a/NetKAN/KerbalismModularScienceScienceOnly.netkan
+++ b/NetKAN/KerbalismModularScienceScienceOnly.netkan
@@ -4,6 +4,8 @@ $vref: '#/ckan/ksp-avc'
 license: Unlicense
 tags:
   - parts
+provides:
+  - Kerbalism-Config
 depends:
   - name: ModuleManager
   - name: Kerbalism


### PR DESCRIPTION
From the mod's description:
"Requires Kerbalism (Kerbalism Code, not the Config) , Module Manager
A Science Only Kerbalism Config."

Current implementation does not work properly: Kerbalism-Config is required by Kerbalism, and installing one with KerbalismModularScienceScienceOnly makes Kerbalism display a "duplicate configs detected" warning.