### PR TITLE
Cleanup for recently unfrozen mods

### DIFF
--- a/NetKAN/AntennaRangePatches.netkan
+++ b/NetKAN/AntennaRangePatches.netkan
@@ -1,23 +1,14 @@
-{
-    "identifier": "AntennaRangePatches",
-    "$kref": "#/ckan/spacedock/876",
-    "$vref": "#/ckan/ksp-avc",
-    "license": "CC-BY-NC-SA-4.0",
-    "depends": [
-        { "name": "AntennaRange" },
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "Antennas" }
-    ],
-    "conflicts": [
-        { "name": "AntennaPatch4AntennaRange"},
-        { "name": "RemoteTech"}
-    ],
-    "install": [
-        {
-            "find"       : "AntennaRangePatches",
-            "install_to" : "GameData"
-        }
-    ]
-}
+identifier: AntennaRangePatches
+$kref: '#/ckan/spacedock/876'
+$vref: '#/ckan/ksp-avc'
+tags:
+  - config
+  - comms
+conflicts:
+  - name: AntennaPatch4AntennaRange
+  - name: RemoteTech
+depends:
+  - name: AntennaRange
+  - name: ModuleManager
+recommends:
+  - name: Antennas

--- a/NetKAN/ContractConfigurator-GrandTours.netkan
+++ b/NetKAN/ContractConfigurator-GrandTours.netkan
@@ -1,32 +1,20 @@
-{
-    "identifier"     : "ContractConfigurator-GrandTours",
-    "$kref"          : "#/ckan/spacedock/50",
-    "$vref"          : "#/ckan/ksp-avc",
-    "release_status" : "stable",
-    "x_netkan_license_ok" : true,
-    "x_netkan_epoch" : "1",
-    "resources" : {
-        "homepage"    : "https://forum.kerbalspaceprogram.com/index.php?/topic/102186-121-spacetux-contract-pack-unmanned-contracts-rover-contracts-grand-tours-and-sprite-missions/",
-        "repository"  : "https://github.com/linuxgurugamer/GrandTours"
-    },
-    "depends" : [
-        { "name": "SpacetuxSA" },
-        { "name": "ContractConfigurator" }
-    ],
-    "install" : [
-        {
-            "find"       : "Grandtours",
-            "install_to" : "GameData/ContractPacks/Spacetux"
-        }
-    ],
-    "x_netkan_override" : [
-        {
-            "version" : "1:0.1.7",
-            "delete" : [ "ksp_version" ],
-            "override" : {
-                "ksp_version_min" : "1.0.2",
-                "ksp_version_max" : "1.0.4"
-            }
-        }
-    ]
-}
+identifier: ContractConfigurator-GrandTours
+$kref: '#/ckan/spacedock/50'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: '1'
+tags:
+  - config
+  - career
+depends:
+  - name: SpacetuxSA
+  - name: ContractConfigurator
+install:
+  - find: Grandtours
+    install_to: GameData/ContractPacks/Spacetux
+x_netkan_override:
+  - version: 1:0.1.7
+    delete:
+      - ksp_version
+    override:
+      ksp_version_min: 1.0.2
+      ksp_version_max: 1.0.4

--- a/NetKAN/ContractConfigurator-RoverMissionsRedux.netkan
+++ b/NetKAN/ContractConfigurator-RoverMissionsRedux.netkan
@@ -3,7 +3,7 @@ $kref: '#/ckan/spacedock/52'
 $vref: '#/ckan/ksp-avc'
 tags:
   - config
-  - Career
+  - career
 depends:
   - name: SpacetuxSA
   - name: ContractConfigurator

--- a/NetKAN/ContractConfigurator-RoverMissionsRedux.netkan
+++ b/NetKAN/ContractConfigurator-RoverMissionsRedux.netkan
@@ -1,25 +1,16 @@
-{
-    "identifier"     : "ContractConfigurator-RoverMissionsRedux",
-    "$kref"          : "#/ckan/spacedock/52",
-    "$vref"          : "#/ckan/ksp-avc",
-    "release_status" : "stable",
-    "x_netkan_license_ok" : true,
-    "resources" : {
-        "homepage"    : "http://forum.kerbalspaceprogram.com/index.php?/topic/129173-/",
-        "repository"  : "https://github.com/linuxgurugamer/RoverContracts"
-    },
-    "depends" : [
-        { "name": "SpacetuxSA" },
-        { "name": "ContractConfigurator", "min_version": "1.9.2.1" },
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "WaypointManager" }
-    ],
-    "install" : [
-        {
-            "find"       : "RoverMissions",
-            "install_to" : "GameData/ContractPacks/Spacetux"
-        }
-    ]
-}
+identifier: ContractConfigurator-RoverMissionsRedux
+$kref: '#/ckan/spacedock/52'
+$vref: '#/ckan/ksp-avc'
+tags:
+  - config
+  - Career
+depends:
+  - name: SpacetuxSA
+  - name: ContractConfigurator
+    min_version: 1.9.2.1
+  - name: ModuleManager
+recommends:
+  - name: WaypointManager
+install:
+  - find: RoverMissions
+    install_to: GameData/ContractPacks/Spacetux

