### PR TITLE
Fix CelestialHarmony relationships

### DIFF
--- a/NetKAN/CelestialHarmony-Chaos.netkan
+++ b/NetKAN/CelestialHarmony-Chaos.netkan
@@ -16,6 +16,9 @@ depends:
   - name: ModuleManager
   - name: Kopernicus
   - name: CelestialHarmony
+suggests:
+  - name: Singularity
+  - name: KopernicusExpansion
 install:
   - find: CelestialHarmony
     install_to: GameData

--- a/NetKAN/CelestialHarmony.netkan
+++ b/NetKAN/CelestialHarmony.netkan
@@ -14,6 +14,7 @@ conflicts:
   - name: KSCSwitcher
   - name: JNSQ
   - name: BeyondHome
+  - name: Parallax
 depends:
   - name: ModuleManager
   - name: Kopernicus
@@ -25,4 +26,4 @@ recommends:
 suggests:
   - name: EnvironmentalVisualEnhancements
   - name: Scatterer
-  - name: Parallax
+  - name: ParallaxContinued


### PR DESCRIPTION
See https://github.com/KSP-CKAN/NetKAN/issues/10024#issuecomment-2925216265.

- CelestialHarmony now suggests ParallaxContinued instead of Parallax, and conflicts with Parallax
- CelestialHarmony-Chaos now suggests Singularity and KopernicusExpansion (which should be provided by KopernicusExpansionContinueder)
