### PR TITLE
Ignore prereleases for BetterRocketDesigns

### DIFF
--- a/NetKAN/BetterRocketDesigns.netkan
+++ b/NetKAN/BetterRocketDesigns.netkan
@@ -2,6 +2,8 @@ identifier: BetterRocketDesigns
 name: Better Rocket Designs
 author: Bloodsucker
 $kref: '#/ckan/github/Bloodsucker/ksp-better-rocket-designs'
+x_netkan_github:
+  prereleases: false
 ksp_version: '1.12.5'
 license: LGPL-3.0
 resources:


### PR DESCRIPTION
This mod has a prerelease with a tag of `canary`, which doesn't look like a version string, so it's probably not very likely to remain stable in the version history.
Now we skip prereleases for this mod.
