### PR TITLE
KerbalPowers Suite modifications

### DIFF
--- a/NetKAN/KerbalPowersArmory.netkan
+++ b/NetKAN/KerbalPowersArmory.netkan
@@ -8,6 +8,7 @@ tags:
   - combat
 depends:
   - name: ModuleManager
+  - name: KerbalPowersCore
   - name: BDArmory
   - name: PhysicsRangeExtender
 suggests:

--- a/NetKAN/KerbalPowersArmory.netkan
+++ b/NetKAN/KerbalPowersArmory.netkan
@@ -14,5 +14,5 @@ depends:
 suggests:
   - name: VABorganizer
 install:
-  - find: KerbalPowers
-    install_to: GameData
+  - find: KerbalPowers/Armory
+    install_to: GameData/KerbalPowers

--- a/NetKAN/KerbalPowersCore.netkan
+++ b/NetKAN/KerbalPowersCore.netkan
@@ -6,6 +6,9 @@ $kref: '#/ckan/spacedock/3943'
 tags:
   - library
   - agency
+suggests:
+  - name: KerbalPowersInterstellar
+  - name: KerbalPowersArmory
 install:
   - find: KerbalPowers
     install_to: GameData

--- a/NetKAN/KerbalPowersCore.netkan
+++ b/NetKAN/KerbalPowersCore.netkan
@@ -4,7 +4,8 @@ $kref: '#/ckan/github/KerbalPowers/KP-Core'
 identifier: KerbalPowersCore
 $kref: '#/ckan/spacedock/3943'
 tags:
-  - dependency
+  - library
+  - agency
 install:
-  - find: KerbalPowers/Agencies
-    install_to: GameData/KerbalPowers
+  - find: KerbalPowers
+    install_to: GameData

--- a/NetKAN/KerbalPowersCore.netkan
+++ b/NetKAN/KerbalPowersCore.netkan
@@ -1,0 +1,10 @@
+identifier: KerbalPowersCore
+$kref: '#/ckan/github/KerbalPowers/KP-Core'
+---
+identifier: KerbalPowersCore
+$kref: '#/ckan/spacedock/3943'
+tags:
+  - dependency
+install:
+  - find: KerbalPowers/Agencies
+    install_to: GameData/KerbalPowers

--- a/NetKAN/KerbalPowersInterstellar.netkan
+++ b/NetKAN/KerbalPowersInterstellar.netkan
@@ -3,8 +3,12 @@ $kref: '#/ckan/spacedock/3821'
 license: restricted
 tags:
   - parts
+  - isv
+  - interstelllar
 depends:
   - name: ModuleManager
+  - name: KerbalPowersCore
+suggests:
   - name: Waterfall
 install:
   - find: KerbalPowers

--- a/NetKAN/KerbalPowersInterstellar.netkan
+++ b/NetKAN/KerbalPowersInterstellar.netkan
@@ -11,7 +11,7 @@ depends:
 suggests:
   - name: Waterfall
 install:
-  - find: KerbalPowers
-    install_to: GameData
+  - find: KerbalPowers/Interstellar
+    install_to: GameData/KerbalPowers
   - find: TURD
     install_to: GameData

--- a/NetKAN/KerbalPowersInterstellar.netkan
+++ b/NetKAN/KerbalPowersInterstellar.netkan
@@ -3,8 +3,6 @@ $kref: '#/ckan/spacedock/3821'
 license: restricted
 tags:
   - parts
-  - isv
-  - interstelllar
 depends:
   - name: ModuleManager
   - name: KerbalPowersCore


### PR DESCRIPTION
These changes should cherry pick only a single subfolder in the same fasion as the USI modset. This will resolve file conflicts.

https://github.com/KSP-CKAN/NetKAN/blob/2b1581184dd0913dd18dbc667df3a32ba6a9efa7/NetKAN/MOLE.netkan#L35

KP Core is added as a new dependency hosting overlapping files between different suite mods. 

SpaceDock | GitHub
:-- | :--
<https://spacedock.info/mod/3821/Kerbal%20Powers%20Interstellar> | <https://github.com/KerbalPowers/KP-Dynamics>
<https://spacedock.info/mod/3767/Kerbal%20Powers%20Armory> | <https://github.com/KerbalPowers/KP-Armory>
<https://spacedock.info/mod/3943/Kerbal%20Powers%20Core> | <https://github.com/KerbalPowers/KP-Core>

___

ckan compat add 1.12
ckan install KerbalPowersInterstellar KerbalPowersArmory
