### PR TITLE
Fix FutureTechnologiesExpansion-FrontierAeronautics install

### DIFF
--- a/NetKAN/FutureTechnologiesExpansion-FrontierAeronautics.netkan
+++ b/NetKAN/FutureTechnologiesExpansion-FrontierAeronautics.netkan
@@ -11,5 +11,5 @@ recommends:
   - name: CommunityTechTree
   - name: FarFutureTechnologies
 install:
-  - find: FutureTechnologiesExpansion
+  - find_regexp: FutureTechnologiesExpansion.*
     install_to: GameData


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/58228176-fa37-4a66-b751-3adde8f2753d)

This mod's folder now has a version string embedded in its name.

![image](https://github.com/user-attachments/assets/b756eae4-b283-45d9-9bcf-c46b49558b77)

Now the install stanza accounts for this.
