### PR TITLE
Asteroid Cleaner

### DIFF
--- a/NetKAN/AsteroidCleaner.netkan
+++ b/NetKAN/AsteroidCleaner.netkan
@@ -1,0 +1,26 @@
+{
+  "spec_version": "v1.4",
+  "identifier": "AsteroidCleaner",
+  "name": "Asteroid Cleaner",
+  "abstract": "Automatically removes excess untracked asteroids and comets from the game.",
+  "author": "KevO",
+  "version": "1.0.0",
+  "license": "MIT",
+  "ksp_version": "1.12.5",
+  "resources": {
+    "homepage": "https://github.com/kevnokeeffe/AsteroidCleaner",
+    "repository": "https://github.com/kevnokeeffe/AsteroidCleaner"
+  },
+  "x_netkan": {
+    "version_strategy": "latest",
+    "github": {
+      "repository": "kevnokeeffe/AsteroidCleaner"
+    }
+  },
+  "install": [
+    {
+      "file": "GameData/AsteroidCleaner",
+      "install_to": "GameData"
+    }
+  ]
+}


### PR DESCRIPTION
📦 Pull Request: Add Asteroid Cleaner Mod to CKAN

Summary:

Adds a new mod that automatically removes excess untracked asteroids and comets from the game world to reduce save bloat and improve long-term performance.

Details:
- Keeps up to 3 untracked asteroids and 2 untracked comets
- Tracked objects are preserved
- Cleanup runs every 10 seconds across all scenes
- Designed to work well alongside AsteroidSpawnLimiter
- Safe for use in single-player and multiplayer (e.g. Luna Multiplayer)