### PR TITLE
Use non-volumetrics asset for QuackPack

### DIFF
--- a/NetKAN/QuackPack.netkan
+++ b/NetKAN/QuackPack.netkan
@@ -1,9 +1,6 @@
 identifier: QuackPack
-$kref: '#/ckan/github/jamespglaze/QuackPack'
-x_netkan_version_edit:
-  find: ^v
-  replace: ''
-  strict: false
+$kref: '#/ckan/github/jamespglaze/QuackPack/asset_match/^(?!.*Volumetrics)'
+x_netkan_version_edit: ^v?(?<version>.*)$
 ksp_version: '1.12'
 license: CC-BY-NC-ND-3.0
 tags:


### PR DESCRIPTION
This mod's latest release has two assets:

<https://github.com/jamespglaze/QuackPack>

![image](https://github.com/user-attachments/assets/851bc4ef-22a0-4933-ba6d-877090452ae1)

We're supposed to use the non-volumetrics one, but the default is the first one.

Now a zero-width lookahead filters out the one with `Volumetrics` in its name.
