### PR TITLE
Add BurstPQS dependency to AdvancedPQSTools

### DIFF
--- a/NetKAN/AdvancedPQSTools.netkan
+++ b/NetKAN/AdvancedPQSTools.netkan
@@ -15,3 +15,4 @@ tags:
 depends:
   - name: ModuleManager
   - name: Kopernicus
+  - name: BurstPQS


### PR DESCRIPTION
The latest version of AdvancedPQSTools now depends on BurstPQS.

Replaces KSP-CKAN/CKAN-meta#3384.
