### PR TITLE
Add KerbVisionIR - Night Vision mod

### DIFF
--- a/NetKAN/KerbVisionIR.netkan
+++ b/NetKAN/KerbVisionIR.netkan
@@ -1,0 +1,28 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "KerbVisionIR",
+    "$kref": "#/ckan/github/garyblu71mods/KerbVisionIR",
+    "$vref": "#/ckan/ksp-avc",
+    "license": "MIT",
+    "tags": [
+        "plugin",
+        "graphics"
+    ],
+    "install": [
+        {
+            "find": "KerbVisionIR",
+            "install_to": "GameData"
+        }
+    ],
+    "resources": {
+        "homepage": "https://github.com/garyblu71mods/KerbVisionIR",
+        "repository": "https://github.com/garyblu71mods/KerbVisionIR",
+        "bugtracker": "https://github.com/garyblu71mods/KerbVisionIR/issues"
+    },
+    "author": "garyblu71mods",
+    "name": "KerbVision IR - Night Vision",
+    "abstract": "Night Vision mod for Kerbal Space Program with old-school CRT artifacts. Features 3 vision modes, adjustable settings, and authentic CRT effects.",
+    "x_netkan_github": {
+        "use_source_archive": false
+    }
+}


### PR DESCRIPTION
# Add KerbVisionIR - Night Vision mod

## Mod Information
- **Name**: KerbVision IR - Night Vision
- **Version**: 0.5.0
- **Author**: garyblu71mods
- **License**: MIT
- **KSP Version**: 1.8.0 - 1.12.99

## Description
Night Vision mod for Kerbal Space Program with old-school CRT artifacts.

Features:
- 3 Vision Modes: Monochrome, Green NV, Amber/Warm
- Adjustable Settings: Brightness, Contrast, Color Tint, Grain
- Processing Quality options (Full, High, Medium, Low)
- CRT Artifacts: Scanlines, phosphor spots, rolling bars, vignette
- Audio feedback on activation
- Hotkey support (Alt + `)
- Toolbar integration

## Links
- Repository: https://github.com/garyblu71mods/KerbVisionIR
- Release: https://github.com/garyblu71mods/KerbVisionIR/releases/tag/v0.5.0

## Checklist
- [x] .netkan file follows CKAN spec v1.4
- [x] GitHub release exists with proper tag (v0.5.0)
- [x] .version file included in mod
- [x] LICENSE file included (MIT)
- [x] Tested locally