### PR TITLE
Add HotReloadKSP

### DIFF
--- a/NetKAN/HotReloadKSP.netkan
+++ b/NetKAN/HotReloadKSP.netkan
@@ -1,0 +1,8 @@
+identifier: HotReloadKSP
+author: steamroller
+$kref: '#/ckan/github/Phantomical/HotReloadKSP'
+x_netkan_version_edit: '^[vV]?(?<version>.+)$'
+$vref: '#/ckan/ksp-avc'
+tags:
+  - plugin
+  - convenience


### PR DESCRIPTION
I have a new mod! Now it's time to add it to CKAN :)

This one allows you to reload DLLs while the game is running. It automatically handles all the details of actually replacing any instantiated versions of its types (i.e. part/vessel/sceneario modules, or arbitrary MonoBehaviors). It also provides a convenient UI to reload the assembly - either manually or automatically when the dll is modified.

I think everything should be right in the netkan - we'll see how CI turns out. The mod has no dependencies so I think I have a good chance here.