### PR TITLE
Relicense ConformalDecals as Apache-2.0

### DIFF
--- a/NetKAN/ConformalDecals.netkan
+++ b/NetKAN/ConformalDecals.netkan
@@ -8,7 +8,7 @@ install:
 identifier: ConformalDecals
 $kref: '#/ckan/spacedock/2451'
 $vref: '#/ckan/ksp-avc'
-license: GPL-3.0
+license: Apache-2.0
 resources:
   manual: https://github.com/drewcassidy/KSP-Conformal-Decals/wiki
 tags:


### PR DESCRIPTION
Given recent news, I no longer feel comfortable using GPL. All future Conformal Decals releases will be licensed as Apache-2.0 instead