### PR TITLE
Add SerializationFix

### DIFF
--- a/NetKAN/SerializationFix.netkan
+++ b/NetKAN/SerializationFix.netkan
@@ -6,3 +6,6 @@ $vref: '#/ckan/ksp-avc'
 tags:
   - plugin
   - library
+install:
+  - find: 000_SerializationFix
+    install_to: GameData

--- a/NetKAN/SerializationFix.netkan
+++ b/NetKAN/SerializationFix.netkan
@@ -1,0 +1,8 @@
+identifier: SerializationFix
+author: steamroller
+$kref: '#/ckan/github/Phantomical/KSPSerializationFix'
+x_netkan_version_edit: '^[vV]?(?<version>.+)$'
+$vref: '#/ckan/ksp-avc'
+tags:
+  - plugin
+  - library


### PR DESCRIPTION
Just a little mod that makes `[Serializable]` attributes work for types defined in mod dlls.

It has no dependencies. I think I got the ckan right, but we'll see what inflate thinks.

- <https://github.com/Phantomical/KSPSerializationFix>
