### PR TITLE
Don't index prereleases for LunaMultiplayer

### DIFF
--- a/NetKAN/LunaMultiplayer.netkan
+++ b/NetKAN/LunaMultiplayer.netkan
@@ -1,12 +1,13 @@
 identifier:   LunaMultiplayer
 name:         Luna Multiplayer Client
 $kref:        '#/ckan/github/LunaMultiplayer/LunaMultiplayer/asset_match/^LunaMultiplayer-Client-Release\.zip$'
-comment:      Version file is outdated
-ksp_version:  '1.12'
+x_netkan_github:
+  prereleases: false
+$vref:        '#/ckan/ksp-avc'
 license:      MIT
 resources:
-  homepage: 'https://lunamultiplayer.com/'
-  manual:   'https://github.com/LunaMultiplayer/LunaMultiplayer/wiki'
+  homepage: https://lunamultiplayer.com/
+  manual:   https://github.com/LunaMultiplayer/LunaMultiplayer/wiki
 tags:
   - plugin
 depends:


### PR DESCRIPTION
## Problems

- <https://github.com/LunaMultiplayer/LunaMultiplayer>

This mod recently started uploading nightly builds by replacing the same upload over and over, which has wreaked a bit of havoc with constant hash changes:

- <https://github.com/KSP-CKAN/CKAN-meta/commits/master/LunaMultiplayer/LunaMultiplayer-0.29.1-Draft.ckan>

Then the latest stable release got deleted or replaced or _something,_ with a ZIP file that was missing files and caused inflation errors, with a timestamp that made it more recent than the prerelease, so it looked like nothing was inflating even though the nightly builds were still updating, and we received several PRs attempting to patch that up in CKAN-meta:

- KSP-CKAN/CKAN-meta#3389
- KSP-CKAN/CKAN-meta#3390
- KSP-CKAN/CKAN-meta#3391
- KSP-CKAN/CKAN-meta#3392

It seems pretty clear that the desired end state of this is for these prereleases to not be in CKAN, since the previous one got deleted.

## Changes

Now the bot will ignore prereleases for this mod. This will avoid the problem of constant hash updates as well as make sure the 0.29.0 release is considered the latest regardless of any future shenanigans, so the bot will handle the hash of the restored release automatically.
