### PR TITLE
Versioning consistency for StarshipExpansionProject

### DIFF
--- a/NetKAN/StarshipExpansionProject.netkan
+++ b/NetKAN/StarshipExpansionProject.netkan
@@ -1,7 +1,6 @@
 identifier: StarshipExpansionProject
 abstract: Starship vehicle by SpaceX
 $kref: '#/ckan/github/Kari1407/Starship-Expansion-Project'
-x_netkan_epoch: 1
 x_netkan_version_edit:
   find: ^v(?<first>[^.])
   replace: v.${first}
@@ -13,7 +12,10 @@ author:
   - Kari
   - Sofie
 $kref: '#/ckan/spacedock/2959'
-x_netkan_epoch: 1
+x_netkan_version_edit:
+  find: ^v(?<first>[^.])
+  replace: v.${first}
+  strict: false
 ksp_version_min: '1.12.3'
 ksp_version_max: '1.12.99'
 license: restricted


### PR DESCRIPTION
<img width="534" height="46" alt="image" src="https://github.com/user-attachments/assets/7bc04433-e7d8-4ddf-a1a7-15505ee47a4f" />

This mod dropped the `.` from its former `v.` prefix.
