### PR TITLE
Add Chemical Core's supported mods

### DIFF
--- a/NetKAN/ChemicalCore.netkan
+++ b/NetKAN/ChemicalCore.netkan
@@ -10,4 +10,6 @@ tags:
 depends:
   - name: ModuleManager
   - name: B9PartSwitch
+supports:
+  - name: CryoTanks
 x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/ChemicalCore.netkan
+++ b/NetKAN/ChemicalCore.netkan
@@ -10,6 +10,6 @@ tags:
 depends:
   - name: ModuleManager
   - name: B9PartSwitch
+  - name: CommunityResourcePack
 supports:
   - name: CryoTanks
-x_via: Automated SpaceDock CKAN submission


### PR DESCRIPTION
# Changes
- Added CryoTanks as a supported mod.
```
 supports:
  - name: CryoTanks
```

See #10503.
