### PR TITLE
Remove release_status property from all netkans

### DIFF
--- a/NetKAN/BDDMP.netkan
+++ b/NetKAN/BDDMP.netkan
@@ -1,18 +1,12 @@
-{
-    "identifier":   "BDDMP",
-    "$kref":        "#/ckan/spacedock/253",
-    "release_status": "development",
-    "license":      "CC-BY-SA-2.0",
-    "tags": [
-        "plugin",
-        "combat"
-    ],
-    "depends": [
-        { "name" : "DarkMultiPlayer"   },
-        { "name" : "BDArmoryContinued" }
-    ],
-    "install": [ {
-        "find":       "zzBDDMP",
-        "install_to": "GameData"
-    } ]
-}
+identifier: BDDMP
+$kref: '#/ckan/spacedock/253'
+license: CC-BY-SA-2.0
+tags:
+  - plugin
+  - combat
+depends:
+  - name: DarkMultiPlayer
+  - name: BDArmoryContinued
+install:
+  - find: zzBDDMP
+    install_to: GameData

--- a/NetKAN/DarkMultiPlayer.netkan
+++ b/NetKAN/DarkMultiPlayer.netkan
@@ -1,22 +1,14 @@
-{
-    "identifier"     : "DarkMultiPlayer",
-    "$kref"          : "#/ckan/spacedock/10",
-    "release_status" : "development",
-    "license"        : "MIT",
-    "resources"      : {
-        "manual"     : "https://github.com/godarklight/DarkMultiPlayer/blob/master/README.md"
-    },
-    "tags": [
-        "plugin"
-    ],
-    "install": [ {
-        "file"       : "DMPClient/GameData/DarkMultiPlayer",
-        "install_to" : "GameData"
-    } ],
-    "x_netkan_override": [ {
-        "version": "v0.3.7.1",
-        "override": {
-            "ksp_version_min": "1.11.1"
-        }
-    } ]
-}
+identifier: DarkMultiPlayer
+$kref: '#/ckan/spacedock/10'
+license: MIT
+resources:
+  manual: https://github.com/godarklight/DarkMultiPlayer/blob/master/README.md
+tags:
+  - plugin
+install:
+  - file: DMPClient/GameData/DarkMultiPlayer
+    install_to: GameData
+x_netkan_override:
+  - version: v0.3.7.1
+    override:
+      ksp_version_min: 1.11.1

--- a/NetKAN/KerbalEngineerRedux.netkan
+++ b/NetKAN/KerbalEngineerRedux.netkan
@@ -1,22 +1,16 @@
-{
-    "identifier":   "KerbalEngineerRedux",
-    "name":         "Kerbal Engineer Redux",
-    "abstract":     "Reveals important statistics about your ship and its orbit during building and flight",
-    "$kref":        "#/ckan/github/jrbudda/KerbalEngineer",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "release_status": "testing",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/17833-*"
-    },
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "install": [
-        {
-            "file":       "KerbalEngineer",
-            "install_to": "GameData"
-        }
-    ]
-}
+identifier: KerbalEngineerRedux
+name: Kerbal Engineer Redux
+abstract: >-
+  Reveals important statistics about your ship and its orbit during building and
+  flight
+$kref: '#/ckan/github/jrbudda/KerbalEngineer'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/17833-*
+tags:
+  - plugin
+  - information
+install:
+  - file: KerbalEngineer
+    install_to: GameData

--- a/NetKAN/KerwisChinaAerospacePack.netkan
+++ b/NetKAN/KerwisChinaAerospacePack.netkan
@@ -1,7 +1,6 @@
 identifier: KerwisChinaAerospacePack
 $kref: '#/ckan/spacedock/2867'
 license: CC-BY-NC-SA-4.0
-release_status: development
 tags:
   - parts
 depends:

