### PR TITLE
Remove Deferred marking old Parallax versions as incompatible

### DIFF
--- a/NetKAN/Deferred.netkan
+++ b/NetKAN/Deferred.netkan
@@ -11,8 +11,6 @@ tags:
   - plugin
   - graphics
 conflicts:
-  - name: Parallax
-    max_version: 2.0.6
   - name: TexturesUnlimited
     max_version: 1.5.10.25
   - name: KerbalKonstructs


### PR DESCRIPTION
Users of Parallax Continued (manual install) will get an error trying to install Deferred "Deferred conflicts with an unmanaged DLL". Remove this version check in the absence of a better option. These old Parallax versions should be mostly phased out by now.