### PR TITLE
Add AdvancedPQSTools.netkan

### DIFF
--- a/NetKAN/AdvancedPQSTools.netkan
+++ b/NetKAN/AdvancedPQSTools.netkan
@@ -1,4 +1,9 @@
 identifier: AdvancedPQSTools
+author:
+  - KSP-RO Team
+  - ballisticfox
+  - pkmniako
+  - CharonSSS
 $kref: '#/ckan/github/CharonSSS/AdvancedPQSTools/asset_match/AdvancedPQSTools.zip'
 resources:
   manual: https://github.com/CharonSSS/AdvancedPQSTools/wiki

--- a/NetKAN/AdvancedPQSTools.netkan
+++ b/NetKAN/AdvancedPQSTools.netkan
@@ -1,22 +1,10 @@
 identifier: AdvancedPQSTools
-name: Advanced PQS Tools
-abstract: >-
-  A plugin includes VertexHeightMapRSS forked from RealSolarSystem, BoundedDecal forked from ballisticfox and VertexMitchellNetravaliHeightMap16 forked from Niako
 $kref: '#/ckan/github/CharonSSS/AdvancedPQSTools/asset_match/AdvancedPQSTools.zip'
-author:
-  - KSP-RO Team, ballisticfox, pkmniako, CharonSSS
 resources:
-  bugtracker: https://github.com/CharonSSS/AdvancedPQSTools/issues/
-  manual: https://github.com/CharonSSS/AdvancedPQSTools/wiki/
-  homepage: https://github.com/CharonSSS/AdvancedPQSTools/
-  repository: https://github.com/CharonSSS/AdvancedPQSTools/
+  manual: https://github.com/CharonSSS/AdvancedPQSTools/wiki
 ksp_version: 1.12
-license: MIT
 tags:
   - config
 depends:
   - name: ModuleManager
   - name: Kopernicus
-install:
-  - find: AdvancedPQSTools
-    install_to: GameData

--- a/NetKAN/AdvancedPQSTools.netkan
+++ b/NetKAN/AdvancedPQSTools.netkan
@@ -1,0 +1,22 @@
+identifier: AdvancedPQSTools
+name: Advanced PQS Tools
+abstract: >-
+  A plugin includes VertexHeightMapRSS forked from RealSolarSystem, BoundedDecal forked from ballisticfox and VertexMitchellNetravaliHeightMap16 forked from Niako
+$kref: '#/ckan/github/CharonSSS/AdvancedPQSTools/asset_match/AdvancedPQSTools.zip'
+author:
+  - KSP-RO Team, ballisticfox, pkmniako, CharonSSS
+resources:
+  bugtracker: https://github.com/CharonSSS/AdvancedPQSTools/issues/
+  manual: https://github.com/CharonSSS/AdvancedPQSTools/wiki/
+  homepage: https://github.com/CharonSSS/AdvancedPQSTools/
+  repository: https://github.com/CharonSSS/AdvancedPQSTools/
+ksp_version: 1.12
+license: MIT
+tags:
+  - config
+depends:
+  - name: ModuleManager
+  - name: Kopernicus
+install:
+  - find: AdvancedPQSTools
+    install_to: GameData

--- a/NetKAN/AdvancedPQSTools.netkan
+++ b/NetKAN/AdvancedPQSTools.netkan
@@ -4,7 +4,9 @@ resources:
   manual: https://github.com/CharonSSS/AdvancedPQSTools/wiki
 ksp_version: 1.12
 tags:
-  - config
+  - plugin
+  - library
+  - planet-pack
 depends:
   - name: ModuleManager
   - name: Kopernicus

--- a/NetKAN/RSSOrigin-TopoRevampConfigs.netkan
+++ b/NetKAN/RSSOrigin-TopoRevampConfigs.netkan
@@ -16,6 +16,10 @@ depends:
   - name: Kopernicus
   - name: KSPCommunityFixes
   - name: RSSOrigin-TopoRevampTextures
+  - name: AdvancedPQSTools
+  - name: VertexMitchellNetravaliHeightMap
+  - name: RSSOrigin
+  - name: VertexColorMapEmissive
 recommends:
   - name: RSSOrigin
 suggests:

--- a/NetKAN/RSSOrigin.netkan
+++ b/NetKAN/RSSOrigin.netkan
@@ -1,11 +1,11 @@
 identifier: RSSOrigin
-name: RSS-Origin CelestialsPack Core
+name: RSS-Origin Core
 abstract: >-
   The major part of RSS-Origin, which adds plenty of asteroids, asteroid moons,
   comets, moons of gas/ice giants, dwarf planets, dwarf planet moons, and
-  interstellar objects into real solar system, currently 198 in total. (dozens
+  interstellar objects into real solar system, currently 200 in total. (dozens
   more in the future). This is the core pack
-$kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.CelestialsPack.Core.zip'
+$kref: '#/ckan/github/CharonSSS/RSS-Origin/asset_match/RSS-Origin.Core.zip'
 ksp_version: 1.12
 license: CC-BY-NC-SA-4.0
 tags:
@@ -15,6 +15,7 @@ depends:
   - name: Kopernicus
   - name: VertexMitchellNetravaliHeightMap
   - name: KSPCommunityFixes
+  - name: AdvancedPQSTools
 #we need to add RSS or KSRSS as a dependency, but KSRSS isn't on CKAN...
 recommends:
   - name: TooManyOrbits
@@ -24,6 +25,7 @@ recommends:
   - name: RealismOverhaul
   - name: RSSOrigin-GalaxyTex
   - name: RSSOrigin-JSUNrings
+  - name: RSSOrigin-TopoRevampConfigs
   - name: RSSOrigin-CelestialsPack-Centaurs
   - name: RSSOrigin-CelestialsPack-Comets
   - name: RSSOrigin-CelestialsPack-InterstellarObjects


### PR DESCRIPTION
Add [AdvancedPQSTools](https://github.com/CharonSSS/AdvancedPQSTools) as dependency for **RSSOrigin-CelestialsPackCore** and **RSSOrigin-TopoRevampConfigs** once [AdvancedPQSTools is added to ckan](https://github.com/KSP-CKAN/NetKAN/issues/10359)

Add [VertexColorMapEmissive](https://github.com/jamespglaze/VertexColorMapEmissive) and [VertexMitchellNetravaliHeightMap](https://github.com/pkmniako/Kopernicus_VertexMitchellNetravaliHeightMap) as dependencies for **RSSOrigin-TopoRevampConfigs**

Add **RSSOrigin-CelestialsPackCore** as dependency for **RSSOrigin-TopoRevampConfigs**

Also, I want to change the title of **_"RSS-Origin CelestialsPack Core"_** to **_"RSS-Origin Core"_**. Its nametag (RSSOrigin-CelestialsPackCore) can remain unchanged to avoid other fussy dependency, recommendation, suggestion and conflicts changes.

The download link of **_"RSS-Origin CelestialsPack Core"_** (now **_"RSS-Origin Core"_**) are changed to https://github.com/CharonSSS/RSS-Origin/releases/download/v1.1.4/RSS-Origin.Core.zip


- <https://github.com/CharonSSS/AdvancedPQSTools>
- <https://github.com/CharonSSS/RSS-Origin>

Fixes #10359.
Fixes #10360.