--- a/NetKAN/ContractConfigurator-UnmannedContracts.netkan
+++ b/NetKAN/ContractConfigurator-UnmannedContracts.netkan
@@ -1,36 +1,23 @@
-{
-    "identifier"     : "ContractConfigurator-UnmannedContracts",
-    "$kref"          : "#/ckan/spacedock/55",
-    "$vref"          : "#/ckan/ksp-avc",
-    "release_status" : "stable",
-    "x_netkan_license_ok" : "true",
-    "resources" : {
-        "homepage"    : "https://forum.kerbalspaceprogram.com/index.php?/topic/102186-121-spacetux-contract-pack-unmanned-contracts-rover-contracts-grand-tours-and-sprite-missions/",
-        "repository"  : "https://github.com/linuxgurugamer/UnmannedContracts"
-    },
-    "depends" : [
-        { "name": "ContractConfigurator" },
-        { "name": "ModuleManager" },
-        { "name": "SpacetuxSA" }
-    ],
-    "install" : [
-        {
-            "find"       : "UnmannedContracts",
-            "install_to" : "GameData/ContractPacks/Spacetux"
-        }
-    ],
-    "recommends" : [
-        { "name": "CoherentContracts" },
-        { "name" : "ContractConfigurator-AdvancedProgression" }
-    ],
-    "x_netkan_override" : [
-        {
-            "version" : "0.3.10",
-            "delete" : [ "ksp_version" ],
-            "override" : {
-                "ksp_version_min" : "1.0.2",
-                "ksp_version_max" : "1.0.4"
-            }
-        }
-    ]
-}
+identifier: ContractConfigurator-UnmannedContracts
+$kref: '#/ckan/spacedock/55'
+$vref: '#/ckan/ksp-avc'
+tags:
+  - config
+  - career
+depends:
+  - name: ContractConfigurator
+  - name: ModuleManager
+  - name: SpacetuxSA
+recommends:
+  - name: CoherentContracts
+  - name: ContractConfigurator-AdvancedProgression
+install:
+  - find: UnmannedContracts
+    install_to: GameData/ContractPacks/Spacetux
+x_netkan_override:
+  - version: 0.3.10
+    delete:
+      - ksp_version
+    override:
+      ksp_version_min: 1.0.2
+      ksp_version_max: 1.0.4

--- a/NetKAN/PersistentDynamicPodNames.netkan
+++ b/NetKAN/PersistentDynamicPodNames.netkan
@@ -1,35 +1,23 @@
-{
-    "identifier"    : "PersistentDynamicPodNames",
-    "name"          : "Persistent Dynamic Pod Names",
-    "abstract"      : "Configurable names for pods and ships",
-    "$kref"         : "#/ckan/github/linuxgurugamer/PersistentDynamicPodNames",
-    "$vref"         : "#/ckan/ksp-avc",
-    "license"       : "CC-BY-SA-4.0",
-    "resources" : {
-        "homepage":   "http://forum.kerbalspaceprogram.com/index.php?/topic/142900-*"
-    },
-    "tags": [
-        "plugin",
-        "convenience"
-    ],
-    "recommends": [
-        { "name": "JanitorsCloset" }
-    ],
-    "depends": [
-        { "name" : "ModuleManager" }
-    ],
-    "install": [ {
-        "find"    : "PersistentDynamicPodNames",
-        "install_to": "GameData",
-        "filter_regexp": "ModuleManager.+\\.dll"
-    } ],
-    "x_netkan_override": [
-        {
-            "version": "0.1.8",
-            "delete": [ "ksp_version_min", "ksp_version_max" ],
-            "override": {
-                "ksp_version" : "1.3.0"
-            }
-        }
-    ]
-}
+identifier: PersistentDynamicPodNames
+abstract: Configurable names for pods and ships
+$kref: '#/ckan/github/linuxgurugamer/PersistentDynamicPodNames'
+x_netkan_github:
+  prereleases: false
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-SA-4.0
+resources:
+  homepage: http://forum.kerbalspaceprogram.com/index.php?/topic/142900-*
+tags:
+  - plugin
+  - convenience
+depends:
+  - name: ModuleManager
+recommends:
+  - name: JanitorsCloset
+x_netkan_override:
+  - version: 0.1.8
+    delete:
+      - ksp_version_min
+      - ksp_version_max
+    override:
+      ksp_version: 1.3.0

