### PR TITLE
Update NightShift requirements

### DIFF
--- a/NetKAN/NightShift.netkan
+++ b/NetKAN/NightShift.netkan
@@ -14,3 +14,5 @@ tags:
   - graphics
 conflicts:
   - name: LightsOutRelit
+depends:
+  - name: Shabby


### PR DESCRIPTION
Version 3.0 of NightShift now requires Shabby to be installed.
By the way, is there a way for this requirement to be version dependent, or is it better to just apply this to all versions?