### PR TITLE
Add VertexHeightOblateAvanced as a dependency of 1ThousandSpecialPlanetPack

### DIFF
--- a/NetKAN/1ThousandSpecialPlanetPack.netkan
+++ b/NetKAN/1ThousandSpecialPlanetPack.netkan
@@ -15,6 +15,7 @@ depends:
   - name: ParallaxContinued
   - name: VertexColorMapEmissive
   - name: VertexMitchellNetravaliHeightMap
+  - name: VertexHeightOblateAdvanced
   - name: ScaledDecorator
 recommends:
   - name: Deferred


### PR DESCRIPTION
It seems like this depends on VertexHeightOblateAdvanced despite it not actually being documented anywhere. I have just helped someone debug an install issue that boiled down to Klumo needing `VertexHeightOblateAdvanced` and that not being installed.