### PR TITLE
NewTantares: b9ps is a dependency

### DIFF
--- a/NetKAN/NewTantares.netkan
+++ b/NetKAN/NewTantares.netkan
@@ -12,6 +12,7 @@ provides:
   - Tantares
 depends:
   - name: ModuleManager
+  - name: B9PartSwitch
 recommends:
   - name: NewTantaresLV
 conflicts:

--- a/NetKAN/NewTantaresLV.netkan
+++ b/NetKAN/NewTantaresLV.netkan
@@ -11,6 +11,8 @@ provides:
   - TantaresLV
 depends:
   - name: ModuleManager
+  - name: Waterfall-Core
+  - name: B9PartSwitch
 recommends:
   - name: NewTantares
 conflicts:

--- a/NetKAN/TantaresSAF.netkan
+++ b/NetKAN/TantaresSAF.netkan
@@ -10,3 +10,4 @@ tags:
   - parts
 depends:
   - name: SimpleAdjustableFairings
+  - name: B9PartSwitch

--- a/NetKAN/TantaresSP.netkan
+++ b/NetKAN/TantaresSP.netkan
@@ -10,6 +10,7 @@ tags:
   - uncrewed
 depends:
   - name: ModuleManager
+  - name: B9PartSwitch
 recommends:
   - name: NeptuneCamera
 install:


### PR DESCRIPTION
per forum thread: https://forum.kerbalspaceprogram.com/topic/73686-112x-tantares-stockalike-soyuz-and-mir-2815022025mars-expedition/

> Tantares: Soviet crewed spacecraft, space station, and [LEO](https://en.wikipedia.org/wiki/Low_Earth_orbit) spacecraft
*Requires B9PartSwitch
Supports System Heat for Nuclear reactors.
Supports Resurfaced for PBR textures.
TantaresLV: Soviet launch vehicles and upper stages
*Requires B9PartSwitch
*Requires Waterfall
TantaresSP: Soviet interplanetary probes
*Requires B9PartSwitch
TantaresSAF: Soviet Aerodynamic Fairings
*Requires Simple Adjustable Fairings
*Requires B9PartSwitch
