### PR TITLE
SystemHeat: Copy metadata from metanetkans

### DIFF
--- a/NetKAN/SystemHeat-Converters.netkan
+++ b/NetKAN/SystemHeat-Converters.netkan
@@ -6,7 +6,7 @@ abstract: >-
 author: Nertea (Chris Adderley)
 $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'
-license: restricted
+license: MIT
 tags:
   - parts
   - plugin

--- a/NetKAN/SystemHeat-Converters.netkan
+++ b/NetKAN/SystemHeat-Converters.netkan
@@ -1,25 +1,22 @@
-spec_version: v1.4
 identifier: SystemHeat-Converters
 name: System Heat - Resource Converter Configuration
-"$kref": "#/ckan/github/KSPModStewards/SystemHeat"
-"$vref": "#/ckan/ksp-avc/SystemHeat.version"
-abstract: 'This System Heat config package changes stock and mod Resource Converters
-  to use the System Heat backend. WARNING: potentially vessel-breaking.'
+abstract: >-
+  This System Heat config package changes stock and mod Resource Converters
+  to use the System Heat backend. WARNING: potentially vessel-breaking.
 author: Nertea (Chris Adderley)
+$kref: '#/ckan/github/KSPModStewards/SystemHeat'
+$vref: '#/ckan/ksp-avc/SystemHeat.version'
 license: CC-BY-NC-SA-4.0
 tags:
-- parts
-- plugin
-resources:
-  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/193909-1
-  repository: https://github.com/KSPModStewards/SystemHeat
+  - parts
+  - plugin
 depends:
-- name: ModuleManager
-- name: SystemHeat
+  - name: ModuleManager
+  - name: SystemHeat
 suggests:
-- name: SystemHeat-FissionReactors
-- name: SystemHeat-FissionEngines
-- name: SystemHeat-Harvesters
+  - name: SystemHeat-FissionReactors
+  - name: SystemHeat-FissionEngines
+  - name: SystemHeat-Harvesters
 install:
-- find: SystemHeatConverters
-  install_to: GameData
+  - find: SystemHeatConverters
+    install_to: GameData

--- a/NetKAN/SystemHeat-Converters.netkan
+++ b/NetKAN/SystemHeat-Converters.netkan
@@ -1,9 +1,25 @@
-{
-    "identifier"     : "SystemHeat-Converters",
-    "$kref"         : "#/ckan/netkan/https://github.com/post-kerbin-mining-corporation/SystemHeat/raw/master/CKAN/SystemHeat-Converters.netkan",
-    "tags": [
-        "parts",
-        "plugin"
-    ]
-}
-
+spec_version: v1.4
+identifier: SystemHeat-Converters
+name: System Heat - Resource Converter Configuration
+"$kref": "#/ckan/github/KSPModStewards/SystemHeat"
+"$vref": "#/ckan/ksp-avc/SystemHeat.version"
+abstract: 'This System Heat config package changes stock and mod Resource Converters
+  to use the System Heat backend. WARNING: potentially vessel-breaking.'
+author: Nertea (Chris Adderley)
+license: CC-BY-NC-SA-4.0
+tags:
+- parts
+- plugin
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/193909-1
+  repository: https://github.com/KSPModStewards/SystemHeat
+depends:
+- name: ModuleManager
+- name: SystemHeat
+suggests:
+- name: SystemHeat-FissionReactors
+- name: SystemHeat-FissionEngines
+- name: SystemHeat-Harvesters
+install:
+- find: SystemHeatConverters
+  install_to: GameData

--- a/NetKAN/SystemHeat-Converters.netkan
+++ b/NetKAN/SystemHeat-Converters.netkan
@@ -6,7 +6,7 @@ abstract: >-
 author: Nertea (Chris Adderley)
 $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'
-license: CC-BY-NC-SA-4.0
+license: restricted
 tags:
   - parts
   - plugin

--- a/NetKAN/SystemHeat-Converters.netkan
+++ b/NetKAN/SystemHeat-Converters.netkan
@@ -8,8 +8,7 @@ $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'
 license: MIT
 tags:
-  - parts
-  - plugin
+  - config
 depends:
   - name: ModuleManager
   - name: SystemHeat

