### PR TITLE
Fix ISVEmporium install

### DIFF
--- a/NetKAN/ISVEmporium.netkan
+++ b/NetKAN/ISVEmporium.netkan
@@ -12,5 +12,5 @@ depends:
   - name: NearFutureConstruction
   - name: ModuleManager
 install:
-  - find: ISVEmporium
+  - find: zISVEmporium
     install_to: GameData


### PR DESCRIPTION
<img width="573" height="75" alt="image" src="https://github.com/user-attachments/assets/c13ad946-ca2f-4ed4-9295-add7eff274a0" />

The mod folder now has a `z` in front of it.
