### PR TITLE
Get PromisedWorlds name, abstract, and author from SpaceDock

### DIFF
--- a/NetKAN/PromisedWorldsCore.netkan
+++ b/NetKAN/PromisedWorldsCore.netkan
@@ -2,10 +2,6 @@ identifier: PromisedWorldsCore
 $kref: '#/ckan/github/PromisedWorlds/PromisedWorlds/asset_match/Core'
 ---
 identifier: PromisedWorldsCore
-name: Promised Worlds Core
-abstract: The core for Promised Worlds
-author:
-  - Promised Worlds Dev Team
 $kref: '#/ckan/spacedock/3974'
 x_netkan_force_v: true
 tags:
@@ -20,6 +16,8 @@ depends:
   - name: VertexMitchellNetravaliHeightMap
   - name: VertexColorMapEmissive
   - name: VertexHeightOblateAdvanced
+suggests:
+  - name: PromisedWorldsDebdeb
 install:
   - find: PromisedWorlds
     install_to: GameData

--- a/NetKAN/PromisedWorldsDebdeb.netkan
+++ b/NetKAN/PromisedWorldsDebdeb.netkan
@@ -2,9 +2,6 @@ identifier: PromisedWorldsDebdeb
 $kref: '#/ckan/github/PromisedWorlds/PromisedWorlds/asset_match/Debdeb'
 ---
 identifier: PromisedWorldsDebdeb
-name: Promised Worlds Debdeb
-author:
-  - Promised Worlds Dev Team
 $kref: '#/ckan/spacedock/3976'
 x_netkan_force_v: true
 tags:

--- a/NetKAN/PromisedWorldsDebdeb.netkan
+++ b/NetKAN/PromisedWorldsDebdeb.netkan
@@ -8,6 +8,7 @@ tags:
   - config
   - planet-pack
 depends:
+  - name: ModuleManager
   - name: PromisedWorldsCore
 install:
   - find: PromisedWorlds


### PR DESCRIPTION
See #10704, #10705, #10707, and #10711 for previous.

Now that this mod is on SpaceDock, we can use the author-maintained values for name, abstract, and author.

And the core now suggests Debdeb.
