### PR TITLE
Vref for StockalikeMiningExtension

### DIFF
--- a/NetKAN/StockalikeMiningExtension.netkan
+++ b/NetKAN/StockalikeMiningExtension.netkan
@@ -1,5 +1,6 @@
 identifier: StockalikeMiningExtension
 $kref: '#/ckan/spacedock/354'
+$vref: '#/ckan/ksp-avc'
 license: CC-BY-NC-SA-4.0
 tags:
   - parts


### PR DESCRIPTION
After #10729, StockalikeMiningExtension has an inflation warning about its unused version file.
Now it has a vref. If that doesn't work, we'll document it with a new `comment`.