### PR TITLE
Unfreeze HeapPadder.frozen with compatibility overrides

### DIFF
--- a/NetKAN/HeapPadder.netkan
+++ b/NetKAN/HeapPadder.netkan
@@ -12,3 +12,13 @@ $vref: '#/ckan/ksp-avc'
 license: MIT
 tags:
   - plugin
+x_netkan_override:
+  - version: '>0'
+    after: spacedock
+    delete:
+      - ksp_version_max
+  - version: '>0'
+    after: spacedock
+    override:
+      ksp_version_min: 1.5
+      ksp_version_max: 1.7


### PR DESCRIPTION
With bad data in HeapPadder's latest version file, there's a strong risk of it being replaced or a new release, so it shouldn't stay frozen.

Now it's unfrozen with a janky `x_netkan_override` property to fix the compatibility no matter what it is upstream.
