### PR TITLE
Multi-hosting for APotato

### DIFF
--- a/NetKAN/APotato.netkan
+++ b/NetKAN/APotato.netkan
@@ -1,4 +1,7 @@
 identifier: APotato
+$kref: '#/ckan/github/zhouyiqing0304/MangoTech_Potato'
+---
+identifier: APotato
 $kref: '#/ckan/spacedock/3884'
 tags:
   - config


### PR DESCRIPTION
KSP-CKAN/CKAN-meta#3355 included a GitHub repo, but KSP-CKAN/NetKAN#10537 did not.
Now the netkan has both it and SpaceDock.