### PR TITLE
Remove Chemical mod properties set in internal .ckans

### DIFF
--- a/NetKAN/ChemicalCore.netkan
+++ b/NetKAN/ChemicalCore.netkan
@@ -1,16 +1,10 @@
 identifier: ChemicalCore
 $kref: '#/ckan/github/CharleRoger/ChemicalCore'
-$vref: '#/ckan/ksp-avc'
 ---
 identifier: ChemicalCore
 $kref: '#/ckan/spacedock/3865'
-$vref: '#/ckan/ksp-avc'
 x_netkan_version_edit: '^(Chemical Core )?(?<version>.*)$'
 tags:
   - parts
-depends:
-  - name: ModuleManager
-  - name: B9PartSwitch
-  - name: CommunityResourcePack
 supports:
   - name: CryoTanks

--- a/NetKAN/ChemicalExotics.netkan
+++ b/NetKAN/ChemicalExotics.netkan
@@ -1,6 +1,5 @@
 identifier: ChemicalExotics
 $kref: '#/ckan/github/CharleRoger/ChemicalPropulsion'
-$vref: '#/ckan/ksp-avc'
 ---
 identifier: ChemicalExotics
 name: Chemical Propulsion - Exotics
@@ -8,15 +7,8 @@ abstract: >-
   An extension pack for Chemical Propulsion which
   adds exotic propellant options to various engines
 $kref: '#/ckan/spacedock/3866'
-$vref: '#/ckan/ksp-avc'
 tags:
   - config
-depends:
-  - name: ModuleManager
-  - name: B9PartSwitch
-  - name: ChemicalCore
-  - name: ChemicalPropulsion
-  - name: CommunityResourcePack
 install:
   - find: ChemicalPropulsionExotics
     install_to: GameData

--- a/NetKAN/ChemicalPropulsion.netkan
+++ b/NetKAN/ChemicalPropulsion.netkan
@@ -5,3 +5,6 @@ identifier: ChemicalPropulsion
 $kref: '#/ckan/spacedock/3866'
 tags:
   - config
+install:
+  - find: ChemicalPropulsion
+    install_to: GameData

--- a/NetKAN/ChemicalPropulsion.netkan
+++ b/NetKAN/ChemicalPropulsion.netkan
@@ -1,56 +1,7 @@
 identifier: ChemicalPropulsion
 $kref: '#/ckan/github/CharleRoger/ChemicalPropulsion'
-$vref: '#/ckan/ksp-avc'
 ---
 identifier: ChemicalPropulsion
 $kref: '#/ckan/spacedock/3866'
-$vref: '#/ckan/ksp-avc'
 tags:
   - config
-depends:
-  - name: ModuleManager
-  - name: B9PartSwitch
-  - name: Ignition
-  - name: ChemicalCore
-  - name: CommunityResourcePack
-recommends:
-  - name: AlcoholicAeronautics
-  - name: CryoEngines
-  - name: CryoTanks
-  - name: KerbalAtomics
-  - name: Labradoodle
-  - name: NearFutureLaunchVehicles
-  - name: NearFutureSpacecraft
-  - name: ReStock
-  - name: ReStockPlus
-  - name: VABOrganizer
-suggested:
-  - name: CommonwealthAeronauticsBlueSteel
-  - name: CRE
-  - name: CryoEnginesExtensions
-  - name: Knes
-  - name: NearFutureAeronautics
-  - name: NearFutureExploration
-  - name: OCRAP
-  - name: Taerobee
-  - name: NewTantares
-  - name: NewTantaresLV
-  - name: TantaresSP
-  - name: UniversalStorage2
-supports:
-  - name: AirplanePlus
-  - name: ConfigurableContainers
-  - name: FarFutureTechnologies
-  - name: Firespitter
-  - name: Grounded
-  - name: SpaceXLegs
-  - name: Kerbalism
-  - name: MissingHistory
-  - name: Mk-33
-  - name: ModularFuelTanks
-  - name: ProbesBeforeCrew
-  - name: ShuttleOrbiterConstructionKit
-  - name: SillyPhotonDrives
-  - name: SystemHeat
-  - name: TundraExploration
-  - name: UnKerballedStart