--- a/NetKAN/Kopernicus.netkan
+++ b/NetKAN/Kopernicus.netkan
@@ -9,7 +9,6 @@ x_netkan_version_edit:
   find: ^(?<version>.+)$
   replace: release-${version}
 x_netkan_allow_out_of_order: true
-release_status: development
 license: LGPL-3.0
 author:
   - BryceSchroeder

--- a/NetKAN/PartOverhauls.netkan
+++ b/NetKAN/PartOverhauls.netkan
@@ -1,24 +1,16 @@
-{
-    "name"           : "Porkjet's Part Overhauls",
-    "abstract"       : "Porkjet's in-progress part overhauls",
-    "identifier"     : "PartOverhauls",
-    "download"       : "https://archive.org/download/PartOverhauls/PartOverhauls.zip",
-    "license"        : "CC-BY-NC-3.0",
-    "version"        : "0.1.0",
-    "author"         : "Porkjet",
-    "release_status" : "development",
-    "ksp_version_min": "1.1.0",
-    "resources" : {
-        "homepage" : "http://forum.kerbalspaceprogram.com/index.php?/topic/147582-*"
-    },
-    "tags": [
-        "parts",
-        "graphics"
-    ],
-    "install" : [
-        {
-            "file"       : "GameData/PartOverhauls",
-            "install_to" : "GameData"
-        }
-    ]
-}
+name: Porkjet's Part Overhauls
+abstract: Porkjet's in-progress part overhauls
+identifier: PartOverhauls
+download: https://archive.org/download/PartOverhauls/PartOverhauls.zip
+license: CC-BY-NC-3.0
+version: 0.1.0
+author: Porkjet
+ksp_version_min: 1.1.0
+resources:
+  homepage: http://forum.kerbalspaceprogram.com/index.php?/topic/147582-*
+tags:
+  - parts
+  - graphics
+install:
+  - file: GameData/PartOverhauls
+    install_to: GameData

--- a/NetKAN/PlanetaryDiversity.netkan
+++ b/NetKAN/PlanetaryDiversity.netkan
@@ -11,7 +11,6 @@ author:
 $kref: '#/ckan/spacedock/2243'
 x_netkan_epoch: '1'
 $vref: '#/ckan/ksp-avc'
-release_status: development
 license: MIT
 tags:
   - plugin

--- a/NetKAN/Scatterer-config.netkan
+++ b/NetKAN/Scatterer-config.netkan
@@ -17,7 +17,6 @@ abstract: >-
 $kref: '#/ckan/spacedock/141'
 x_netkan_force_v: true
 x_netkan_epoch: '3'
-release_status: development
 license: GPL-3.0
 tags:
   - graphics

--- a/NetKAN/Scatterer-sunflare.netkan
+++ b/NetKAN/Scatterer-sunflare.netkan
@@ -14,7 +14,6 @@ abstract: >-
 $kref: '#/ckan/spacedock/141'
 x_netkan_force_v: true
 x_netkan_epoch: '3'
-release_status: development
 license: GPL-3.0
 tags:
   - graphics

--- a/NetKAN/Scatterer.netkan
+++ b/NetKAN/Scatterer.netkan
@@ -6,7 +6,6 @@ identifier: Scatterer
 $kref: '#/ckan/spacedock/141'
 x_netkan_force_v: true
 x_netkan_epoch: '3'
-release_status: development
 license: GPL-3.0
 tags:
   - graphics

