### PR TITLE
Remove Parallax Conflicts for MRKI.netkan

### DIFF
--- a/NetKAN/MRKI.netkan
+++ b/NetKAN/MRKI.netkan
@@ -9,8 +9,6 @@ tags:
   - planet-pack
 provides:
   - ParallaxContinued-Planet-Textures
-conflicts:
-  - name: ParallaxContinued-Planet-Textures
 depends:
   - name: ModuleManager
   - name: Kopernicus


### PR DESCRIPTION
The new MRKI v1.0.6 update removes the mod conflicts with Parallax_StockPlanetTextures.