### PR TITLE
Filter placeholder file out of HideEmptyTechNodes

### DIFF
--- a/NetKAN/HideEmptyTechNodes.netkan
+++ b/NetKAN/HideEmptyTechNodes.netkan
@@ -19,3 +19,4 @@ suggests:
 install:
   - file: GameData/HideEmptyTechTreeNodes
     install_to: GameData
+    filter: HETTN.TechTree


### PR DESCRIPTION
## Problem

If you install this mod, run the game, and then uninstall this mod, the "Remove Hide Empty Tech Tree Nodes" progress bar looks weird:

![image](https://github.com/user-attachments/assets/568f8219-aa50-445e-a694-426d7b63af99)

Reported by Discord user Shadlock.

## Cause

This mod installs `GameData/HideEmptyTechTreeNodes/Resources/HETTN.TechTree` with a short placeholder comment and then live-edits it while the game is running to contain a dump of the tech tree:

<https://github.com/Orthethac/HideEmptyTechTreeNodes/blob/master/GameData/HideEmptyTechTreeNodes/Resources/HETTN.TechTree>

Before/after:

![image](https://github.com/user-attachments/assets/57be3725-54df-42da-80ca-55ee075a4ea5)

This makes this mod's `install_size` property inaccurate, since one of the files CKAN installed is now dozens of KiB larger than it was in the ZIP. We use `install_size` to determine how close we are to completion of a removal, so the progress bar thinks it has removed more than the number of bytes that were originally in the mod (because it has).

## Changes

- The mod's netkan is unfrozen
- The placeholder is no longer installed.
  - I confirmed the mod still generates it.
  - This makes `install_size` accurate, so the progress bar won't look weird.
  - The user will be asked whether they want to delete `HETTN.TechTree` after uninstalling (see KSP-CKAN/CKAN#2962).

We can also look into making the progress bars's code more robust to handle cases like this, but this fix will work for anyone using the current client.
