### PR TITLE
Update authors for KSPTextureLoader

### DIFF
--- a/NetKAN/KSPTextureLoader.netkan
+++ b/NetKAN/KSPTextureLoader.netkan
@@ -2,6 +2,7 @@ identifier: KSPTextureLoader
 $kref: '#/ckan/github/Phantomical/KSPTextureLoader/asset_match/KSPTextureLoader.zip'
 x_netkan_version_edit: '^[vV]?(?<version>.+)$'
 $vref: '#/ckan/ksp-avc'
+author: steamroller
 tags:
   - plugin
   - library


### PR DESCRIPTION
It seems like this isn't picked up from the internal ckan file? Whatever the case, this fixes the metadata.