### PR TITLE
Multi-part 16k texture pack for RSSOrigin

### DIFF
--- a/NetKAN/RSSOrigin-TopoRevampTextures16k.netkan
+++ b/NetKAN/RSSOrigin-TopoRevampTextures16k.netkan
@@ -13,8 +13,8 @@ provides:
 conflicts:
   - name: RSSOrigin-TopoRevampTextures
 depends:
-  - name: RSSOrigin-TopoRevampConfigs
   - name: RSSOrigin-TopoRevampTextures16kPart2
+  - name: RSSOrigin-TopoRevampConfigs
 install:
   - find: RSSOrigin
     install_to: GameData

--- a/NetKAN/RSSOrigin-TopoRevampTextures16k.netkan
+++ b/NetKAN/RSSOrigin-TopoRevampTextures16k.netkan
@@ -1,9 +1,9 @@
 identifier: RSSOrigin-TopoRevampTextures16k
-name: RSS-Origin RSS Texture & Topo Revamp Textures 16k
+name: RSS-Origin RSS Texture & Topo Revamp Textures 16k Part 1
 abstract: >-
   The texture pack of RSS-Origin RSSTexture&TopoRevamp.
-  This is the 16k version.
-$kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/TopoRevamp.Textures16k'
+  This is part 1 of the 16k version.
+$kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/TopoRevamp.Textures16k.Part1'
 license: CC-BY-NC-SA-4.0
 tags:
   - config
@@ -14,6 +14,7 @@ conflicts:
   - name: RSSOrigin-TopoRevampTextures
 depends:
   - name: RSSOrigin-TopoRevampConfigs
+  - name: RSSOrigin-TopoRevampTextures16kPart2
 install:
   - find: RSSOrigin
     install_to: GameData

--- a/NetKAN/RSSOrigin-TopoRevampTextures16kPart2.netkan
+++ b/NetKAN/RSSOrigin-TopoRevampTextures16kPart2.netkan
@@ -9,8 +9,8 @@ tags:
   - config
   - planet-pack
 depends:
-  - name: RSSOrigin-TopoRevampConfigs
   - name: RSSOrigin-TopoRevampTextures16k
+  - name: RSSOrigin-TopoRevampConfigs
 install:
   - find: RSSOrigin
     install_to: GameData

--- a/NetKAN/RSSOrigin-TopoRevampTextures16kPart2.netkan
+++ b/NetKAN/RSSOrigin-TopoRevampTextures16kPart2.netkan
@@ -8,8 +8,6 @@ license: CC-BY-NC-SA-4.0
 tags:
   - config
   - planet-pack
-provides:
-  - RSSOrigin-TopoRevampTextures
 depends:
   - name: RSSOrigin-TopoRevampConfigs
   - name: RSSOrigin-TopoRevampTextures16k

--- a/NetKAN/RSSOrigin-TopoRevampTextures16kPart2.netkan
+++ b/NetKAN/RSSOrigin-TopoRevampTextures16kPart2.netkan
@@ -1,0 +1,18 @@
+identifier: RSSOrigin-TopoRevampTextures16kPart2
+name: RSS-Origin RSS Texture & Topo Revamp Textures 16k Part 2
+abstract: >-
+  The texture pack of RSS-Origin RSSTexture&TopoRevamp.
+  This is part 2 of the 16k version.
+$kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/TopoRevamp.Textures16k.Part2'
+license: CC-BY-NC-SA-4.0
+tags:
+  - config
+  - planet-pack
+provides:
+  - RSSOrigin-TopoRevampTextures
+depends:
+  - name: RSSOrigin-TopoRevampConfigs
+  - name: RSSOrigin-TopoRevampTextures16k
+install:
+  - find: RSSOrigin
+    install_to: GameData


### PR DESCRIPTION
This mod's 16k texture pack is now larger than the upload size limit on GitHub, which has been circumvented by splitting the file.

- <https://github.com/CharonSSS/RSS-Origin>

Fixes #10292.
