### PR TITLE
AutoLoadGame: add dependency on AT-Utils

### DIFF
--- a/NetKAN/AutoLoadGame.frozen
+++ b/NetKAN/AutoLoadGame.frozen
@@ -13,3 +13,5 @@ license: MIT
 tags:
   - plugin
   - convenience
+depends:
+  - name: AT-Utils


### PR DESCRIPTION
this can break the game when not installed together:
```
[WRN 14:31:43.812] [KSPCF] A ReflectionTypeLoadException thrown by Assembly.GetTypes() has been handled by KSP Community Fixes.
It happened because "AutoLoadGame" is missing the following dependencies : "000_AT_Utils"
```

The dependency isn't declared anywhere that I can see, but there is a reference in the csproj file: https://github.com/allista/AutoLoadGame/blob/4c092239fec6273e39d3708e56d473a132450fc4/AutoLoadGame.csproj#L68

I'm going to leave this file frozen and go update the .ckan file directly.