### PR TITLE
Change toolbar recommendations to suggestions

### DIFF
--- a/NetKAN/AmbientLightAdjustment.frozen
+++ b/NetKAN/AmbientLightAdjustment.frozen
@@ -1,18 +1,12 @@
-{
-    "$kref": "#/ckan/spacedock/184",
-    "identifier": "AmbientLightAdjustment",
-    "license" : "GPL-3.0",
-    "depends": [
-        { "name": "Toolbar" }
-    ],
-    "x_netkan_override" : [
-        {
-            "version" : "1.4.4.1",
-            "delete" : [ "ksp_version" ],
-            "override" : {
-                "ksp_version_min" : "1.0.2",
-                "ksp_version_max" : "1.0.4"
-            }
-        }
-    ]
-}
+identifier: AmbientLightAdjustment
+$kref: '#/ckan/spacedock/184'
+license: GPL-3.0
+suggests:
+  - name: Toolbar
+x_netkan_override:
+  - version: 1.4.4.1
+    delete:
+      - ksp_version
+    override:
+      ksp_version_min: 1.0.2
+      ksp_version_max: 1.0.4

--- a/NetKAN/AmpYearPowerManager.frozen
+++ b/NetKAN/AmpYearPowerManager.frozen
@@ -1,29 +1,21 @@
-{
-    "identifier":   "AmpYearPowerManager",
-    "$kref":        "#/ckan/spacedock/144",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_epoch": "1",
-    "license":      "GPL-3.0",
-    "tags": [
-        "plugin",
-        "parts",
-        "resources"
-    ],
-    "depends" : [
-        { "name": "ModuleManager", "min_version" : "2.3.5" },
-        { "name": "REPOSoftTech-Agencies" }
-    ],
-    "recommends": [
-        { "name": "Toolbar" }
-    ],
-    "install": [
-        {
-            "find": "REPOSoftTech",
-            "install_to": "GameData",
-            "filter": [
-                "Agencies",
-                "RSTKSPUtils"
-            ]
-        }
-    ]
-}
+identifier: AmpYearPowerManager
+$kref: '#/ckan/spacedock/144'
+$vref: '#/ckan/ksp-avc'
+x_netkan_epoch: '1'
+license: GPL-3.0
+tags:
+  - plugin
+  - parts
+  - resources
+depends:
+  - name: ModuleManager
+    min_version: 2.3.5
+  - name: REPOSoftTech-Agencies
+suggests:
+  - name: Toolbar
+install:
+  - find: REPOSoftTech
+    install_to: GameData
+    filter:
+      - Agencies
+      - RSTKSPUtils

--- a/NetKAN/ChampagneBottleRedux.netkan
+++ b/NetKAN/ChampagneBottleRedux.netkan
@@ -13,8 +13,9 @@ depends:
   - name: ToolbarController
   - name: ClickThroughBlocker
 recommends:
-  - name: Toolbar
   - name: JanitorsCloset
+suggests:
+  - name: Toolbar
 install:
   - find: Champagne
     install_to: GameData

--- a/NetKAN/ControlLock.frozen
+++ b/NetKAN/ControlLock.frozen
@@ -1,24 +1,18 @@
-{
-    "identifier":   "ControlLock",
-    "name":         "Control Lock",
-    "abstract":     "Lock KSP so that when entering text in a text field, you do not pass commands to your vessel.",
-    "author":       "Diazo",
-    "$kref":        "#/ckan/github/SirDiazo/ControlLock",
-    "license":      "Unlicense",
-    "ksp_version":  "1.1",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/97829-*"
-    },
-    "tags": [
-        "plugin"
-    ],
-    "recommends": [
-        { "name": "Toolbar" }
-    ],
-    "install": [
-        {
-            "file":       "GameData/001ControlLock",
-            "install_to": "GameData"
-        }
-    ]
-}
+identifier: ControlLock
+name: Control Lock
+abstract: >-
+  Lock KSP so that when entering text in a text field, you do not pass commands
+  to your vessel.
+author: Diazo
+$kref: '#/ckan/github/SirDiazo/ControlLock'
+license: Unlicense
+ksp_version: '1.1'
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/97829-*
+tags:
+  - plugin
+suggests:
+  - name: Toolbar
+install:
+  - file: GameData/001ControlLock
+    install_to: GameData

