### PR TITLE
Update MinorPlanetsExpansion relationships and install

### DIFF
--- a/NetKAN/MinorPlanetsExpansion.netkan
+++ b/NetKAN/MinorPlanetsExpansion.netkan
@@ -9,7 +9,17 @@ tags:
 depends:
   - name: ModuleManager
   - name: Kopernicus
+  - name: KSPCommunityFixes
   - name: OuterPlanetsMod
+suggests:
+  - name: FinalFrontier
+supports:
+  - name: FinalFrontier
 install:
   - find: MPE
+    install_to: GameData
+  - find: Localizations
+    install_to: GameData
+    as: MPE
+  - find: Nereid
     install_to: GameData


### PR DESCRIPTION
#10512 said:

> !NOTICE! I made this mod believing that the original MPE doesn't include ribbons. Turns out, there is an official one on the [github repository of MPE](https://github.com/ExosLab/Minor-Planets-Expansion/tree/main) that isn't present on CKAN. This is why I've labeled this pack as an alternative version.

Upon investigation, this turned out to be true.

- Now MPE's ribbon pack is installed, and FinalFrontier is suggested and supported
- Now MPE depends on KSPCommunityFixes as specified in its latest release notes
- Now the Spanish and Russian translations are installed (the ZIP has them split into a separate folder unnecessarily)
