### PR TITLE
Add new CelestialHarmony submodule

### DIFF
--- a/NetKAN/CelestialHarmony-Chaos.netkan
+++ b/NetKAN/CelestialHarmony-Chaos.netkan
@@ -2,6 +2,7 @@ identifier: CelestialHarmony-Chaos
 name: Celestial Harmony - Chaos
 abstract: >-
   a brand new star system that isn't needed for Celestial Harmony to function
+  but strongly recommended if the user wants to profit off the whole mod
   to please some low end hardware user for RAM usage
 $kref: '#/ckan/github/ProximaCentauri-star/Celestial-Harmony/asset_match/Chaos'
 x_netkan_epoch: 1

--- a/NetKAN/CelestialHarmony-Chaos.netkan
+++ b/NetKAN/CelestialHarmony-Chaos.netkan
@@ -15,3 +15,6 @@ depends:
   - name: ModuleManager
   - name: Kopernicus
   - name: CelestialHarmony
+install:
+  - find: CelestialHarmony
+    install_to: GameData

--- a/NetKAN/CelestialHarmony-Chaos.netkan
+++ b/NetKAN/CelestialHarmony-Chaos.netkan
@@ -1,0 +1,17 @@
+identifier: CelestialHarmony-Chaos
+name: Celestial Harmony - Chaos
+abstract: >-
+  a brand new star system that isn't needed for Celestial Harmony to function
+  to please some low end hardware user for RAM usage
+$kref: '#/ckan/github/ProximaCentauri-star/Celestial-Harmony/asset_match/Chaos'
+x_netkan_epoch: 1
+x_netkan_version_edit: '^(Alpha-)?(?<version>.*)$'
+license: restricted
+tags:
+  - planet-pack
+provides:
+  - Scatterer-sunflare
+depends:
+  - name: ModuleManager
+  - name: Kopernicus
+  - name: CelestialHarmony

--- a/NetKAN/CelestialHarmony.netkan
+++ b/NetKAN/CelestialHarmony.netkan
@@ -1,13 +1,10 @@
 identifier: CelestialHarmony
 abstract: >-
   A brand new star system set in the far future where Kerbals
-  have migrated towards a luxurious binary habitable worlds
-$kref: '#/ckan/github/ProximaCentauri-star/Celestial-Harmony'
+  have migrated towards luxurious binary habitable worlds
+$kref: '#/ckan/github/ProximaCentauri-star/Celestial-Harmony/asset_match/Harmonia'
 x_netkan_epoch: 1
-x_netkan_version_edit:
-  find: ^Alpha-
-  replace: ''
-  strict: false
+x_netkan_version_edit: '^(Alpha-)?(?<version>.*)$'
 license: restricted
 tags:
   - planet-pack
@@ -27,3 +24,4 @@ suggests:
   - name: EnvironmentalVisualEnhancements
   - name: Scatterer
   - name: Parallax
+  - name: CelestialHarmony-Chaos

--- a/NetKAN/CelestialHarmony.netkan
+++ b/NetKAN/CelestialHarmony.netkan
@@ -20,8 +20,9 @@ depends:
   - name: VertexMitchellNetravaliHeightMap
   - name: VertexHeightOblateAdvanced
   - name: VertexColorMapEmissive
+recommends:
+  - name: CelestialHarmony-Chaos
 suggests:
   - name: EnvironmentalVisualEnhancements
   - name: Scatterer
   - name: Parallax
-  - name: CelestialHarmony-Chaos


### PR DESCRIPTION
There are two assets attached to the latest release of CelestialHarmony:

![Image](https://github.com/user-attachments/assets/e4486a39-e7e5-41b1-8ad6-a66ae8f0f2be)

![Image](https://github.com/user-attachments/assets/29589ad6-5f36-4b0f-a0c2-242e400758b5)

As a default, the bot has chosen to use the first one in the list, `_Chaos.zip`, but `_Harmonia.zip` is meant to be the core module.

See also comment from author at https://github.com/KSP-CKAN/NetKAN/issues/10253#issuecomment-2925159856.

Now `CelestialHarmony` has `asset_match/Harmonia`, and a new `CelestialHarmony-Chaos` module is added with `asset_match/Chaos`.