--- a/NetKAN/SystemHeat-CryoTanks.netkan
+++ b/NetKAN/SystemHeat-CryoTanks.netkan
@@ -2,7 +2,7 @@ spec_version: v1.4
 identifier: SystemHeat-CryoTanks
 name: System Heat - Cryo Tanks Configuration
 "$kref": "#/ckan/github/KSPModStewards/SystemHeat"
-"$vref": "#/ckan/ksp-avc"
+"$vref": "#/ckan/ksp-avc/SystemHeat.version"
 abstract: 'This System Heat config package changes zero boiloff cryogenic tanks to
   need cooling instead of power. WARNING: potentially vessel-breaking.'
 author: Nertea (Chris Adderley)

--- a/NetKAN/SystemHeat-CryoTanks.netkan
+++ b/NetKAN/SystemHeat-CryoTanks.netkan
@@ -6,7 +6,7 @@ abstract: >-
 author: Nertea (Chris Adderley)
 $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'
-license: restricted
+license: MIT
 tags:
   - parts
   - config

--- a/NetKAN/SystemHeat-CryoTanks.netkan
+++ b/NetKAN/SystemHeat-CryoTanks.netkan
@@ -1,0 +1,27 @@
+spec_version: v1.4
+identifier: SystemHeat-CryoTanks
+name: System Heat - Cryo Tanks Configuration
+"$kref": "#/ckan/github/KSPModStewards/SystemHeat"
+"$vref": "#/ckan/ksp-avc"
+abstract: 'This System Heat config package changes zero boiloff cryogenic tanks to
+  need cooling instead of power. WARNING: potentially vessel-breaking.'
+author: Nertea (Chris Adderley)
+license: CC-BY-NC-SA-4.0
+tags:
+- parts
+- config
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/193909-1
+  repository: https://github.com/KSPModStewards/SystemHeat
+depends:
+- name: ModuleManager
+- name: SystemHeat
+- name: CommunityResourcePack
+suggests:
+- name: SystemHeat-Converters
+- name: SystemHeat-FissionReactors
+- name: SystemHeat-Harvesters
+- name: NearFuturePropulsion
+install:
+- find: SystemHeatBoiloff
+  install_to: GameData

--- a/NetKAN/SystemHeat-CryoTanks.netkan
+++ b/NetKAN/SystemHeat-CryoTanks.netkan
@@ -1,27 +1,24 @@
-spec_version: v1.4
 identifier: SystemHeat-CryoTanks
 name: System Heat - Cryo Tanks Configuration
-"$kref": "#/ckan/github/KSPModStewards/SystemHeat"
-"$vref": "#/ckan/ksp-avc/SystemHeat.version"
-abstract: 'This System Heat config package changes zero boiloff cryogenic tanks to
-  need cooling instead of power. WARNING: potentially vessel-breaking.'
+abstract: >-
+  This System Heat config package changes zero boiloff cryogenic tanks to
+  need cooling instead of power. WARNING: potentially vessel-breaking.
 author: Nertea (Chris Adderley)
+$kref: '#/ckan/github/KSPModStewards/SystemHeat'
+$vref: '#/ckan/ksp-avc/SystemHeat.version'
 license: CC-BY-NC-SA-4.0
 tags:
-- parts
-- config
-resources:
-  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/193909-1
-  repository: https://github.com/KSPModStewards/SystemHeat
+  - parts
+  - config
 depends:
-- name: ModuleManager
-- name: SystemHeat
-- name: CommunityResourcePack
+  - name: ModuleManager
+  - name: SystemHeat
+  - name: CommunityResourcePack
 suggests:
-- name: SystemHeat-Converters
-- name: SystemHeat-FissionReactors
-- name: SystemHeat-Harvesters
-- name: NearFuturePropulsion
+  - name: SystemHeat-Converters
+  - name: SystemHeat-FissionReactors
+  - name: SystemHeat-Harvesters
+  - name: NearFuturePropulsion
 install:
-- find: SystemHeatBoiloff
-  install_to: GameData
+  - find: SystemHeatBoiloff
+    install_to: GameData

--- a/NetKAN/SystemHeat-CryoTanks.netkan
+++ b/NetKAN/SystemHeat-CryoTanks.netkan
@@ -8,7 +8,6 @@ $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'
 license: MIT
 tags:
