### PR TITLE
Add KerbalFX 0.7 modular packages

### DIFF
--- a/NetKAN/KerbalFX-AeroFX.netkan
+++ b/NetKAN/KerbalFX-AeroFX.netkan
@@ -1,0 +1,21 @@
+identifier: KerbalFX-AeroFX
+name: KerbalFX - AeroFX
+abstract: KerbalFX module for atmospheric ribbon condensation trails.
+description: KerbalFX AeroFX adds atmospheric ribbon condensation trails for suitable wing-like aircraft parts, driven by speed, air density, dynamic pressure, and maneuver load. Requires KerbalFX Core.
+author: bimo1d
+license: Unlicense
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/topic/230118-wip1125-kerbalfx-lightweight-modular-fx-framework-v062-15042026/
+  repository: https://github.com/bimo1d/KerbalFX
+  bugtracker: https://github.com/bimo1d/KerbalFX/issues
+  spacedock: https://spacedock.info/mod/4190/KerbalFX
+  remote-avc: https://raw.githubusercontent.com/bimo1d/KerbalFX/main/AeroFX/KerbalFX-AeroFX.version
+$kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-AeroFX-.*\.zip$'
+x_netkan_version_edit: '^[vV]?(?<version>.+)$'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: KerbalFX
+    install_to: GameData
+depends:
+  - name: KerbalFX-Core

--- a/NetKAN/KerbalFX-AeroFX.netkan
+++ b/NetKAN/KerbalFX-AeroFX.netkan
@@ -8,9 +8,7 @@ description: >-
   Requires KerbalFX Core.
 $kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-AeroFX-.*\.zip$'
 $vref: '#/ckan/ksp-avc'
-license: Unlicense
 resources:
-  homepage: https://forum.kerbalspaceprogram.com/topic/230118-wip1125-kerbalfx-lightweight-modular-fx-framework-v062-15042026/
   spacedock: https://spacedock.info/mod/4190/KerbalFX
 tags:
   - plugin

--- a/NetKAN/KerbalFX-AeroFX.netkan
+++ b/NetKAN/KerbalFX-AeroFX.netkan
@@ -1,21 +1,22 @@
 identifier: KerbalFX-AeroFX
 name: KerbalFX - AeroFX
 abstract: KerbalFX module for atmospheric ribbon condensation trails.
-description: KerbalFX AeroFX adds atmospheric ribbon condensation trails for suitable wing-like aircraft parts, driven by speed, air density, dynamic pressure, and maneuver load. Requires KerbalFX Core.
-author: bimo1d
+description: >-
+  KerbalFX AeroFX adds atmospheric ribbon condensation trails for suitable
+  wing-like aircraft parts, driven by speed, air density, dynamic pressure,
+  and maneuver load.
+  Requires KerbalFX Core.
+$kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-AeroFX-.*\.zip$'
+$vref: '#/ckan/ksp-avc'
 license: Unlicense
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/topic/230118-wip1125-kerbalfx-lightweight-modular-fx-framework-v062-15042026/
-  repository: https://github.com/bimo1d/KerbalFX
-  bugtracker: https://github.com/bimo1d/KerbalFX/issues
   spacedock: https://spacedock.info/mod/4190/KerbalFX
-  remote-avc: https://raw.githubusercontent.com/bimo1d/KerbalFX/main/AeroFX/KerbalFX-AeroFX.version
-$kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-AeroFX-.*\.zip$'
-x_netkan_version_edit: '^[vV]?(?<version>.+)$'
-$vref: '#/ckan/ksp-avc'
+tags:
+  - plugin
+  - graphics
+depends:
+  - name: KerbalFX-Core
 install:
   - find: KerbalFX
     install_to: GameData
-depends:
-  - name: KerbalFX-Core

--- a/NetKAN/KerbalFX-BlastFX.netkan
+++ b/NetKAN/KerbalFX-BlastFX.netkan
@@ -1,0 +1,21 @@
+identifier: KerbalFX-BlastFX
+name: KerbalFX - BlastFX
+abstract: KerbalFX module for separator and decoupler visual effects.
+description: KerbalFX BlastFX adds separator and decoupler visual effects, including sparks, fragments, smoke, and softer ordinary decoupler puffs. Requires KerbalFX Core.
+author: bimo1d
+license: Unlicense
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/topic/230118-wip1125-kerbalfx-lightweight-modular-fx-framework-v062-15042026/
+  repository: https://github.com/bimo1d/KerbalFX
+  bugtracker: https://github.com/bimo1d/KerbalFX/issues
+  spacedock: https://spacedock.info/mod/4190/KerbalFX
+  remote-avc: https://raw.githubusercontent.com/bimo1d/KerbalFX/main/BlastFX/KerbalFX-BlastFX.version
+$kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-BlastFX-.*\.zip$'
+x_netkan_version_edit: '^[vV]?(?<version>.+)$'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: KerbalFX
+    install_to: GameData
+depends:
+  - name: KerbalFX-Core

