### PR TITLE
Drop SpaceDock support for PromisedWorlds

### DIFF
--- a/NetKAN/PromisedWorldsCore.netkan
+++ b/NetKAN/PromisedWorldsCore.netkan
@@ -1,11 +1,6 @@
 identifier: PromisedWorldsCore
 $kref: '#/ckan/github/PromisedWorlds/PromisedWorlds/asset_match/Core'
 $vref: '#/ckan/ksp-avc'
----
-identifier: PromisedWorldsCore
-$kref: '#/ckan/spacedock/3974'
-$vref: '#/ckan/ksp-avc'
-x_netkan_force_v: true
 tags:
   - config
   - planet-pack

--- a/NetKAN/PromisedWorldsCore.netkan
+++ b/NetKAN/PromisedWorldsCore.netkan
@@ -1,6 +1,7 @@
 identifier: PromisedWorldsCore
 $kref: '#/ckan/github/PromisedWorlds/PromisedWorlds/asset_match/Core'
 $vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA
 tags:
   - config
   - planet-pack

--- a/NetKAN/PromisedWorldsDebdeb.netkan
+++ b/NetKAN/PromisedWorldsDebdeb.netkan
@@ -1,11 +1,6 @@
 identifier: PromisedWorldsDebdeb
 $kref: '#/ckan/github/PromisedWorlds/PromisedWorlds/asset_match/Debdeb'
 $vref: '#/ckan/ksp-avc'
----
-identifier: PromisedWorldsDebdeb
-$kref: '#/ckan/spacedock/3976'
-$vref: '#/ckan/ksp-avc'
-x_netkan_force_v: true
 tags:
   - config
   - planet-pack

--- a/NetKAN/PromisedWorldsDebdeb.netkan
+++ b/NetKAN/PromisedWorldsDebdeb.netkan
@@ -1,6 +1,7 @@
 identifier: PromisedWorldsDebdeb
 $kref: '#/ckan/github/PromisedWorlds/PromisedWorlds/asset_match/Debdeb'
 $vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA
 tags:
   - config
   - planet-pack


### PR DESCRIPTION
SpaceDock is very slow and mostly just cancels your upload.
This Pull request removes SpaceDock support for PromisedWorlds.