### PR TITLE
Fix install for StarstroSpaceSystems

### DIFF
--- a/NetKAN/StarstroSpaceSystems.netkan
+++ b/NetKAN/StarstroSpaceSystems.netkan
@@ -12,6 +12,3 @@ depends:
   - name: TexturesUnlimited
 recommends:
   - name: ShuttleOrbiterConstructionKit
-install:
-  - find: StarstroSpaceSystems-main
-    install_to: GameData


### PR DESCRIPTION
This mod's release ZIPs are copies of the source archives, so they contain a folder with a `-main` branch name suffix. The bot incorrectly guessed that that's the folder to install in #9534.

[Reported on the forum](https://forum.kerbalspaceprogram.com/topic/197082-ckan-mod-manager-for-ksp1-and-ksp2/page/34/#findComment-4487474).

Now the default install stanza is used.