-  - parts
   - config
 depends:
   - name: ModuleManager

--- a/NetKAN/SystemHeat-CryoTanks.netkan
+++ b/NetKAN/SystemHeat-CryoTanks.netkan
@@ -6,7 +6,7 @@ abstract: >-
 author: Nertea (Chris Adderley)
 $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'
-license: CC-BY-NC-SA-4.0
+license: restricted
 tags:
   - parts
   - config

--- a/NetKAN/SystemHeat-FissionEngines.netkan
+++ b/NetKAN/SystemHeat-FissionEngines.netkan
@@ -6,7 +6,7 @@ abstract: >-
 author: Nertea (Chris Adderley)
 $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'
-license: restricted
+license: MIT
 tags:
   - parts
   - config

--- a/NetKAN/SystemHeat-FissionEngines.netkan
+++ b/NetKAN/SystemHeat-FissionEngines.netkan
@@ -8,7 +8,6 @@ $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'
 license: MIT
 tags:
-  - parts
   - config
 depends:
   - name: ModuleManager

--- a/NetKAN/SystemHeat-FissionEngines.netkan
+++ b/NetKAN/SystemHeat-FissionEngines.netkan
@@ -1,8 +1,29 @@
-{
-    "identifier"     : "SystemHeat-FissionEngines",
-    "$kref"         : "#/ckan/netkan/https://github.com/post-kerbin-mining-corporation/SystemHeat/raw/master/CKAN/SystemHeat-FissionEngines.netkan",
-    "tags": [
-        "parts",
-        "plugin"
-    ]
-}
+spec_version: v1.4
+identifier: SystemHeat-FissionEngines
+name: System Heat - Nuclear Engine Configuration
+"$kref": "#/ckan/github/KSPModStewards/SystemHeat"
+"$vref": "#/ckan/ksp-avc/SystemHeat.version"
+abstract: 'This System Heat config package changes nuclear thermal engines to use
+  the System Heat backend. WARNING: potentially vessel-breaking.'
+author: Nertea (Chris Adderley)
+license: CC-BY-NC-SA-4.0
+tags:
+- parts
+- config
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/193909-1
+  repository: https://github.com/KSPModStewards/SystemHeat
+depends:
+- name: ModuleManager
+- name: SystemHeat
+- name: CommunityResourcePack
+suggests:
+- name: SystemHeat-Converters
+- name: SystemHeat-FissionReactors
+- name: SystemHeat-Harvesters
+- name: KerbalAtomics
+conflicts:
+- name: KerbalAtomics-NFECompatibility
+install:
+- find: SystemHeatFissionEngines
+  install_to: GameData

--- a/NetKAN/SystemHeat-FissionEngines.netkan
+++ b/NetKAN/SystemHeat-FissionEngines.netkan
@@ -6,7 +6,7 @@ abstract: >-
 author: Nertea (Chris Adderley)
 $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'
-license: CC-BY-NC-SA-4.0
+license: restricted
 tags:
   - parts
   - config

--- a/NetKAN/SystemHeat-FissionEngines.netkan
+++ b/NetKAN/SystemHeat-FissionEngines.netkan
@@ -1,29 +1,26 @@
-spec_version: v1.4
 identifier: SystemHeat-FissionEngines
 name: System Heat - Nuclear Engine Configuration
-"$kref": "#/ckan/github/KSPModStewards/SystemHeat"
-"$vref": "#/ckan/ksp-avc/SystemHeat.version"
-abstract: 'This System Heat config package changes nuclear thermal engines to use
-  the System Heat backend. WARNING: potentially vessel-breaking.'
+abstract: >-
+  This System Heat config package changes nuclear thermal engines to use
+  the System Heat backend. WARNING: potentially vessel-breaking.
 author: Nertea (Chris Adderley)
+$kref: '#/ckan/github/KSPModStewards/SystemHeat'
+$vref: '#/ckan/ksp-avc/SystemHeat.version'
 license: CC-BY-NC-SA-4.0
 tags:
-- parts
-- config
-resources:
-  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/193909-1
-  repository: https://github.com/KSPModStewards/SystemHeat
+  - parts
+  - config
 depends:
-- name: ModuleManager
-- name: SystemHeat
-- name: CommunityResourcePack
+  - name: ModuleManager
+  - name: SystemHeat
+  - name: CommunityResourcePack
 suggests:
-- name: SystemHeat-Converters
-- name: SystemHeat-FissionReactors
-- name: SystemHeat-Harvesters
-- name: KerbalAtomics
+  - name: SystemHeat-Converters
+  - name: SystemHeat-FissionReactors
+  - name: SystemHeat-Harvesters
+  - name: KerbalAtomics
 conflicts:
-- name: KerbalAtomics-NFECompatibility
+  - name: KerbalAtomics-NFECompatibility
 install:
-- find: SystemHeatFissionEngines
-  install_to: GameData
+  - find: SystemHeatFissionEngines
+    install_to: GameData

--- a/NetKAN/SystemHeat-FissionReactors.netkan
+++ b/NetKAN/SystemHeat-FissionReactors.netkan
@@ -10,7 +10,6 @@ $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'
 license: MIT
 tags:
-  - parts
   - config
 depends:
   - name: ModuleManager

--- a/NetKAN/SystemHeat-FissionReactors.netkan
+++ b/NetKAN/SystemHeat-FissionReactors.netkan
@@ -1,8 +1,29 @@
-{
-    "identifier"     : "SystemHeat-FissionReactors",
-    "$kref"         : "#/ckan/netkan/https://github.com/post-kerbin-mining-corporation/SystemHeat/raw/master/CKAN/SystemHeat-FissionReactors.netkan",
-    "tags": [
-        "parts",
-        "plugin"
-    ]
-}
+spec_version: v1.4
+identifier: SystemHeat-FissionReactors
+name: System Heat - Nuclear Reactor Configuration
+"$kref": "#/ckan/github/KSPModStewards/SystemHeat"
+"$vref": "#/ckan/ksp-avc/SystemHeat.version"
+abstract: 'This System Heat configuration pack modifies nuclear reactors to use the
+  SystemHeat backend. This principally applies to Near Future Electrical reactors.
+  WARNING: potentially vessel-breaking.'
+author: Nertea (Chris Adderley)
+license: CC-BY-NC-SA-4.0
+tags:
+- parts
+- config
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/193909-1
+  repository: https://github.com/KSPModStewards/SystemHeat
+depends:
+- name: ModuleManager
+- name: SystemHeat
+- name: CommunityResourcePack
+recommends:
+- name: NearFutureElectrical
+suggests:
+- name: SystemHeat-Converters
+- name: SystemHeat-FissionEngines
+- name: SystemHeat-Harvesters
+install:
+- find: SystemHeatFissionReactors
+  install_to: GameData

--- a/NetKAN/SystemHeat-FissionReactors.netkan
+++ b/NetKAN/SystemHeat-FissionReactors.netkan
@@ -8,7 +8,7 @@ abstract: >-
 author: Nertea (Chris Adderley)
 $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'
-license: CC-BY-NC-SA-4.0
+license: restricted
 tags:
   - parts
   - config

--- a/NetKAN/SystemHeat-FissionReactors.netkan
+++ b/NetKAN/SystemHeat-FissionReactors.netkan
@@ -1,29 +1,26 @@
-spec_version: v1.4
 identifier: SystemHeat-FissionReactors
 name: System Heat - Nuclear Reactor Configuration
-"$kref": "#/ckan/github/KSPModStewards/SystemHeat"
-"$vref": "#/ckan/ksp-avc/SystemHeat.version"
-abstract: 'This System Heat configuration pack modifies nuclear reactors to use the
+abstract: >-
+  This System Heat configuration pack modifies nuclear reactors to use the
   SystemHeat backend. This principally applies to Near Future Electrical reactors.
-  WARNING: potentially vessel-breaking.'
+  WARNING: potentially vessel-breaking.
 author: Nertea (Chris Adderley)
+$kref: '#/ckan/github/KSPModStewards/SystemHeat'
+$vref: '#/ckan/ksp-avc/SystemHeat.version'
 license: CC-BY-NC-SA-4.0
 tags:
-- parts
-- config
-resources:
-  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/193909-1
-  repository: https://github.com/KSPModStewards/SystemHeat
+  - parts
+  - config
 depends:
-- name: ModuleManager
-- name: SystemHeat
-- name: CommunityResourcePack
+  - name: ModuleManager
+  - name: SystemHeat
+  - name: CommunityResourcePack
 recommends:
-- name: NearFutureElectrical
+  - name: NearFutureElectrical
 suggests:
-- name: SystemHeat-Converters
-- name: SystemHeat-FissionEngines
-- name: SystemHeat-Harvesters
+  - name: SystemHeat-Converters
+  - name: SystemHeat-FissionEngines
+  - name: SystemHeat-Harvesters
 install:
-- find: SystemHeatFissionReactors
-  install_to: GameData
+  - find: SystemHeatFissionReactors
+    install_to: GameData

--- a/NetKAN/SystemHeat-FissionReactors.netkan
+++ b/NetKAN/SystemHeat-FissionReactors.netkan
@@ -2,7 +2,8 @@ identifier: SystemHeat-FissionReactors
 name: System Heat - Nuclear Reactor Configuration
 abstract: >-
   This System Heat configuration pack modifies nuclear reactors to use the
-  SystemHeat backend. This principally applies to Near Future Electrical reactors.
+  SystemHeat backend. This principally applies to Near Future Electrical
+  reactors.
   WARNING: potentially vessel-breaking.
 author: Nertea (Chris Adderley)
 $kref: '#/ckan/github/KSPModStewards/SystemHeat'

--- a/NetKAN/SystemHeat-FissionReactors.netkan
+++ b/NetKAN/SystemHeat-FissionReactors.netkan
@@ -8,7 +8,7 @@ abstract: >-
 author: Nertea (Chris Adderley)
 $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'
-license: restricted
+license: MIT
 tags:
   - parts
   - config

--- a/NetKAN/SystemHeat-Harvesters.netkan
+++ b/NetKAN/SystemHeat-Harvesters.netkan
@@ -1,8 +1,25 @@
-{
-    "identifier"     : "SystemHeat-Harvesters",
-    "$kref"         : "#/ckan/netkan/https://github.com/post-kerbin-mining-corporation/SystemHeat/raw/master/CKAN/SystemHeat-Harvesters.netkan",
-    "tags": [
-        "parts",
-        "plugin"
-    ]
-}
+spec_version: v1.4
+identifier: SystemHeat-Harvesters
+name: System Heat - Resource Harvester Configuration
+"$kref": "#/ckan/github/KSPModStewards/SystemHeat"
+"$vref": "#/ckan/ksp-avc/SystemHeat.version"
+abstract: 'This System Heat config package changes stock and mod Resource Harvesters
+  to use the SystemHeat backend. WARNING: potentially vessel-breaking.'
+author: Nertea (Chris Adderley)
+license: CC-BY-NC-SA-4.0
+tags:
+- parts
+- config
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/193909-1
+  repository: https://github.com/KSPModStewards/SystemHeat
+depends:
+- name: ModuleManager
+- name: SystemHeat
+suggests:
+- name: SystemHeat-Converters
+- name: SystemHeat-FissionReactors
+- name: SystemHeat-FissionEngines
+install:
+- find: SystemHeatHarvesters
+  install_to: GameData

--- a/NetKAN/SystemHeat-Harvesters.netkan
+++ b/NetKAN/SystemHeat-Harvesters.netkan
@@ -6,7 +6,7 @@ abstract: >-
 author: Nertea (Chris Adderley)
 $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'
-license: restricted
+license: MIT
 tags:
   - parts
   - config

--- a/NetKAN/SystemHeat-Harvesters.netkan
+++ b/NetKAN/SystemHeat-Harvesters.netkan
@@ -8,7 +8,6 @@ $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'
 license: MIT
 tags:
-  - parts
   - config
 depends:
   - name: ModuleManager

--- a/NetKAN/SystemHeat-Harvesters.netkan
+++ b/NetKAN/SystemHeat-Harvesters.netkan
@@ -6,7 +6,7 @@ abstract: >-
 author: Nertea (Chris Adderley)
 $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'
-license: CC-BY-NC-SA-4.0
+license: restricted
 tags:
   - parts
   - config

