### PR TITLE
Fix OuterParallax licenses

### DIFF
--- a/NetKAN/OuterParallax-MPE.netkan
+++ b/NetKAN/OuterParallax-MPE.netkan
@@ -3,6 +3,7 @@ $kref: '#/ckan/github/jthero3/OuterParallaxContinued/asset_match/MPE'
 ---
 identifier: OuterParallax-MPE
 $kref: '#/ckan/spacedock/3834'
+license: restricted
 tags:
   - config
   - planet-pack

--- a/NetKAN/OuterParallax-OPM.netkan
+++ b/NetKAN/OuterParallax-OPM.netkan
@@ -3,6 +3,7 @@ $kref: '#/ckan/github/jthero3/OuterParallaxContinued/asset_match/OPM'
 ---
 identifier: OuterParallax-OPM
 $kref: '#/ckan/spacedock/3833'
+license: restricted
 tags:
   - config
   - planet-pack

--- a/NetKAN/OuterParallax.netkan
+++ b/NetKAN/OuterParallax.netkan
@@ -5,6 +5,7 @@ identifier: OuterParallax
 name: Outer Parallax Common Files
 abstract: Files common to OuterParallax-OPM and OuterParallax-MPE
 $kref: '#/ckan/spacedock/3833'
+license: restricted
 tags:
   - config
   - library


### PR DESCRIPTION
These mods have had their licenses changed on SpaceDock. Formerly they were a standard license identifier, now they're a custom `CC-BY-NC-SA,-ARR` string, so we have to set them to `restricted` in the netkans.

<img width="661" height="203" alt="image" src="https://github.com/user-attachments/assets/40730378-0294-4822-b127-ab747380e75a" />
