### PR TITLE
Update Panocean canal to be compatible with Kerbinside (Original, not Remastered)

### DIFF
--- a/NetKAN/PanoceanCanal.netkan
+++ b/NetKAN/PanoceanCanal.netkan
@@ -4,8 +4,6 @@ license: MIT
 tags:
   - config
   - buildings
-conflicts:
-  - name: KerbinSide
 depends:
   - name: KerbalKonstructs
   - name: KerbinSideCore


### PR DESCRIPTION
The original Kerbinside mod doesn't actually conflict with this mod, Caerfinon just wanted to make sure people didn't install the old version. But if you do want to use the old Kerbinside, CKAN won't let you install Panocean.

None of the KK statics added by this mod conflict with anything modified by KS (the nearest base is hundreds of kms away from the canal, actually)

I actually brought this up last year (https://forum.kerbalspaceprogram.com/topic/204511-1125the-panocean-canal-v1022025-06-01/page/2/) but never got around to making a PR.

Although if @caerfinon wishes, I can close this PR if he isn't ok with the change being made