### PR TITLE
Fix Indentifier Spelling Error

### DIFF
--- a/NetKAN/KerbalColonies.netkan
+++ b/NetKAN/KerbalColonies.netkan
@@ -18,4 +18,4 @@ depends:
   - name: CustomPreLaunchChecks
   - name: ClickThroughBlocker
 suggests:
-  - name: KerbalColonies-ExtraplanetaryLaunchpadsConfig
+  - name: KerbalColoniesExtraplanetaryLaunchpadsConfig


### PR DESCRIPTION
## Changes
- Changed `KerbalColonies-ExtraplanetaryLaunchpadsConfig` Identifier to `KerbalColoniesExtraplanetaryLaunchpadsConfig` 