### PR TITLE
Try to trim junk off 1ThousandSpecialPlanetPack version strings

### DIFF
--- a/NetKAN/1ThousandSpecialPlanetPack.netkan
+++ b/NetKAN/1ThousandSpecialPlanetPack.netkan
@@ -1,6 +1,6 @@
 identifier: 1ThousandSpecialPlanetPack
 $kref: '#/ckan/spacedock/3931'
-x_netkan_version_edit: ^(RELEASE )?(?<version>.*)( .*)?$
+x_netkan_version_edit: ^(RELEASE )?(?<version>[^ ]*).*$
 license: restricted
 tags:
   - config


### PR DESCRIPTION
<img width="1023" height="656" alt="image" src="https://github.com/user-attachments/assets/bfe2edfc-c5b0-4109-8aea-27634eec11e4" />

A git pull now fails in CKAN-meta on Windows because of this.

<img width="1214" height="279" alt="image" src="https://github.com/user-attachments/assets/6398bfd0-f24e-4fee-9969-6713a5d8786c" />

Now in addition to trimming "RELEASE" off the start, we trim a trailing space and any additional junk off the end.

A new PR in CKAN-meta will be needed to delete that file after this.
