### PR TITLE
Add Archipelago

### DIFF
--- a/NetKAN/Archipelago.netkan
+++ b/NetKAN/Archipelago.netkan
@@ -1,0 +1,33 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "Archipelago",
+    "name": "KSP Archipelago Randomizer",
+    "abstract": "Client side mod for running Archipelago (archipelago.gg). See https://github.com/nickdavies/Archipelago/releases for the server side",
+    "author": "Nick Davies",
+    "license": "MIT",
+    "$kref": "#/ckan/github/nickdavies/KSP1-Archipelago-client",
+    "ksp_version_min": "1.12.0",
+    "ksp_version_max": "1.12.99",
+    "resources": {
+        "homepage": "https://github.com/nickdavies/KSP1-Archipelago-client",
+        "repository": "https://github.com/nickdavies/KSP1-Archipelago-client",
+        "bugtracker": "https://github.com/nickdavies/Archipelago/issues"
+    },
+    "tags": [
+        "plugin"
+    ],
+    "install": [
+        {
+            "find": "KSPArchipelago",
+            "install_to": "GameData"
+        }
+    ],
+    "x_netkan_version_edit": {
+        "find": "v(?<version>.+)",
+        "replace": "${version}",
+        "strict": true
+    },
+    "x_netkan_github": {
+        "prereleases": false
+    }
+}

--- a/NetKAN/Archipelago.netkan
+++ b/NetKAN/Archipelago.netkan
@@ -1,33 +1,20 @@
-{
-    "spec_version": "v1.4",
-    "identifier": "Archipelago",
-    "name": "KSP Archipelago Randomizer",
-    "abstract": "Client side mod for running Archipelago (archipelago.gg). See https://github.com/nickdavies/Archipelago/releases for the server side",
-    "author": "Nick Davies",
-    "license": "MIT",
-    "$kref": "#/ckan/github/nickdavies/KSP1-Archipelago-client",
-    "ksp_version_min": "1.12.0",
-    "ksp_version_max": "1.12.99",
-    "resources": {
-        "homepage": "https://github.com/nickdavies/KSP1-Archipelago-client",
-        "repository": "https://github.com/nickdavies/KSP1-Archipelago-client",
-        "bugtracker": "https://github.com/nickdavies/Archipelago/issues"
-    },
-    "tags": [
-        "plugin"
-    ],
-    "install": [
-        {
-            "find": "KSPArchipelago",
-            "install_to": "GameData"
-        }
-    ],
-    "x_netkan_version_edit": {
-        "find": "v(?<version>.+)",
-        "replace": "${version}",
-        "strict": true
-    },
-    "x_netkan_github": {
-        "prereleases": false
-    }
-}
+identifier: Archipelago
+name: KSP Archipelago Randomizer
+abstract: >-
+  Client side mod for running Archipelago (archipelago.gg). See
+  https://github.com/nickdavies/Archipelago/releases for the server side
+author: Nick Davies
+$kref: '#/ckan/github/nickdavies/KSP1-Archipelago-client'
+x_netkan_github:
+  prereleases: false
+x_netkan_version_edit:
+  find: v(?<version>.+)
+  replace: ${version}
+  strict: true
+ksp_version_min: 1.12.0
+ksp_version_max: 1.12.99
+tags:
+  - plugin
+install:
+  - find: KSPArchipelago
+    install_to: GameData

--- a/NetKAN/Archipelago.netkan
+++ b/NetKAN/Archipelago.netkan
@@ -11,6 +11,3 @@ x_netkan_github:
 ksp_version: 1.12
 tags:
   - plugin
-install:
-  - find: KSPArchipelago
-    install_to: GameData

--- a/NetKAN/Archipelago.netkan
+++ b/NetKAN/Archipelago.netkan
@@ -5,14 +5,10 @@ abstract: >-
   https://github.com/nickdavies/Archipelago/releases for the server side
 author: Nick Davies
 $kref: '#/ckan/github/nickdavies/KSP1-Archipelago-client'
+x_netkan_version_edit: ^v?(?<version>.*)$
 x_netkan_github:
   prereleases: false
-x_netkan_version_edit:
-  find: v(?<version>.+)
-  replace: ${version}
-  strict: true
-ksp_version_min: 1.12.0
-ksp_version_max: 1.12.99
+ksp_version: 1.12
 tags:
   - plugin
 install:

--- a/NetKAN/Archipelago.netkan
+++ b/NetKAN/Archipelago.netkan
@@ -1,8 +1,17 @@
 identifier: KSPArchipelago
 name: KSP Archipelago Randomizer
 abstract: >-
