### PR TITLE
De-multihost KSPTOTConnect

### DIFF
--- a/NetKAN/KSPTOTConnect.netkan
+++ b/NetKAN/KSPTOTConnect.netkan
@@ -1,11 +1,4 @@
 identifier: KSPTOTConnect
-$kref: '#/ckan/github/Arrowstar/ksptot/asset_match/^(?!.*linux)'
-x_netkan_version_edit:
-  find: ^v
-  replace: ''
-  strict: false
----
-identifier: KSPTOTConnect
 name: KSP Trajectory Optimization Tool Connect
 $kref: '#/ckan/spacedock/3737'
 tags:


### PR DESCRIPTION
This mod has the following quirks:

- Multi-hosting inflation error due to version 1.6.10.1 existing on SpaceDock and not GitHub
- 1-GB download thanks to 2 embedded copies of the MATLAB runtime

In combination, this means an extra 1 GB of downloading for the bot every 30 minutes, which may be causing the freezes that we've been seeing.

Now this mod is SpaceDock-only, which means its users (2882 downloads on GitHub, 369 on SpaceDock) will be deprived of GitHub's nicer download speeds, but the better metadata from SpaceDock won't disappear. We can restore the multi-hosting if the version numbers become consistent at some point.