--- a/NetKAN/DeepFreeze.netkan
+++ b/NetKAN/DeepFreeze.netkan
@@ -27,13 +27,13 @@ depends:
   - name: ClickThroughBlocker
   - name: ToolbarController
 recommends:
-  - name: Toolbar
   - name: RasterPropMonitor
   - name: BackgroundProcessing
   - name: ShipManifest
   - name: ConnectedLivingSpace
   - name: AmpYearPowerManager
 suggests:
+  - name: Toolbar
   - name: USI-LS
   - name: TACLS
   - name: Snacks

--- a/NetKAN/Deltaglider.frozen
+++ b/NetKAN/Deltaglider.frozen
@@ -1,26 +1,23 @@
-{
-    "identifier"    : "Deltaglider",
-    "$kref"         : "#/ckan/spacedock/164",
-    "license"       : "CC-BY-NC-ND-4.0",
-    "x_netkan_epoch": "1",
-    "depends" : [
-        { "name" : "ModuleManager" },
-        { "name" : "ASETProps" },
-        { "name" : "AGExt" },
-        { "name" : "RasterPropMonitor" },
-        { "name" : "RasterPropMonitor-Core" },
-        { "name" : "KAS" },
-        { "name" : "KIS" },
-        { "name" : "ShipManifest" },
-        { "name" : "ThrottleControlledAvionics" }
-    ],
-    "recommends": [
-        { "name" : "Toolbar" },
-        { "name" : "TMSTACLSRetexture" },
-        { "name" : "VesselView"},
-        { "name" : "SCANsat" },
-        { "name" : "DockingSounds" },
-        { "name" : "DockingPortAlignmentIndicator" }
-    ],
-    "x_netkan_force_v": true
-}
+identifier: Deltaglider
+$kref: '#/ckan/spacedock/164'
+x_netkan_force_v: true
+x_netkan_epoch: '1'
+license: CC-BY-NC-ND-4.0
+depends:
+  - name: ModuleManager
+  - name: ASETProps
+  - name: AGExt
+  - name: RasterPropMonitor
+  - name: RasterPropMonitor-Core
+  - name: KAS
+  - name: KIS
+  - name: ShipManifest
+  - name: ThrottleControlledAvionics
+recommends:
+  - name: TMSTACLSRetexture
+  - name: VesselView
+  - name: SCANsat
+  - name: DockingSounds
+  - name: DockingPortAlignmentIndicator
+suggests:
+  - name: Toolbar

--- a/NetKAN/ExtraPlanetaryLaunchpads.netkan
+++ b/NetKAN/ExtraPlanetaryLaunchpads.netkan
@@ -15,6 +15,7 @@ recommends:
   - name: KAS
   - name: InfernalRobotics
   - name: KerbalStats
+suggests:
   - name: Toolbar
 install:
   - file: ExtraplanetaryLaunchpads

--- a/NetKAN/Insight.frozen
+++ b/NetKAN/Insight.frozen
@@ -1,20 +1,15 @@
-{
-    "identifier"   : "Insight",
-    "$kref"        : "#/ckan/spacedock/2058",
-    "$vref"        : "#/ckan/ksp-avc",
-    "license"      : "GPL-3.0",
-    "tags": [
-        "parts"
-    ],
-    "recommends": [
-        { "name": "Toolbar" },
-        { "name": "ToolbarController" }
-    ],
-    "install": [ {
-        "find":       "Kunedo",
-        "install_to": "GameData"
-    }, {
-        "find":       "Ships",
-        "install_to": "Ships"
-    } ]
-}
+identifier: Insight
+$kref: '#/ckan/spacedock/2058'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+tags:
+  - parts
+suggests:
+  - name: Toolbar
+recommends:
+  - name: ToolbarController
+install:
+  - find: Kunedo
+    install_to: GameData
+  - find: Ships
+    install_to: Ships

