### PR TITLE
Remove trailing space from PhysicsRangeExtender name

### DIFF
--- a/NetKAN/PhysicsRangeExtender.netkan
+++ b/NetKAN/PhysicsRangeExtender.netkan
@@ -1,17 +1,12 @@
-{
-    "identifier"   : "PhysicsRangeExtender",
-    "$kref"        : "#/ckan/github/jrodrigv/PhysicsRangeExtender",
-    "$vref"        : "#/ckan/ksp-avc",
-    "name"         : "Physics Range Extender ",
-    "license"      : "Unlicense",
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/158344-*"
-    },
-    "tags": [
-        "plugin",
-        "physics"
-    ],
-    "suggests"     : [
-        { "name" : "KerbalJointReinforcement" }
-    ]
-}
+identifier: PhysicsRangeExtender
+name: Physics Range Extender
+$kref: '#/ckan/github/jrodrigv/PhysicsRangeExtender'
+$vref: '#/ckan/ksp-avc'
+license: Unlicense
+resources:
+  homepage: http://forum.kerbalspaceprogram.com/index.php?/topic/158344-*
+tags:
+  - plugin
+  - physics
+suggests:
+  - name: KerbalJointReinforcement


### PR DESCRIPTION
This mod has an extra space at the end of its `name`:

![image](https://github.com/user-attachments/assets/830f980a-22d1-4ee7-8b82-6c17702a2716)

Now it's removed.
