### PR TITLE
Remove ModuleManager dependency for Tide

### DIFF
--- a/NetKAN/ChemicalCore.netkan
+++ b/NetKAN/ChemicalCore.netkan
@@ -10,4 +10,6 @@ tags:
 depends:
   - name: ModuleManager
   - name: B9PartSwitch
+supports:
+  - name: CryoTanks
 x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/ChemicalCore.netkan
+++ b/NetKAN/ChemicalCore.netkan
@@ -10,6 +10,6 @@ tags:
 depends:
   - name: ModuleManager
   - name: B9PartSwitch
+  - name: CommunityResourcePack
 supports:
   - name: CryoTanks
-x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/Tide.netkan
+++ b/NetKAN/Tide.netkan
@@ -4,7 +4,6 @@ tags:
   - config
   - planet-pack
 depends:
-  - name: ModuleManager
   - name: Kopernicus
   - name: VertexMitchellNetravaliHeightMap
 suggests:


### PR DESCRIPTION
# Changes
- Removed ModuleManager dependency for Tide.netkan because it is not needed.