### PR TITLE
Bump Kopernicus KSPTL dependency and update authors

### DIFF
--- a/NetKAN/Kopernicus.netkan
+++ b/NetKAN/Kopernicus.netkan
@@ -21,6 +21,7 @@ author:
   - Sigma88
   - R-T-B
   - prestja
+  - steamroller
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/200143-*
 tags:
@@ -28,7 +29,7 @@ tags:
   - library
 depends:
   - name: KSPTextureLoader
-    min_version: 0.0.22
+    min_version: 1.0.26
   - name: ModuleManager
     min_version: 2.8.0
   - name: ModularFlightIntegrator


### PR DESCRIPTION
Kopernicus now depends on new features in KSPTextureLoader 1.0.26. This updates the dependency version and then also updates the author list to include me, now that I'm helping to maintain Kopernicus.