--- a/NetKAN/SystemHeat-Harvesters.netkan
+++ b/NetKAN/SystemHeat-Harvesters.netkan
@@ -1,25 +1,22 @@
-spec_version: v1.4
 identifier: SystemHeat-Harvesters
 name: System Heat - Resource Harvester Configuration
-"$kref": "#/ckan/github/KSPModStewards/SystemHeat"
-"$vref": "#/ckan/ksp-avc/SystemHeat.version"
-abstract: 'This System Heat config package changes stock and mod Resource Harvesters
-  to use the SystemHeat backend. WARNING: potentially vessel-breaking.'
+abstract: >-
+  This System Heat config package changes stock and mod Resource Harvesters
+  to use the SystemHeat backend. WARNING: potentially vessel-breaking.
 author: Nertea (Chris Adderley)
+$kref: '#/ckan/github/KSPModStewards/SystemHeat'
+$vref: '#/ckan/ksp-avc/SystemHeat.version'
 license: CC-BY-NC-SA-4.0
 tags:
-- parts
-- config
-resources:
-  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/193909-1
-  repository: https://github.com/KSPModStewards/SystemHeat
+  - parts
+  - config
 depends:
-- name: ModuleManager
-- name: SystemHeat
+  - name: ModuleManager
+  - name: SystemHeat
 suggests:
-- name: SystemHeat-Converters
-- name: SystemHeat-FissionReactors
-- name: SystemHeat-FissionEngines
+  - name: SystemHeat-Converters
+  - name: SystemHeat-FissionReactors
+  - name: SystemHeat-FissionEngines
 install:
-- find: SystemHeatHarvesters
-  install_to: GameData
+  - find: SystemHeatHarvesters
+    install_to: GameData

--- a/NetKAN/SystemHeat-Harvesters.netkan
+++ b/NetKAN/SystemHeat-Harvesters.netkan
@@ -2,7 +2,7 @@ identifier: SystemHeat-Harvesters
 name: System Heat - Resource Harvester Configuration
 abstract: >-
   This System Heat config package changes stock and mod Resource Harvesters
-  to use the SystemHeat backend. WARNING: potentially vessel-breaking.
+  to use the System Heat backend. WARNING: potentially vessel-breaking.
 author: Nertea (Chris Adderley)
 $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'

--- a/NetKAN/SystemHeat-IonEngines.netkan
+++ b/NetKAN/SystemHeat-IonEngines.netkan
@@ -6,7 +6,7 @@ abstract: >-
 author: Nertea (Chris Adderley)
 $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'
-license: restricted
+license: MIT
 tags:
   - parts
   - config

--- a/NetKAN/SystemHeat-IonEngines.netkan
+++ b/NetKAN/SystemHeat-IonEngines.netkan
@@ -2,7 +2,7 @@ spec_version: v1.4
 identifier: SystemHeat-IonEngines
 name: System Heat - Electric Engine Configuration
 "$kref": "#/ckan/github/KSPModStewards/SystemHeat"
-"$vref": "#/ckan/ksp-avc"
+"$vref": "#/ckan/ksp-avc/SystemHeat.version"
 abstract: 'This System Heat config package changes ion engines to require some level
   of cooling. WARNING: potentially vessel-breaking.'
 author: Nertea (Chris Adderley)

--- a/NetKAN/SystemHeat-IonEngines.netkan
+++ b/NetKAN/SystemHeat-IonEngines.netkan
@@ -8,7 +8,6 @@ $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'
 license: MIT
 tags:
-  - parts
   - config
 depends:
   - name: ModuleManager

--- a/NetKAN/SystemHeat-IonEngines.netkan
+++ b/NetKAN/SystemHeat-IonEngines.netkan
@@ -6,7 +6,7 @@ abstract: >-
 author: Nertea (Chris Adderley)
 $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'
-license: CC-BY-NC-SA-4.0
+license: restricted
 tags:
   - parts
   - config

--- a/NetKAN/SystemHeat-IonEngines.netkan
+++ b/NetKAN/SystemHeat-IonEngines.netkan
@@ -1,27 +1,24 @@
-spec_version: v1.4
 identifier: SystemHeat-IonEngines
 name: System Heat - Electric Engine Configuration
