### PR TITLE
Add asset_match for TourismOverhaul

### DIFF
--- a/NetKAN/TourismOverhaul.netkan
+++ b/NetKAN/TourismOverhaul.netkan
@@ -1,5 +1,5 @@
 identifier: TourismOverhaul
-$kref: '#/ckan/github/iLikeGothMommys/TourismOverhaul'
+$kref: '#/ckan/github/iLikeGothMommys/TourismOverhaul/asset_match/^(?!.*Patch)'
 x_netkan_version_edit: ^Release(?<version>.+)$
 $vref: '#/ckan/ksp-avc'
 ---


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3fb3a724-c83d-4e3c-bad5-1646aa234dfa)

![image](https://github.com/user-attachments/assets/fcf1bfb6-d5d6-46a6-bdf1-35520ae6bc43)

The bot got lucky and chose the second one.
Now we tell it to ignore assets with "Patch" in the name.
