### PR TITLE
Better manual inflate action

### DIFF
--- a/.github/actions/manual_inflate/action.yml
+++ b/.github/actions/manual_inflate/action.yml
@@ -1,0 +1,31 @@
+name: Inflate Module
+description: Run commands in the NetKAN container to inflate a given module
+
+inputs:
+  AWS_ACCESS_KEY_ID:
+    description: Credentials for AWS
+    required: true
+  AWS_SECRET_ACCESS_KEY:
+    description: Credentials for AWS
+    required: true
+  AWS_DEFAULT_REGION:
+    description: Region for AWS
+    required: true
+  identifier:
+    description: The netkan to inflate
+    required: true
+
+runs:
+  using: docker
+  image: kspckan/netkan
+  env:
+    GAME_ID:               ksp
+    NETKAN_REMOTES:        ksp=https://github.com/KSP-CKAN/NetKAN.git
+    CKANMETA_REMOTES:      ksp=https://github.com/KSP-CKAN/CKAN-meta.git
+    INFLATION_QUEUES:      ksp=Inbound.fifo
+    AWS_ACCESS_KEY_ID:     ${{ inputs.AWS_ACCESS_KEY_ID     }}
+    AWS_SECRET_ACCESS_KEY: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
+    AWS_DEFAULT_REGION:    ${{ inputs.AWS_DEFAULT_REGION    }}
+  args:
+    - inflate-netkan
+    - ${{ inputs.identifier }}

--- a/.github/workflows/manual_inflate.yml
+++ b/.github/workflows/manual_inflate.yml
@@ -9,20 +9,11 @@ jobs:
     Inflate_module:
         runs-on: ubuntu-latest
         steps:
-            - name: Get NetKAN repo
-              uses: actions/checkout@v4
-              with:
-                  path: NetKAN
-            - name: Get CKAN-meta repo
-              uses: actions/checkout@v4
-              with:
-                  repository: KSP-CKAN/CKAN-meta
-                  path: CKAN-meta
+            - uses: actions/checkout@v4
             - name: Manual inflate
-              uses: HebaruSan/inflate-netkan@master
-              env:
+              uses: ./.github/actions/manual_inflate
+              with:
                   AWS_ACCESS_KEY_ID:     ${{ secrets.AWS_ACCESS_KEY_ID     }}
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
                   AWS_DEFAULT_REGION:    ${{ secrets.AWS_DEFAULT_REGION    }}
-              with:
-                  identifier: ${{ github.event.inputs.identifier }}
+                  identifier:            ${{ github.event.inputs.identifier }}


### PR DESCRIPTION
## Motivation

See KSP-CKAN/NetKAN-Infra#355; the manual inflate workflow can be improved, and that PR created a way to do that.

## Changes

Now the `manual_inflate` workflow uses a new `manual_inflate` action to run the new `inflate-netkan` command in the `kspckan/netkan` container.
