### PR TITLE
Default install stanza for VuhrantiSystem

### DIFF
--- a/NetKAN/VuhrantiSystem.netkan
+++ b/NetKAN/VuhrantiSystem.netkan
@@ -16,3 +16,4 @@ depends:
   - name: OrbitIconsPack
 recommends:
   - name: BetterTimeWarpCont
+  - name: HUDReplacer

--- a/NetKAN/VuhrantiSystem.netkan
+++ b/NetKAN/VuhrantiSystem.netkan
@@ -16,10 +16,3 @@ depends:
   - name: OrbitIconsPack
 recommends:
   - name: BetterTimeWarpCont
-install:
-  - find: GameData/VuhrantiSystem
-    install_to: GameData
-  - find: GameData/VuhrantiSystem-Terrain
-    install_to: GameData
-  - find: GameData/VuhrantiSystem-Textures
-    install_to: GameData


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0c60d999-c2cb-4482-a720-a34b7c01ff8d)

This mod's ZIP no longer has `GameData`, `VuhrantiSystem-Terrain`, or `GameData/VuhrantiSystem-Textures`.