-"$kref": "#/ckan/github/KSPModStewards/SystemHeat"
-"$vref": "#/ckan/ksp-avc/SystemHeat.version"
-abstract: 'This System Heat config package changes ion engines to require some level
-  of cooling. WARNING: potentially vessel-breaking.'
+abstract: >-
+  This System Heat config package changes ion engines to require some level
+  of cooling. WARNING: potentially vessel-breaking.
 author: Nertea (Chris Adderley)
+$kref: '#/ckan/github/KSPModStewards/SystemHeat'
+$vref: '#/ckan/ksp-avc/SystemHeat.version'
 license: CC-BY-NC-SA-4.0
 tags:
-- parts
-- config
-resources:
-  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/193909-1
-  repository: https://github.com/KSPModStewards/SystemHeat
+  - parts
+  - config
 depends:
-- name: ModuleManager
-- name: SystemHeat
-- name: CommunityResourcePack
+  - name: ModuleManager
+  - name: SystemHeat
+  - name: CommunityResourcePack
 suggests:
-- name: SystemHeat-Converters
-- name: SystemHeat-FissionReactors
-- name: SystemHeat-Harvesters
-- name: NearFuturePropulsion
+  - name: SystemHeat-Converters
+  - name: SystemHeat-FissionReactors
+  - name: SystemHeat-Harvesters
+  - name: NearFuturePropulsion
 install:
-- find: SystemHeatIonEngines
-  install_to: GameData
+  - find: SystemHeatIonEngines
+    install_to: GameData

--- a/NetKAN/SystemHeat-IonEngines.netkan
+++ b/NetKAN/SystemHeat-IonEngines.netkan
@@ -1,0 +1,27 @@
+spec_version: v1.4
+identifier: SystemHeat-IonEngines
+name: System Heat - Electric Engine Configuration
+"$kref": "#/ckan/github/KSPModStewards/SystemHeat"
+"$vref": "#/ckan/ksp-avc"
+abstract: 'This System Heat config package changes ion engines to require some level
+  of cooling. WARNING: potentially vessel-breaking.'
+author: Nertea (Chris Adderley)
+license: CC-BY-NC-SA-4.0
+tags:
+- parts
+- config
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/193909-1
+  repository: https://github.com/KSPModStewards/SystemHeat
+depends:
+- name: ModuleManager
+- name: SystemHeat
+- name: CommunityResourcePack
+suggests:
+- name: SystemHeat-Converters
+- name: SystemHeat-FissionReactors
+- name: SystemHeat-Harvesters
+- name: NearFuturePropulsion
+install:
+- find: SystemHeatIonEngines
+  install_to: GameData

--- a/NetKAN/SystemHeat.netkan
+++ b/NetKAN/SystemHeat.netkan
@@ -9,6 +9,9 @@ abstract: System Heat revamps the Core Heat system used in stock KSP to drive dr
   and the like to use Systemheat
 author: Nertea (Chris Adderley)
 license: CC-BY-NC-SA-4.0
+tags:
+- parts
+- plugin
 resources:
   homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/193909-1
   repository: https://github.com/KSPModStewards/SystemHeat

--- a/NetKAN/SystemHeat.netkan
+++ b/NetKAN/SystemHeat.netkan
@@ -24,6 +24,8 @@ suggests:
 - name: SystemHeat-FissionReactors
 - name: SystemHeat-FissionEngines
 - name: SystemHeat-Harvesters
+- name: SystemHeat-IonEngines
+- name: SystemHeat-CryoTanks
 install:
 - find: SystemHeat
   install_to: GameData

--- a/NetKAN/SystemHeat.netkan
+++ b/NetKAN/SystemHeat.netkan
@@ -2,9 +2,9 @@ identifier: SystemHeat
 name: System Heat
 abstract: >-
   System Heat revamps the Core Heat system used in stock KSP to drive drills
-  and harvesters with a new, more powerful system. This core package does not make
-  changes to the base game - install other SystemHeat packs to change drills, converters
-  and the like to use SystemHeat
+  and harvesters with a new, more powerful system. This core package does not
+  make changes to the base game - install other SystemHeat packs to change
+  drills, converters and the like to use System Heat
 author: Nertea (Chris Adderley)
 $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'

