### PR TITLE
Fix ShineFix depends

### DIFF
--- a/NetKAN/ShineFix.netkan
+++ b/NetKAN/ShineFix.netkan
@@ -14,6 +14,9 @@ tags:
   - config
 depends:
   - name: ModuleManager
+  - name: Harmony2
+  - name: Deferred
+  - name: Shabby
 install:
   - find: 000_ShineFix
     install_to: GameData


### PR DESCRIPTION
@Clayell pointed out in https://github.com/KSP-CKAN/NetKAN/pull/10291#issuecomment-2564122763 that I missed some of this mod's dependencies. (I think I was distracted by the problem with the ZIP file, the early multi-hosting inconsistencies, and the bot overwriting my changes and forgot to go back and check everything.)

Now they're added.
