### PR TITLE
Vref for BLEAK

### DIFF
--- a/NetKAN/BLEAK.netkan
+++ b/NetKAN/BLEAK.netkan
@@ -1,6 +1,7 @@
 identifier: BLEAK
 name: BLEAK - TUFX Profiles
 $kref: '#/ckan/github/aspctt/BLEAK'
+$vref: '#/ckan/ksp-avc'
 license: GPL-3.0
 tags:
   - config


### PR DESCRIPTION
As far as I can tell, this is the only field from #10297 that actually should be added.

Fixes #10297.
