### PR TITLE
TweakscaleRescaled-Redist: remove recommendation for tweakscaleRescaled

### DIFF
--- a/NetKAN/TweakScaleRescaled-Redist.netkan
+++ b/NetKAN/TweakScaleRescaled-Redist.netkan
@@ -22,8 +22,6 @@ author:
 tags:
   - plugin
   - library
-recommends:
-  - name: TweakScaleRescaled
 conflicts:
   - name: TweakScale-Redist
 provides:


### PR DESCRIPTION
Someone who is installing the redist on their own (or via a dependency) probably doesn't want this recommendation.