### PR TITLE
Add supports to deferred

### DIFF
--- a/NetKAN/Deferred.netkan
+++ b/NetKAN/Deferred.netkan
@@ -21,6 +21,35 @@ conflicts:
     max_version: 3:0.45.1
 depends:
   - name: Shabby
+supports:
+  - name: TexturesUnlimited
+  min_version: 1.6.0.26
+  - name: Parallax
+  min_version: 2.0.8
+  - name: ConformalDecals
+  min_version: 0.2.14
+  - name: B9-PWings-Fork
+  min_version: 3:0.46.0
+  - name: Scatterer
+  min_version: 3:v0.0878
+  - name: EnvironmentalVisualEnhancements
+  min_version: 3:1.11.7.2
+  - name: TUFX
+  - name: Kopernicus
+  - name: Waterfall
+  - name: SimpleAdjustableFairings
+  - name: KerbalKonstructs
+  min_version: v1.8.9.0
+  - name: EngineLightRelit
+  - name: KVVContinued
+  - name: RealSolarSystem
+  - name: RasterPropMonitor-Core
+  min_version: 1:v1.0.1
+  - name: FreeIva
+  min_version: 0.2.19.0
+  - name: Shaddy
+  - name: NeptuneCamera
+  min_version: v4.3
 install:
   - find: zzz_Deferred
     install_to: GameData


### PR DESCRIPTION
Add supports from https://github.com/LGhassen/Deferred?tab=readme-ov-file#mod-compatibility-status.
This PR is currently a draft, as I am waiting for a response relating to an incompatibility with Procedural Fairings. (https://github.com/KSP-RO/ProceduralFairings/issues/59)

There are certain mods that seem to have been always compatible with the public versions of deferred or where deferred itself was seemingly updated to be compatible with these mods, as the mods themselves do not have any patch notes relating to deferred compatibility.
Additionally, if a mod seems to have had multiple patch notes relating to deferred, I went with the most recent one as the supported one.
I have left out Planetshine, as even though it is technically compatible, as LGhassen states it does not a reason to be used with deferred under normal settings, which is what a majority of users will be using.
I also left out the ASET props mod(s) as its compatibility depends on RPM as stated by the mod author.