### PR TITLE
KSPArchipelago: suggest KerbalKonstructs and index experimental builds

### DIFF
--- a/NetKAN/KSPArchipelago.netkan
+++ b/NetKAN/KSPArchipelago.netkan
@@ -17,9 +17,22 @@ $kref: '#/ckan/github/nickdavies/KSP1-Archipelago-client'
 x_netkan_version_edit: ^v?(?<version>.*)$
 x_netkan_github:
   prereleases: false
+x_netkan_allow_out_of_order: true
 ksp_version: 1.12
 tags:
   - plugin
+suggests:
+  - name: KerbalKonstructs
 resources:
   homepage: https://archipelago.gg/faq/en/
   manual: https://github.com/nickdavies/Archipelago/blob/ksp1/worlds/ksp1/docs/setup_en.md
+x_netkan_override:
+  # Experimental builds are tagged v999.X.Y-experimental. The 999 major sorts
+  # above any plausible stable version, so the >=999 constraint catches every
+  # experimental without per-release maintenance. release_status is set
+  # explicitly here rather than relying on the GitHub prerelease flag, so
+  # forgetting that checkbox doesn't accidentally publish an experimental
+  # as stable.
+  - version: '>=999'
+    override:
+      release_status: testing


### PR DESCRIPTION
- <https://github.com/nickdavies/Archipelago>

## Summary

- Add `suggests: KerbalKonstructs` for all builds
- Add an `x_netkan_override` keyed on `version: '>=999'` that sets `release_status: testing` for experimental builds.

## Tagging convention

Experimental builds are tagged `v999.0.0-experimental.<N>` on GitHub and marked as prereleases. The 999 major sorts above any plausible stable version under CKAN's comparator, so the `>=999` constraint reliably catches every experimental without needing a NetKAN PR per release. Stable releases (`v0.1.0`+) fall outside the range and are unaffected.