### PR TITLE
Fixes #10474: KerbinSideRemasteredGAP: add dependencies on StockalikeStructures and KerbinsideCore

### DIFF
--- a/NetKAN/KerbinSideRemasteredGAP.netkan
+++ b/NetKAN/KerbinSideRemasteredGAP.netkan
@@ -9,6 +9,8 @@ depends:
   - name: KerbinSideRemastered
   - name: KerbalKonstructs
   - name: ContractConfigurator
+  - name: StockalikeStructures
+  - name: KerbinsideCore
 suggests:
   - name: NavUtilities
   - name: KramaxAutopilotContinued

--- a/NetKAN/KerbinSideRemasteredGAP.netkan
+++ b/NetKAN/KerbinSideRemasteredGAP.netkan
@@ -10,7 +10,7 @@ depends:
   - name: KerbalKonstructs
   - name: ContractConfigurator
   - name: StockalikeStructures
-  - name: KerbinsideCore
+  - name: KerbinSideCore
 suggests:
   - name: NavUtilities
   - name: KramaxAutopilotContinued


### PR DESCRIPTION
Per author's request on the forum: https://forum.kerbalspaceprogram.com/topic/197082-ckan-the-comprehensive-kerbal-archive-network-v1332-laplace-ksp-2-support/?do=findComment&comment=4454740

However...  Kerbinside Core is only marked as compatible with KSP 1.5.1.  In order for someone to install your mod from CKAN, they will have to get CKAN to install that (ideally by force-installing it from the versions tab, but some people change ckan's compatibility settings to do this which often results in them unintentionally getting old versions of dependencies that break their game).

KerbinSideRemasteredGAP already depends on KerbinSideRemastered.  Is it even feasible to install both KerbinSideRemastered and Kerbinside Core together?

As a policy, we do not change KSP version compatibility for a mod without the author's consent.  So there's a few options:

Get [@Ger_space](https://forum.kerbalspaceprogram.com/profile/167349-ger_space/)'s blessing to change the version compatibility of Kerbinside Core
Find some other way to get the assets you need
Adopt the mod yourself (but you'd still need to get permission from the author since it's ARR)

ckan compat add 1.5.1