### PR TITLE
Make ContractConfiguratorExtended conflict with original ContractConfigurator

### DIFF
--- a/NetKAN/ContractConfiguratorExtended.netkan
+++ b/NetKAN/ContractConfiguratorExtended.netkan
@@ -4,9 +4,12 @@ $vref: '#/ckan/ksp-avc'
 tags:
   - config
   - plugin
+provides:
+  - ContractConfigurator
+conflicts:
+  - name: ContractConfigurator
 depends:
   - name: ModuleManager
 install:
   - find: ContractConfigurator
     install_to: GameData
-x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/ContractConfiguratorExtended.netkan
+++ b/NetKAN/ContractConfiguratorExtended.netkan
@@ -5,8 +5,6 @@ tags:
   - plugin
   - library
   - career
-provides:
-  - ContractConfigurator
 conflicts:
   - name: ContractConfigurator
 depends:

--- a/NetKAN/ContractConfiguratorExtended.netkan
+++ b/NetKAN/ContractConfiguratorExtended.netkan
@@ -2,8 +2,9 @@ identifier: ContractConfiguratorExtended
 $kref: '#/ckan/spacedock/4073'
 $vref: '#/ckan/ksp-avc'
 tags:
-  - config
   - plugin
+  - library
+  - career
 provides:
   - ContractConfigurator
 conflicts:


### PR DESCRIPTION
#10844 added a new fork of ContractConfigurator, without marking it as such.

- <https://spacedock.info/mod/4073/Contract%20Configurator%20Extended>

Now it ~~provides and~~ conflicts with that mod.
(`provides` removed because we probably don't want anyone installing this by accident.)

Also the tags are updated to match.
