### PR TITLE
Remove KSPCommunityFixes conflict from PersistentRotationUpgraded

### DIFF
--- a/NetKAN/PersistentRotationUpgraded.netkan
+++ b/NetKAN/PersistentRotationUpgraded.netkan
@@ -13,7 +13,6 @@ provides:
   - PersistentRotation
 conflicts:
   - name: PersistentRotation
-  - name: KSPCommunityFixes
 depends:
   - name: ToolbarController
   - name: ClickThroughBlocker


### PR DESCRIPTION
The bug that motivated #10409 has been fixed in linuxgurugamer/PersistentRotation#15, and the fixed release was indexed in https://github.com/KSP-CKAN/CKAN-meta/commit/376745a492cb9099fbf8acbfb4e9f235606836ab.
