### PR TITLE
Add ParallaxContinued-Planet-Textures to CelesialHarmony's provides

### DIFF
--- a/NetKAN/CelestialHarmony.netkan
+++ b/NetKAN/CelestialHarmony.netkan
@@ -10,6 +10,7 @@ tags:
   - planet-pack
 provides:
   - Scatterer-sunflare
+  - ParallaxContinued-Planet-Textures
 conflicts:
   - name: KSCSwitcher
   - name: JNSQ


### PR DESCRIPTION
pending confirmation on forum (but I think this is in accordance with the installation instructions): 

https://forum.kerbalspaceprogram.com/topic/226204-112x-celestial-harmony-v110-wip/page/3/#findComment-4486664

___

ckan compat add 1.12
ckan install CelestialHarmony ParallaxContinued