--- a/NetKAN/PersistentDynamicPodNames.netkan
+++ b/NetKAN/PersistentDynamicPodNames.netkan
@@ -16,5 +16,11 @@ recommends:
   - name: JanitorsCloset
 x_netkan_override:
   - version: 0.1.8
+    after: avc
+    delete:
+      - ksp_version_min
+      - ksp_version_max
+  - version: 0.1.8
+    before: localizations
     override:
       ksp_version: 1.3.0

--- a/NetKAN/PersistentDynamicPodNames.netkan
+++ b/NetKAN/PersistentDynamicPodNames.netkan
@@ -15,9 +15,9 @@ depends:
 recommends:
   - name: JanitorsCloset
 x_netkan_override:
-  - version: 0.1.8
+  - version: '0.1.8'
     delete:
       - ksp_version_min
       - ksp_version_max
     override:
-      ksp_version: 1.3.0
+      ksp_version: '1.3.0'

--- a/NetKAN/PersistentDynamicPodNames.netkan
+++ b/NetKAN/PersistentDynamicPodNames.netkan
@@ -15,9 +15,6 @@ depends:
 recommends:
   - name: JanitorsCloset
 x_netkan_override:
-  - version: '0.1.8'
-    delete:
-      - ksp_version_min
-      - ksp_version_max
+  - version: 0.1.8
     override:
-      ksp_version: '1.3.0'
+      ksp_version: 1.3.0

--- a/NetKAN/ZPIF-4-Stock.netkan
+++ b/NetKAN/ZPIF-4-Stock.netkan
@@ -1,30 +1,17 @@
-{
-    "identifier"    : "ZPIF-4-Stock",
-    "$kref"         : "#/ckan/spacedock/616",
-    "$vref"         : "#/ckan/ksp-avc",
-    "license"       : "GPL-3.0",
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "ZeroPointInlineFairings" },
-        { "name" : "AnimatedDecouplers" }
-    ],
-    "install": [
-        {
-            "find"      :   "0PIF_4_Stock",
-            "install_to": "GameData"
-        }
-    ],
-    "suggests": [
-        { "name": "ModularRocketSystem" },
-        { "name": "SpaceY-Lifters" },
-        { "name": "ColorCodedCans"},
-        { "name": "FuelTanksPlus"}
-    ],
-    "name": "Zero Point Inline Fairings for Stock (no FAR)",
-    "abstract": "This is a patch which lets ZPIF be used without FAR",
-    "resources": {
-        "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/85178-104revived-zero-point-inline-fairings-v101-2015-06-09",
-        "repository":"https://github.com/linuxgurugamer/0PIF_4_Stock"
-    }
-}
-
+identifier: ZPIF-4-Stock
+$kref: '#/ckan/spacedock/616'
+$vref: '#/ckan/ksp-avc'
+tags:
+  - config
+depends:
+  - name: ModuleManager
+  - name: ZeroPointInlineFairings
+  - name: AnimatedDecouplers
+suggests:
+  - name: ModularRocketSystem
+  - name: SpaceY-Lifters
+  - name: ColorCodedCans
+  - name: FuelTanksPlus
+install:
+  - find: 0PIF_4_Stock
+    install_to: GameData


### PR DESCRIPTION
These mods had some inflation warnings that weren't addressed in #10328.

Mod | Warnings
:-- | :--
AntennaRangePatches, ContractConfigurator-GrandTours, ContractConfigurator-UnmannedContracts, ContractConfigurator-RoverMissionsRedux, ZPIF-4-Stock | Tags added
PersistentDynamicPodNames | The latest release is a prerelease, and its structure is a mess. It has separate assets for three different game versions; there's no reasonable way we could pick out the right file to index. To fix this, prereleases are now disabled for this mod, and we'll have to freeze whatever was added for that prerelease separately.