--- a/NetKAN/KerbalFX-BlastFX.netkan
+++ b/NetKAN/KerbalFX-BlastFX.netkan
@@ -1,21 +1,21 @@
 identifier: KerbalFX-BlastFX
 name: KerbalFX - BlastFX
 abstract: KerbalFX module for separator and decoupler visual effects.
-description: KerbalFX BlastFX adds separator and decoupler visual effects, including sparks, fragments, smoke, and softer ordinary decoupler puffs. Requires KerbalFX Core.
-author: bimo1d
+description: >-
+  KerbalFX BlastFX adds separator and decoupler visual effects, including
+  sparks, fragments, smoke, and softer ordinary decoupler puffs.
+  Requires KerbalFX Core.
+$kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-BlastFX-.*\.zip$'
+$vref: '#/ckan/ksp-avc'
 license: Unlicense
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/topic/230118-wip1125-kerbalfx-lightweight-modular-fx-framework-v062-15042026/
-  repository: https://github.com/bimo1d/KerbalFX
-  bugtracker: https://github.com/bimo1d/KerbalFX/issues
   spacedock: https://spacedock.info/mod/4190/KerbalFX
-  remote-avc: https://raw.githubusercontent.com/bimo1d/KerbalFX/main/BlastFX/KerbalFX-BlastFX.version
-$kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-BlastFX-.*\.zip$'
-x_netkan_version_edit: '^[vV]?(?<version>.+)$'
-$vref: '#/ckan/ksp-avc'
+tags:
+  - plugin
+  - graphics
+depends:
+  - name: KerbalFX-Core
 install:
   - find: KerbalFX
     install_to: GameData
-depends:
-  - name: KerbalFX-Core

--- a/NetKAN/KerbalFX-BlastFX.netkan
+++ b/NetKAN/KerbalFX-BlastFX.netkan
@@ -7,9 +7,7 @@ description: >-
   Requires KerbalFX Core.
 $kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-BlastFX-.*\.zip$'
 $vref: '#/ckan/ksp-avc'
-license: Unlicense
 resources:
-  homepage: https://forum.kerbalspaceprogram.com/topic/230118-wip1125-kerbalfx-lightweight-modular-fx-framework-v062-15042026/
   spacedock: https://spacedock.info/mod/4190/KerbalFX
 tags:
   - plugin

--- a/NetKAN/KerbalFX-Core.netkan
+++ b/NetKAN/KerbalFX-Core.netkan
@@ -1,0 +1,26 @@
+identifier: KerbalFX-Core
+name: KerbalFX Core
+abstract: Shared KerbalFX runtime required by KerbalFX visual modules.
+description: KerbalFX Core provides the shared runtime, settings, and helper code required by KerbalFX visual modules. It does not add a visual effect by itself.
+author: bimo1d
+license: Unlicense
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/topic/230118-wip1125-kerbalfx-lightweight-modular-fx-framework-v062-15042026/
+  repository: https://github.com/bimo1d/KerbalFX
+  bugtracker: https://github.com/bimo1d/KerbalFX/issues
+  spacedock: https://spacedock.info/mod/4190/KerbalFX
+  remote-avc: https://raw.githubusercontent.com/bimo1d/KerbalFX/main/Core/KerbalFX-Core.version
+$kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-Core-.*\.zip$'
+x_netkan_version_edit: '^[vV]?(?<version>.+)$'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: KerbalFX
+    install_to: GameData
+depends:
+  - name: ModuleManager
+recommends:
+  - name: KerbalFX-AeroFX
+  - name: KerbalFX-BlastFX
+  - name: KerbalFX-ImpactPuffs
+  - name: KerbalFX-RoverDust

--- a/NetKAN/KerbalFX-Core.netkan
+++ b/NetKAN/KerbalFX-Core.netkan
@@ -7,9 +7,7 @@ description: >-
   It does not add a visual effect by itself.
 $kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-Core-.*\.zip$'
 $vref: '#/ckan/ksp-avc'
-license: Unlicense
 resources:
-  homepage: https://forum.kerbalspaceprogram.com/topic/230118-wip1125-kerbalfx-lightweight-modular-fx-framework-v062-15042026/
   spacedock: https://spacedock.info/mod/4190/KerbalFX
 tags:
   - plugin

--- a/NetKAN/KerbalFX-Core.netkan
+++ b/NetKAN/KerbalFX-Core.netkan
@@ -1,22 +1,20 @@
 identifier: KerbalFX-Core
 name: KerbalFX Core
 abstract: Shared KerbalFX runtime required by KerbalFX visual modules.
