### PR TITLE
Update SpaceWeatherAndAtmosphericOrbitalDecay.netkan

### DIFF
--- a/NetKAN/SpaceWeatherAndAtmosphericOrbitalDecay.netkan
+++ b/NetKAN/SpaceWeatherAndAtmosphericOrbitalDecay.netkan
@@ -9,4 +9,5 @@ tags:
   - physics
 depends:
   - name: ClickThroughBlocker
+recommends:
   - name: Kerbalism


### PR DESCRIPTION
Kerbalism is currently listed as a dependency, but it would be more appropriate as a recommended installation. Please merge this change, thank you very much.