### PR TITLE
Add BreakingGround-DLC dep for HabTechRobotics

### DIFF
--- a/NetKAN/HabTechRobotics.netkan
+++ b/NetKAN/HabTechRobotics.netkan
@@ -8,6 +8,7 @@ tags:
 depends:
   - name: ModuleManager
   - name: B9PartSwitch
+  - name: BreakingGround-DLC
 suggests:
   - name: Habtech2
   - name: ShuttleOrbiterConstructionKit


### PR DESCRIPTION
<https://github.com/benjee10/htRobotics>

```
DEPENDENCIES
- B9PartSwitch
- KSP Breaking Ground DLC
```

<https://github.com/benjee10/htRobotics/commit/267d4e46bcda650a9346022e2012713bb8eace06>

Pointed out by @Clayell in <https://github.com/KSP-CKAN/NetKAN/pull/9582#issuecomment-2791375947>.
