### PR TITLE
Multi-hosting for FuelTanksPlus

### DIFF
--- a/NetKAN/FuelTanksPlus.netkan
+++ b/NetKAN/FuelTanksPlus.netkan
@@ -1,7 +1,13 @@
-license: CC-BY-NC-SA
+identifier: FuelTanksPlus
+$kref: '#/ckan/github/linuxgurugamer/FuelTanksPlus'
+$vref: '#/ckan/ksp-avc'
+---
 identifier: FuelTanksPlus
 $kref: '#/ckan/spacedock/92'
 $vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA
+tags:
+  - parts
 depends:
   - name: ModuleManager
 suggests:
@@ -19,12 +25,9 @@ supports:
   - name: DeadlyReentry
   - name: ModularFuelTanks
   - name: InterstellarFuelSwitch
-tags:
-  - parts
 install:
   - find: GameData/FuelTanksPlus
     install_to: GameData
-    filter:
-      - Ships
+    filter: Ships
   - find: VAB
     install_to: Ships


### PR DESCRIPTION
#10909 unfroze this mod as only sourced from SpaceDock, but it also has a GitHub repo with releases.
Now both hosts are indexed.

- <https://github.com/linuxgurugamer/FuelTanksPlus>
- <https://spacedock.info/mod/92/Fuel%20Tanks%20Plus%20(FTP)%20by%20NecroBones%20(aka%20Orvidius>
- <https://forum.kerbalspaceprogram.com/topic/97541-141-fuel-tanks-plus-202-2018-03-14/>
