### PR TITLE
Get JebFarAway from GitHub instead of SpaceDock

### DIFF
--- a/NetKAN/JebFarAway.netkan
+++ b/NetKAN/JebFarAway.netkan
@@ -1,5 +1,5 @@
 identifier: JebFarAway
-$kref: '#/ckan/spacedock/3565'
+$kref: '#/ckan/github/D4RKN3R/JFA'
 license: MIT
 tags:
   - config


### PR DESCRIPTION
The SpaceDock download of this mod doesn't pass ZIP validation in the Inflator:

![image](https://github.com/user-attachments/assets/e2521901-d77f-4539-85b7-f0d967bdeb18)

<http://status.ksp-ckan.space/>

![image](https://github.com/user-attachments/assets/c711933c-7a06-4f9e-8d36-747d5552fa9b)

But the one on GitHub is OK. Now we get it from GitHub.

Fixes #10281.