--- a/NetKAN/SystemHeat.netkan
+++ b/NetKAN/SystemHeat.netkan
@@ -8,7 +8,7 @@ abstract: >-
 author: Nertea (Chris Adderley)
 $kref: '#/ckan/github/KSPModStewards/SystemHeat'
 $vref: '#/ckan/ksp-avc/SystemHeat.version'
-license: CC-BY-NC-SA-4.0
+license: restricted
 tags:
   - parts
   - plugin

--- a/NetKAN/SystemHeat.netkan
+++ b/NetKAN/SystemHeat.netkan
@@ -1,8 +1,26 @@
-{
-    "identifier"     : "SystemHeat",
-    "$kref"         : "#/ckan/netkan/https://github.com/post-kerbin-mining-corporation/SystemHeat/raw/master/CKAN/SystemHeat.netkan",
-    "tags": [
-        "parts",
-        "plugin"
-    ]
-}
+spec_version: v1.4
+identifier: SystemHeat
+name: System Heat
+"$kref": "#/ckan/github/KSPModStewards/SystemHeat"
+"$vref": "#/ckan/ksp-avc"
+abstract: System Heat revamps the Core Heat system used in stock KSP to drive drills
+  and harvesters with a new, more powerful system. This core package does not make
+  changes to the base game - install other SystemHeat packs to change drills, converters
+  and the like to use Systemheat
+author: Nertea (Chris Adderley)
+license: CC-BY-NC-SA-4.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/193909-1
+  repository: https://github.com/KSPModStewards/SystemHeat
+depends:
+- name: ModuleManager
+recommends:
+- name: HeatControl
+suggests:
+- name: SystemHeat-Converters
+- name: SystemHeat-FissionReactors
+- name: SystemHeat-FissionEngines
+- name: SystemHeat-Harvesters
+install:
+- find: SystemHeat
+  install_to: GameData

--- a/NetKAN/SystemHeat.netkan
+++ b/NetKAN/SystemHeat.netkan
@@ -1,31 +1,28 @@
-spec_version: v1.4
 identifier: SystemHeat
 name: System Heat
-"$kref": "#/ckan/github/KSPModStewards/SystemHeat"
-"$vref": "#/ckan/ksp-avc"
-abstract: System Heat revamps the Core Heat system used in stock KSP to drive drills
+abstract: >-
+  System Heat revamps the Core Heat system used in stock KSP to drive drills
   and harvesters with a new, more powerful system. This core package does not make
   changes to the base game - install other SystemHeat packs to change drills, converters
-  and the like to use Systemheat
+  and the like to use SystemHeat
 author: Nertea (Chris Adderley)
+$kref: '#/ckan/github/KSPModStewards/SystemHeat'
+$vref: '#/ckan/ksp-avc/SystemHeat.version'
 license: CC-BY-NC-SA-4.0
 tags:
-- parts
-- plugin
-resources:
-  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/193909-1
-  repository: https://github.com/KSPModStewards/SystemHeat
+  - parts
+  - plugin
 depends:
-- name: ModuleManager
+  - name: ModuleManager
 recommends:
-- name: HeatControl
+  - name: HeatControl
 suggests:
-- name: SystemHeat-Converters
-- name: SystemHeat-FissionReactors
-- name: SystemHeat-FissionEngines
-- name: SystemHeat-Harvesters
-- name: SystemHeat-IonEngines
-- name: SystemHeat-CryoTanks
+  - name: SystemHeat-Converters
+  - name: SystemHeat-FissionReactors
+  - name: SystemHeat-FissionEngines
+  - name: SystemHeat-Harvesters
+  - name: SystemHeat-IonEngines
+  - name: SystemHeat-CryoTanks
 install:
-- find: SystemHeat
-  install_to: GameData
+  - find: SystemHeat
+    install_to: GameData


### PR DESCRIPTION
eventually we will switch this mod to use embedded .ckan files, and then we can remove any redundant info from here.

Note this also adds SystemHeat-IonEngines and SystemHeat-CryoTanks which were previously missing

- <https://github.com/KSPModStewards/SystemHeat>
- <https://forum.kerbalspaceprogram.com/topic/193909-112x-systemheat-a-replacement-for-the-coreheat-system-july-21/>
