### PR TITLE
Add BurstPQS as dependency to AdvancedPQSTools

### DIFF
--- a/NetKAN/AdvancedPQSTools.netkan
+++ b/NetKAN/AdvancedPQSTools.netkan
@@ -15,3 +15,4 @@ tags:
 depends:
   - name: ModuleManager
   - name: Kopernicus
+  - name: BurstPQS


### PR DESCRIPTION
Replaces KSP-CKAN/CKAN-meta#3384.