### PR TITLE
Add KSPCommunityFixes conflict to PersistentRotationUpgraded

### DIFF
--- a/NetKAN/PersistentRotationUpgraded.netkan
+++ b/NetKAN/PersistentRotationUpgraded.netkan
@@ -13,6 +13,7 @@ provides:
   - PersistentRotation
 conflicts:
   - name: PersistentRotation
+  - name: KSPCommunityFixes
 depends:
   - name: ToolbarController
   - name: ClickThroughBlocker


### PR DESCRIPTION
See linuxgurugamer/PersistentRotation#13, this mod depends on exploiting a stock bug that is fixed by KSPCommunityFixes, so when both are installed, PersistentRotationUpgraded doesn't work.

@linuxgurugamer acknowledged the problem and said a fix is not currently in the works:

- <https://forum.kerbalspaceprogram.com/topic/197082-ckan-the-comprehensive-kerbal-archive-network-v1332-laplace-ksp-2-support/?do=findComment&comment=4443730>

Now they're marked as conflicting.
