### PR TITLE
Add StockAutoCutDrogues to CKAN

### DIFF
--- a/NetKAN/StockAutoCutDrogues.netkan
+++ b/NetKAN/StockAutoCutDrogues.netkan
@@ -1,0 +1,11 @@
+identifier: StockAutoCutDrogues
+$kref: '#/ckan/github/SofieBrink/StockAutoCutDrogues'
+---
+identifier: StockAutoCutDrogues
+$kref: '#/ckan/spacedock/3773'
+license: MIT
+tags:
+  - config
+  - convenience
+abstract: >-
+  This mod is a simple ModuleManager patch to add the ModuleAutoCutDrogue module from KSPCommunityPartModules to all the stock parachutes.

--- a/NetKAN/StockAutoCutDrogues.netkan
+++ b/NetKAN/StockAutoCutDrogues.netkan
@@ -3,9 +3,6 @@ $kref: '#/ckan/github/SofieBrink/StockAutoCutDrogues'
 ---
 identifier: StockAutoCutDrogues
 $kref: '#/ckan/spacedock/3773'
-license: MIT
 tags:
   - config
   - convenience
-abstract: >-
-  This mod is a simple ModuleManager patch to add the ModuleAutoCutDrogue module from KSPCommunityPartModules to all the stock parachutes.


### PR DESCRIPTION
https://github.com/SofieBrink/StockAutoCutDrogues/releases
https://spacedock.info/mod/3773/StockAutoCutDrogues
https://forum.kerbalspaceprogram.com/topic/226347-112x-stockautocutdrogues-v100-01dec2024/
StockAutoCutDrogues has just released,


The mod contains an internal .ckan file that contains all the dependencies and other fields [here](https://github.com/SofieBrink/StockAutoCutDrogues/blob/main/GameData/StockAutoCutDrogues/Versioning/StockAutoCutDrogues.ckan)

Versioning is done with the internal version file [here
](https://github.com/SofieBrink/StockAutoCutDrogues/blob/main/GameData/StockAutoCutDrogues/Versioning/StockAutoCutDrogues.version)