-description: KerbalFX Core provides the shared runtime, settings, and helper code required by KerbalFX visual modules. It does not add a visual effect by itself.
-author: bimo1d
+description: >-
+  KerbalFX Core provides the shared runtime, settings, and helper code
+  required by KerbalFX visual modules.
+  It does not add a visual effect by itself.
+$kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-Core-.*\.zip$'
+$vref: '#/ckan/ksp-avc'
 license: Unlicense
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/topic/230118-wip1125-kerbalfx-lightweight-modular-fx-framework-v062-15042026/
-  repository: https://github.com/bimo1d/KerbalFX
-  bugtracker: https://github.com/bimo1d/KerbalFX/issues
   spacedock: https://spacedock.info/mod/4190/KerbalFX
-  remote-avc: https://raw.githubusercontent.com/bimo1d/KerbalFX/main/Core/KerbalFX-Core.version
-$kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-Core-.*\.zip$'
-x_netkan_version_edit: '^[vV]?(?<version>.+)$'
-$vref: '#/ckan/ksp-avc'
-install:
-  - find: KerbalFX
-    install_to: GameData
+tags:
+  - plugin
+  - graphics
+  - library
 depends:
   - name: ModuleManager
 recommends:
@@ -24,3 +22,6 @@ recommends:
   - name: KerbalFX-BlastFX
   - name: KerbalFX-ImpactPuffs
   - name: KerbalFX-RoverDust
+install:
+  - find: KerbalFX
+    install_to: GameData

--- a/NetKAN/KerbalFX-ImpactPuffs.netkan
+++ b/NetKAN/KerbalFX-ImpactPuffs.netkan
@@ -1,0 +1,21 @@
+identifier: KerbalFX-ImpactPuffs
+name: KerbalFX - Impact Puffs
+abstract: KerbalFX module for engine plume-ground dust puffs and touchdown bursts.
+description: KerbalFX Impact Puffs adds engine plume-ground dust puffs for launch and landing, plus one-shot touchdown bursts on harder landings. Requires KerbalFX Core.
+author: bimo1d
+license: Unlicense
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/topic/230118-wip1125-kerbalfx-lightweight-modular-fx-framework-v062-15042026/
+  repository: https://github.com/bimo1d/KerbalFX
+  bugtracker: https://github.com/bimo1d/KerbalFX/issues
+  spacedock: https://spacedock.info/mod/4190/KerbalFX
+  remote-avc: https://raw.githubusercontent.com/bimo1d/KerbalFX/main/ImpactPuffs/KerbalFX-ImpactPuffs.version
+$kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-ImpactPuffs-.*\.zip$'
+x_netkan_version_edit: '^[vV]?(?<version>.+)$'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: KerbalFX
+    install_to: GameData
+depends:
+  - name: KerbalFX-Core

--- a/NetKAN/KerbalFX-ImpactPuffs.netkan
+++ b/NetKAN/KerbalFX-ImpactPuffs.netkan
@@ -8,9 +8,7 @@ description: >-
   Requires KerbalFX Core.
 $kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-ImpactPuffs-.*\.zip$'
 $vref: '#/ckan/ksp-avc'
-license: Unlicense
 resources:
-  homepage: https://forum.kerbalspaceprogram.com/topic/230118-wip1125-kerbalfx-lightweight-modular-fx-framework-v062-15042026/
   spacedock: https://spacedock.info/mod/4190/KerbalFX
 tags:
   - plugin

--- a/NetKAN/KerbalFX-ImpactPuffs.netkan
+++ b/NetKAN/KerbalFX-ImpactPuffs.netkan
@@ -1,21 +1,22 @@
 identifier: KerbalFX-ImpactPuffs
 name: KerbalFX - Impact Puffs
-abstract: KerbalFX module for engine plume-ground dust puffs and touchdown bursts.
-description: KerbalFX Impact Puffs adds engine plume-ground dust puffs for launch and landing, plus one-shot touchdown bursts on harder landings. Requires KerbalFX Core.
-author: bimo1d
+abstract: >-
+  KerbalFX module for engine plume-ground dust puffs and touchdown bursts.
+description: >-
+  KerbalFX Impact Puffs adds engine plume-ground dust puffs for launch and
+  landing, plus one-shot touchdown bursts on harder landings.
+  Requires KerbalFX Core.
+$kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-ImpactPuffs-.*\.zip$'
+$vref: '#/ckan/ksp-avc'
 license: Unlicense
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/topic/230118-wip1125-kerbalfx-lightweight-modular-fx-framework-v062-15042026/
-  repository: https://github.com/bimo1d/KerbalFX
-  bugtracker: https://github.com/bimo1d/KerbalFX/issues
   spacedock: https://spacedock.info/mod/4190/KerbalFX
