### PR TITLE
Add LunaCompat

### DIFF
--- a/NetKAN/LunaCompat.netkan
+++ b/NetKAN/LunaCompat.netkan
@@ -3,7 +3,7 @@ $kref: '#/ckan/github/TheXankriegor/LunaCompat'
 $vref: '#/ckan/ksp-avc'
 abstract: Compatibility patches to make KSP's Luna Multiplayer support other mods.
 description: >-
-  Complex mods are incompatible with Luna Multiplayer.
+  Complex mods don't work with Luna Multiplayer.
   LunaCompat adds compatibility patches for various mods
   via LMP part module configurations and Harmony patches.
   Patches are only applied to mods added to the modlist.

--- a/NetKAN/LunaCompat.netkan
+++ b/NetKAN/LunaCompat.netkan
@@ -6,9 +6,9 @@ tags:
   - plugin
   - config
 install:
-  - file: LunaCompat
+  - find: LunaCompat
     install_to: GameData
-  - file: LunaMultiplayer
+  - find: LunaMultiplayer
     install_to: GameData
 depends:
   - name: ModuleManager

--- a/NetKAN/LunaCompat.netkan
+++ b/NetKAN/LunaCompat.netkan
@@ -1,0 +1,26 @@
+identifier: LunaCompat
+$kref: '#/ckan/github/TheXankriegor/LunaCompat'
+$vref: '#/ckan/ksp-avc'
+release_status: development
+resources:
+  bugtracker: https://github.com/TheXankriegor/LunaCompat/issues
+  license: https://github.com/TheXankriegor/LunaCompat/blob/main/LICENSE
+  homepage: https://github.com/TheXankriegor/LunaCompat
+  repository: https://github.com/TheXankriegor/LunaCompat
+tags:
+  - plugin
+install:
+  - file: GameData/LunaCompat
+    install_to: GameData
+    as: LunaCompat
+  - file: GameData/LunaMultiplayer
+    install_to: GameData
+    as: LunaMultiplayer
+ksp_version: '1.12'
+depends:
+  - name: ModuleManager
+    min_version: 4.2.3
+  - name: Harmony2
+    min_version: 2.2.1.0
+  - name: LunaMultiplayer
+    min_version: 0.29.0-Draft

--- a/NetKAN/LunaCompat.netkan
+++ b/NetKAN/LunaCompat.netkan
@@ -1,26 +1,16 @@
 identifier: LunaCompat
 $kref: '#/ckan/github/TheXankriegor/LunaCompat'
 $vref: '#/ckan/ksp-avc'
-release_status: development
-resources:
-  bugtracker: https://github.com/TheXankriegor/LunaCompat/issues
-  license: https://github.com/TheXankriegor/LunaCompat/blob/main/LICENSE
-  homepage: https://github.com/TheXankriegor/LunaCompat
-  repository: https://github.com/TheXankriegor/LunaCompat
+ksp_version: '1.12'
 tags:
   - plugin
+  - config
 install:
-  - file: GameData/LunaCompat
+  - file: LunaCompat
     install_to: GameData
-    as: LunaCompat
-  - file: GameData/LunaMultiplayer
+  - file: LunaMultiplayer
     install_to: GameData
-    as: LunaMultiplayer
-ksp_version: '1.12'
 depends:
   - name: ModuleManager
-    min_version: 4.2.3
   - name: Harmony2
-    min_version: 2.2.1.0
   - name: LunaMultiplayer
-    min_version: 0.29.0-Draft

--- a/NetKAN/LunaCompat.netkan
+++ b/NetKAN/LunaCompat.netkan
@@ -20,3 +20,5 @@ depends:
   - name: ModuleManager
   - name: Harmony2
   - name: LunaMultiplayer
+supports:
+  - name: LunaMultiplayer

--- a/NetKAN/LunaCompat.netkan
+++ b/NetKAN/LunaCompat.netkan
@@ -1,7 +1,6 @@
 identifier: LunaCompat
 $kref: '#/ckan/github/TheXankriegor/LunaCompat'
 $vref: '#/ckan/ksp-avc'
-abstract: Compatibility patches to make KSP's Luna Multiplayer support other mods.
 description: >-
   Complex mods don't work with Luna Multiplayer.
   LunaCompat adds compatibility patches for various mods

--- a/NetKAN/LunaCompat.netkan
+++ b/NetKAN/LunaCompat.netkan
@@ -2,7 +2,7 @@ identifier: LunaCompat
 $kref: '#/ckan/github/TheXankriegor/LunaCompat'
 $vref: '#/ckan/ksp-avc'
 description: >-
-  Complex mods don't work with Luna Multiplayer.
+  Complex mods are incompatible with Luna Multiplayer.
   LunaCompat adds compatibility patches for various mods
   via LMP part module configurations and Harmony patches.
   Patches are only applied to mods added to the modlist.

--- a/NetKAN/LunaCompat.netkan
+++ b/NetKAN/LunaCompat.netkan
@@ -1,6 +1,13 @@
 identifier: LunaCompat
 $kref: '#/ckan/github/TheXankriegor/LunaCompat'
 $vref: '#/ckan/ksp-avc'
+abstract: Compatibility patches to make KSP's Luna Multiplayer support other mods.
+description: >-
+  Complex mods are incompatible with Luna Multiplayer.
+  LunaCompat adds compatibility patches for various mods
+  via LMP part module configurations and Harmony patches.
+  Patches are only applied to mods added to the modlist.
+  Check the repository to see the full list of supported mods.
 ksp_version: '1.12'
 tags:
   - plugin


### PR DESCRIPTION
https://github.com/TheXankriegor/LunaCompat

Miscellaneous compatibility patches for KSP's [Luna Multiplayer Mod](https://github.com/LunaMultiplayer/LunaMultiplayer).

```yaml
identifier: LunaCompat
$kref: '#/ckan/github/TheXankriegor/LunaCompat'
$vref: '#/ckan/ksp-avc'
release_status: development
resources:
  bugtracker: https://github.com/TheXankriegor/LunaCompat/issues
  license: https://github.com/TheXankriegor/LunaCompat/blob/main/LICENSE
  homepage: https://github.com/TheXankriegor/LunaCompat
  repository: https://github.com/TheXankriegor/LunaCompat
tags:
  - plugin
install:
  - file: GameData/LunaCompat
    install_to: GameData
    as: LunaCompat
  - file: GameData/LunaMultiplayer
    install_to: GameData
    as: LunaMultiplayer
ksp_version: '1.12'
depends:
  - name: ModuleManager
    min_version: 4.2.3
  - name: Harmony2
    min_version: 2.2.1.0
  - name: LunaMultiplayer
    min_version: 0.29.0-Draft
x_via: Generated by Metadata Webtool

```
Fixes https://github.com/KSP-CKAN/NetKAN/issues/10653