-  Client side mod for running Archipelago (archipelago.gg). See
-  https://github.com/nickdavies/Archipelago/releases for the server side
+  Archipelago allows you to play a solo or cooperative randomized version of one or more supported games.
+
+  With Archipelago for KSP you start with a small selection of random parts and must performing missions to unlock additional parts
+  to get closer to your goal. Any time you achieve something for the first time such as orbiting a planet, taking a surface sample, planting a flag etc
+  you will unlock new parts for yourself or other players in their games.
+
+  Goals are selected by the player when they generate a new game and things like flying to duna and back, planting a flag on all bodies,
+  returning a surface sample from every body are default goals players can chose from.
+
+  For more information on Archipelago in general see (https://archipelago.gg/faq/en/) and for more details on hosting your own game
+  see https://github.com/nickdavies/Archipelago/blob/ksp1/worlds/ksp1/docs/setup_en.md for the server side setup
 author: Nick Davies
 $kref: '#/ckan/github/nickdavies/KSP1-Archipelago-client'
 x_netkan_version_edit: ^v?(?<version>.*)$

--- a/NetKAN/Archipelago.netkan
+++ b/NetKAN/Archipelago.netkan
@@ -1,4 +1,4 @@
-identifier: Archipelago
+identifier: KSPArchipelago
 name: KSP Archipelago Randomizer
 abstract: >-
   Client side mod for running Archipelago (archipelago.gg). See

--- a/NetKAN/KSPArchipelago.netkan
+++ b/NetKAN/KSPArchipelago.netkan
@@ -1,16 +1,17 @@
 identifier: KSPArchipelago
 name: KSP Archipelago Randomizer
-abstract: Play a solo or cooperative randomized version of one or more supported games
+abstract: >-
+  Play a solo or cooperative randomized version of one or more supported games
 description: >-
-  With Archipelago for KSP you start with a small selection of random parts and must performing missions to unlock additional parts
-  to get closer to your goal. Any time you achieve something for the first time such as orbiting a planet, taking a surface sample, planting a flag etc
-  you will unlock new parts for yourself or other players in their games.
+  With Archipelago for KSP, you start with a small selection of random parts
+  and must perform missions to unlock additional parts to get closer to
+  your goal. Any time you achieve something for the first time such as
+  orbiting a planet, taking a surface sample, planting a flag, etc., you will
+  unlock new parts for yourself or other players in their games.
 
-  Goals are selected by the player when they generate a new game and things like flying to duna and back, planting a flag on all bodies,
-  returning a surface sample from every body are default goals players can chose from.
-
-  For more information on Archipelago in general see (https://archipelago.gg/faq/en/) and for more details on hosting your own game
-  see https://github.com/nickdavies/Archipelago/blob/ksp1/worlds/ksp1/docs/setup_en.md for the server side setup
+  Goals are selected by the player when they generate a new game, and things
+  like flying to Duna and back, planting a flag on all bodies, returning a
+  surface sample from every body are default goals players can chose from.
 author: Nick Davies
 $kref: '#/ckan/github/nickdavies/KSP1-Archipelago-client'
 x_netkan_version_edit: ^v?(?<version>.*)$
@@ -19,3 +20,6 @@ x_netkan_github:
 ksp_version: 1.12
 tags:
   - plugin
+resources:
+  homepage: https://archipelago.gg/faq/en/
+  manual: https://github.com/nickdavies/Archipelago/blob/ksp1/worlds/ksp1/docs/setup_en.md

--- a/NetKAN/KSPArchipelago.netkan
+++ b/NetKAN/KSPArchipelago.netkan
@@ -1,8 +1,7 @@
 identifier: KSPArchipelago
 name: KSP Archipelago Randomizer
-abstract: >-
-  Archipelago allows you to play a solo or cooperative randomized version of one or more supported games.
-
+abstract: Play a solo or cooperative randomized version of one or more supported games
+description: >-
   With Archipelago for KSP you start with a small selection of random parts and must performing missions to unlock additional parts
   to get closer to your goal. Any time you achieve something for the first time such as orbiting a planet, taking a surface sample, planting a flag etc
   you will unlock new parts for yourself or other players in their games.


### PR DESCRIPTION
Adds the KSP Archipelago Randomizer client mod.

- Repo: <https://github.com/nickdavies/KSP1-Archipelago-client>
- Releases: <https://github.com/nickdavies/KSP1-Archipelago-client/releases>

Locally inflated all 8 releases with `kspckan/inflator` and the prerelease filter — 7 non-prerelease versions produced `.ckan` files; `v0.1.0` (pre-release) was correctly skipped.