### PR TITLE
Vref for MSP3000a

### DIFF
--- a/NetKAN/MSP3000a.netkan
+++ b/NetKAN/MSP3000a.netkan
@@ -1,9 +1,10 @@
 identifier: MSP3000a
 $kref: '#/ckan/github/linuxgurugamer/Material-Science-Pod'
+$vref: '#/ckan/ksp-avc'
 ---
 identifier: MSP3000a
 $kref: '#/ckan/spacedock/2642'
-comment: Version file has invalid KSP_VERSION_MIN 1.12.99
+$vref: '#/ckan/ksp-avc'
 license: MIT
 tags:
   - parts


### PR DESCRIPTION
linuxgurugamer/Material-Science-Pod#4 has been merged and released, so the version file should now be usable.