### PR TITLE
Make Kerbalism-Config-RO conflict with BluedogDB

### DIFF
--- a/NetKAN/Kerbalism-Config-RO.netkan
+++ b/NetKAN/Kerbalism-Config-RO.netkan
@@ -14,6 +14,7 @@ conflicts:
   - name: TACLS
   - name: Snacks
   - name: USI-LS
+  - name: BluedogDB
 depends:
   - name: ModuleManager
   - name: Kerbalism


### PR DESCRIPTION
This combination creates a fatal error at game startup, and I see it *constantly* in support forums.