### PR TITLE
Coerce StarshipExpansionProject versioning into consistency

### DIFF
--- a/NetKAN/StarshipExpansionProject.netkan
+++ b/NetKAN/StarshipExpansionProject.netkan
@@ -1,5 +1,10 @@
 identifier: StarshipExpansionProject
 $kref: '#/ckan/github/Kari1407/Starship-Expansion-Project'
+abstract: Starship vehicle by SpaceX
+x_netkan_version_edit:
+  find: ^v(?<first>[^.])
+  replace: v.${first}
+  strict: false
 ---
 identifier: StarshipExpansionProject
 name: Starship Expansion Project

--- a/NetKAN/StarshipExpansionProjectIVA.netkan
+++ b/NetKAN/StarshipExpansionProjectIVA.netkan
@@ -1,5 +1,9 @@
 identifier: StarshipExpansionProjectIVA
 $kref: '#/ckan/github/Kari1407/Starship-Expansion-Project'
+x_netkan_version_edit:
+  find: ^v(?<first>[^.])
+  replace: v.${first}
+  strict: false
 ---
 identifier: StarshipExpansionProjectIVA
 name: Starship Expansion Project IVA


### PR DESCRIPTION
This mod's last three versions are:

<https://github.com/Kari1407/Starship-Expansion-Project/releases>

- `v.2.1.0`
- `v.2.2.0`
- `v3.0.0-b1` (a pre-release)

It currently has an out-of-order inflation error because the dot after the v is dropped in the pre-release.

Now we put the dot back.
We also have to set the `abstract` because it isn't set on the GitHub repo.
