### PR TITLE
Strip v/V prefix from ETT versions

### DIFF
--- a/NetKAN/ETT.netkan
+++ b/NetKAN/ETT.netkan
@@ -1,28 +1,18 @@
-{
-    "identifier":   "ETT",
-    "$kref":        "#/ckan/spacedock/199",
-    "x_netkan_epoch": "3",
-    "license":      "CC-BY-4.0",
-    "install": [ {
-        "find":       "ETT",
-        "install_to": "GameData"
-    } ],
-    "tags": [
-        "config",
-        "tech-tree"
-    ],
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "YongeTechTreesPlugin" }
-    ],
-    "recommends":[
-        { "name": "DMagicOrbitalScience" }
-    ],
-    "suggests":[
-        { "name": "KSPInterstellarExtended" },
-        { "name": "FASA" },
-        { "name": "KWRocketry" },
-        { "name": "AIESAerospace-Unofficial" },
-        { "name": "Firespitter" }
-    ]
-}
+identifier: ETT
+$kref: '#/ckan/spacedock/199'
+x_netkan_version_edit: '^[vV]?(?<version>.*)$'
+license: CC-BY-4.0
+tags:
+  - config
+  - tech-tree
+depends:
+  - name: ModuleManager
+  - name: YongeTechTreesPlugin
+recommends:
+  - name: DMagicOrbitalScience
+suggests:
+  - name: KSPInterstellarExtended
+  - name: FASA
+  - name: KWRocketry
+  - name: AIESAerospace-Unofficial
+  - name: Firespitter


### PR DESCRIPTION
See https://github.com/KSP-CKAN/CKAN-meta/pull/3361#issuecomment-2922679697; this mod's version strings have switched freely between a 'v' prefix, a 'V' prefix, and no prefix. It is now the most-epoched mod.

It's currently in a no-prefix phase, so its netkan is updated to strip `v` and `V` prefixes so it won't need to be epoched again.
