### PR TITLE
Remove SpaceDock hosting for Lt_Duckweed's mods

### DIFF
--- a/NetKAN/BetterKerbol.netkan
+++ b/NetKAN/BetterKerbol.netkan
@@ -1,5 +1,6 @@
 identifier: BetterKerbol
 $kref: '#/ckan/github/jamespglaze/BetterKerbol'
+ksp_version: '1.12'
 license: CC-BY-NC-ND-3.0
 tags:
   - config

--- a/NetKAN/BetterKerbol.netkan
+++ b/NetKAN/BetterKerbol.netkan
@@ -1,8 +1,5 @@
 identifier: BetterKerbol
 $kref: '#/ckan/github/jamespglaze/BetterKerbol'
----
-identifier: BetterKerbol
-$kref: '#/ckan/spacedock/3118'
 license: CC-BY-NC-ND-3.0
 tags:
   - config

--- a/NetKAN/QuackPack.netkan
+++ b/NetKAN/QuackPack.netkan
@@ -4,6 +4,7 @@ x_netkan_version_edit:
   find: ^v
   replace: ''
   strict: false
+ksp_version: '1.12'
 license: CC-BY-NC-ND-3.0
 tags:
   - config

--- a/NetKAN/QuackPack.netkan
+++ b/NetKAN/QuackPack.netkan
@@ -4,9 +4,6 @@ x_netkan_version_edit:
   find: ^v
   replace: ''
   strict: false
----
-identifier: QuackPack
-$kref: '#/ckan/spacedock/3136'
 license: CC-BY-NC-ND-3.0
 tags:
   - config

--- a/NetKAN/VertexColorMapEmissive.netkan
+++ b/NetKAN/VertexColorMapEmissive.netkan
@@ -1,8 +1,6 @@
 identifier: VertexColorMapEmissive
+abstract: VertexColorMapEmissive is a custom PQS Mod intended for use by planet modders to give more control over planetary emissives than can be achieved with the current alternatives
 $kref: '#/ckan/github/jamespglaze/VertexColorMapEmissive'
----
-identifier: VertexColorMapEmissive
-$kref: '#/ckan/spacedock/3620'
 license: MIT
 tags:
   - plugin

--- a/NetKAN/VertexColorMapEmissive.netkan
+++ b/NetKAN/VertexColorMapEmissive.netkan
@@ -1,9 +1,9 @@
 identifier: VertexColorMapEmissive
 abstract: >-
-  VertexColorMapEmissive is a custom PQS Mod intended for use by planet
-  modders to give more control over planetary emissives than can be
-  achieved with the current alternatives
+  A custom PQS Mod intended for use by planet modders to give more control
+  over planetary emissives than can be achieved with the current alternatives
 $kref: '#/ckan/github/jamespglaze/VertexColorMapEmissive'
+ksp_version: '1.12'
 license: MIT
 tags:
   - plugin

--- a/NetKAN/VertexColorMapEmissive.netkan
+++ b/NetKAN/VertexColorMapEmissive.netkan
@@ -1,5 +1,8 @@
 identifier: VertexColorMapEmissive
-abstract: VertexColorMapEmissive is a custom PQS Mod intended for use by planet modders to give more control over planetary emissives than can be achieved with the current alternatives
+abstract: >-
+  VertexColorMapEmissive is a custom PQS Mod intended for use by planet
+  modders to give more control over planetary emissives than can be
+  achieved with the current alternatives
 $kref: '#/ckan/github/jamespglaze/VertexColorMapEmissive'
 license: MIT
 tags:

--- a/NetKAN/VertexHeightOblateAdvanced.netkan
+++ b/NetKAN/VertexHeightOblateAdvanced.netkan
@@ -1,5 +1,8 @@
 identifier: VertexHeightOblateAdvanced
-abstract: VertexHeightOblateAdvanced is a custom PQS Mod intended for use by planet modders to enable easy creation of oblate bodies via a simple PQS Mod, rather than via a heightmap
+abstract: >-
+  VertexHeightOblateAdvanced is a custom PQS Mod intended for use by planet
+  modders to enable easy creation of oblate bodies via a simple PQS Mod,
+  rather than via a heightmap
 $kref: '#/ckan/github/jamespglaze/VertexHeightOblateAdvanced'
 license: MIT
 tags:

--- a/NetKAN/VertexHeightOblateAdvanced.netkan
+++ b/NetKAN/VertexHeightOblateAdvanced.netkan
@@ -1,8 +1,6 @@
 identifier: VertexHeightOblateAdvanced
+abstract: VertexHeightOblateAdvanced is a custom PQS Mod intended for use by planet modders to enable easy creation of oblate bodies via a simple PQS Mod, rather than via a heightmap
 $kref: '#/ckan/github/jamespglaze/VertexHeightOblateAdvanced'
----
-identifier: VertexHeightOblateAdvanced
-$kref: '#/ckan/spacedock/3543'
 license: MIT
 tags:
   - plugin

--- a/NetKAN/VertexHeightOblateAdvanced.netkan
+++ b/NetKAN/VertexHeightOblateAdvanced.netkan
@@ -1,9 +1,9 @@
 identifier: VertexHeightOblateAdvanced
 abstract: >-
-  VertexHeightOblateAdvanced is a custom PQS Mod intended for use by planet
-  modders to enable easy creation of oblate bodies via a simple PQS Mod,
-  rather than via a heightmap
+  A custom PQS Mod intended for use by planet modders to enable easy creation
+  of oblate bodies via a simple PQS Mod, rather than via a heightmap
 $kref: '#/ckan/github/jamespglaze/VertexHeightOblateAdvanced'
+ksp_version: '1.12'
 license: MIT
 tags:
   - plugin


### PR DESCRIPTION
## Problem

@jamespglaze has reported difficulties uploading to SpaceDock and wishes to have his mods indexed from GitHub only.

- <https://github.com/jamespglaze/BetterKerbol>
- <https://github.com/jamespglaze/QuackPack>
- <https://github.com/jamespglaze/VertexColorMapEmissive>
- <https://github.com/jamespglaze/VertexHeightOblateAdvanced>

## Changes

Now this author's mods are retrieved only from GitHub.