--- a/NetKAN/TextureReplacerReplaced.netkan
+++ b/NetKAN/TextureReplacerReplaced.netkan
@@ -1,41 +1,35 @@
-{
-    "identifier":   "TextureReplacerReplaced",
-    "name":         "Texture Replacer Replaced",
-    "abstract":     "Kerbal and suits personalisation, texture replacement and reflections",
-    "$kref":        "#/ckan/github/HaArLiNsH/TextureReplacerReplaced",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "MIT",
-    "comment":      "Plugin is MIT, but some parts CC-BY-NC-SA, and we always specify most restrictive in metadata.",
-    "author":       [ "shaw", "RangeMachine", "HaArLiNsH" ],
-    "release_status": "testing",
-    "resources": {
-        "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/161898-*",
-        "repository": "https://github.com/HaArLiNsH/TextureReplacerReplaced"
-    },
-    "tags": [
-        "plugin",
-        "graphics"
-    ],
-    "provides": [
-        "TextureReplacer"
-    ],
-    "conflicts": [
-        { "name": "TextureReplacer" }
-    ],
-    "install"  : [ {
-        "find"       : "000_TRR_Config",
-        "install_to" : "GameData"
-    }, {
-        "find"       : "TextureReplacerReplaced",
-        "install_to" : "GameData"
-    } ],
-    "recommends" : [
-        { "name" : "WindowShine" }
-    ],
-    "suggests" : [
-        { "name" : "DiverseKerbalHeads" },
-        { "name" : "TRRGuide"           },
-        { "name" : "TRR-MyTextureMod"   },
-        { "name" : "UKS"                }
-    ]
-}
+identifier: TextureReplacerReplaced
+name: Texture Replacer Replaced
+abstract: Kerbal and suits personalisation, texture replacement and reflections
+$kref: '#/ckan/github/HaArLiNsH/TextureReplacerReplaced'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+comment: >-
+  Plugin is MIT, but some parts CC-BY-NC-SA, and we always specify most
+  restrictive in metadata.
+author:
+  - shaw
+  - RangeMachine
+  - HaArLiNsH
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/161898-*
+  repository: https://github.com/HaArLiNsH/TextureReplacerReplaced
+tags:
+  - plugin
+  - graphics
+provides:
+  - TextureReplacer
+conflicts:
+  - name: TextureReplacer
+install:
+  - find: 000_TRR_Config
+    install_to: GameData
+  - find: TextureReplacerReplaced
+    install_to: GameData
+recommends:
+  - name: WindowShine
+suggests:
+  - name: DiverseKerbalHeads
+  - name: TRRGuide
+  - name: TRR-MyTextureMod
+  - name: UKS

--- a/NetKAN/USI-NuclearRockets.netkan
+++ b/NetKAN/USI-NuclearRockets.netkan
@@ -5,7 +5,6 @@ author: RoverDude
 $kref: '#/ckan/github/UmbraSpaceIndustries/NuclearRockets'
 $vref: '#/ckan/ksp-avc'
 license: restricted
-release_status: development
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/121597-*
   manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/

--- a/NetKAN/kOSPropMonitor.netkan
+++ b/NetKAN/kOSPropMonitor.netkan
@@ -13,7 +13,6 @@ identifier: kOSPropMonitor
 $kref: '#/ckan/spacedock/3473'
 $vref: '#/ckan/ksp-avc'
 license: GPL-3.0
-release_status: development
 tags:
   - plugin
   - information


### PR DESCRIPTION
## Motivation

The spec defines `release_status` as `stable`, `testing`, and `development`, in decreasing order of stability.

Currently no code looks at this value, which means we effectively treat all mods as `stable` today (since all mods will be installed for all users).

KSP-CKAN/CKAN#4159 is requesting that we finally follow through on the implicit promise of this property and make available a setting where users can choose their preferred mod stability. This **cannot** work if _Scatterer_, of all things, is telling us that it is a pre-pre-release only suited for the very most adventurous users.

## Changes

Now all active netkans have non-`stable` values of `release_status` removed so we can start populating it with useful, meaningful metadata such as whether a release is marked as a pre-release on GitHub. No future netkan should set `release_status` unless it is actually a completely raw in-development mod whose developer is seeking early feedback (and probably some additional limitations such as a timeline for a full release and not being a dependency of any other mods).

We will probably need to do this in CKAN-meta as well, for users who insist on trying old game versions that are only compatible with historical mod releases indexed with these bogus values of `release_status`.
