### PR TITLE
Remove release status from TweakScaleRescaled auxiliary mods

### DIFF
--- a/NetKAN/TweakScaleRescaled-Redist.netkan
+++ b/NetKAN/TweakScaleRescaled-Redist.netkan
@@ -14,7 +14,6 @@ abstract: >-
   This plugin has no overhead when TweakScaleRescaled is not installed.
 $kref: '#/ckan/spacedock/3514'
 $vref: '#/ckan/ksp-avc/GameData/999_Scale_Redist.version'
-release_status: stable
 license: CC-BY-NC-SA
 author:
   - Biotronic

--- a/NetKAN/TweakScaleRescaled-SafetyNet.netkan
+++ b/NetKAN/TweakScaleRescaled-SafetyNet.netkan
@@ -13,7 +13,6 @@ abstract: >-
   has been removed from an install.
 $kref: '#/ckan/spacedock/3514'
 $vref: '#/ckan/ksp-avc/GameData/TSSafetyNet/TweakScaleSafetyNet.version'
-release_status: stable
 license: CC-BY-NC-SA
 tags:
   - plugin


### PR DESCRIPTION
These mods currently have a prerelease, but the netkans hard-code `release_status: stable`, which used to do nothing and now breaks things.

![image](https://github.com/user-attachments/assets/787e54df-a70b-406d-8205-71a00b879198)

Now that's removed so the `release_status` can reflect the actual stability of the releases.
