### PR TITLE
Change mods that "support" b9partswitch to "suggest" instead

### DIFF
--- a/NetKAN/DMTanks-SphericalTanks.netkan
+++ b/NetKAN/DMTanks-SphericalTanks.netkan
@@ -16,6 +16,8 @@ recommends:
   - name: DMTanks-AeroRTG
   - name: DMTanks-CargoBays
   - name: DMTanks-Fuselage
+suggests:
+  - name: B9PartSwitch
 supports:
   - name: TweakScale
   - name: KerbalChangelog

--- a/NetKAN/DMTanks-SphericalTanks.netkan
+++ b/NetKAN/DMTanks-SphericalTanks.netkan
@@ -19,7 +19,6 @@ recommends:
 supports:
   - name: TweakScale
   - name: KerbalChangelog
-  - name: B9PartSwitch
   - name: Snacks
   - name: TACLS
   - name: InterstellarFuelSwitch

--- a/NetKAN/KeridianDynamicsVesselAssembly.netkan
+++ b/NetKAN/KeridianDynamicsVesselAssembly.netkan
@@ -24,6 +24,7 @@ suggests:
   - name: KIS
   - name: KerbalInventorySystemNoFun
   - name: TweakScale
+  - name: B9PartSwitch
 supports:
   - name: SimpleConstruction
   - name: SimpleLogistics
@@ -34,7 +35,6 @@ supports:
   - name: TankSwitcher
   - name: InterstellarFuelSwitchCore
   - name: FirespitterCore
-  - name: B9PartSwitch
   - name: SimplexColonies
   - name: TweakScale
   - name: PatchManager

--- a/NetKAN/MoldaviteMachines.netkan
+++ b/NetKAN/MoldaviteMachines.netkan
@@ -11,7 +11,6 @@ tags:
   - crewed
   - resources
 supports:
-  - name: B9PartSwitch
   - name: TACLS
   - name: IFILS
   - name: RealFuels
@@ -22,3 +21,4 @@ depends:
   - name: ModuleManager
 suggests:
   - name: MoldaviteMachinesKerbalism
+  - name: B9PartSwitch

--- a/NetKAN/SimpleConstruction.netkan
+++ b/NetKAN/SimpleConstruction.netkan
@@ -24,8 +24,8 @@ suggests:
   - name: StockalikeMiningExtension
   - name: ISRUThanksButNoTanks
   - name: KerbalJointReinforcementNext
-supports:
   - name: B9PartSwitch
+supports:
   - name: CommunityCategoryKit
   - name: CommunityResourcePack
   - name: InterstellarFuelSwitch


### PR DESCRIPTION
b9partswitch is a foundational mod that is rarely installed directly by a user's choice.  When trying to craft a .ckan modpack that has a dependency on B9PartSwitch, I was presented with a choice to install these 4 mods when they have nothing to do with my pack.  This isn't what "supports" is meant to be used for.  If the relationship isn't strong enough to be a dependency or recommendation, then "suggests" is appropriate.