### PR TITLE
Change Kiwi Orbital Designs Systems kref to GitHub

### DIFF
--- a/NetKAN/KiwiOrbitalDesignsServices.netkan
+++ b/NetKAN/KiwiOrbitalDesignsServices.netkan
@@ -2,7 +2,7 @@ identifier: KiwiOrbitalDesignsServices
 $kref: '#/ckan/github/nolifejordan/Kiwi-Orbital-Designs-Systems'
 x_netkan_github:
   use_source_archive: true
-x_netkan_verison_edit: '^v(?<version>.*)$'
+x_netkan_version_edit: '^v(?<version>.*)$'
 license: restricted
 tags:
   - parts

--- a/NetKAN/KiwiOrbitalDesignsServices.netkan
+++ b/NetKAN/KiwiOrbitalDesignsServices.netkan
@@ -1,5 +1,5 @@
 identifier: KiwiOrbitalDesignsServices
-$kref: '#/ckan/spacedock/3602'
+$kref: '#/ckan/github/nolifejordan/Kiwi-Orbital-Designs-Systems'
 license: restricted
 tags:
   - parts

--- a/NetKAN/KiwiOrbitalDesignsServices.netkan
+++ b/NetKAN/KiwiOrbitalDesignsServices.netkan
@@ -1,5 +1,7 @@
 identifier: KiwiOrbitalDesignsServices
 $kref: '#/ckan/github/nolifejordan/Kiwi-Orbital-Designs-Systems'
+x_netkan_github:
+  use_source_archive: true
 license: restricted
 tags:
   - parts

--- a/NetKAN/KiwiOrbitalDesignsServices.netkan
+++ b/NetKAN/KiwiOrbitalDesignsServices.netkan
@@ -2,6 +2,7 @@ identifier: KiwiOrbitalDesignsServices
 $kref: '#/ckan/github/nolifejordan/Kiwi-Orbital-Designs-Systems'
 x_netkan_github:
   use_source_archive: true
+x_netkan_verison_edit: '^v(?<version>.*)$'
 license: restricted
 tags:
   - parts


### PR DESCRIPTION
- <https://spacedock.info/mod/3602/KODS%20-%20Kiwi%20Orbital%20Designs%20Services>
- <https://github.com/nolifejordan/Kiwi-Orbital-Designs-Systems>

Requested by @nolifejordan

Unsure if other changes need to be made due to different auto-filled fields on GitHub vs SpaceDock.