### PR TITLE
Pick the right asset for KSPTextureLoader

### DIFF
--- a/NetKAN/KSPTextureLoader.netkan
+++ b/NetKAN/KSPTextureLoader.netkan
@@ -1,7 +1,7 @@
 identifier: KSPTextureLoader
-$kref: '#/ckan/github/Phantomical/KSPTextureLoader'
+$kref: '#/ckan/github/Phantomical/KSPTextureLoader/asset_match/KSPTextureLoader.zip'
+x_netkan_version_edit: '^[vV]?(?<version>.+)$'
 $vref: '#/ckan/ksp-avc'
 tags:
   - plugin
   - library
-x_netkan_version_edit: '^[vV]?(?<version>.+)$'


### PR DESCRIPTION
<img width="671" height="99" alt="image" src="https://github.com/user-attachments/assets/a16f8360-2e5b-4e63-bdd9-88096cd4446a" />

Apparently this repo is going to have multiple assets per release:

<img width="285" height="263" alt="image" src="https://github.com/user-attachments/assets/f05a36e0-d709-432d-8544-b003b70883df" />

Now the netkan specifies which one contains the actual mod.
