### PR TITLE
Compatibility tweaks for a few mods

### DIFF
--- a/NetKAN/GRAPEFRUIT.netkan
+++ b/NetKAN/GRAPEFRUIT.netkan
@@ -1,6 +1,8 @@
 identifier: GRAPEFRUIT
+$kref: '#/ckan/github/KSPModStewards/GRAPEFRUIT'
+---
+identifier: GRAPEFRUIT
 $kref: '#/ckan/spacedock/3511'
-$vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA
 tags:
   - parts

--- a/NetKAN/Grounded.netkan
+++ b/NetKAN/Grounded.netkan
@@ -1,7 +1,10 @@
 identifier: Grounded
-"$kref": "#/ckan/spacedock/1715"
+$kref: '#/ckan/spacedock/1715'
+$vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-ND-4.0
-ksp_version: 1.10
 tags:
-- parts
-
+  - parts
+x_netkan_override:
+  - version: '5.0'
+    override:
+      ksp_version_max: '1.10'

--- a/NetKAN/MSP3000a.netkan
+++ b/NetKAN/MSP3000a.netkan
@@ -3,7 +3,7 @@ $kref: '#/ckan/github/linuxgurugamer/Material-Science-Pod'
 ---
 identifier: MSP3000a
 $kref: '#/ckan/spacedock/2642'
-$vref: '#/ckan/ksp-avc'
+comment: Version file has invalid KSP_VERSION_MIN 1.12.99
 license: MIT
 tags:
   - parts

--- a/NetKAN/RetroFuture.netkan
+++ b/NetKAN/RetroFuture.netkan
@@ -9,7 +9,6 @@ author:
   - amankduffers
 $kref: '#/ckan/spacedock/2153'
 $vref: '#/ckan/ksp-avc'
-x_netkan_epoch: '2'
 license: CC-BY-NC-SA-4.0
 tags:
   - parts


### PR DESCRIPTION
- GRAPEFRUIT must have had a version file at some point, but it no longer does.
  Now the `$vref` is removed, and while looking into that I noticed we can multi-host it as well.
- Grounded has a version file, but it's out of date. The current netkan uses `ksp_version` to set the compatibility based on the forum thread, but if this mod ever does another release with an up to date version file, we'll want to use it.
  Now it uses `$vref` to get the version file's compatibility, and `x_netkan_override` to set `ksp_version_max` for the current release.
- MSP3000a's version file has bad data (see linuxgurugamer/Material-Science-Pod#4), but it currently has a `$vref` anyway since the SpaceDock translator will override the error.
  Now the `$vref` is replaced by a `comment` explaining the problem with the version file.
- RetroFuture has a hard-coded `x_netkan_epoch` for one of its two `$kref`s, which makes it generate two different versions when inflating locally without `--highest-version`
  Now the hard-coded epoch is removed, since auto-epoching will handle this properly.