--- a/NetKAN/KSPInterstellarLite.frozen
+++ b/NetKAN/KSPInterstellarLite.frozen
@@ -1,35 +1,28 @@
-{
-    "identifier"            : "KSPInterstellarLite",
-    "name"                  : "KSP Interstellar Lite",
-    "abstract"              : "Lite version of KSP Interstellar",
-    "$kref"                 : "#/ckan/github/WaveFunctionP/KSPInterstellar",
-    "license"               : "unrestricted",
-    "ksp_version"           : "0.24.2",
-    "x_netkan_license_ok"   : true,
-    "x_maintained_by"       : "distantcam",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/82882-*"
-    },
-    "tags": [
-        "plugin",
-        "parts",
-        "resources",
-        "crewed"
-    ],
-    "provides"              : [ "KSPInterstellar" ],
-    "conflicts"             : [ { "name" : "KSPInterstellar" } ],
-    "depends": [
-        { "name": "OpenResourceSystem" },
-        { "name": "TreeLoader" },
-        { "name": "ModuleManager" },
-        { "name": "Toolbar" },
-        { "name": "TweakScale" },
-        { "name": "CommunityResourcePack" }
-    ],
-    "install": [
-        {
-            "file"       : "GameData/Interstellar",
-            "install_to" : "GameData"
-        }
-    ]
-}
+identifier: KSPInterstellarLite
+name: KSP Interstellar Lite
+abstract: Lite version of KSP Interstellar
+$kref: '#/ckan/github/WaveFunctionP/KSPInterstellar'
+ksp_version: 0.24.2
+license: unrestricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/82882-*
+tags:
+  - plugin
+  - parts
+  - resources
+  - crewed
+provides:
+  - KSPInterstellar
+conflicts:
+  - name: KSPInterstellar
+depends:
+  - name: OpenResourceSystem
+  - name: TreeLoader
+  - name: ModuleManager
+  - name: TweakScale
+  - name: CommunityResourcePack
+suggests:
+  - name: Toolbar
+install:
+  - file: GameData/Interstellar
+    install_to: GameData

--- a/NetKAN/KabinKraziness.frozen
+++ b/NetKAN/KabinKraziness.frozen
@@ -1,15 +1,15 @@
-{
-    "$kref": "#/ckan/kerbalstuff/684",
-    "$vref": "#/ckan/ksp-avc",
-    "identifier": "KabinKraziness",
-    "license": "CC-BY-NC-SA-3.0",
-    "resources" : {
-        "homepage"     : "https://forum.kerbalspaceprogram.com/index.php?/topic/103558-wip13-kabinkraziness-v045-31st-may-2017/"
-    },
-    "depends" : [   { "name" : "ModuleManager" },
-                    { "name" : "AmpYearPowerManager" } ],
-    "recommends" : [ { "name" : "Toolbar" } ],
-    "install" : [ { "find" : "REPOSoftTech",
-                    "install_to" : "GameData",
-                    "filter_regexp" : "KKInterfaces.dll" } ]
-}
+$kref: '#/ckan/kerbalstuff/684'
+$vref: '#/ckan/ksp-avc'
+identifier: KabinKraziness
+license: CC-BY-NC-SA-3.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/103558-wip13-kabinkraziness-v045-31st-may-2017/
+depends:
+  - name: ModuleManager
+  - name: AmpYearPowerManager
+suggests:
+  - name: Toolbar
+install:
+  - find: REPOSoftTech
+    install_to: GameData
+    filter_regexp: KKInterfaces.dll

--- a/NetKAN/NotSoSimpleConstruction.netkan
+++ b/NetKAN/NotSoSimpleConstruction.netkan
@@ -13,11 +13,11 @@ depends:
   - name: ModuleManager
   - name: SimpleConstruction
 recommends:
-  - name: Toolbar
   - name: KerbalStats
   - name: KIS
   - name: KAS
 suggests:
