### PR TITLE
Set asset_match for EstrelaDobre

### DIFF
--- a/NetKAN/EstrelaDobre.netkan
+++ b/NetKAN/EstrelaDobre.netkan
@@ -1,5 +1,5 @@
 identifier: EstrelaDobre
-$kref: '#/ckan/github/JcoolTheShipBuilder/Estrela-Dobre'
+$kref: '#/ckan/github/JcoolTheShipBuilder/Estrela-Dobre/asset_match/EstrelaDobre'
 $vref: '#/ckan/ksp-avc'
 ---
 identifier: EstrelaDobre


### PR DESCRIPTION
This mod's repo seems to be having another mod's releases uploaded to it, which is causing inflation errors:

- <https://github.com/JcoolTheShipBuilder/Estrela-Dobre/releases>

![image](https://github.com/user-attachments/assets/7cd440de-c42a-4021-bb0b-2e33799243aa)

Now the `$kref` has an `asset_match` filter to pick up only the correct mod.
