### PR TITLE
Asset match for repos with multiple assets

### DIFF
--- a/NetKAN/BDArmoryMultiplayer.netkan
+++ b/NetKAN/BDArmoryMultiplayer.netkan
@@ -3,7 +3,7 @@ author:
   - BahamutoD
   - Papa_Joe
   - jrodrigv
-$kref: '#/ckan/github/jrodrigv/BDAMultiplayer'
+$kref: '#/ckan/github/jrodrigv/BDAMultiplayer/asset_match/^(?!Server_Settings)'
 comment: Version file is badly out of date
 ksp_version: 1.12
 license: CC-BY-SA-2.0

--- a/NetKAN/BDArmoryMultiplayer.netkan
+++ b/NetKAN/BDArmoryMultiplayer.netkan
@@ -3,7 +3,7 @@ author:
   - BahamutoD
   - Papa_Joe
   - jrodrigv
-$kref: '#/ckan/github/jrodrigv/BDAMultiplayer/asset_match/^(?!Server_Settings)'
+$kref: '#/ckan/github/jrodrigv/BDAMultiplayer/asset_match/^(?!.*Server_Settings)'
 comment: Version file is badly out of date
 ksp_version: 1.12
 license: CC-BY-SA-2.0

--- a/NetKAN/StockRealism.netkan
+++ b/NetKAN/StockRealism.netkan
@@ -1,5 +1,5 @@
 identifier: StockRealism
-$kref: '#/ckan/github/ZombieStriker/StockRealism/asset_match/^(?!NoOPM)'
+$kref: '#/ckan/github/ZombieStriker/StockRealism/asset_match/^(?!.*NoOPM)'
 $vref: '#/ckan/ksp-avc'
 ---
 identifier: StockRealism

--- a/NetKAN/StockRealism.netkan
+++ b/NetKAN/StockRealism.netkan
@@ -1,5 +1,5 @@
 identifier: StockRealism
-$kref: '#/ckan/github/ZombieStriker/StockRealism'
+$kref: '#/ckan/github/ZombieStriker/StockRealism/asset_match/^(?!NoOPM)'
 $vref: '#/ckan/ksp-avc'
 ---
 identifier: StockRealism


### PR DESCRIPTION
These mods have multiple assets in the latest release without `asset_match` or `version_from_asset`. This means the inflator will simply grab the first asset, which may be the actual mod or some optional side download that has been added to the release. Fortunately, they are correctly indexed already because in both cases the first asset is correct, but this isn't guaranteed to be the case in future updates.

Now an `asset_match` is added to filter out the optional side downloads.