--- a/NetKAN/ChemicalPropulsionHypergolics.netkan
+++ b/NetKAN/ChemicalPropulsionHypergolics.netkan
@@ -1,6 +1,5 @@
 identifier: ChemicalPropulsionHypergolics
 $kref: '#/ckan/github/CharleRoger/ChemicalPropulsion'
-$vref: '#/ckan/ksp-avc'
 ---
 identifier: ChemicalPropulsionHypergolics
 name: Chemical Propulsion - Hypergolics
@@ -8,15 +7,8 @@ abstract: >-
   An extension pack for Chemical Propulsion which
   adds low-tech hypergolic propellant options
 $kref: '#/ckan/spacedock/3866'
-$vref: '#/ckan/ksp-avc'
 tags:
   - config
-depends:
-  - name: ModuleManager
-  - name: B9PartSwitch
-  - name: ChemicalCore
-  - name: ChemicalPropulsion
-  - name: CommunityResourcePack
 install:
   - find: ChemicalPropulsionHypergolics
     install_to: GameData

--- a/NetKAN/ChemicalPropulsionKeroxide.netkan
+++ b/NetKAN/ChemicalPropulsionKeroxide.netkan
@@ -1,6 +1,5 @@
 identifier: ChemicalPropulsionKeroxide
 $kref: '#/ckan/github/CharleRoger/ChemicalPropulsion'
-$vref: '#/ckan/ksp-avc'
 ---
 identifier: ChemicalPropulsionKeroxide
 name: Chemical Propulsion - Keroxide
@@ -8,15 +7,8 @@ abstract: >-
   An extension pack for Chemical Propulsion which
   adds an HTP oxidizer option to kerolox engines
 $kref: '#/ckan/spacedock/3866'
-$vref: '#/ckan/ksp-avc'
 tags:
   - config
-depends:
-  - name: ModuleManager
-  - name: B9PartSwitch
-  - name: ChemicalCore
-  - name: ChemicalPropulsion
-  - name: CommunityResourcePack
 install:
   - find: ChemicalPropulsionKeroxide
     install_to: GameData

--- a/NetKAN/ChemicalPropulsionNuclear.netkan
+++ b/NetKAN/ChemicalPropulsionNuclear.netkan
@@ -1,22 +1,14 @@
 identifier: ChemicalPropulsionNuclear
 $kref: '#/ckan/github/CharleRoger/ChemicalPropulsion'
-$vref: '#/ckan/ksp-avc'
 ---
 identifier: ChemicalPropulsionNuclear
 name: Chemical Propulsion - Thermal
 abstract: >-
   An extension pack for Chemical Propulsion which
-  adds high-thrust, low-isp propellant options to NTRs
+  adds high-thrust, low-isp propellant options to thermal rockets
 $kref: '#/ckan/spacedock/3866'
-$vref: '#/ckan/ksp-avc'
 tags:
   - config
-depends:
-  - name: ModuleManager
-  - name: B9PartSwitch
-  - name: ChemicalCore
-  - name: ChemicalPropulsion
-  - name: CommunityResourcePack
 install:
   - find: ChemicalPropulsionThermal
     install_to: GameData

--- a/NetKAN/ChemicalTechTree.netkan
+++ b/NetKAN/ChemicalTechTree.netkan
@@ -1,16 +1,8 @@
 identifier: ChemicalTechTree
 $kref: '#/ckan/github/CharleRoger/ChemicalTechTree'
-$vref: '#/ckan/ksp-avc'
 ---
 identifier: ChemicalTechTree
 $kref: '#/ckan/spacedock/4214'
-$vref: '#/ckan/ksp-avc'
 tags:
   - config
   - tech-tree
-depends:
-  - name: ModuleManager
-  - name: CommunityResourcePack
-  - name: ChemicalCore
-    min_version: 1.5.0
-  - name: HideEmptyTechNodes


### PR DESCRIPTION
These mods have recently had internal .ckans added. After KSP-CKAN/CKAN#4640, they will be usable.

Now `$vref` and the relationship properties are removed from the netkans so the internal ckans can set them.