+  - name: Toolbar
   - name: SimpleLogistics
   - name: CommunityResourcePack
   - name: StockalikeMiningExtension

--- a/NetKAN/PersistentTrails.frozen
+++ b/NetKAN/PersistentTrails.frozen
@@ -1,9 +1,5 @@
-{
-    "$kref" : "#/ckan/kerbalstuff/796",
-    "license" : "MIT",
-    "identifier" : "PersistentTrails",
-    "depends" : [
-        { "name" : "Toolbar" }
-    ]
-}
-
+$kref: '#/ckan/kerbalstuff/796'
+license: MIT
+identifier: PersistentTrails
+suggests:
+  - name: Toolbar

--- a/NetKAN/ProbeControlRoom.frozen
+++ b/NetKAN/ProbeControlRoom.frozen
@@ -1,38 +1,27 @@
-{
-    "identifier"  : "ProbeControlRoom",
-    "$kref"       : "#/ckan/github/icedown/KSP-ProbeControlRoom",
-    "$vref"       : "#/ckan/ksp-avc",
-    "license"     : "CC-BY-NC-SA-3.0",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/151963-*"
-    },
-    "tags": [
-        "plugin",
-        "uncrewed"
-    ],
-    "install"      : [ {
-        "file"    : "GameData/ProbeControlRoom",
-        "install_to": "GameData"
-    } ],
-    "depends"       : [
-        { "name"  : "ModuleManager" },
-        { "name"  : "RasterPropMonitor"}
-    ],
-    "recommends"  : [
-        { "name"  : "Toolbar" }
-    ],
-    "suggests"    : [
-        { "name"  : "SCANSat" },
-        { "name"  : "VesselViewer" },
-        { "name"  : "MechJeb2" },
-        { "name"  : "DockingPortAlignment" },
-        { "name"  : "kOS" },
-        { "name"  : "KPS-AVC" }
-    ],
-    "x_netkan_override": [ {
-        "version": "1.2.2.4",
-        "override": {
-            "ksp_version_max": "1.2.2"
-        }
-    } ]
-}
+identifier: ProbeControlRoom
+$kref: '#/ckan/github/icedown/KSP-ProbeControlRoom'
+$vref: '#/ckan/ksp-avc'
+license: CC-BY-NC-SA-3.0
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/151963-*
+tags:
+  - plugin
+  - uncrewed
+install:
+  - file: GameData/ProbeControlRoom
+    install_to: GameData
+depends:
+  - name: ModuleManager
+  - name: RasterPropMonitor
+suggests:
+  - name: Toolbar
+  - name: SCANSat
+  - name: VesselViewer
+  - name: MechJeb2
+  - name: DockingPortAlignment
+  - name: kOS
+  - name: KPS-AVC
+x_netkan_override:
+  - version: 1.2.2.4
+    override:
+      ksp_version_max: 1.2.2

--- a/NetKAN/ResourceOverview.frozen
+++ b/NetKAN/ResourceOverview.frozen
@@ -14,5 +14,5 @@ depends:
   - name: ToolbarController
   - name: ClickThroughBlocker
   - name: SpaceTuxLibrary
-recommends:
+suggests:
   - name: Toolbar

