### PR TITLE
Move ProceduralParts relationships to internal ckan

### DIFF
--- a/NetKAN/ProceduralParts.netkan
+++ b/NetKAN/ProceduralParts.netkan
@@ -14,8 +14,6 @@ author:
 $kref: '#/ckan/github/KSP-RO/ProceduralParts'
 $vref: '#/ckan/ksp-avc'
 license: CC-BY-SA
-resources:
-  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/204080-*
 tags:
   - plugin
   - parts

--- a/NetKAN/ProceduralParts.netkan
+++ b/NetKAN/ProceduralParts.netkan
@@ -1,36 +1,28 @@
-{
-    "identifier"        :   "ProceduralParts",
-    "author"            :   [ "Ancient Gammoner", "NathanKell", "Swamp-Ig", "Starwaster", "Tidal-Stream", "jrodrigv", "KSP-RO" ],
-    "$kref"             :   "#/ckan/github/KSP-RO/ProceduralParts",
-    "$vref"             :   "#/ckan/ksp-avc",
-    "x_netkan_allow_out_of_order": true,
-    "name"              :   "Procedural Parts",
-    "abstract"          :   "ProceduralParts allows you to procedurally generate a number of different parts in a range of sizes and shapes.",
-    "license"           :   "CC-BY-SA",
-    "resources" : {
-        "homepage"     : "https://forum.kerbalspaceprogram.com/index.php?/topic/204080-*"
-    },
-    "tags": [
-        "plugin",
-        "parts"
-    ],
-    "depends" : [
-        { "name" : "ModuleManager" },
-        { "name" : "KSPCommunityFixes" }
-    ],
-    "suggests" : [
-        { "name" : "PPTextures" },
-        { "name" : "FreedomTex" },
-        { "name" : "BasicProceduralTextures" }
-    ],
-    "x_netkan_override": [
-        {
-            "version": "v1.2.10",
-            "delete" : [ "ksp_version" ],
-            "override": {
-                "ksp_version_min" : "1.2.0",
-                "ksp_version_max" : "1.2.8"
-            }
-        }
-    ]
-}
+identifier: ProceduralParts
+name: Procedural Parts
+abstract: >-
+  ProceduralParts allows you to procedurally generate a number of different
+  parts in a range of sizes and shapes.
+author:
+  - Ancient Gammoner
+  - NathanKell
+  - Swamp-Ig
+  - Starwaster
+  - Tidal-Stream
+  - jrodrigv
+  - KSP-RO
+$kref: '#/ckan/github/KSP-RO/ProceduralParts'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-SA
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/204080-*
+tags:
+  - plugin
+  - parts
+x_netkan_override:
+  - version: v1.2.10
+    delete:
+      - ksp_version
+    override:
+      ksp_version_min: 1.2.0
+      ksp_version_max: 1.2.8


### PR DESCRIPTION
@siimav is considering a new ProceduralParts release with an internal .ckan file (see KSP-RO/ProceduralParts#373) so a new dependency can be added smoothly (see KSP-RO/ProceduralParts#359).

Now the main netkan:

- is YAMLized
- has its relationships removed so they can be set by the internal ckan file
- has `x_netkan_allow_out_of_order` removed because the reason from #7644 (retrofits for KSP 1.7.3) no longer applies
- has `resources.homepage` removed because it's now set in the repo

Note that we can't merge this until there is an internal ckan because the relationships should not actually disappear from the module.
