### PR TITLE
Add KAC to recommends of LTP

### DIFF
--- a/NetKAN/LunarTransferPlanner.netkan
+++ b/NetKAN/LunarTransferPlanner.netkan
@@ -7,3 +7,5 @@ license: MIT
 tags:
   - plugin
   - information
+recommends:
+  - name: KerbalAlarmClock


### PR DESCRIPTION
The "Add Alarm" button for this mod requires KAC to be installed. It'll grey itself out if KAC isn't installed.

(this is from my [LTP remake](https://github.com/Clayell/LunarTransferPlanner), but the original still uses KAC in [about the same way](https://github.com/KSP-RO/LunarTransferPlanner/blob/master/LunarTransferPlanner.cs#L453-L467))
![image](https://github.com/user-attachments/assets/254e2101-eec6-41f4-9c31-484ef8004390)
