### PR TITLE
Use non-source asset for EasyISP

### DIFF
--- a/NetKAN/EasyISP.netkan
+++ b/NetKAN/EasyISP.netkan
@@ -5,7 +5,6 @@ $vref: '#/ckan/ksp-avc'
 identifier: EasyISP
 $kref: '#/ckan/spacedock/4132'
 $vref: '#/ckan/ksp-avc'
-license: Unlicense
 tags:
   - physics
   - convenience


### PR DESCRIPTION
- <https://github.com/Tempus-superest/EasyISP>

This pull request updates the `EasyISP.netkan` metadata file to correct the source location and remove "use_source_archive: true". 

The initial GitHub release did not have proper release tags set up, and now releases occur with properly versioned tags. This was preventing CKAN from displaying download counts in the CKAN UI.

Spacedock references were added for user benefit, but Spacedock should not be the authoritative source. GitHub release automation will upload to Spacedock