--- a/NetKAN/SETI-MetaModPack.frozen
+++ b/NetKAN/SETI-MetaModPack.frozen
@@ -1,119 +1,112 @@
-{
-    "identifier":   "SETI-MetaModPack",
-    "name":         "SETI-MetaModPack",
-    "abstract":     "This is the fulcrum for the SETI meta mod pack. Only select this mod in CKAN, then click ApplyChanges and accept all recommendations and optionally the suggestions you like, to get a more balanced and challenging KSP experience!",
-    "$kref":        "#/ckan/github/Y3mo/SETI-MetaModPack",
-    "$vref":        "#/ckan/ksp-avc",
-    "license":      "restricted",
-    "resources": {
-        "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*"
-    },
-    "tags": [
-        "config"
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "recommends": [
-        { "name": "AlternateResourcePanel" },
-        { "name": "AllYAll" },
-        { "name": "AugmentedReality" },
-        { "name": "AutoAction" },
-        { "name": "BAMCont" },
-        { "name": "BetterBurnTime" },
-        { "name": "BetterTimeWarpCont" },
-        { "name": "CapCom" },
-        { "name": "CommunityTechTree" },
-        { "name": "ContractConfigurator" },
-        { "name": "ContractConfigurator-AnomalySurveyor" },
-        { "name": "ContractConfigurator-FieldResearch" },
-        { "name": "ContractConfigurator-KerbinSpaceStation" },
-        { "name": "ContractConfigurator-Tourism" },
-        { "name": "ContractsWindowPlus" },
-        { "name": "CorrectCoL" },
-        { "name": "CrowdSourcedScience" },
-        { "name": "CustomBarnKit" },
-        { "name": "DistantObject-default" },
-        { "name": "DMagicOrbitalScience" },
-        { "name": "DockingPortAlignmentIndicator" },
-        { "name": "EasyVesselSwitch" },
-        { "name": "EditorExtensionsRedux" },
-        { "name": "EVAEnhancementsContinued" },
-        { "name": "EVAParachutes" },
-        { "name": "FilterExtensionsDefaultConfig" },
-        { "name": "FinalFrontier" },
-        { "name": "FlexibleDocking" },
-        { "name": "FMRSContinued" },
-        { "name": "FuseBoxContinued" },
-        { "name": "HullcamVDSContinued" },
-        { "name": "JanitorsCloset" },
-        { "name": "K2CommandPodCont" },
-        { "name": "KerbalAlarmClock" },
-        { "name": "KerbalEngineerRedux" },
-        { "name": "KerbalJointReinforcement" },
-        { "name": "KerbalNRAP" },
-        { "name": "KAS" },
-        { "name": "KIS" },
-        { "name": "KSP-AVC" },
-        { "name": "KSPRescuePodFix" },
-        { "name": "LandingHeight" },
-        { "name": "LightsOut" },
-        { "name": "MechJeb2" },
-        { "name": "NavballDockAlignIndCE" },
-        { "name": "PartOverhaulsSETI" },
-        { "name": "PlanetShine-Config-Default" },
-        { "name": "PreciseManeuver" },
-        { "name": "ProceduralFairings" },
-        { "name": "QuickSearch" },
-        { "name": "RCSBuildAid" },
-        { "name": "RealChute" },
-        { "name": "RealPlume-StockConfigs" },
-        { "name": "RemoteTech" },
-        { "name": "SAVE" },
-        { "name": "SCANsat" },
-        { "name": "SETI-BalanceMod" },
-        { "name": "SETI-CareerChallenge" },
-        { "name": "SETI-Contracts" },
-        { "name": "SETI-CustomBarnKit" },
-        { "name": "SETI-Greenhouse" },
-        { "name": "SETI-ProbeParts" },
-        { "name": "SETI-RebalanceMaterialsGoo" },
-        { "name": "SETI-RemoteTech" },
-        { "name": "ShipManifest" },
-        { "name": "SmartActuation" },
-        { "name": "StageRecovery" },
-        { "name": "StationScienceContinued" },
-        { "name": "TacFuelBalancer" },
-        { "name": "TACLS" },
-        { "name": "TakeCommandContinued" },
-        { "name": "Toolbar" },
-        { "name": "Trajectories" },
-        { "name": "TransferWindowPlanner" },
-        { "name": "TweakbleEverythingCont" },
-        { "name": "TweakScale" },
-        { "name": "UniversalStorage" },
-        { "name": "UnmannedBeforeManned" },
-        { "name": "UnmannedBeforeMannedChallenge" },
-        { "name": "VenStockRevamp" },
-        { "name": "WaypointManager" },
-        { "name": "Workshop" },
-        { "name": "xScience" }
-    ],
-    "suggests"   : [
-        { "name": "B9-PWings-Fork" },
-        { "name": "BackgroundProcessing" },
-        { "name": "KerbalConstructionTime" },
-        { "name": "KRASH" },
-        { "name": "ProceduralParts" },
-        { "name": "SETI-ProbeControlEnabler" },
-        { "name": "StateFundingContinued" },
-        { "name": "Strategia" },
-        { "name": "ThrottleControlledAvionics" }
-    ],
-    "install" : [
-        {
-            "find"       : "SETImetaModPack",
-            "install_to" : "GameData"
-        }
-    ]
-}
+identifier: SETI-MetaModPack
+name: SETI-MetaModPack
+abstract: >-
+  This is the fulcrum for the SETI meta mod pack. Only select this mod in CKAN,
+  then click ApplyChanges and accept all recommendations and optionally the
+  suggestions you like, to get a more balanced and challenging KSP experience!
+$kref: '#/ckan/github/Y3mo/SETI-MetaModPack'
+$vref: '#/ckan/ksp-avc'
+license: restricted
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/index.php?/topic/95645-*
+tags:
+  - config
+depends:
+  - name: ModuleManager
+recommends:
+  - name: AlternateResourcePanel
+  - name: AllYAll
+  - name: AugmentedReality
+  - name: AutoAction
+  - name: BAMCont
+  - name: BetterBurnTime
+  - name: BetterTimeWarpCont
+  - name: CapCom
+  - name: CommunityTechTree
+  - name: ContractConfigurator
+  - name: ContractConfigurator-AnomalySurveyor
+  - name: ContractConfigurator-FieldResearch
+  - name: ContractConfigurator-KerbinSpaceStation
+  - name: ContractConfigurator-Tourism
+  - name: ContractsWindowPlus
+  - name: CorrectCoL
+  - name: CrowdSourcedScience
+  - name: CustomBarnKit
+  - name: DistantObject-default
+  - name: DMagicOrbitalScience
+  - name: DockingPortAlignmentIndicator
+  - name: EasyVesselSwitch
+  - name: EditorExtensionsRedux
+  - name: EVAEnhancementsContinued
+  - name: EVAParachutes
+  - name: FilterExtensionsDefaultConfig
+  - name: FinalFrontier
+  - name: FlexibleDocking
+  - name: FMRSContinued
+  - name: FuseBoxContinued
+  - name: HullcamVDSContinued
+  - name: JanitorsCloset
+  - name: K2CommandPodCont
+  - name: KerbalAlarmClock
+  - name: KerbalEngineerRedux
+  - name: KerbalJointReinforcement
+  - name: KerbalNRAP
+  - name: KAS
+  - name: KIS
+  - name: KSP-AVC
+  - name: KSPRescuePodFix
+  - name: LandingHeight
+  - name: LightsOut
+  - name: MechJeb2
+  - name: NavballDockAlignIndCE
+  - name: PartOverhaulsSETI
+  - name: PlanetShine-Config-Default
+  - name: PreciseManeuver
+  - name: ProceduralFairings
+  - name: QuickSearch
+  - name: RCSBuildAid
+  - name: RealChute
+  - name: RealPlume-StockConfigs
+  - name: RemoteTech
+  - name: SAVE
+  - name: SCANsat
+  - name: SETI-BalanceMod
+  - name: SETI-CareerChallenge
+  - name: SETI-Contracts
+  - name: SETI-CustomBarnKit
+  - name: SETI-Greenhouse
+  - name: SETI-ProbeParts
+  - name: SETI-RebalanceMaterialsGoo
+  - name: SETI-RemoteTech
+  - name: ShipManifest
+  - name: SmartActuation
+  - name: StageRecovery
+  - name: StationScienceContinued
+  - name: TacFuelBalancer
+  - name: TACLS
+  - name: TakeCommandContinued
+  - name: Trajectories
+  - name: TransferWindowPlanner
+  - name: TweakbleEverythingCont
+  - name: TweakScale
+  - name: UniversalStorage
+  - name: UnmannedBeforeManned
+  - name: UnmannedBeforeMannedChallenge
+  - name: VenStockRevamp
+  - name: WaypointManager
+  - name: Workshop
+  - name: xScience
+suggests:
+  - name: B9-PWings-Fork
+  - name: BackgroundProcessing
+  - name: KerbalConstructionTime
+  - name: KRASH
+  - name: ProceduralParts
+  - name: SETI-ProbeControlEnabler
+  - name: StateFundingContinued
+  - name: Strategia
+  - name: ThrottleControlledAvionics
+  - name: Toolbar
+install:
+  - find: SETImetaModPack
+    install_to: GameData

--- a/NetKAN/SimpleConstruction.frozen
+++ b/NetKAN/SimpleConstruction.frozen
@@ -10,12 +10,16 @@ license: GPL-3.0
 tags:
   - plugin
   - resources
+provides:
+  - ExtraPlanetaryLaunchpads
+conflicts:
+  - name: ExtraPlanetaryLaunchpads
 depends:
   - name: ModuleManager
 recommends:
   - name: KerbalStats
-  - name: Toolbar
 suggests:
+  - name: Toolbar
   - name: KeridianDynamicsVesselAssembly
   - name: GPOSpeedPump
   - name: NotSoSimpleConstruction
@@ -37,10 +41,6 @@ supports:
   - name: StationPartsExpansionRedux
   - name: TweakScale
   - name: USI-FTT
-conflicts:
-  - name: ExtraPlanetaryLaunchpads
-provides:
-  - ExtraPlanetaryLaunchpads
 install:
   - find: SimpleConstruction
     install_to: GameData

--- a/NetKAN/TarsierSpaceTechnologyWithGalaxies.frozen
+++ b/NetKAN/TarsierSpaceTechnologyWithGalaxies.frozen
@@ -1,30 +1,22 @@
-{
-    "identifier":   "TarsierSpaceTechnologyWithGalaxies",
-    "$kref":        "#/ckan/spacedock/143",
-    "$vref":        "#/ckan/ksp-avc",
-    "x_netkan_version_edit": {
-        "find":    "^[vV]?(?<version>.+)$",
-        "replace": "${version}"
-    },
-    "x_netkan_epoch": "1",
-    "license":      "MIT",
-    "tags": [
-        "plugin",
-        "parts",
-        "science"
-    ],
-    "install": [
-        {
-            "find":       "TarsierSpaceTech",
-            "install_to": "GameData"
-        }
-    ],
-    "recommends": [
-        { "name": "KAS"     },
-        { "name": "KIS"     },
-        { "name": "Toolbar" }
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ]
-}
+identifier: TarsierSpaceTechnologyWithGalaxies
+$kref: '#/ckan/spacedock/143'
+$vref: '#/ckan/ksp-avc'
+x_netkan_version_edit:
+  find: ^[vV]?(?<version>.+)$
+  replace: ${version}
+x_netkan_epoch: '1'
+license: MIT
+tags:
+  - plugin
+  - parts
+  - science
+install:
+  - find: TarsierSpaceTech
+    install_to: GameData
+recommends:
+  - name: KAS
+  - name: KIS
+suggests:
+  - name: Toolbar
+depends:
+  - name: ModuleManager

--- a/NetKAN/ToolbarController.netkan
+++ b/NetKAN/ToolbarController.netkan
@@ -14,7 +14,7 @@ tags:
   - library
 depends:
   - name: ClickThroughBlocker
-recommends:
+suggests:
   - name: Toolbar
 install:
   - find: 001_ToolbarControl


### PR DESCRIPTION
Apparently a lot of new users are unintentionally ending up with Blizzy's Toolbar installed when they don't even know what it is, and then it clutters some corner of their screen. Supposedly this happens because it is a recommendation in CKAN for some set of popular mods or dependencies (likely `ToolbarController`).

Now all netkans that had `depends` or `recommends` for `Toolbar` suggest it instead. This will make it opt-in instead of opt-out, so users will only have it installed if they actually want it.

Note that a second pull request in CKAN-meta will be needed to update the frozen modules, which are updated here solely for consistency and in case of future unfreezing.
