### PR TITLE
Bump minimum required KSPTextureLoader version for Kopernicus

### DIFF
--- a/NetKAN/Kopernicus.netkan
+++ b/NetKAN/Kopernicus.netkan
@@ -28,7 +28,7 @@ tags:
   - library
 depends:
   - name: KSPTextureLoader
-    min_version: 0.0.19
+    min_version: 0.0.22
   - name: ModuleManager
     min_version: 2.8.0
   - name: ModularFlightIntegrator


### PR DESCRIPTION
We now use new methods added in v22, so kopernicus will fail to load without that.