### PR TITLE
Add license for TourismOverhaul

### DIFF
--- a/NetKAN/TourismOverhaul.netkan
+++ b/NetKAN/TourismOverhaul.netkan
@@ -9,6 +9,7 @@ abstract: Completely revamps tourism contracts
 $kref: '#/ckan/spacedock/3788'
 x_netkan_version_edit: '^(?<version>[^ ]+).*$'
 $vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA
 resources:
   remote-avc: https://raw.githubusercontent.com/iLikeGothMommys/TourismOverhaul/refs/heads/main/ContractPack-TourismOverhaul.version
 tags:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a4becb05-09d0-4e9f-8196-123006258320)

This mod now has [a prerelease](https://github.com/iLikeGothMommys/TourismOverhaul/releases/tag/Release1.2PreRelease) only on GitHub, which doesn't provide the CC-BY-NC-SA license appropriately (for normal multi-hosted releases, we get the license from SpaceDock):

https://api.github.com/repos/iLikeGothMommys/TourismOverhaul

```json
  "license": {
    "key": "other",
    "name": "Other",
    "spdx_id": "NOASSERTION",
    "url": null,
    "node_id": "MDc6TGljZW5zZTA="
  },
```

Now it's hard-coded in the netkan.
