### PR TITLE
Add Chemical Propulsion - Solids

### DIFF
--- a/NetKAN/ChemicalPropulsionSolids.netkan
+++ b/NetKAN/ChemicalPropulsionSolids.netkan
@@ -1,0 +1,14 @@
+identifier: ChemicalPropulsionSolids
+$kref: '#/ckan/github/CharleRoger/ChemicalPropulsion'
+---
+identifier: ChemicalPropulsionSolids
+name: Chemical Propulsion - Solids
+abstract: >-
+  An extension pack for Chemical Propulsion which
+  adds extra propellant options to solid rockets
+$kref: '#/ckan/spacedock/3866'
+tags:
+  - config
+install:
+  - find: ChemicalPropulsionSolids
+    install_to: GameData


### PR DESCRIPTION
This is a new(ish) extra modlet for Chemical Propulsion. The main metadata file is embedded within the mod, like the other Chemical Propulsion extras.