### PR TITLE
Remove ExtraplanetaryLaunchpads depdency from KerbalColonies (core) since it is not needed anymore

### DIFF
--- a/NetKAN/KerbalColonies.netkan
+++ b/NetKAN/KerbalColonies.netkan
@@ -17,6 +17,5 @@ depends:
   - name: KerbalKonstructs
   - name: CustomPreLaunchChecks
   - name: ClickThroughBlocker
-  - name: ExtraPlanetaryLaunchpads
 suggests:
   - name: KerbalColonies-ExtraplanetaryLaunchpadsConfig


### PR DESCRIPTION
## Changes
- Removed ExtraplanetaryLaunchpads as a dependency from KerbalColonies

![image](https://github.com/user-attachments/assets/4f4298fd-da8c-4fb9-857e-cd0144d54488)
