### PR TITLE
Update ZTheme license field

### DIFF
--- a/NetKAN/ZTheme.netkan
+++ b/NetKAN/ZTheme.netkan
@@ -7,7 +7,6 @@ author:
   - UltraJohn
 $kref: '#/ckan/spacedock/3396'
 ksp_version: 1.12
-license: GPL-3.0
 tags:
   - config
   - graphics


### PR DESCRIPTION
Now that [HUDReplacer's relicensed to GPL-3.0](https://github.com/KSPModStewards/HUDReplacer), ZTheme is now fully under GPL-3.0 too (instead of GPL-3.0+HUDReplacer's ARR due to the example theme).

Also, is the license field really needed? I noticed that HUDReplacer's netkan doesn't have one yet its license still shows up fine in CKAN...