### PR TITLE
Adopt HUDReplacer into KSPModStewards

### DIFF
--- a/NetKAN/HUDReplacer.netkan
+++ b/NetKAN/HUDReplacer.netkan
@@ -1,5 +1,7 @@
 identifier: HUDReplacer
-author: UltraJohn, steamroller
+author:
+  - UltraJohn
+  - steamroller
 $kref: '#/ckan/github/KSPModStewards/HUDReplacer'
 $vref: '#/ckan/ksp-avc'
 ksp_version: 1.12


### PR DESCRIPTION
With @UltraJohn's permission I am adopting HUDReplacer. See the discussion here for more details: https://github.com/UltraJohn/HUDReplacer/pull/9.

This commit changes the following:
- Point the CKAN repository to https://github.com/KSPModStewards/HUDReplacer
- Point the forum thread to the new forum thread
- Update the author field to list both UltraJohn and me