### PR TITLE
XensPlanetCollectionRevived: move some supports to suggests

### DIFF
--- a/NetKAN/XensPlanetCollectionRevived.netkan
+++ b/NetKAN/XensPlanetCollectionRevived.netkan
@@ -15,11 +15,14 @@ tags:
 depends:
   - name: ModuleManager
   - name: Kopernicus
-supports:
+suggests:
   - name: DistantObject
+  - name: PlanetShine
   - name: OuterPlanetsMod
   - name: ResearchBodies
-  - name: PlanetShine
+supports:
+  - name: OuterPlanetsMod
+  - name: ResearchBodies
 install:
   - find: XPCR
     install_to: GameData


### PR DESCRIPTION
This mod was offered as a "supports" when installing distant object enhancement, which seems wrong.  I'm leaving OPM and ResearchBodies since those could be more gameplay-oriented and someone installing those mods might be interested in planet packs that work with it.