### PR TITLE
Remove broken Kethane recommendation from ExtraPlanetaryLaunchpads

### DIFF
--- a/NetKAN/ExtraPlanetaryLaunchpads.netkan
+++ b/NetKAN/ExtraPlanetaryLaunchpads.netkan
@@ -15,7 +15,6 @@ recommends:
   - name: KAS
   - name: InfernalRobotics
   - name: KerbalStats
-  - name: Kethane
   - name: Toolbar
 install:
   - file: ExtraplanetaryLaunchpads


### PR DESCRIPTION
A user reported Kethane's corrupted download while trying to install this modpack:

- <https://github.com/KSPModStewards/Community-Lifeboat-Project/>

That modpack includes ExtraplanetaryLaunchpads, which recommends Kethane, so that's most likely how people are encountering this. Kethane cannot be downloaded due to a combination of licensing (not mirrorable) and degraded hosting (taniwha.org provides corrupted files). This means anybody attempting to install that modpack is likely to run into this issue.

Now the recommendation is removed, so ExtraplanetaryLaunchpads users do not need to uncheck Kethane to install.
