### PR TITLE
MinorPlanetsExpansion: switch to github

### DIFF
--- a/NetKAN/MinorPlanetsExpansion.netkan
+++ b/NetKAN/MinorPlanetsExpansion.netkan
@@ -1,6 +1,8 @@
+identifier: MinorPlanetsExpansion
+$kref: '#/ckan/github/ExosLab/Minor-Planets-Expansion'
 ---
 identifier: MinorPlanetsExpansion
-"$kref": "#/ckan/spacedock/2383"
+$kref: '#/ckan/spacedock/2383'
 license: MIT
 tags:
 - config

--- a/NetKAN/MinorPlanetsExpansion.netkan
+++ b/NetKAN/MinorPlanetsExpansion.netkan
@@ -1,8 +1,5 @@
 identifier: MinorPlanetsExpansion
 $kref: '#/ckan/github/ExosLab/Minor-Planets-Expansion'
----
-identifier: MinorPlanetsExpansion
-$kref: '#/ckan/spacedock/2383'
 license: MIT
 tags:
 - config

--- a/NetKAN/MinorPlanetsExpansion.netkan
+++ b/NetKAN/MinorPlanetsExpansion.netkan
@@ -1,18 +1,14 @@
-{
-    "identifier":   "MinorPlanetsExpansion",
-    "$kref":        "#/ckan/spacedock/2383",
-    "license":      "MIT",
-    "tags": [
-        "config",
-        "planet-pack"
-    ],
-    "depends": [
-        { "name": "ModuleManager"   },
-        { "name": "Kopernicus"      },
-        { "name": "OuterPlanetsMod" }
-    ],
-    "install": [ {
-        "find":       "MPE",
-        "install_to": "GameData"
-    } ]
-}
+---
+identifier: MinorPlanetsExpansion
+"$kref": "#/ckan/spacedock/2383"
+license: MIT
+tags:
+- config
+- planet-pack
+depends:
+- name: ModuleManager
+- name: Kopernicus
+- name: OuterPlanetsMod
+install:
+- find: MPE
+  install_to: GameData


### PR DESCRIPTION
The author has been unable to update this mod on spacedock, and the current release has a gamebreaking bug when installed with parallax.  The fix is available on github, so let's just make that the primary download.

> A Word of Warning: SpaceDock/CKAN Still Carries the Initial 1.1.0 Build
DO NOT Use 1.1.0's Parallax Config - THEY ARE UNSTABLE

https://forum.kerbalspaceprogram.com/topic/192848-112x-planet-pack-minor-planets-expansion/

https://forum.kerbalspaceprogram.com/topic/192848-112x-planet-pack-minor-planets-expansion/?do=findComment&comment=4439323