### PR TITLE
More flexible install for CollisionFXReUpdated

### DIFF
--- a/NetKAN/CollisionFXReUpdated.netkan
+++ b/NetKAN/CollisionFXReUpdated.netkan
@@ -18,5 +18,5 @@ tags:
 depends:
   - name: ModuleManager
 install:
-  - find: GameData/CollisionFXReUpdated
+  - find_regexp: GameData/CollisionFX(ReUpdated)?
     install_to: GameData


### PR DESCRIPTION
The folder name for the current stable version of this mod is CollisionFXReUpdated, but the prerelease just uses CollisionFX. Now the netkan handles both.