### PR TITLE
Remove release_status property from all netkans

### DIFF
--- a/NetKAN/AGExt.netkan
+++ b/NetKAN/AGExt.netkan
@@ -11,8 +11,6 @@ resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/167269-1
   spacedock: https://spacedock.info/mod/1685/Action%20Groups%20Extended
   repository: https://github.com/linuxgurugamer/AGExt
-  x_screenshot: >-
-    https://spacedock.info/content/linuxgurugamer_179/Action_Groups_Extended/Action_Groups_Extended-1517453673.540609.jpg
 tags:
   - plugin
   - convenience

--- a/NetKAN/AGExt.netkan
+++ b/NetKAN/AGExt.netkan
@@ -6,7 +6,6 @@
     "$kref":        "#/ckan/github/linuxgurugamer/AGExt",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "GPL-3.0",
-    "release_status": "stable",
     "resources": {
         "homepage":     "https://forum.kerbalspaceprogram.com/index.php?/topic/167269-1",
         "spacedock":    "https://spacedock.info/mod/1685/Action%20Groups%20Extended",

--- a/NetKAN/AGExt.netkan
+++ b/NetKAN/AGExt.netkan
@@ -1,28 +1,25 @@
-{
-    "identifier":   "AGExt",
-    "name":         "Action Groups Extended",
-    "abstract":     "Increases the number of action groups to 250 and allows in-flight editing.",
-    "author":       [ "Diazo", "linuxgurugamer" ],
-    "$kref":        "#/ckan/github/linuxgurugamer/AGExt",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "GPL-3.0",
-    "resources": {
-        "homepage":     "https://forum.kerbalspaceprogram.com/index.php?/topic/167269-1",
-        "spacedock":    "https://spacedock.info/mod/1685/Action%20Groups%20Extended",
-        "repository":   "https://github.com/linuxgurugamer/AGExt",
-        "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/Action_Groups_Extended/Action_Groups_Extended-1517453673.540609.jpg"
-    },
-    "tags": [
-        "plugin",
-        "convenience"
-    ],
-    "depends": [
-        { "name": "ModuleManager"       },
-        { "name": "ClickThroughBlocker" },
-        { "name": "SpaceTuxLibrary" }
-    ],
-    "install": [ {
-        "file":       "GameData/Diazo",
-        "install_to": "GameData"
-    } ]
-}
+identifier: AGExt
+name: Action Groups Extended
+abstract: Increases the number of action groups to 250 and allows in-flight editing.
+author:
+  - Diazo
+  - linuxgurugamer
+$kref: '#/ckan/github/linuxgurugamer/AGExt'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/167269-1
+  spacedock: https://spacedock.info/mod/1685/Action%20Groups%20Extended
+  repository: https://github.com/linuxgurugamer/AGExt
+  x_screenshot: >-
+    https://spacedock.info/content/linuxgurugamer_179/Action_Groups_Extended/Action_Groups_Extended-1517453673.540609.jpg
+tags:
+  - plugin
+  - convenience
+depends:
+  - name: ModuleManager
+  - name: ClickThroughBlocker
+  - name: SpaceTuxLibrary
+install:
+  - file: GameData/Diazo
+    install_to: GameData

--- a/NetKAN/AMEG.frozen
+++ b/NetKAN/AMEG.frozen
@@ -3,7 +3,6 @@
     "author"          : "Justin Kerbice",
     "$kref"           : "#/ckan/kerbalstuff/279",
     "license"         : "restricted",
-    "release_status"  : "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/67336-kerbice-group-misc-parts-to-make-your-life-easier-lpje-01/"
     },

--- a/NetKAN/AVP-2kTextures.netkan
+++ b/NetKAN/AVP-2kTextures.netkan
@@ -6,7 +6,6 @@
     "$kref"          : "#/ckan/github/themaster402/AstronomersVisualPack/asset_match/AVP_2kTextures.zip",
     "ksp_version_min": "1.8",
     "license"        : "LGPL-3.0",
-    "release_status" : "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/160878-*"
     },

--- a/NetKAN/AVP-4kTextures.netkan
+++ b/NetKAN/AVP-4kTextures.netkan
@@ -6,7 +6,6 @@
     "$kref"          : "#/ckan/github/themaster402/AstronomersVisualPack/asset_match/AVP_4kTextures.zip",
     "ksp_version_min": "1.8",
     "license"        : "LGPL-3.0",
-    "release_status" : "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/160878-*"
     },

--- a/NetKAN/AVP-8kTextures.netkan
+++ b/NetKAN/AVP-8kTextures.netkan
@@ -6,7 +6,6 @@
     "$kref"          : "#/ckan/github/themaster402/AstronomersVisualPack/asset_match/AVP_8kTextures.zip",
     "ksp_version_min": "1.8",
     "license"        : "LGPL-3.0",
-    "release_status" : "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/160878-*"
     },

--- a/NetKAN/ActsEW.frozen
+++ b/NetKAN/ActsEW.frozen
@@ -6,7 +6,6 @@
     "$kref":        "#/ckan/github/SirDiazo/ActsEverywhere",
     "ksp_version":  "1.0",
     "license":      "GPL-3.0",
-    "release_status" : "stable",
     "resources" : {
         "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/91023-*"
     },

--- a/NetKAN/AdvancedFlyByWire-Linux.netkan
+++ b/NetKAN/AdvancedFlyByWire-Linux.netkan
@@ -6,7 +6,6 @@
     "license": "MIT",
     "$kref": "#/ckan/github/linuxgurugamer/ksp-advanced-flybywire/asset_match/linux",
     "$vref": "#/ckan/ksp-avc",
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/175359-*",
         "spacedock": "https://spacedock.info/mod/1870/AFBW%20Revived%20(Linux%20version)",

--- a/NetKAN/AdvancedFlyByWire-Linux.netkan
+++ b/NetKAN/AdvancedFlyByWire-Linux.netkan
@@ -1,49 +1,31 @@
-{
-    "identifier": "AdvancedFlyByWire-Linux",
-    "name": "Advanced Fly-By-Wire (Linux)",
-    "abstract": "AFBW is an input overhaul mod. It dramatically enhances the stock input system with a bunch of fixes and many new features.",
-    "author": "linuxgurugamer",
-    "license": "MIT",
-    "$kref": "#/ckan/github/linuxgurugamer/ksp-advanced-flybywire/asset_match/linux",
-    "$vref": "#/ckan/ksp-avc",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/175359-*",
-        "spacedock": "https://spacedock.info/mod/1870/AFBW%20Revived%20(Linux%20version)",
-        "repository": "https://github.com/linuxgurugamer/ksp-advanced-flybywire",
-        "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/AFBW_Revived_Linux_version/AFBW_Revived_Linux_version-1527384062.2632098.png"
-    },
-    "tags": [
-        "plugin",
-        "control"
-    ],
-    "provides": [
-        "AdvancedFlyByWireRevived"
-    ],
-    "depends": [
-        {
-            "name": "ToolbarController"
-        },
-        {
-            "name": "ClickThroughBlocker"
-        }
-    ],
-    "recommends": [
-        {
-            "name": "ToolbarController"
-        },
-        {
-            "name": "ClickThroughBlocker"
-        }
-    ],
-    "conflicts": [
-        {
-            "name": "AdvancedFlyByWireRevived"
-        }
-    ],
-    "install": [
-        {
-            "file": "GameData/ksp-advanced-flybywire",
-            "install_to": "GameData"
-        }
-    ]
-}
+identifier: AdvancedFlyByWire-Linux
+name: Advanced Fly-By-Wire (Linux)
+abstract: >-
+  AFBW is an input overhaul mod. It dramatically enhances the stock input system
+  with a bunch of fixes and many new features.
+author: linuxgurugamer
+license: MIT
+$kref: '#/ckan/github/linuxgurugamer/ksp-advanced-flybywire/asset_match/linux'
+$vref: '#/ckan/ksp-avc'
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/175359-*
+  spacedock: https://spacedock.info/mod/1870/AFBW%20Revived%20(Linux%20version)
+  repository: https://github.com/linuxgurugamer/ksp-advanced-flybywire
+  x_screenshot: >-
+    https://spacedock.info/content/linuxgurugamer_179/AFBW_Revived_Linux_version/AFBW_Revived_Linux_version-1527384062.2632098.png
+tags:
+  - plugin
+  - control
+provides:
+  - AdvancedFlyByWireRevived
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+recommends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+conflicts:
+  - name: AdvancedFlyByWireRevived
+install:
+  - file: GameData/ksp-advanced-flybywire
+    install_to: GameData

--- a/NetKAN/AdvancedFlyByWire-OSX.netkan
+++ b/NetKAN/AdvancedFlyByWire-OSX.netkan
@@ -6,7 +6,6 @@
     "license": "MIT",
     "$kref": "#/ckan/github/linuxgurugamer/ksp-advanced-flybywire/asset_match/osx",
     "$vref": "#/ckan/ksp-avc",
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/175359-*",
         "spacedock": "https://spacedock.info/mod/1878/ABFW%20Revived%20(OSX%20version)",

--- a/NetKAN/AdvancedFlyByWire-OSX.netkan
+++ b/NetKAN/AdvancedFlyByWire-OSX.netkan
@@ -1,49 +1,31 @@
-{
-    "identifier": "AdvancedFlyByWire-OSX",
-    "name": "Advanced Fly-By-Wire (OSX)",
-    "abstract": "AFBW is an input overhaul mod. It dramatically enhances the stock input system with a bunch of fixes and many new features.",
-    "author": "linuxgurugamer",
-    "license": "MIT",
-    "$kref": "#/ckan/github/linuxgurugamer/ksp-advanced-flybywire/asset_match/osx",
-    "$vref": "#/ckan/ksp-avc",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/175359-*",
-        "spacedock": "https://spacedock.info/mod/1878/ABFW%20Revived%20(OSX%20version)",
-        "repository": "https://github.com/linuxgurugamer/ksp-advanced-flybywire",
-        "x_screenshot": "https://spacedock.info/content/linuxgurugamer_179/ABFW_Revived_OSX_version/ABFW_Revived_OSX_version-1527782505.4308672.png"
-    },
-    "tags": [
-        "plugin",
-        "control"
-    ],
-    "provides": [
-        "AdvancedFlyByWireRevived"
-    ],
-    "depends": [
-        {
-            "name": "ToolbarController"
-        },
-        {
-            "name": "ClickThroughBlocker"
-        }
-    ],
-    "recommends": [
-        {
-            "name": "ToolbarController"
-        },
-        {
-            "name": "ClickThroughBlocker"
-        }
-    ],
-    "conflicts": [
-        {
-            "name": "AdvancedFlyByWireRevived"
-        }
-    ],
-    "install": [
-        {
-            "file": "GameData/ksp-advanced-flybywire",
-            "install_to": "GameData"
-        }
-    ]
-}
+identifier: AdvancedFlyByWire-OSX
+name: Advanced Fly-By-Wire (OSX)
+abstract: >-
+  AFBW is an input overhaul mod. It dramatically enhances the stock input system
+  with a bunch of fixes and many new features.
+author: linuxgurugamer
+license: MIT
+$kref: '#/ckan/github/linuxgurugamer/ksp-advanced-flybywire/asset_match/osx'
+$vref: '#/ckan/ksp-avc'
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/175359-*
+  spacedock: https://spacedock.info/mod/1878/ABFW%20Revived%20(OSX%20version)
+  repository: https://github.com/linuxgurugamer/ksp-advanced-flybywire
+  x_screenshot: >-
+    https://spacedock.info/content/linuxgurugamer_179/ABFW_Revived_OSX_version/ABFW_Revived_OSX_version-1527782505.4308672.png
+tags:
+  - plugin
+  - control
+provides:
+  - AdvancedFlyByWireRevived
+depends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+recommends:
+  - name: ToolbarController
+  - name: ClickThroughBlocker
+conflicts:
+  - name: AdvancedFlyByWireRevived
+install:
+  - file: GameData/ksp-advanced-flybywire
+    install_to: GameData

