### PR TITLE
Fix RestockWaterfallExpansion install

### DIFF
--- a/NetKAN/RestockWaterfallExpansion.netkan
+++ b/NetKAN/RestockWaterfallExpansion.netkan
@@ -10,4 +10,12 @@ depends:
   - name: Waterfall
   - name: ReStock
 conflicts:
+  - name: WaterfallRestock
   - name: StockWaterfallEffects
+install:
+  - find: RestockWaterfallExpansion
+    install_to: GameData
+  - find: WaterfallRestock
+    install_to: GameData
+  - find: StockWaterfallEffects
+    install_to: GameData


### PR DESCRIPTION
This mod seemingly bundles two other mods, but altered, which is a bad practice but not in our power to change.

CKAN wasn't installing those other folders, but now it does, and this mod conflicts with the other two.

Fixes #10616.
