### PR TITLE
Add TURD configurations from Github sources

### DIFF
--- a/NetKAN/AviatorArsenal.netkan
+++ b/NetKAN/AviatorArsenal.netkan
@@ -1,0 +1,13 @@
+identifier: AviatorArsenal
+$kref: '#/ckan/spacedock/2593'
+license: restricted
+tags:
+  - parts
+  - plugin
+  - combat
+depends:
+  - name: BDArmoryForRunwayProject
+  - name: PhysicsRangeExtender
+install:
+  - find: AviatorArsenal
+    install_to: GameData

--- a/NetKAN/KerbalPowersArmory.netkan
+++ b/NetKAN/KerbalPowersArmory.netkan
@@ -9,7 +9,7 @@ tags:
 depends:
   - name: ModuleManager
   - name: KerbalPowersCore
-  - name: BDArmory
+  - name: BDArmoryForRunwayProject
   - name: PhysicsRangeExtender
 suggests:
   - name: VABOrganizer

--- a/NetKAN/KerbalPowersInterstellar.netkan
+++ b/NetKAN/KerbalPowersInterstellar.netkan
@@ -7,7 +7,8 @@ depends:
   - name: ModuleManager
   - name: KerbalPowersCore
 suggests:
-  - name: Waterfall
+  - name: Waterfall  
+  - name: RecycledPartsAtomicAge
   - name: VABorganizer
 install:
   - find: KerbalPowers/Interstellar

--- a/NetKAN/KerbalPowersInterstellar.netkan
+++ b/NetKAN/KerbalPowersInterstellar.netkan
@@ -7,7 +7,7 @@ depends:
   - name: ModuleManager
   - name: KerbalPowersCore
 suggests:
-  - name: Waterfall  
+  - name: Waterfall
   - name: RecycledPartsAtomicAge
   - name: VABorganizer
 install:

--- a/NetKAN/TURD-BDArmory.netkan
+++ b/NetKAN/TURD-BDArmory.netkan
@@ -1,0 +1,17 @@
+identifier: TURD-BDArmory
+name: TURD - BD Armory
+abstract: Collection of Textures Unlimited recolours for BD Armory
+author: Spartwo
+$kref: '#/ckan/github/KerbalPowers/TURD-BDArmory/asset_match/TU_BD_Recolour.zip'
+license: CC-BY-NC-SA-4.0
+tags:
+  - config
+  - graphics
+depends:
+  - name: ModuleManager
+  - name: TexturesUnlimited
+suggests:
+  - name: BDArmory
+install:
+  - find: TURD
+    install_to: GameData

--- a/NetKAN/TURD-BDAssociated.netkan
+++ b/NetKAN/TURD-BDAssociated.netkan
@@ -1,0 +1,24 @@
+identifier: TURD-BDAssociated
+name: TURD - BD Associated
+abstract: >-
+  Collection of Textures Unlimited recolours
+  for BD Armory expansion packs
+author: Spartwo
+$kref: '#/ckan/github/KerbalPowers/TURD-BDArmory/asset_match/TU_BD_Associated_Recolour.zip'
+license: CC-BY-NC-SA-4.0
+tags:
+  - config
+  - graphics
+depends:
+  - name: ModuleManager
+  - name: TexturesUnlimited
+suggests:
+  - name: KerbalPowersArmory
+  - name: RefurbishedArmory
+  - name: NAS
+  - name: BDArmoryExtended
+  - name: Wraithforge
+  - name: AviatorArsenal
+install:
+  - find: TURD
+    install_to: GameData

--- a/NetKAN/TURD-BreakingGround.netkan
+++ b/NetKAN/TURD-BreakingGround.netkan
@@ -1,0 +1,15 @@
+identifier: TURD-BreakingGround
+name: TURD - Breaking Ground
+abstract: Collection of Textures Unlimited recolours for the Breaking Ground DLC
+author: OnlyLightMatters
+$kref: '#/ckan/github/KerbalPowers/TURD-MH-BG'
+license: CC-BY-NC-SA-4.0
+tags:
+  - config
+  - graphics
+depends:
+  - name: ModuleManager
+  - name: TexturesUnlimited
+install:
+  - find: TURD/TU_BG_AllInOne
+    install_to: GameData/TURD

--- a/NetKAN/TURD-KerbalFoundries.netkan
+++ b/NetKAN/TURD-KerbalFoundries.netkan
@@ -1,0 +1,19 @@
+identifier: TURD-KerbalFoundries
+name: TURD - Kerbal Foundries
+abstract: >-
+  Collection of Textures Unlimited recolours
+  for Kerbal Foundries Continued
+author: Spartwo
+$kref: '#/ckan/github/KerbalPowers/TURD-KerbalFoundries'
+license: CC-BY-NC-SA-4.0
+tags:
+  - config
+  - graphics
+depends:
+  - name: ModuleManager
+  - name: TexturesUnlimited
+suggests:
+  - name: KerbalFoundriesContinued
+install:
+  - find: TURD
+    install_to: GameData

--- a/NetKAN/TURD-MakingHistory.netkan
+++ b/NetKAN/TURD-MakingHistory.netkan
@@ -1,0 +1,15 @@
+identifier: TURD-MakingHistory
+name: TURD - Making History
+abstract: Collection of Textures Unlimited recolours for the Making History DLC
+author: OnlyLightMatters
+$kref: '#/ckan/github/KerbalPowers/TURD-MH-BG'
+license: CC-BY-NC-SA-4.0
+tags:
+  - config
+  - graphics
+depends:
+  - name: ModuleManager
+  - name: TexturesUnlimited
+install:
+  - find: TURD/TU_MH_AllInOne
+    install_to: GameData/TURD

--- a/NetKAN/TURD-StockRecolour.netkan
+++ b/NetKAN/TURD-StockRecolour.netkan
@@ -1,0 +1,15 @@
+identifier: TURD-StockRecolour
+name: TURD - Stock Recolour
+abstract: Collection of Textures Unlimited recolours for the vanilla game
+author: Manwith Noname
+$kref: '#/ckan/github/KerbalPowers/TURD-StockRecolour'
+license: CC-BY-NC-SA-1.0
+tags:
+  - config
+  - graphics
+depends:
+  - name: ModuleManager
+  - name: TexturesUnlimited
+install:
+  - find: TURD
+    install_to: GameData


### PR DESCRIPTION
- TURD Ckans
  - https://github.com/KerbalPowers/TURD-StockRecolour
  - https://github.com/KerbalPowers/TURD-MH-BG
  - https://github.com/KerbalPowers/TURD-KerbalFoundries
  - https://github.com/KerbalPowers/TURD-BDArmory
- Adjust authors and display names to originals
- Aviator arsenal ckan file
  - https://spacedock.info/mod/2593/Aviator%20Arsenal%20Continued
  - https://github.com/tetryds/AviatorArsenal
- Tie BD armory into what should be the most modern version ( BDArmory => BDArmoryForRunwayProject) in Armory Dependencies