--- a/NetKAN/AdvancedFlyByWire.netkan
+++ b/NetKAN/AdvancedFlyByWire.netkan
@@ -7,7 +7,6 @@ name: Advanced Fly-By-Wire (Windows)
 $kref: '#/ckan/spacedock/1869'
 $vref: '#/ckan/ksp-avc'
 license: MIT
-release_status: stable
 tags:
   - plugin
   - control

--- a/NetKAN/AlcubierreStandalone.netkan
+++ b/NetKAN/AlcubierreStandalone.netkan
@@ -7,7 +7,6 @@ author: RoverDude
 $kref: '#/ckan/github/UmbraSpaceIndustries/WarpDrive'
 $vref: '#/ckan/ksp-avc'
 license: restricted
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/90899-*
   manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/

--- a/NetKAN/AlternateResourcePanel.netkan
+++ b/NetKAN/AlternateResourcePanel.netkan
@@ -5,7 +5,6 @@
     "$kref"          : "#/ckan/github/TriggerAu/AlternateResourcePanel",
     "$vref"          : "#/ckan/ksp-avc",
     "license"        : "MIT",
-    "release_status" : "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/54876-*",
         "license":  "https://github.com/TriggerAu/AlternateResourcePanel/blob/master/LICENSE",

--- a/NetKAN/AlternateResourcePanel.netkan
+++ b/NetKAN/AlternateResourcePanel.netkan
@@ -1,27 +1,20 @@
-{
-    "identifier"     : "AlternateResourcePanel",
-    "name"           : "Alternate Resource Panel",
-    "abstract"       : "An alternate view of vessel resources plugin for Kerbal Space Program",
-    "$kref"          : "#/ckan/github/TriggerAu/AlternateResourcePanel",
-    "$vref"          : "#/ckan/ksp-avc",
-    "license"        : "MIT",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/54876-*",
-        "license":  "https://github.com/TriggerAu/AlternateResourcePanel/blob/master/LICENSE",
-        "manual":   "https://sites.google.com/site/kspalternateresourcepanel/"
-    },
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "recommends": [
-        { "name": "TriggerAu-Flags" }
-    ],
-    "suggests": [
-        { "name": "Olympic1ARPIcons" }
-    ],
-    "install": [ {
-        "find":       "KSPAlternateResourcePanel",
-        "install_to": "GameData/TriggerTech"
-    } ]
-}
+identifier: AlternateResourcePanel
+name: Alternate Resource Panel
+abstract: An alternate view of vessel resources plugin for Kerbal Space Program
+$kref: '#/ckan/github/TriggerAu/AlternateResourcePanel'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/54876-*
+  license: https://github.com/TriggerAu/AlternateResourcePanel/blob/master/LICENSE
+  manual: https://sites.google.com/site/kspalternateresourcepanel/
+tags:
+  - plugin
+  - information
+recommends:
+  - name: TriggerAu-Flags
+suggests:
+  - name: Olympic1ARPIcons
+install:
+  - find: KSPAlternateResourcePanel
+    install_to: GameData/TriggerTech

--- a/NetKAN/AntennaRangePatch4Antennas.frozen
+++ b/NetKAN/AntennaRangePatch4Antennas.frozen
@@ -2,7 +2,6 @@
     "identifier"     : "AntennaRangePatch4Antennas",
     "$kref"       : "#/ckan/kerbalstuff/1191",
     "$vref"       : "#/ckan/ksp-avc",
-    "release_status" : "stable",
     "x_netkan_license_ok": true,
     "resources" : {
         "repository"  : "https://github.com/linuxgurugamer/AntennaPatch4AntennaRange"

--- a/NetKAN/BetterLookingOceans-HighRes.frozen
+++ b/NetKAN/BetterLookingOceans-HighRes.frozen
@@ -5,7 +5,6 @@
     "$kref":        "#/ckan/github/Galileo88/Better-Looking-Oceans/asset_match/BLO_High.zip",
     "$vref":        "#/ckan/ksp-avc",
     "license": "CC-BY-NC-ND",
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/171638-*"
     },

--- a/NetKAN/BetterLookingOceans-LowRes.frozen
+++ b/NetKAN/BetterLookingOceans-LowRes.frozen
@@ -5,7 +5,6 @@
     "$kref":        "#/ckan/github/Galileo88/Better-Looking-Oceans/asset_match/BLO_Low.zip",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "CC-BY-NC-ND",
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/171638-*"
     },

--- a/NetKAN/BetterLookingOceans-MedRes.frozen
+++ b/NetKAN/BetterLookingOceans-MedRes.frozen
@@ -5,7 +5,6 @@
     "$kref":        "#/ckan/github/Galileo88/Better-Looking-Oceans/asset_match/BLO_Med.zip",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "CC-BY-NC-ND",
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/171638-*"
     },

--- a/NetKAN/BetterScienceLabsContinued.netkan
+++ b/NetKAN/BetterScienceLabsContinued.netkan
@@ -6,7 +6,6 @@
     "license": "MIT",
     "$kref": "#/ckan/github/linuxgurugamer/BetterScienceLabsContinued",
     "$vref": "#/ckan/ksp-avc",
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/112754-*",
         "spacedock": "https://spacedock.info/mod/45/Better%20Science%20Labs%20Continued",

--- a/NetKAN/BlackRibbon.frozen
+++ b/NetKAN/BlackRibbon.frozen
@@ -8,7 +8,6 @@
     "abstract"       : "This is an add-on for BDArmory. It adds new weapons and parts.",
     "author"         : "Shuudoushi",
     "license"        : "MIT",
