### PR TITLE
Vref for Nibrek

### DIFF
--- a/NetKAN/Nibrek.netkan
+++ b/NetKAN/Nibrek.netkan
@@ -1,6 +1,6 @@
 identifier: Nibrek
 $kref: '#/ckan/spacedock/3840'
-comment: The version files are from bundled mods
+$vref: '#/ckan/ksp-avc'
 tags:
   - config
   - planet-pack


### PR DESCRIPTION
It looks like this mod may have its own version file now (as opposed to ones from bundled mods):

<img width="775" height="108" alt="image" src="https://github.com/user-attachments/assets/44c7929d-fa50-4118-bdd4-81a4239eed37" />
