### PR TITLE
Add Kerbalism NFE Nuclear Patch

### DIFF
--- a/NetKAN/KerbalismNFEFRpatch.netkan
+++ b/NetKAN/KerbalismNFEFRpatch.netkan
@@ -1,0 +1,4 @@
+{
+  "identifier": "KerbalismNFEFRpatch",
+  "$kref": "#/ckan/netkan/https://github.com/bimo1d/Kerbalism-NFENuclearPatch/raw/main/CKAN/KerbalismNFEFRpatch.netkan"
+}

--- a/NetKAN/KerbalismNFEFRpatch.netkan
+++ b/NetKAN/KerbalismNFEFRpatch.netkan
@@ -1,2 +1,6 @@
 identifier: KerbalismNFEFRpatch
 $kref: '#/ckan/netkan/https://github.com/bimo1d/Kerbalism-NFENuclearPatch/raw/main/CKAN/KerbalismNFEFRpatch.netkan'
+tags:
+  - plugin
+  - config
+  - resources

--- a/NetKAN/KerbalismNFEFRpatch.netkan
+++ b/NetKAN/KerbalismNFEFRpatch.netkan
@@ -1,4 +1,2 @@
-{
-  "identifier": "KerbalismNFEFRpatch",
-  "$kref": "#/ckan/netkan/https://github.com/bimo1d/Kerbalism-NFENuclearPatch/raw/main/CKAN/KerbalismNFEFRpatch.netkan"
-}
+identifier: KerbalismNFEFRpatch
+$kref: '#/ckan/netkan/https://github.com/bimo1d/Kerbalism-NFENuclearPatch/raw/main/CKAN/KerbalismNFEFRpatch.netkan'


### PR DESCRIPTION
Adds a NetKAN entry for KerbalismNFEFRpatch.

KerbalismNFEFRpatch is a compatibility patch between Kerbalism and Near Future Electrical.
It restores stable background electric generation for NFE fission reactors on unloaded vessels and keeps reactor-related resource flows synchronized in background simulation.

- <https://github.com/bimo1d/Kerbalism-NFENuclearPatch>
