### PR TITLE
Update EnhancedAstronautComplex license

### DIFF
--- a/NetKAN/EnhancedAstronautComplex.netkan
+++ b/NetKAN/EnhancedAstronautComplex.netkan
@@ -2,6 +2,7 @@ identifier: EnhancedAstronautComplex
 name: Enhanced Astronaut Complex
 $kref: '#/ckan/github/ItchyBrother/EAC'
 $vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-ND-4.0
 tags:
   - plugin
   - crewed


### PR DESCRIPTION
This mod's license file has changed from MIT to CC-BY-NC-ND-4.0, which GitHub is not recognizing.

- <https://github.com/ItchyBrother/EAC/commit/2fb74278362f29504a0cc249411405fbab27afd9>
