### PR TITLE
Grounded: set ksp version to 1.10 per forum

### DIFF
--- a/NetKAN/Grounded.netkan
+++ b/NetKAN/Grounded.netkan
@@ -1,9 +1,7 @@
-{
-    "identifier"   : "Grounded",
-    "$kref"        : "#/ckan/spacedock/1715",
-    "$vref"        : "#/ckan/ksp-avc",
-    "license"      : "CC-BY-NC-ND-4.0",
-    "tags"         : [
-        "parts"
-    ]
-}
+identifier: Grounded
+"$kref": "#/ckan/spacedock/1715"
+license: CC-BY-NC-ND-4.0
+ksp_version: 1.10
+tags:
+- parts
+


### PR DESCRIPTION
This is a parts-only mod and doesn't really have any version restrictions, but the forum thread says 1.10

- <https://forum.kerbalspaceprogram.com/topic/171377-110x-grounded-modular-vehicles-r50-mining-modules-rotor-emergency-light-jun-5-2019/>