-    "release_status" : "stable",
     "ksp_version"    : "1.0.5",
     "depends": [
         { "name": "BDArmory" },

--- a/NetKAN/BoxSat-prototypes.frozen
+++ b/NetKAN/BoxSat-prototypes.frozen
@@ -7,7 +7,6 @@
     "version":      "A.02f",
     "ksp_version_min": "1.0.4",
     "ksp_version_max": "1.0.5",
-    "release_status": "development",
     "license":      "restricted",
     "resources": {
         "curse": "http://kerbal.curseforge.com/ksp-mods/224250-boxsat",

--- a/NetKAN/ChinesePackContinued.frozen
+++ b/NetKAN/ChinesePackContinued.frozen
@@ -2,7 +2,6 @@
     "identifier": "ChinesePackContinued",
     "$kref": "#/ckan/spacedock/303",
     "license": "CC-BY-NC-SA-4.0",
-    "release_status": "development",
     "resources": {
         "repository": "https://github.com/Wavechaser/ChinesePackContinued"
     },

--- a/NetKAN/CommNetAntennasConsumptor.netkan
+++ b/NetKAN/CommNetAntennasConsumptor.netkan
@@ -6,7 +6,6 @@
     "$vref"        : "#/ckan/ksp-avc",
     "x_netkan_allow_out_of_order": true,
     "license"      : "GPL-3.0",
-    "release_status": "stable",
     "resources" : {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177292-*"
     },

--- a/NetKAN/CommNetAntennasExtension.netkan
+++ b/NetKAN/CommNetAntennasExtension.netkan
@@ -5,7 +5,6 @@
     "$kref"        : "#/ckan/github/yalov/CommNetAntennasExtension",
     "$vref"        : "#/ckan/ksp-avc",
     "license"      : "GPL-3.0",
-    "release_status": "stable",
     "resources" : {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177292-*"
     },

--- a/NetKAN/CommNetAntennasInfo.netkan
+++ b/NetKAN/CommNetAntennasInfo.netkan
@@ -6,7 +6,6 @@
     "$vref"        : "#/ckan/ksp-avc",
     "x_netkan_allow_out_of_order": true,
     "license"      : "GPL-3.0",
-    "release_status": "stable",
     "resources" : {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/177292-*"
     },

--- a/NetKAN/CommunityCategoryKit.netkan
+++ b/NetKAN/CommunityCategoryKit.netkan
@@ -5,7 +5,6 @@ author: RoverDude
 $kref: '#/ckan/github/UmbraSpaceIndustries/CommunityCategoryKit'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-4.0
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/149840-*
   manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/

--- a/NetKAN/CommunityResourcePack.netkan
+++ b/NetKAN/CommunityResourcePack.netkan
@@ -5,7 +5,6 @@ author: RoverDude
 $kref: '#/ckan/github/UmbraSpaceIndustries/CommunityResourcePack'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-4.0
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/83007-*
   manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/

--- a/NetKAN/ContractConfigurator-ContractPack-SCANsat.frozen
+++ b/NetKAN/ContractConfigurator-ContractPack-SCANsat.frozen
@@ -4,7 +4,6 @@
     "abstract": "A contract pack containing contracts for SCANSat.",
     "name": "Contract Pack: SCANSat",
     "license": "CC-BY-NC-SA-4.0",
-    "release_status": "stable",
     "author": "DBT85",
     "x_netkan_force_v": true,
     "$vref": "#/ckan/ksp-avc",

--- a/NetKAN/ContractConfigurator-Round8.frozen
+++ b/NetKAN/ContractConfigurator-Round8.frozen
@@ -6,7 +6,6 @@
     "$kref"        : "#/ckan/github/jrossignol/ContractPack-Round8",
     "$vref"        : "#/ckan/ksp-avc",
     "license"      : "CC-BY-NC-SA-4.0",
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/104231-O",
         "bugtracker": "https://github.com/jrossignol/ContractPack-Round8/issues",

--- a/NetKAN/ContractConfigurator-SpriteMissions.frozen
+++ b/NetKAN/ContractConfigurator-SpriteMissions.frozen
@@ -1,7 +1,6 @@
 {
     "identifier"     : "ContractConfigurator-SpriteMissions",
     "$kref"          : "#/ckan/kerbalstuff/703",
-    "release_status" : "stable",
     "x_netkan_license_ok" : true,
     "resources" : {
         "homepage"    : "https://forum.kerbalspaceprogram.com/index.php?/topic/102186-121-spacetux-contract-pack-unmanned-contracts-rover-contracts-grand-tours-and-sprite-missions/",

--- a/NetKAN/ControlLock.frozen
+++ b/NetKAN/ControlLock.frozen
@@ -5,7 +5,6 @@
     "author":       "Diazo",
     "$kref":        "#/ckan/github/SirDiazo/ControlLock",
     "license":      "Unlicense",
-    "release_status": "stable",
     "ksp_version":  "1.1",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/97829-*"

--- a/NetKAN/CoolRockets.frozen
+++ b/NetKAN/CoolRockets.frozen
@@ -7,7 +7,6 @@
     "version":      "0.08",
     "ksp_version":  "1.1",
     "license":      "public-domain",
-    "release_status": "development",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/61925-*"
     },

--- a/NetKAN/CrewFiles.frozen
+++ b/NetKAN/CrewFiles.frozen
@@ -1,7 +1,6 @@
 {
     "identifier"     : "CrewFiles",
     "$kref"          : "#/ckan/kerbalstuff/39",
-    "release_status" : "stable",
     "x_netkan_license_ok" : true,
     "resources" : {
             "homepage"     : "https://forum.kerbalspaceprogram.com/index.php?/topic/75640-090-crewfiles-persistence-files-for-individual-kerbals-16-dec-2014/",

--- a/NetKAN/CustomBiomes-Data-RSS.frozen
+++ b/NetKAN/CustomBiomes-Data-RSS.frozen
@@ -4,7 +4,6 @@
     "identifier"     : "CustomBiomes-Data-RSS",
     "abstract"       : "Custom biomes for the Real Solar System",
     "license"        : "CC-BY-NC-SA",
-    "release_status" : "stable",
     "ksp_version"    : "any",
     "depends"        : [
         { "name" : "RealSolarSystem" },

--- a/NetKAN/CustomBiomes-Data-Stock.frozen
+++ b/NetKAN/CustomBiomes-Data-Stock.frozen
@@ -5,7 +5,6 @@
     "$kref"          : "#/ckan/github/NathanKell/CustomBiomes",
     "author"         : "Trueborn",
     "ksp_version"    : "0.90",
-    "release_status" : "stable",
     "license"        : "CC-BY-NC-SA-3.0",
     "resources" : {
         "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/60163-*"

--- a/NetKAN/CustomBiomes.frozen
+++ b/NetKAN/CustomBiomes.frozen
@@ -5,7 +5,6 @@
     "abstract"       : "Add or replace biomes to any celestial body in KSP",
     "author"         : "Trueborn",
     "ksp_version"    : "0.90",
-    "release_status" : "stable",
     "license"        : "CC-BY-NC-SA-3.0",
     "resources" : {
         "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/60163-*"

--- a/NetKAN/CustomDesignSpacesuits-Steampunk.frozen
+++ b/NetKAN/CustomDesignSpacesuits-Steampunk.frozen
@@ -26,7 +26,6 @@
       ]
     }
   ],
-  "release_status": "testing",
   "name": "Steam Punk Pack v0.38",
   "abstract": "Steampunk Space Suits",
   "description": "Provides Space Suits in a Steampunky flavour",

--- a/NetKAN/DangIt.frozen
+++ b/NetKAN/DangIt.frozen
@@ -1,6 +1,5 @@
 {
     "identifier"     : "DangIt",
-    "release_status" : "development",
     "license"        : "GPL-3.0",
     "$kref"          : "#/ckan/spacedock/307",
     "depends" : [

--- a/NetKAN/DepthCharge.frozen
+++ b/NetKAN/DepthCharge.frozen
@@ -3,7 +3,6 @@
     "identifier": "DepthCharge",
     "license": "CC-BY-SA-4.0",
     "abstract": "An expansion of BDArmory, providing a plugin and a few parts for naval weapon depth charges. It is still WIP.",
-    "release_status": "development",
     "author": [ "Kerwis", "BahamutoD" ],
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/135771-11-v155-moduledepthcharge"

--- a/NetKAN/DiazosLandingHeight.netkan
+++ b/NetKAN/DiazosLandingHeight.netkan
@@ -6,7 +6,6 @@
     "$kref"          : "#/ckan/spacedock/1844",
     "$vref"          : "#/ckan/ksp-avc",
     "license"        : "GPL-3.0",
-    "release_status" : "stable",
     "tags": [
         "plugin",
         "information"

--- a/NetKAN/DiazosLandingHeight.netkan
+++ b/NetKAN/DiazosLandingHeight.netkan
@@ -1,21 +1,22 @@
-{
-    "name"           : "Diazo's Landing Height Display",
-    "identifier"     : "DiazosLandingHeight",
-    "author"         : [ "Diazo", "linuxgurugamer" ],
-    "abstract"       : "Display true height to ground from the bottom of your vessel on in-game altimeter when in surface mode. Display altitude above sea level (KSP Default) when in orbit mode.",
-    "$kref"          : "#/ckan/spacedock/1844",
-    "$vref"          : "#/ckan/ksp-avc",
-    "license"        : "GPL-3.0",
-    "tags": [
-        "plugin",
-        "information"
-    ],
-    "conflicts": [
-        { "name" : "LandingHeight" }
-    ],
-    "provides": [ "LandingHeight" ],
-    "install": [ {
-        "find"       : "LandingHeight",
-        "install_to" : "GameData"
-    } ]
-}
+name: Diazo's Landing Height Display
+identifier: DiazosLandingHeight
+author:
+  - Diazo
+  - linuxgurugamer
+abstract: >-
+  Display true height to ground from the bottom of your vessel on in-game
+  altimeter when in surface mode. Display altitude above sea level (KSP Default)
+  when in orbit mode.
+$kref: '#/ckan/spacedock/1844'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - plugin
+  - information
+conflicts:
+  - name: LandingHeight
+provides:
+  - LandingHeight
+install:
+  - find: LandingHeight
+    install_to: GameData

--- a/NetKAN/DistantObject.netkan
+++ b/NetKAN/DistantObject.netkan
@@ -14,7 +14,6 @@ x_netkan_force_v: true
 license:
   - GPL-2.0
   - restricted
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/205063-*
   repository: https://github.com/net-lisias-ksp/DistantObject

--- a/NetKAN/DraftTwitchViewers.frozen
+++ b/NetKAN/DraftTwitchViewers.frozen
@@ -1,7 +1,6 @@
 {
     "$kref"          : "#/ckan/spacedock/258",
     "identifier"     : "DraftTwitchViewers",
-    "release_status" : "stable",
     "license"        : "GPL-3.0",
     "resources" : {
         "homepage"     : "http://forum.kerbalspaceprogram.com/index.php?/topic/99876-ksp-103-105-draft-twitch-viewers-v213-draft-or-rescue-your-viewers-as-kerbals/",
@@ -9,4 +8,3 @@
         "repository"   : "https://github.com/IRnifty/DraftTwitchViewers"
     }
 }
-

--- a/NetKAN/EngineIgnitor-Unofficial-Repack.frozen
+++ b/NetKAN/EngineIgnitor-Unofficial-Repack.frozen
@@ -6,7 +6,6 @@
     "$kref"          : "#/ckan/github/pjf/EngineIgnitor",
     "$vref"          : "#/ckan/ksp-avc",
     "license"        : "MIT",
-    "release_status" : "stable",
     "resources" : {
         "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/47648-*"
     },

--- a/NetKAN/EngineerLevelFixer.frozen
+++ b/NetKAN/EngineerLevelFixer.frozen
@@ -1,7 +1,6 @@
 {
     "identifier": "EngineerLevelFixer",
     "abstract": "Small mod that allows Engineers to fix tires and landing gear at any level you want (default 1)",
-    "release_status": "stable",
     "license": "MIT",
     "$kref": "#/ckan/spacedock/205",
     "$vref": "#/ckan/ksp-avc",

--- a/NetKAN/Entropy.frozen
+++ b/NetKAN/Entropy.frozen
@@ -1,6 +1,5 @@
 {
     "identifier"     : "Entropy",
-    "release_status" : "development",
     "license"        : "GPL-3.0",
     "$kref"          : "#/ckan/kerbalstuff/388",
     "depends" : [

--- a/NetKAN/EntropyRealChute.frozen
+++ b/NetKAN/EntropyRealChute.frozen
@@ -1,6 +1,5 @@
 {
     "identifier"     : "EntropyRealChute",
-    "release_status" : "development",
     "license"        : "GPL-3.0",
     "name"           : "Entropy extensions for RealChute",
     "$kref"          : "#/ckan/kerbalstuff/388",

--- a/NetKAN/ExceptionDetector.frozen
+++ b/NetKAN/ExceptionDetector.frozen
@@ -2,7 +2,6 @@
     "identifier":   "ExceptionDetector",
     "$kref":        "#/ckan/spacedock/600",
     "license":      "Unlicense",
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/98658-*",
         "repository": "https://github.com/godarklight/ExceptionDetector"

--- a/NetKAN/ExtraPlanetaryLaunchpads-RegolithAdaptation.frozen
+++ b/NetKAN/ExtraPlanetaryLaunchpads-RegolithAdaptation.frozen
@@ -2,7 +2,6 @@
     "identifier"     : "ExtraPlanetaryLaunchpads-RegolithAdaptation",
     "$kref"          : "#/ckan/kerbalstuff/494",
     "license"        : "GPL-3.0",
-    "release_status" : "stable",
     "resources"      : {
           "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/80988-102-50extraplanetary-launchpads-extended-part-pack-and-extras/"
     },

--- a/NetKAN/FilterExtensions.netkan
+++ b/NetKAN/FilterExtensions.netkan
@@ -9,7 +9,6 @@ abstract: >-
 $kref: '#/ckan/spacedock/1972'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-4.0
-release_status: stable
 tags:
   - plugin
   - convenience

--- a/NetKAN/FilterExtensionsDefaultConfig.netkan
+++ b/NetKAN/FilterExtensionsDefaultConfig.netkan
@@ -10,7 +10,6 @@ abstract: >-
 $kref: '#/ckan/spacedock/1972'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-4.0
-release_status: stable
 tags:
   - config
   - convenience

--- a/NetKAN/FilterExtensionsStockRework.frozen
+++ b/NetKAN/FilterExtensionsStockRework.frozen
@@ -5,7 +5,6 @@
     "identifier"     : "FilterExtensionsStockRework",
     "abstract"       : "Rearrangement of parts in the stock categories",
     "license"        : "CC-BY-NC-SA-4.0",
-    "release_status" : "stable",
     "depends" : [
         { "name" : "FilterExtensions" }
     ],

--- a/NetKAN/FusTek-SharedAssets.frozen
+++ b/NetKAN/FusTek-SharedAssets.frozen
@@ -4,7 +4,6 @@
     "name"           : "FusTek Aerospace - Shared Assets",
     "abstract"       : "Agency folders shared by multiple FusTek-branded add-ons for Kerbal Space Program ",
     "license"        : "CC-BY-SA-4.0",
-    "release_status" : "stable",
     "ksp_version"    : "any",
     "comment"        : "agencymod",
     "x_netkan_license_ok": true,

--- a/NetKAN/FwiffoRaredenSkybox.frozen
+++ b/NetKAN/FwiffoRaredenSkybox.frozen
@@ -8,7 +8,6 @@
     "ksp_version_min"    : "1.0.2",
     "ksp_version_max"    : "1.3.99",
     "license"            : "CC-BY-NC-SA-4.0",
-    "release_status"     : "stable",
     "resources"          : {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/78778-*"
     },

--- a/NetKAN/GPOSpeedPump.netkan
+++ b/NetKAN/GPOSpeedPump.netkan
@@ -11,7 +11,6 @@ $kref: '#/ckan/spacedock/546'
 $vref: '#/ckan/ksp-avc'
 x_netkan_force_v: true
 license: GPL-3.0
-release_status: stable
 tags:
   - plugin
   - resources

--- a/NetKAN/HaystackContinued.frozen
+++ b/NetKAN/HaystackContinued.frozen
@@ -1,6 +1,5 @@
 {
     "identifier"     : "HaystackContinued",
     "$kref"          : "#/ckan/spacedock/547",
-    "license"        : "CC-BY-NC-SA-4.0",
-    "release_status" : "stable"
+    "license"        : "CC-BY-NC-SA-4.0"
 }

--- a/NetKAN/HeatControl-Core.frozen
+++ b/NetKAN/HeatControl-Core.frozen
@@ -4,7 +4,6 @@
     "abstract": "This is the HeatControl plugin stand-alone, for adding functionality to other mods. It contains no parts and does nothing by itself.",
     "author": "Nertea",
     "license": "CC-BY-NC-SA-4.0",
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/112027-131-heat-control-more-radiators-updated-october-13/",
         "kerbalstuff": "https://kerbalstuff.com/mod/890/Heat%20Control",

--- a/NetKAN/InfernalRoboticsNext.netkan
+++ b/NetKAN/InfernalRoboticsNext.netkan
@@ -9,7 +9,6 @@ author:
 $kref: '#/ckan/github/meirumeiru/InfernalRobotics'
 $vref: '#/ckan/ksp-avc'
 license: GPL-3.0
-release_status: stable
 tags:
   - parts
   - plugin

--- a/NetKAN/KKL.frozen
+++ b/NetKAN/KKL.frozen
@@ -4,7 +4,6 @@
     "identifier"     : "KKL",
     "$kref"          : "#/ckan/github/craidler/KerbalKustomzLtd",
     "license"        : "LGPL-2.1",
-    "release_status" : "stable",
     "ksp_version_min": "1.4.0",
     "resources" : {
         "repository"   : "https://github.com/craidler/KerbalKustomzLtd"

--- a/NetKAN/KPlus.frozen
+++ b/NetKAN/KPlus.frozen
@@ -5,7 +5,6 @@
     "abstract"      : "Kerbol Plus is a planetary expansion for KSP adding in 6 new planets and 6 moons for players to discover. Note: This version is a revisioned version of KerbolPlus.",
     "license"       : "CC-BY-NC-SA-4.0",
     "author"        : [ "KillAshley", "Thomas P." ],
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/124505-105-kopernicus-kerbol-plus-remade-v11-19nov15-reborn-and-revived/"
     },

--- a/NetKAN/KSP-Recall.netkan
+++ b/NetKAN/KSP-Recall.netkan
@@ -8,7 +8,6 @@ author:
 $kref: '#/ckan/spacedock/2434'
 $vref: '#/ckan/ksp-avc'
 x_netkan_force_v: true
-release_status: stable
 license:
   - GPL-2.0
   - restricted

--- a/NetKAN/KSPRC-CityLights.frozen
+++ b/NetKAN/KSPRC-CityLights.frozen
@@ -4,7 +4,6 @@
     "abstract":     "Standalone city lights from KSPRC.",
     "$kref":        "#/ckan/spacedock/690",
     "ksp_version_min": "1.1.2",
-    "release_status": "stable",
     "license":      "CC-BY-ND",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/69702-*"

--- a/NetKAN/KSPRC-Textures.frozen
+++ b/NetKAN/KSPRC-Textures.frozen
@@ -4,7 +4,6 @@
     "abstract":     "Standalone KSPRC Textures. Kinda useless without proper configs.",
     "$kref":        "#/ckan/spacedock/690",
     "ksp_version":  "any",
-    "release_status": "stable",
     "license":      "CC-BY-ND",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/69702-*"

--- a/NetKAN/KSPTips.frozen
+++ b/NetKAN/KSPTips.frozen
@@ -4,7 +4,6 @@
     "identifier": "KSPTips",
     "abstract": "Plugin that provides 'Helpful' in game tips and tricks",
     "license": "MIT",
-    "release_status": "stable",
     "author": "TriggerAu",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/93336-090-ksp-tips-v3000-jan-18/",

--- a/NetKAN/KVASS.netkan
+++ b/NetKAN/KVASS.netkan
@@ -4,7 +4,6 @@
     "name"         : "KVASS - Kerbal Very Simplified Simulation and Planning",
     "author"       : "flart",
     "license"      : "GPL-3.0",
-    "release_status" : "stable",
     "$vref" : "#/ckan/ksp-avc",
     "resources" : {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/183393-*"

--- a/NetKAN/Karbonite.netkan
+++ b/NetKAN/Karbonite.netkan
@@ -10,7 +10,6 @@ $kref: '#/ckan/github/UmbraSpaceIndustries/Karbonite'
 $vref: '#/ckan/ksp-avc'
 x_netkan_epoch: '1'
 license: restricted
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/83948-*
   manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/

--- a/NetKAN/KerbalAlarmClock.netkan
+++ b/NetKAN/KerbalAlarmClock.netkan
@@ -5,7 +5,6 @@
     "identifier": "KerbalAlarmClock",
     "abstract": "An in-game alarm clock to help you stop missing important moments",
     "license": "MIT",
-    "release_status": "stable",
     "author": "TriggerAu",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/22809-14x-kerbal-alarm-clock-v3900-mar-17/",

--- a/NetKAN/KerbalConfigEditor.frozen
+++ b/NetKAN/KerbalConfigEditor.frozen
@@ -1,7 +1,6 @@
 {
     "$kref"          : "#/ckan/spacedock/446",
     "identifier"     : "KerbalConfigEditor",
-    "release_status" : "stable",
     "license"        : "GPL-3.0",
     "resources" : {
         "homepage"     : "http://forum.kerbalspaceprogram.com/index.php?/topic/96493-win-kerbal-config-editor-v104-release/",

--- a/NetKAN/KerbalConstructionTime-RP-0-Config.frozen
+++ b/NetKAN/KerbalConstructionTime-RP-0-Config.frozen
@@ -6,7 +6,6 @@
     "license": "CC-BY-4.0",
     "ksp_version_min": "0.25",
     "ksp_version_max": "0.90",
-    "release_status": "development",
     "resources": {
         "repository": "https://github.com/KSP-RO/RP-0"
     },

--- a/NetKAN/KerbalFlightData.frozen
+++ b/NetKAN/KerbalFlightData.frozen
@@ -5,7 +5,6 @@
     "author"       : "DaMichel",
     "$kref"        : "#/ckan/github/DaMichel/KerbalFlightData",
     "ksp_version"  : "1.3",
-    "release_status": "stable",
     "license"      : "GPL-3.0",
     "resources" : {
         "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/73053-*"

--- a/NetKAN/KerbalFlightIndicators.netkan
+++ b/NetKAN/KerbalFlightIndicators.netkan
@@ -11,4 +11,3 @@ resources:
 tags:
   - plugin
   - information
-release_status: stable

--- a/NetKAN/KerbalJointReinforcement.frozen
+++ b/NetKAN/KerbalJointReinforcement.frozen
@@ -6,7 +6,6 @@
     "abstract"       : "KJR tightens up the joints between parts and adds some physics-adjusting parameters to make vehicles more stable when loading on the launchpad or coming out of timewarp.",
     "author"         : "ferram4",
     "license"        : "GPL-3.0",
-    "release_status" : "stable",
     "x_netkan_override" : [
         {
             "version" : "v3.1.4",

--- a/NetKAN/KerbalJointReinforcementContinued.netkan
+++ b/NetKAN/KerbalJointReinforcementContinued.netkan
@@ -6,7 +6,6 @@
     "abstract"       : "KJR tightens up the joints between parts and adds some physics-adjusting parameters to make vehicles more stable when loading on the launchpad or coming out of timewarp.",
     "author"         : [ "ferram4", "Starwaster" ],
     "license"        : "GPL-3.0",
-    "release_status" : "stable",
     "resources": {
         "homepage":  "https://forum.kerbalspaceprogram.com/index.php?/topic/184019-*",
         "repository": "https://github.com/KSP-RO/Kerbal-Joint-Reinforcement-Continued"

--- a/NetKAN/KerbalJointReinforcementNext.netkan
+++ b/NetKAN/KerbalJointReinforcementNext.netkan
@@ -9,7 +9,6 @@ $kref: >-
 $vref: '#/ckan/ksp-avc'
 x_netkan_allow_out_of_order: true
 license: GPL-3.0
-release_status: stable
 tags:
   - plugin
   - physics

--- a/NetKAN/KerbalMechanics.frozen
+++ b/NetKAN/KerbalMechanics.frozen
@@ -1,7 +1,6 @@
 {
     "$kref"          : "#/ckan/spacedock/257",
     "identifier"     : "KerbalMechanics",
-    "release_status" : "development",
     "license"        : "GPL-3.0",
     "resources" : {
         "homepage"     : "http://forum.kerbalspaceprogram.com/index.php?/topic/77449-ksp-10x-kerbal-mechanics-part-failures-and-repairs-v0641/",

--- a/NetKAN/KerbalSimpit.netkan
+++ b/NetKAN/KerbalSimpit.netkan
@@ -8,7 +8,6 @@ author:
 $kref: '#/ckan/github/Simpit-team/KerbalSimpitRevamped'
 $vref: '#/ckan/ksp-avc'
 license: BSD-2-clause
-release_status: stable
 resources:
   homepage: >-
     https://forum.kerbalspaceprogram.com/index.php?/topic/204852-112x-simpit-revamped-simpit-20/

--- a/NetKAN/KittopiaTech.frozen
+++ b/NetKAN/KittopiaTech.frozen
@@ -12,7 +12,6 @@
     ],
     "$kref"         : "#/ckan/github/Kopernicus/KittopiaTech-Legacy",
     "ksp_version"   : "1.3",
-    "release_status": "development",
     "license"       : "LGPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/140581-*"

--- a/NetKAN/KiwiTechTree.frozen
+++ b/NetKAN/KiwiTechTree.frozen
@@ -4,7 +4,6 @@
     "name":             "Kiwi Tech Tree Overhaul",
     "$kref":            "#/ckan/spacedock/2567",
     "$vref":             "#/ckan/ksp-avc",
-    "release_status":   "stable",
     "license":          "MIT",
     "tags": [
         "tech-tree",

--- a/NetKAN/Konstruction.netkan
+++ b/NetKAN/Konstruction.netkan
@@ -6,7 +6,6 @@ author: RoverDude
 $kref: '#/ckan/github/UmbraSpaceIndustries/Konstruction'
 $vref: '#/ckan/ksp-avc'
 license: restricted
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/149233-*
   manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/

--- a/NetKAN/KopernicusExpansion.frozen
+++ b/NetKAN/KopernicusExpansion.frozen
@@ -7,7 +7,6 @@
     "ksp_version"  : "1.0.5",
 
     "author"       : "MrHappyFace",
-    "release_status": "development",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/119211-KopernicusExpansion"
     },

--- a/NetKAN/LandingHeight.frozen
+++ b/NetKAN/LandingHeight.frozen
@@ -5,7 +5,6 @@
     "author" : "Diazo",
     "abstract" : "Display true height to ground from the bottom of your vessel on in-game altimeter when in surface mode. Display altitude above sea level (KSP Default) when in orbit mode.",
     "license" : "GPL-3.0",
-    "release_status" : "stable",
     "ksp_version_min" : "1.2",
     "ksp_version_max" : "1.3",
     "resources" : {

--- a/NetKAN/LightsOut-Fwiffo.frozen
+++ b/NetKAN/LightsOut-Fwiffo.frozen
@@ -18,7 +18,6 @@
             "install_to": "GameData"
         }
     ],
-    "release_status": "stable",
     "version": "v0.1.5.1",
     "ksp_version_min": "1.1.1",
     "ksp_version_max": "1.1.99",

--- a/NetKAN/MOARStationScience.netkan
+++ b/NetKAN/MOARStationScience.netkan
@@ -23,7 +23,6 @@ author:
 $kref: '#/ckan/spacedock/2670'
 $vref: '#/ckan/ksp-avc'
 x_netkan_force_v: true
-release_status: stable
 license: restricted
 resources:
   x_screenshot: http://i.imgur.com/63DTlDLl.png

--- a/NetKAN/MalemuteRover.netkan
+++ b/NetKAN/MalemuteRover.netkan
@@ -5,7 +5,6 @@ author: RoverDude
 $kref: '#/ckan/github/UmbraSpaceIndustries/Malemute'
 $vref: '#/ckan/ksp-avc'
 license: restricted
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/139668-*
   manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/

--- a/NetKAN/MapResourceOverlay.frozen
+++ b/NetKAN/MapResourceOverlay.frozen
@@ -7,7 +7,6 @@
     "x_broken_vref" : "#/ckan/ksp-avc",
     "license"       : "CC-BY-NC-SA",
     "ksp_version"   : "0.90",
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/83356-*"
     },

--- a/NetKAN/MethaneRockets.frozen
+++ b/NetKAN/MethaneRockets.frozen
@@ -2,7 +2,6 @@
     "$kref": "#/ckan/spacedock/337",
     "identifier": "MethaneRockets",
     "license": "restricted",
-    "release_status": "stable",
     "depends": [
         { "name": "RealPlume" },
         { "name": "ModuleManager" }

--- a/NetKAN/Mk2Essentials.frozen
+++ b/NetKAN/Mk2Essentials.frozen
@@ -5,7 +5,6 @@
     "author" : "JoePatrick1",
     "license" : "MIT",
     "version" : "6",
-    "release_status" : "stable",
     "ksp_version_min" : "0.90",
     "ksp_version_max" : "1.0.5",
     "resources" :

--- a/NetKAN/ModActions.netkan
+++ b/NetKAN/ModActions.netkan
@@ -5,7 +5,6 @@
     "author":        [ "Diazo", "linuxgurugamer" ],
     "$kref":        "#/ckan/github/linuxgurugamer/ModActions",
     "$vref":        "#/ckan/ksp-avc",
-    "release_status": "stable",
     "license":      "GPL-3.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/191914-*"

--- a/NetKAN/ModularFuelTanks.frozen
+++ b/NetKAN/ModularFuelTanks.frozen
@@ -17,7 +17,6 @@ version: 5.13.1
 ksp_version_min: '1.8'
 ksp_version_max: '1.9'
 license: CC-BY-SA
-release_status: stable
 resources:
   homepage: http://forum.kerbalspaceprogram.com/index.php?/topic/58235-*
   repository: https://github.com/NathanKell/ModularFuelSystem

--- a/NetKAN/ModuleAnimateEmissive.frozen
+++ b/NetKAN/ModuleAnimateEmissive.frozen
@@ -4,7 +4,6 @@
     "name"          :   "Animate Emissive Module",
     "abstract"      :   "ModuleAnimateEmissive replaces ModuleAnimateHeat with a more flexible, configurable module.",
     "license"       :   "LGPL-2.1",
-    "release_status":   "stable",
     "ksp_version"   :   "1.0.4",
     "install"       :   [ { "find" : "SolverEngines",
                             "install_to" : "GameData",

--- a/NetKAN/ModuleAnimateGenericEffects.netkan
+++ b/NetKAN/ModuleAnimateGenericEffects.netkan
@@ -5,7 +5,6 @@
     "$kref":        "#/ckan/github/linuxgurugamer/ModuleAnimateGenericEffects",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "MIT",
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/191807-18x-*"
     },

--- a/NetKAN/ModuleRCSFX.frozen
+++ b/NetKAN/ModuleRCSFX.frozen
@@ -7,7 +7,6 @@
     "ksp_version_min": "1.0.0",
     "ksp_version_max": "1.0.4",
     "license":      "CC-BY-SA",
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/83259-*",
         "repository": "https://github.com/NathanKell/ModuleRCSFX"

--- a/NetKAN/ModuleSequentialAnimateGeneric.netkan
+++ b/NetKAN/ModuleSequentialAnimateGeneric.netkan
@@ -5,7 +5,6 @@
     "$kref":        "#/ckan/github/linuxgurugamer/ModuleSequentialAnimateGeneric",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "MIT",
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/184488-*"
     },

--- a/NetKAN/NKRsDEM.frozen
+++ b/NetKAN/NKRsDEM.frozen
@@ -1,7 +1,6 @@
 {
     "identifier"     : "NKRsDEM",
     "$kref"          : "#/ckan/spacedock/425",
-    "release_status" : "development",
     "license"        : "CC-BY-SA-4.0",
     "tags": [
         "parts"

--- a/NetKAN/NearFuturePropulsion-LowThrustEP.frozen
+++ b/NetKAN/NearFuturePropulsion-LowThrustEP.frozen
@@ -4,7 +4,6 @@
     "name"           : "Near Future Propulsion Extras: Reduced Thrust Configs",
     "abstract"       : "This optional patch provides a user-editable config file that can reduce (or potentially even increase) the thrust output of all electric engines, while keeping other performance values constant.",
     "author"         : "Nertea",
-    "release_status" : "stable",
     "license"        : "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/155465-131-near-future-technologies-bugfix-updates-march-2/"

--- a/NetKAN/NearFuturePropulsionExtras.frozen
+++ b/NetKAN/NearFuturePropulsionExtras.frozen
@@ -4,7 +4,6 @@
     "$kref"          : "#/ckan/kerbalstuff/347",
     "name"           : "Near Future Propulsion Extras: Hydrogen NTR Configs",
     "abstract"       : "This patch changes most known nuclear thermal rocket engines (stock and modded) to use liquid hydrogen instead of stock liquid fuel. Having a mod that provides matching tanks (like Near Future Propulsion) is recommended.",
-    "release_status" : "stable",
     "license"        : "CC-BY-NC-SA-4.0",
     "ksp_version_max" : "1.0.4",
     "depends" : [

--- a/NetKAN/NewHorizons.frozen
+++ b/NetKAN/NewHorizons.frozen
@@ -6,7 +6,6 @@
     "$kref"         : "#/ckan/github/KillAshley/New_Horizons",
     "ksp_version"   : "1.3",
     "x_netkan_epoch": "1",
-    "release_status": "stable",
     "license"       : "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "http://forum.kerbalspaceprogram.com/index.php?/topic/102776-*"

--- a/NetKAN/Oddiseo.frozen
+++ b/NetKAN/Oddiseo.frozen
@@ -6,7 +6,6 @@
     "$kref":        "#/ckan/github/oddiseo-ksp/oddiseo",
     "ksp_version":  "1.10.1",
     "license":       "GPL-3.0",
-    "release_status": "development",
     "depends": [
         { "name": "ContractConfigurator" }
     ],

--- a/NetKAN/OkramSA.frozen
+++ b/NetKAN/OkramSA.frozen
@@ -5,7 +5,6 @@
     "author"         : "Orum",
     "$kref"          : "#/ckan/github/Orum/OkramSharedAssets",
     "license"        : "unknown",
-    "release_status" : "stable",
     "resources": {
         "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/60383-*",
         "repository": "https://github.com/Orum/OkramSharedAssets"

--- a/NetKAN/OptionalAtm.frozen
+++ b/NetKAN/OptionalAtm.frozen
@@ -6,7 +6,6 @@
     "x_netkan_epoch" : 1,
     "ksp_version_min" : "1.3.0",
     "ksp_version_max" : "1.3.1",
-    "release_status" : "stable",
     "license"        : "MIT",
     "resources" : {
         "homepage"   : "https://forum.kerbalspaceprogram.com/index.php?/topic/167316-*",

--- a/NetKAN/PartMapper.frozen
+++ b/NetKAN/PartMapper.frozen
@@ -4,7 +4,6 @@
     "author"         : "katateochi",
     "name"           : "KerbalX Part Mapper",
     "abstract"       : "Mapping tool for craft sharing site with Auto Mod Detection and Search-By-Mod feature. Not the primary KerbalX Mod",
-    "release_status" : "testing",
     "ksp_version"    : "any",
     "license"        : "GPL-3.0",
     "resources" : {

--- a/NetKAN/PartWizard.frozen
+++ b/NetKAN/PartWizard.frozen
@@ -1,7 +1,6 @@
 {
     "$kref": "#/ckan/github/ozraven/PartWizard",
     "identifier": "PartWizard",
-    "release_status": "stable",
     "license" : "BSD-3-clause",
     "name" : "Part Wizard",
     "abstract" : "Part Wizard is a vehicle design utility plugin that adds a few conveniences when building your next strut/booster carrier.  It provides a list of parts with part highlighting for easier identification, allows deleting of parts from the list on eligible parts, allows complete control of symmetry on eligible parts, allows selecting parts for Action Group assignment, shows either all parts or only those that are hidden from the editor's Parts List. (Helpful in finding obsolete parts when mod authors make updates.) and shows unavailable parts in career modes with options to buy one or all necessary parts for launch.",

--- a/NetKAN/Pathfinder-USILS-CommunityPatch.frozen
+++ b/NetKAN/Pathfinder-USILS-CommunityPatch.frozen
@@ -2,7 +2,6 @@
     "identifier"     : "Pathfinder-USILS-CommunityPatch",
     "$kref"       : "#/ckan/kerbalstuff/1180",
     "$vref"       : "#/ckan/ksp-avc",
-    "release_status" : "stable",
     "x_netkan_license_ok": true,
     "resources" : {
         "kerbalstuff" : "https://kerbalstuff.com/mod/1180/Pathfinder-USILS-CommunityPatch",

--- a/NetKAN/PhoenixIndustriesCargoResupplySystem.frozen
+++ b/NetKAN/PhoenixIndustriesCargoResupplySystem.frozen
@@ -2,7 +2,6 @@
     "x_netkan_license_ok": true,
     "identifier": "PhoenixIndustriesCargoResupplySystem",
     "license": "CC-BY-NC-SA-4.0",
-    "release_status" : "stable",
     "$kref": "#/ckan/spacedock/245",
     "x_netkan_force_v": true,
     "depends": [

--- a/NetKAN/PoodsOPMVO.frozen
+++ b/NetKAN/PoodsOPMVO.frozen
@@ -5,7 +5,6 @@
     "author"         : "Poodmund",
     "$kref"          : "#/ckan/github/Poodmund/PoodsOPMVO",
     "$vref"          : "#/ckan/ksp-avc",
-    "release_status" : "development",
     "license"        : "restricted",
     "tags"           : [
         "config",

--- a/NetKAN/PreciseNode.netkan
+++ b/NetKAN/PreciseNode.netkan
@@ -12,7 +12,6 @@ author:
 $kref: '#/ckan/spacedock/1691'
 $vref: '#/ckan/ksp-avc'
 license: BSD-2-clause
-release_status: stable
 tags:
   - plugin
   - information

--- a/NetKAN/RCSLandAid.netkan
+++ b/NetKAN/RCSLandAid.netkan
@@ -5,7 +5,6 @@
     "$kref"        : "#/ckan/github/linuxgurugamer/RCSLandAid",
     "$vref"        : "#/ckan/ksp-avc",
     "license"      : "GPL-3.0",
-    "release_status" : "stable",
     "resources" : {
         "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/175403-*",
         "repository": "https://github.com/linuxgurugamer/RCSLandAid"

--- a/NetKAN/ROEngines.netkan
+++ b/NetKAN/ROEngines.netkan
@@ -9,7 +9,6 @@ license: CC-BY-NC-ND
 author:
   - pap1723
   - KSP-RO
-release_status: stable
 resources:
   bugtracker: https://github.com/KSP-RO/ROEngines/issues
   repository: https://github.com/KSP-RO/ROEngines

--- a/NetKAN/ROTanks.netkan
+++ b/NetKAN/ROTanks.netkan
@@ -9,7 +9,6 @@ license: CC-BY-SA
 author:
   - pap1723
   - KSP-RO
-release_status: stable
 resources:
   bugtracker: https://github.com/KSP-RO/ROTanks/issues
   repository: https://github.com/KSP-RO/ROTanks

--- a/NetKAN/RSS-CanaveralHD.netkan
+++ b/NetKAN/RSS-CanaveralHD.netkan
@@ -6,7 +6,6 @@
     "abstract"       : "Provides a high-detail Cape Canaveral for RSS. Based on Katniss218's and AnticlockwisePropeller's independent mods.",
     "license"        : "CC-BY-NC-SA-4.0",
     "author"         : ["NathanKell","Katniss218","AnticlockwisePropeller","KSP-RO"],
-    "release_status" : "stable",
     "resources" : {
         "bugtracker"   : "https://github.com/KSP-RO/RSS-CanaveralHD/issues",
         "repository"   : "https://github.com/KSP-RO/RSS-CanaveralHD",

--- a/NetKAN/RSSDateTimeFormatter.netkan
+++ b/NetKAN/RSSDateTimeFormatter.netkan
@@ -5,7 +5,6 @@
     "$kref":        "#/ckan/github/KSP-RO/RSSTimeFormatter",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "CC-BY-NC-SA-4.0",
-    "release_status": "stable",
     "resources" : {
         "homepage" : "http://forum.kerbalspaceprogram.com/index.php?/topic/139335-*",
         "repository" : "https://github.com/KSP-RO/RSSTimeFormatter",

--- a/NetKAN/RSSTextures2048.netkan
+++ b/NetKAN/RSSTextures2048.netkan
@@ -4,7 +4,6 @@
     "identifier"      : "RSSTextures2048",
     "abstract"        : "Textures for Real Solar Systems",
     "license"         : "CC-BY-NC-SA",
-    "release_status"  : "stable",
     "ksp_version_min" : "1.8",
     "resources": {
         "repository" : "https://github.com/KSP-RO/RSS-Textures",

--- a/NetKAN/RSSTextures4096.netkan
+++ b/NetKAN/RSSTextures4096.netkan
@@ -4,7 +4,6 @@
     "identifier"      : "RSSTextures4096",
     "abstract"        : "Textures for Real Solar Systems",
     "license"         : "CC-BY-NC-SA",
-    "release_status"  : "stable",
     "ksp_version_min" : "1.8",
     "resources": {
         "repository" : "https://github.com/KSP-RO/RSS-Textures",

--- a/NetKAN/RSSTextures8192.netkan
+++ b/NetKAN/RSSTextures8192.netkan
@@ -4,7 +4,6 @@
     "identifier"      : "RSSTextures8192",
     "abstract"        : "Textures for Real Solar Systems",
     "license"         : "CC-BY-NC-SA",
-    "release_status"  : "stable",
     "ksp_version_min" : "1.8",
     "resources": {
         "repository" : "https://github.com/KSP-RO/RSS-Textures",

--- a/NetKAN/RadarAltitude.frozen
+++ b/NetKAN/RadarAltitude.frozen
@@ -5,7 +5,6 @@
     "$vref"        : "#/ckan/ksp-avc",
     "name"         : "Radar Altitude",
     "license"      : "GPL-2.0",
-    "release_status" : "stable",
     "resources" : {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/179811-*"
     },

--- a/NetKAN/RemoteTech-ProbeControlEnabler.frozen
+++ b/NetKAN/RemoteTech-ProbeControlEnabler.frozen
@@ -5,7 +5,6 @@
     "identifier"     : "RemoteTech-ProbeControlEnabler",
     "abstract"       : "Optional ModuleManager patch by Felger to re-enable probe control when a link is not present.  You will still need a link to transmit science data.",
     "license"        : "CC-BY-SA",
-    "release_status" : "stable",
     "depends" : [
         { "name" : "ModuleManager" }
     ],

--- a/NetKAN/RemoteTech.netkan
+++ b/NetKAN/RemoteTech.netkan
@@ -8,7 +8,6 @@ author: Remote Technologies Group
 $kref: '#/ckan/spacedock/520'
 $vref: '#/ckan/ksp-avc'
 x_netkan_force_v: true
-release_status: stable
 license: GPL-2.0
 tags:
   - plugin

--- a/NetKAN/RetractableLiftingSurface.netkan
+++ b/NetKAN/RetractableLiftingSurface.netkan
@@ -5,7 +5,6 @@
     "$kref":        "#/ckan/github/linuxgurugamer/RetractableLiftingSurface",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "MIT",
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/145583-*"
     },

--- a/NetKAN/RoadToCosmosCore.frozen
+++ b/NetKAN/RoadToCosmosCore.frozen
@@ -4,7 +4,6 @@
     "identifier"     : "RoadToCosmosCore",
     "abstract"       : "Soviet and American-style tech trees",
     "license"        : "CC-BY-NC-SA-4.0",
-    "release_status" : "stable",
     "depends" : [
         { "name" : "DMagicOrbitalScience" },
         { "name" : "ModuleManager" },

--- a/NetKAN/SDHI-SharedAssets.frozen
+++ b/NetKAN/SDHI-SharedAssets.frozen
@@ -6,7 +6,6 @@
     "license"        : "CC-BY-SA-4.0",
     "ksp_version"    : "any",
     "comment"        : "agencymod",
-    "release_status" : "stable",
     "resources" : {
         "repository"   : "https://github.com/sumghai/SDHI_ServiceModuleSystem",
         "homepage"     : "https://forum.kerbalspaceprogram.com/index.php?/topic/48073-*"

--- a/NetKAN/SVE-HighResolution.frozen
+++ b/NetKAN/SVE-HighResolution.frozen
@@ -8,7 +8,6 @@
     "x_netkan_epoch" : "3",
     "x_netkan_staging": true,
     "license"        : "CC-BY-NC-SA",
-    "release_status" : "stable",
     "resources" : {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/143288-*"
     },

--- a/NetKAN/SVE-LowResolution.frozen
+++ b/NetKAN/SVE-LowResolution.frozen
@@ -8,7 +8,6 @@
     "x_netkan_epoch" : "3",
     "x_netkan_staging": true,
     "license"        : "CC-BY-NC-SA",
-    "release_status" : "stable",
     "resources" : {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/143288-*"
     },

--- a/NetKAN/SVE-MediumResolution.frozen
+++ b/NetKAN/SVE-MediumResolution.frozen
@@ -8,7 +8,6 @@
     "x_netkan_epoch" : "3",
     "x_netkan_staging": true,
     "license"        : "CC-BY-NC-SA",
-    "release_status" : "stable",
     "resources" : {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/143288-*"
     },

--- a/NetKAN/SVE-Scatterer-Config.frozen
+++ b/NetKAN/SVE-Scatterer-Config.frozen
@@ -7,7 +7,6 @@
     "ksp_version"    : "1.2",
     "x_netkan_epoch" : "2",
     "license"        : "CC-BY-NC-SA",
-    "release_status" : "stable",
     "resources" : {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/143288-*"
     },

--- a/NetKAN/SVE-Sunflare.frozen
+++ b/NetKAN/SVE-Sunflare.frozen
@@ -6,7 +6,6 @@
     "name"           : "Stock Visual Enhancements: Sunflare",
     "abstract"       : "Stock Visual Enhancements version of the sunflare component of scatterer",
     "license"        : "CC-BY-NC-SA",
-    "release_status" : "stable",
     "x_netkan_epoch" : "2",
     "resources" : {
         "homepage"   : "https://forum.kerbalspaceprogram.com/index.php?/topic/143288-*"

--- a/NetKAN/SVT-HighResolution.frozen
+++ b/NetKAN/SVT-HighResolution.frozen
@@ -5,7 +5,6 @@
     "name"           : "Stock Visual Terrain-High Res",
     "abstract"       : "A terrain enhancement pack using Kopernicus for the stock planets.",
     "license"        : "CC-BY-NC-ND",
-    "release_status" : "stable",
     "provides": [ "SVE-Terrain" ],
     "conflicts": [
         { "name": "SVE-Terrain" }

--- a/NetKAN/SVT-LowResolution.frozen
+++ b/NetKAN/SVT-LowResolution.frozen
@@ -5,7 +5,6 @@
     "name"           : "Stock Visual Terrain-Low Res",
     "abstract"       : "A terrain enhancement pack using Kopernicus for the stock planets.",
     "license"        : "CC-BY-NC-ND",
-    "release_status" : "stable",
     "provides": [ "SVE-Terrain" ],
     "conflicts": [
         { "name": "SVE-Terrain" }

--- a/NetKAN/SVT-MacLinux.frozen
+++ b/NetKAN/SVT-MacLinux.frozen
@@ -5,7 +5,6 @@
     "name"           : "Stock Visual Terrain (for Mac & Linux)",
     "abstract"       : "A terrain enhancement pack using Kopernicus for the stock planets.",
     "license"        : "CC-BY-NC-ND",
-    "release_status" : "stable",
     "provides": [ "SVE-Terrain" ],
     "conflicts": [
         { "name": "SVE-Terrain" }

--- a/NetKAN/SVT-Windows.frozen
+++ b/NetKAN/SVT-Windows.frozen
@@ -5,7 +5,6 @@
     "name"           : "Stock Visual Terrain (for Windows)",
     "abstract"       : "A terrain enhancement pack using Kopernicus for the stock planets.",
     "license"        : "CC-BY-NC-ND",
-    "release_status" : "stable",
     "provides": [ "SVE-Terrain" ],
     "conflicts": [
        { "name": "SVE-Terrain" }

--- a/NetKAN/SamBelangerFlags.frozen
+++ b/NetKAN/SamBelangerFlags.frozen
@@ -7,7 +7,6 @@
     "ksp_version"    : "any",
     "x_netkan_epoch" : 1,
     "comment"        : "flagmod",
-    "release_status" : "stable",
     "install" : [
         {
             "find"       : "Flags",

--- a/NetKAN/SatBatts.frozen
+++ b/NetKAN/SatBatts.frozen
@@ -4,7 +4,6 @@
     "identifier"     : "SatBatts",
     "$kref"          : "#/ckan/kerbalstuff/290",
     "license"        : "restricted",
-    "release_status" : "stable",
     "x_netkan_license_ok": true,
     "resources" : {
         "homepage"     : "https://forum.kerbalspaceprogram.com/index.php?/topic/60383-okram-industries-satbatts-v2-ksp-090/"

--- a/NetKAN/ScienceLabInfo.netkan
+++ b/NetKAN/ScienceLabInfo.netkan
@@ -4,7 +4,6 @@
     "name"         : "Science Lab Info (and 6 Crew Lab)",
     "author"       : "flart",
     "license"      : "GPL-3.0",
-    "release_status" : "stable",
     "$vref" : "#/ckan/ksp-avc",
     "resources" : {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/179385-*"

--- a/NetKAN/SelectableDataTransmitter.netkan
+++ b/NetKAN/SelectableDataTransmitter.netkan
@@ -4,7 +4,6 @@
     "author":       "linuxgurugamer",
     "$kref":        "#/ckan/github/linuxgurugamer/SelectableDataTransmitter",
     "$vref":        "#/ckan/ksp-avc",
-    "release_status": "stable",
     "license":      "MIT",
     "install": [ {
         "find": "SelectableDataTransmitter",

--- a/NetKAN/SemiSaturatableRW.frozen
+++ b/NetKAN/SemiSaturatableRW.frozen
@@ -6,7 +6,6 @@
     "$vref":        "#/ckan/ksp-avc",
     "x_netkan_epoch": 1,
     "license":      "GPL-3.0",
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/200480-*"
     },

--- a/NetKAN/ShipManifest.netkan
+++ b/NetKAN/ShipManifest.netkan
@@ -6,7 +6,6 @@ author:
   - Micha
 $kref: '#/ckan/github/PapaJoesSoup/ShipManifest'
 $vref: '#/ckan/ksp-avc'
-release_status: stable
 license: CC-BY-NC-SA-4.0
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/56643-*

--- a/NetKAN/ShowAllFuels.frozen
+++ b/NetKAN/ShowAllFuels.frozen
@@ -1,7 +1,6 @@
 {
     "identifier": "ShowAllFuels",
     "$kref": "#/ckan/kerbalstuff/354",
-    "release_status": "development",
     "license": "MIT",
     "depends" : [
         { "name" : "ModuleManager", "min_version" : "2.5.1"}

--- a/NetKAN/SolarSailNavigator.frozen
+++ b/NetKAN/SolarSailNavigator.frozen
@@ -5,7 +5,6 @@
     "author"       : "mrsolarsail",
     "$kref"        : "#/ckan/github/bld/SolarSailNavigator",
     "ksp_version"  : "1.4",
-    "release_status" : "development",
     "license"      : "LGPL-2.1",
     "resources" : {
         "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/107676-*"

--- a/NetKAN/SolverEngines.netkan
+++ b/NetKAN/SolverEngines.netkan
@@ -5,7 +5,6 @@
     "name"          :   "Solver Engines plugin",
     "abstract"      :   "SolverEngines is at its heart a replacement paradigm for how KSP deals with engines",
     "license"       :   "LGPL-2.1",
-    "release_status":   "stable",
     "install"       :   [ { "find" : "SolverEngines",
                             "install_to" : "GameData",
                             "filter" : [ "ModuleAnimateEmissive.dll", "PluginData" ] } ],

--- a/NetKAN/SoundingRockets.netkan
+++ b/NetKAN/SoundingRockets.netkan
@@ -5,7 +5,6 @@ author: RoverDude
 $kref: '#/ckan/github/UmbraSpaceIndustries/SoundingRockets'
 $vref: '#/ckan/ksp-avc'
 license: restricted
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/92434-*
   manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/

--- a/NetKAN/SpaceDock.frozen
+++ b/NetKAN/SpaceDock.frozen
@@ -7,7 +7,6 @@
     "version"        : "0.2.1",
     "ksp_version"    : "1.2",
     "license"        : "CC-BY-NC-SA-4.0",
-    "release_status" : "stable",
     "resources" : {
         "homepage"     : "http://forum.kerbalspaceprogram.com/index.php?/topic/150589-*",
         "repository"   : "https://github.com/SpaceShipShipYardEnterprises/SpaceDock"

--- a/NetKAN/SpacetuxSA.netkan
+++ b/NetKAN/SpacetuxSA.netkan
@@ -3,7 +3,6 @@
     "$kref"          : "#/ckan/spacedock/53",
     "$vref"          : "#/ckan/ksp-avc",
     "license"        : "MIT",
-    "release_status" : "stable",
     "tags": [
         "config",
         "library"

--- a/NetKAN/Spectra-Scatterer.netkan
+++ b/NetKAN/Spectra-Scatterer.netkan
@@ -8,7 +8,6 @@ $kref: '#/ckan/spacedock/1505'
 $vref: '#/ckan/ksp-avc'
 x_netkan_force_v: true
 license: MIT
-release_status: stable
 tags:
   - config
   - graphics

--- a/NetKAN/Spectra.netkan
+++ b/NetKAN/Spectra.netkan
@@ -8,7 +8,6 @@ $kref: '#/ckan/spacedock/1505'
 $vref: '#/ckan/ksp-avc'
 x_netkan_force_v: true
 license: MIT
-release_status: stable
 tags:
   - config
   - graphics

--- a/NetKAN/SpeedUnitAnnex.netkan
+++ b/NetKAN/SpeedUnitAnnex.netkan
@@ -4,7 +4,6 @@
     "name"         : "Speed Unit Annex",
     "author"       : "flart",
     "license"      : "GPL-3.0",
-    "release_status" : "stable",
     "$vref" : "#/ckan/ksp-avc",
     "resources" : {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/169611-*"

--- a/NetKAN/StationPartsExpansion.frozen
+++ b/NetKAN/StationPartsExpansion.frozen
@@ -2,7 +2,6 @@
     "identifier"     : "StationPartsExpansion",
     "$kref"          : "#/ckan/spacedock/736",
     "$vref"          : "#/ckan/ksp-avc",
-    "release_status" : "stable",
     "license"        : "CC-BY-NC-SA-4.0",
     "tags": [
         "parts",

--- a/NetKAN/StationScience.frozen
+++ b/NetKAN/StationScience.frozen
@@ -7,7 +7,6 @@
     "version":      "2.0",
     "ksp_version":  "1.1.2",
     "license":      "restricted",
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/50145-*",
         "curse": "http://kerbal.curseforge.com/ksp-mods/220216",

--- a/NetKAN/StationScienceContinued.frozen
+++ b/NetKAN/StationScienceContinued.frozen
@@ -7,7 +7,6 @@
     "$kref":        "#/ckan/github/tomforwood/StationScience",
     "$vref":        "#/ckan/ksp-avc",
     "x_netkan_force_v": true,
-    "release_status": "stable",
     "license":      "restricted",
     "resources": {
         "homepage":  "http://forum.kerbalspaceprogram.com/index.php?/topic/154629-*",

--- a/NetKAN/StockVisualEnhancements.frozen
+++ b/NetKAN/StockVisualEnhancements.frozen
@@ -5,7 +5,6 @@
     "$kref"          : "#/ckan/github/Galileo88/StockVisualEnhancements/asset_match/SVE.v.*.zip",
     "$vref"          : "#/ckan/ksp-avc",
     "license"        : "CC-BY-NC-SA",
-    "release_status" : "stable",
     "x_netkan_epoch" : "3",
     "x_netkan_staging": true,
     "x_netkan_staging_reason": "Tricky dependencies, make sure the SVE-Textures providers are indexed",

--- a/NetKAN/StripSymmetry.frozen
+++ b/NetKAN/StripSymmetry.frozen
@@ -7,7 +7,6 @@
     "ksp_version_min": "1.0.0",
     "ksp_version_max": "1.0.99",
     "license"       : "WTFPL",
-    "release_status": "stable",
     "tags": [
         "plugin",
         "editor",

--- a/NetKAN/TACLS-Config-RealismOverhaul.frozen
+++ b/NetKAN/TACLS-Config-RealismOverhaul.frozen
@@ -5,7 +5,6 @@
     "identifier"     : "TACLS-Config-RealismOverhaul",
     "abstract"       : "Realism Overhaul config for TACLS",
     "license"        : "CC-BY-SA",
-    "release_status" : "stable",
     "depends" : [
         { "name" : "RealismOverhaul" },
         { "name" : "TACLS" }

--- a/NetKAN/TACLS-Config-Stock.frozen
+++ b/NetKAN/TACLS-Config-Stock.frozen
@@ -6,7 +6,6 @@
     "$kref"          : "#/ckan/github/KSP-RO/TacLifeSupport",
     "license"        : "CC-BY-NC-SA-3.0",
     "ksp_version"    : "any",
-    "release_status" : "stable",
     "depends"        : [ { "name" : "TACLS" } ],
     "provides"       : [ "TACLS-Config" ],
     "conflicts"      : [ { "name" : "TACLS-Config" } ],

--- a/NetKAN/TRR-Guide.frozen
+++ b/NetKAN/TRR-Guide.frozen
@@ -4,7 +4,6 @@
     "author":       "HaArLiNsH",
     "$kref":        "#/ckan/github/HaArLiNsH/TRR_Guide",
     "$vref":        "#/ckan/ksp-avc",
-    "release_status": "testing",
     "license":      "MIT",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/161898-*",

--- a/NetKAN/TRR-MyTextureMod.frozen
+++ b/NetKAN/TRR-MyTextureMod.frozen
@@ -5,7 +5,6 @@
     "$kref":        "#/ckan/github/HaArLiNsH/TRR_MyTextureMod",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "MIT",
-    "release_status": "testing",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/161898-*",
         "repository": "https://github.com/HaArLiNsH/TRR_MyTextureMod"

--- a/NetKAN/TWR1.netkan
+++ b/NetKAN/TWR1.netkan
@@ -5,7 +5,6 @@
     "$kref":        "#/ckan/spacedock/1871",
     "$vref":        "#/ckan/ksp-avc",
     "license":      "GPL-3.0",
-    "release_status": "stable",
     "tags": [
         "plugin",
         "control"

--- a/NetKAN/TacFuelBalancer.netkan
+++ b/NetKAN/TacFuelBalancer.netkan
@@ -12,7 +12,6 @@ $kref: '#/ckan/spacedock/640'
 $vref: '#/ckan/ksp-avc'
 x_netkan_force_v: true
 license: CC-BY-NC-SA-3.0
-release_status: stable
 tags:
   - plugin
   - convenience

--- a/NetKAN/Tantares.frozen
+++ b/NetKAN/Tantares.frozen
@@ -5,7 +5,6 @@
     "author"         : "Beale",
     "abstract"       : "Stockalike Soyuz and MIR",
     "license"        : "CC-BY-NC-SA-4.0",
-    "release_status" : "stable",
     "resources" : {
         "homepage"      : "https://forum.kerbalspaceprogram.com/index.php?/topic/73686-142-tantares-stockalike-soyuz-and-mir-11030032018proton-rocket/"
     },

--- a/NetKAN/TantaresLV.frozen
+++ b/NetKAN/TantaresLV.frozen
@@ -5,7 +5,6 @@
   "author" : "Beale",
   "abstract" : "Stockalike Proton & More",
   "license" : "CC-BY-NC-SA-4.0",
-  "release_status" : "stable",
   "resources" : {
     "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/73686-142-tantares-stockalike-soyuz-and-mir-11030032018proton-rocket/"
   },

--- a/NetKAN/TelemachusReborn.netkan
+++ b/NetKAN/TelemachusReborn.netkan
@@ -7,7 +7,6 @@
     "$vref"          : "#/ckan/ksp-avc",
     "x_netkan_version_edit": "^[vV]?(?<version>[\\d\\.]+)(?:-.+)*",
     "license"        : "MIT",
-    "release_status" : "stable",
     "resources"      : {
         "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/179887-*",
         "spacedock" : "https://spacedock.info/mod/2012/Telemachus%20Reborn"

--- a/NetKAN/TestFlight.netkan
+++ b/NetKAN/TestFlight.netkan
@@ -6,7 +6,6 @@
     "$vref":        "#/ckan/ksp-avc",
     "license":      "CC-BY-NC-SA-4.0",
     "author":       [ "Agathorn", "KSP-RO Group" ],
-    "release_status": "stable",
     "resources": {
         "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/99043-*"
     },

--- a/NetKAN/TestFlightConfig-KerbalAtomics.frozen
+++ b/NetKAN/TestFlightConfig-KerbalAtomics.frozen
@@ -4,7 +4,6 @@ abstract: >-
   This config pack adds TestFlight support for Kerbal Atomics parts. It does not
   affect stock parts; install a stock TestFlight config if desired.
 $kref: '#/ckan/github/Starstrider42/TestFlight-Configs'
-release_status: testing
 license: MIT
 resources:
   bugtracker: https://github.com/Starstrider42/TestFlight-Configs/issues

--- a/NetKAN/TestFlightConfig-NFPropulsion.frozen
+++ b/NetKAN/TestFlightConfig-NFPropulsion.frozen
@@ -4,7 +4,6 @@ abstract: >-
   This config pack adds TestFlight support for Near Future Propulsion parts. It
   does not affect stock parts; install a stock TestFlight config if desired.
 $kref: '#/ckan/github/Starstrider42/TestFlight-Configs'
-release_status: testing
 license: MIT
 resources:
   bugtracker: https://github.com/Starstrider42/TestFlight-Configs/issues

--- a/NetKAN/TestFlightConfig-NFSpacecraft.frozen
+++ b/NetKAN/TestFlightConfig-NFSpacecraft.frozen
@@ -4,7 +4,6 @@ abstract: >-
   This config pack adds TestFlight support for Near Future Spacecraft parts. It
   does not affect stock parts; install a stock TestFlight config if desired.
 $kref: '#/ckan/github/Starstrider42/TestFlight-Configs'
-release_status: testing
 license: MIT
 resources:
   bugtracker: https://github.com/Starstrider42/TestFlight-Configs/issues

--- a/NetKAN/TestFlightConfig-Stock-S42.frozen
+++ b/NetKAN/TestFlightConfig-Stock-S42.frozen
@@ -5,7 +5,6 @@ $kref: '#/ckan/github/Starstrider42/TestFlight-Configs'
 ksp_version_min: '1.4'
 ksp_version_max: '1.9'
 comment: ksp_version_max because each release adds TF-eligible parts
-release_status: testing
 license: MIT
 resources:
   bugtracker: https://github.com/Starstrider42/TestFlight-Configs/issues

--- a/NetKAN/TestFlightConfigLibrary.frozen
+++ b/NetKAN/TestFlightConfigLibrary.frozen
@@ -4,7 +4,6 @@ abstract: >-
   ModuleManager scripts for simplifying and standardizing TestFlight configs. Do
   *not* provide TestFlight support by themselves.
 $kref: '#/ckan/github/Starstrider42/TestFlight-Configs'
-release_status: testing
 license: MIT
 resources:
   bugtracker: https://github.com/Starstrider42/TestFlight-Configs/issues

--- a/NetKAN/TestFlightConfigRO.frozen
+++ b/NetKAN/TestFlightConfigRO.frozen
@@ -5,7 +5,6 @@
     "$vref" : "#/ckan/ksp-avc",
     "$kref" : "#/ckan/github/KSP-RO/TestFlight/asset_match/TestFlightConfigRO*",
     "license" : "CC-BY-NC-SA-4.0",
-    "release_status" : "stable",
     "resources" : {
         "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/99043-122-testflight-v180-01-may-2017-bring-flight-testing-to-ksp/",
         "repository" : "https://github.com/KSP-RO/TestFlight",

--- a/NetKAN/TestFlightConfigStock.frozen
+++ b/NetKAN/TestFlightConfigStock.frozen
@@ -6,7 +6,6 @@
     "$vref":        "#/ckan/ksp-avc",
     "license":      "CC-BY-NC-SA-4.0",
     "author":       [ "Agathorn", "KSP-RO Group" ],
-    "release_status": "stable",
     "resources": {
         "homepage":   "https://forum.kerbalspaceprogram.com/index.php?/topic/99043-*",
         "repository": "https://github.com/KSP-RO/TestFlight",

--- a/NetKAN/Toolbar.netkan
+++ b/NetKAN/Toolbar.netkan
@@ -12,7 +12,6 @@ $kref: '#/ckan/spacedock/2090'
 $vref: '#/ckan/ksp-avc'
 x_netkan_epoch: '1'
 license: BSD-2-clause
-release_status: stable
 tags:
   - plugin
   - convenience

--- a/NetKAN/TriggerAu-Flags.netkan
+++ b/NetKAN/TriggerAu-Flags.netkan
@@ -5,7 +5,6 @@
     "author"         : "TriggerAu",
     "$kref"          : "#/ckan/github/TriggerAu/AlternateResourcePanel",
     "license"        : "MIT",
-    "release_status" : "stable",
     "ksp_version"    : "any",
     "comment"        : "flagmod",
     "resources": {

--- a/NetKAN/TweakScale-Redist.netkan
+++ b/NetKAN/TweakScale-Redist.netkan
@@ -12,7 +12,6 @@ $vref: '#/ckan/ksp-avc/GameData/TweakScale/TweakScale.version'
 x_netkan_force_v: true
 license:
   - WTFPL
-release_status: stable
 conflicts:
   - name: TweakScaleRescaled-Redist
 tags:

--- a/NetKAN/TweakScale.netkan
+++ b/NetKAN/TweakScale.netkan
@@ -15,7 +15,6 @@ x_netkan_force_v: true
 license:
   - GPL-2.0
   - restricted
-release_status: stable
 tags:
   - plugin
   - convenience

--- a/NetKAN/TweakScaleCompanion-ReStockPlus.frozen
+++ b/NetKAN/TweakScaleCompanion-ReStockPlus.frozen
@@ -7,7 +7,6 @@ author:
 $kref: '#/ckan/spacedock/2424'
 $vref: '#/ckan/ksp-avc'
 x_netkan_force_v: true
-release_status: stable
 license:
   - GPL-2.0
   - restricted

--- a/NetKAN/UKS.netkan
+++ b/NetKAN/UKS.netkan
@@ -18,7 +18,6 @@ $kref: '#/ckan/github/UmbraSpaceIndustries/MKS'
 $vref: '#/ckan/ksp-avc'
 x_netkan_epoch: '1'
 license: restricted
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/154587-*
   manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/

--- a/NetKAN/USI-ART.netkan
+++ b/NetKAN/USI-ART.netkan
@@ -8,7 +8,6 @@ $kref: '#/ckan/github/UmbraSpaceIndustries/ART'
 $vref: '#/ckan/ksp-avc'
 x_netkan_epoch: '1'
 license: restricted
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/82809-*
   manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/

--- a/NetKAN/USI-Core.netkan
+++ b/NetKAN/USI-Core.netkan
@@ -5,7 +5,6 @@ author: RoverDude
 $kref: '#/ckan/github/UmbraSpaceIndustries/USI_Core'
 $vref: '#/ckan/ksp-avc'
 license: restricted
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/122420-*
   manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/

--- a/NetKAN/USI-EXP.netkan
+++ b/NetKAN/USI-EXP.netkan
@@ -5,7 +5,6 @@ author: RoverDude
 $kref: '#/ckan/github/UmbraSpaceIndustries/ExplorationPack'
 $vref: '#/ckan/ksp-avc'
 license: restricted
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/78242-*
   manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/

--- a/NetKAN/USI-FTT.netkan
+++ b/NetKAN/USI-FTT.netkan
@@ -7,7 +7,6 @@ author: RoverDude
 $kref: '#/ckan/github/UmbraSpaceIndustries/FTT'
 $vref: '#/ckan/ksp-avc'
 license: restricted
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/82730-*
   manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/

--- a/NetKAN/USI-LS.netkan
+++ b/NetKAN/USI-LS.netkan
@@ -5,7 +5,6 @@ author: RoverDude
 $kref: '#/ckan/github/UmbraSpaceIndustries/USI-LS'
 $vref: '#/ckan/ksp-avc'
 license: restricted
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/105202-*
   manual: https://umbraspaceindustries.github.io/UmbraSpaceIndustries/

--- a/NetKAN/USITools.netkan
+++ b/NetKAN/USITools.netkan
@@ -5,7 +5,6 @@ author: RoverDude
 $kref: '#/ckan/github/UmbraSpaceIndustries/USITools'
 $vref: '#/ckan/ksp-avc/GameData/000_USITools/USITools.version'
 license: restricted
-release_status: stable
 resources:
   manual: http://umbraspaceindustries.github.io/UmbraSpaceIndustries/
 tags:

--- a/NetKAN/UnchartedLands.frozen
+++ b/NetKAN/UnchartedLands.frozen
@@ -5,7 +5,6 @@
     "author"        : "KillAshley",
     "$kref"         : "#/ckan/github/KillAshley/UL",
     "ksp_version"   : "1.3",
-    "release_status": "stable",
     "x_netkan_force_v": true,
     "license"       : "CC-BY-NC-SA-4.0",
     "resources": {

--- a/NetKAN/UtilityWeight.netkan
+++ b/NetKAN/UtilityWeight.netkan
@@ -5,7 +5,6 @@
     "$kref"        : "#/ckan/github/yalov/UtilityWeight",
     "$vref"        : "#/ckan/ksp-avc",
     "license"      : "GPL-3.0",
-    "release_status": "stable",
     "resources" : {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/189536-*"
     },

--- a/NetKAN/VesselMover.frozen
+++ b/NetKAN/VesselMover.frozen
@@ -8,6 +8,5 @@
     "abstract": "A quick and easy way to move vessels around in KSP. Press alt+P to activate while landed.",
     "license": "MIT",
     "ksp_version_min": "1.1.0",
-    "ksp_version_max": "1.1.2",
-    "release_status": "stable"
+    "ksp_version_max": "1.1.2"
 }

--- a/NetKAN/WaterLaunchSites.netkan
+++ b/NetKAN/WaterLaunchSites.netkan
@@ -5,7 +5,6 @@
     "$kref"        : "#/ckan/github/yalov/WaterLaunchSites",
     "$vref"        : "#/ckan/ksp-avc",
     "license"      : "GPL-3.0",
-    "release_status": "stable",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/183937-*"
     },

--- a/NetKAN/Year2200.frozen
+++ b/NetKAN/Year2200.frozen
@@ -1,7 +1,6 @@
 {
     "identifier": "Year2200",
     "$kref": "#/ckan/spacedock/722",
-    "release_status": "testing",
     "x_netkan_license_ok": true,
     "depends": [
         {


### PR DESCRIPTION
#10283 removed `release_status` from all netkans that set it to anything other than `stable` so they wouldn't be treated as prereleases and KSP-CKAN/CKAN#4260 could add support for prereleases.

Turns out that setting it to `stable` causes problems as well, see #10397 for an example. The author of InfernalRoboticsNext reported that his mod had a prerelease indexed as a normal release in CKAN because of this.

Now they're all purged, including frozen in case they're unfrozen in the future or used as templates by other authors.
