### PR TITLE
Updated the metadata to promote RealFuels from a recommendation to a hard dependency.

### DIFF
--- a/NetKAN/EngineAnalyzer.netkan
+++ b/NetKAN/EngineAnalyzer.netkan
@@ -6,5 +6,5 @@ $kref: '#/ckan/spacedock/4210'
 tags:
   - plugin
   - information
-recommends:
+depends:
   - name: RealFuels


### PR DESCRIPTION
Reason:
The current version of EngineAnalyzer now strictly requires RealFuels to function properly.