-  remote-avc: https://raw.githubusercontent.com/bimo1d/KerbalFX/main/ImpactPuffs/KerbalFX-ImpactPuffs.version
-$kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-ImpactPuffs-.*\.zip$'
-x_netkan_version_edit: '^[vV]?(?<version>.+)$'
-$vref: '#/ckan/ksp-avc'
+tags:
+  - plugin
+  - graphics
+depends:
+  - name: KerbalFX-Core
 install:
   - find: KerbalFX
     install_to: GameData
-depends:
-  - name: KerbalFX-Core

--- a/NetKAN/KerbalFX-RoverDust.netkan
+++ b/NetKAN/KerbalFX-RoverDust.netkan
@@ -1,0 +1,21 @@
+identifier: KerbalFX-RoverDust
+name: KerbalFX - Rover Dust
+abstract: KerbalFX module for wheel-ground dust on rovers and wheeled craft.
+description: KerbalFX Rover Dust adds wheel-ground dust effects driven by wheel contact, speed, slip, lighting, and surface tint. Requires KerbalFX Core.
+author: bimo1d
+license: Unlicense
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/topic/230118-wip1125-kerbalfx-lightweight-modular-fx-framework-v062-15042026/
+  repository: https://github.com/bimo1d/KerbalFX
+  bugtracker: https://github.com/bimo1d/KerbalFX/issues
+  spacedock: https://spacedock.info/mod/4190/KerbalFX
+  remote-avc: https://raw.githubusercontent.com/bimo1d/KerbalFX/main/RoverDust/KerbalFX-RoverDust.version
+$kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-RoverDust-.*\.zip$'
+x_netkan_version_edit: '^[vV]?(?<version>.+)$'
+$vref: '#/ckan/ksp-avc'
+install:
+  - find: KerbalFX
+    install_to: GameData
+depends:
+  - name: KerbalFX-Core

--- a/NetKAN/KerbalFX-RoverDust.netkan
+++ b/NetKAN/KerbalFX-RoverDust.netkan
@@ -7,9 +7,7 @@ description: >-
   Requires KerbalFX Core.
 $kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-RoverDust-.*\.zip$'
 $vref: '#/ckan/ksp-avc'
-license: Unlicense
 resources:
-  homepage: https://forum.kerbalspaceprogram.com/topic/230118-wip1125-kerbalfx-lightweight-modular-fx-framework-v062-15042026/
   spacedock: https://spacedock.info/mod/4190/KerbalFX
 tags:
   - plugin

--- a/NetKAN/KerbalFX-RoverDust.netkan
+++ b/NetKAN/KerbalFX-RoverDust.netkan
@@ -1,21 +1,21 @@
 identifier: KerbalFX-RoverDust
 name: KerbalFX - Rover Dust
 abstract: KerbalFX module for wheel-ground dust on rovers and wheeled craft.
-description: KerbalFX Rover Dust adds wheel-ground dust effects driven by wheel contact, speed, slip, lighting, and surface tint. Requires KerbalFX Core.
-author: bimo1d
+description: >-
+  KerbalFX Rover Dust adds wheel-ground dust effects driven by wheel contact,
+  speed, slip, lighting, and surface tint.
+  Requires KerbalFX Core.
+$kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-RoverDust-.*\.zip$'
+$vref: '#/ckan/ksp-avc'
 license: Unlicense
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/topic/230118-wip1125-kerbalfx-lightweight-modular-fx-framework-v062-15042026/
-  repository: https://github.com/bimo1d/KerbalFX
-  bugtracker: https://github.com/bimo1d/KerbalFX/issues
   spacedock: https://spacedock.info/mod/4190/KerbalFX
-  remote-avc: https://raw.githubusercontent.com/bimo1d/KerbalFX/main/RoverDust/KerbalFX-RoverDust.version
-$kref: '#/ckan/github/bimo1d/KerbalFX/asset_match/^KerbalFX-RoverDust-.*\.zip$'
-x_netkan_version_edit: '^[vV]?(?<version>.+)$'
-$vref: '#/ckan/ksp-avc'
+tags:
+  - plugin
+  - graphics
+depends:
+  - name: KerbalFX-Core
 install:
   - find: KerbalFX
     install_to: GameData
-depends:
-  - name: KerbalFX-Core


### PR DESCRIPTION
Adds NetKAN metadata for the modular KerbalFX 0.7 release.

Packages:
- KerbalFX-Core
- KerbalFX-AeroFX
- KerbalFX-BlastFX
- KerbalFX-ImpactPuffs
- KerbalFX-RoverDust

Release:
https://github.com/bimo1d/KerbalFX/releases/tag/0.7

SpaceDock:
https://spacedock.info/mod/4190/KerbalFX

Forum thread:
https://forum.kerbalspaceprogram.com/topic/230118-wip1125-kerbalfx-lightweight-modular-fx-framework-v062-15042026/

KerbalFX 0.7 is split into a required Core package plus optional module packages.
