### PR TITLE
Gitea kref for ConformalDecals

### DIFF
--- a/NetKAN/ConformalDecals.netkan
+++ b/NetKAN/ConformalDecals.netkan
@@ -1,15 +1,11 @@
 identifier: ConformalDecals
-$kref: '#/ckan/ksp-avc/https://git.offworldcolonies.nexus/drewcassidy/KSP-Conformal-Decals/releases/download/latest/ConformalDecals.version'
+$kref: '#/ckan/gitea/git.offworldcolonies.nexus/drewcassidy/KSP-Conformal-Decals'
 $vref: '#/ckan/ksp-avc'
 ---
 identifier: ConformalDecals
 $kref: '#/ckan/spacedock/2451'
 $vref: '#/ckan/ksp-avc'
 license: Apache-2.0
-resources:
-  homepage: 'https://forum.kerbalspaceprogram.com/index.php?/topic/194802-*'
-  manual: 'https://git.offworldcolonies.nexus/drewcassidy/KSP-Conformal-Decals/wiki'
-  repository: 'https://git.offworldcolonies.nexus/drewcassidy/KSP-Conformal-Decals'
 tags:
   - plugin
   - parts


### PR DESCRIPTION
KSP-CKAN/CKAN#4494 added support for hosting mods on Gitea servers.
Now this is used for ConformalDecals.
