### PR TITLE
Add Custom Science Contracts with selectable Stock/SOL profiles

### DIFF
--- a/NetKAN/CustomScienceContracts-SOLConfig.netkan
+++ b/NetKAN/CustomScienceContracts-SOLConfig.netkan
@@ -1,13 +1,15 @@
 identifier: CustomScienceContracts-SOLConfig
 name: Custom Science Contracts - SOL Campaign
-abstract: "The Custom Science Contracts campaign profile for the SOL real-solar-system planet pack."
-description: "Installs the handcrafted SOL campaign catalog for Custom Science Contracts. Select this profile only for a game using the SOL planet pack; it references bodies such as Earth, Moon, Mars, Jupiter and Saturn."
+abstract: >-
+  The Custom Science Contracts campaign profile for the SOL real-solar-system
+  planet pack.
+description: >-
+  Installs the handcrafted SOL campaign catalog for Custom Science Contracts.
+  Select this profile only for a game using the SOL planet pack; it references
+  bodies such as Earth, Moon, Mars, Jupiter and Saturn.
 author: timduebi
 license: GPL-3.0
 $kref: '#/ckan/github/timduebi/ksp-custom-science-contracts/version_from_asset/^CustomScienceContracts-v(?<version>[0-9.]+)_SOL-Config\.zip$'
-x_netkan_github:
-  use_source_archive: false
-  prerelease: false
 ksp_version_min: '1.12.0'
 ksp_version_max: '1.12.99'
 tags:
@@ -20,7 +22,3 @@ conflicts:
 install:
   - find: Contracts
     install_to: GameData/CustomScienceContracts
-resources:
-  homepage: https://github.com/timduebi/ksp-custom-science-contracts
-  repository: https://github.com/timduebi/ksp-custom-science-contracts
-  bugtracker: https://github.com/timduebi/ksp-custom-science-contracts/issues

--- a/NetKAN/CustomScienceContracts-SOLConfig.netkan
+++ b/NetKAN/CustomScienceContracts-SOLConfig.netkan
@@ -1,0 +1,26 @@
+identifier: CustomScienceContracts-SOLConfig
+name: Custom Science Contracts - SOL Campaign
+abstract: "The Custom Science Contracts campaign profile for the SOL real-solar-system planet pack."
+description: "Installs the handcrafted SOL campaign catalog for Custom Science Contracts. Select this profile only for a game using the SOL planet pack; it references bodies such as Earth, Moon, Mars, Jupiter and Saturn."
+author: timduebi
+license: GPL-3.0
+$kref: '#/ckan/github/timduebi/ksp-custom-science-contracts/version_from_asset/^CustomScienceContracts-v(?<version>[0-9.]+)_SOL-Config\.zip$'
+x_netkan_github:
+  use_source_archive: false
+  prerelease: false
+ksp_version_min: '1.12.0'
+ksp_version_max: '1.12.99'
+tags:
+  - config
+  - science
+provides:
+  - CustomScienceContracts-Config
+conflicts:
+  - name: CustomScienceContracts-Config
+install:
+  - find: Contracts
+    install_to: GameData/CustomScienceContracts
+resources:
+  homepage: https://github.com/timduebi/ksp-custom-science-contracts
+  repository: https://github.com/timduebi/ksp-custom-science-contracts
+  bugtracker: https://github.com/timduebi/ksp-custom-science-contracts/issues

--- a/NetKAN/CustomScienceContracts-StockConfig.netkan
+++ b/NetKAN/CustomScienceContracts-StockConfig.netkan
@@ -1,0 +1,26 @@
+identifier: CustomScienceContracts-StockConfig
+name: Custom Science Contracts - Stock Campaign
+abstract: "The recommended Custom Science Contracts campaign profile for the normal Stock Kerbol system."
+description: "Installs the Stock Kerbol campaign catalog for Custom Science Contracts. This is the recommended default for games that do not use the SOL planet pack."
+author: timduebi
+license: GPL-3.0
+$kref: '#/ckan/github/timduebi/ksp-custom-science-contracts/version_from_asset/^CustomScienceContracts-v(?<version>[0-9.]+)\.zip$'
+x_netkan_github:
+  use_source_archive: false
+  prerelease: false
+ksp_version_min: '1.12.0'
+ksp_version_max: '1.12.99'
+tags:
+  - config
+  - science
+provides:
+  - CustomScienceContracts-Config
+conflicts:
+  - name: CustomScienceContracts-Config
+install:
+  - find: Contracts
+    install_to: GameData/CustomScienceContracts
+resources:
+  homepage: https://github.com/timduebi/ksp-custom-science-contracts
+  repository: https://github.com/timduebi/ksp-custom-science-contracts
+  bugtracker: https://github.com/timduebi/ksp-custom-science-contracts/issues

--- a/NetKAN/CustomScienceContracts-StockConfig.netkan
+++ b/NetKAN/CustomScienceContracts-StockConfig.netkan
@@ -1,15 +1,15 @@
 identifier: CustomScienceContracts-StockConfig
 name: Custom Science Contracts - Stock Campaign
-abstract: "The recommended Custom Science Contracts campaign profile for the normal Stock Kerbol system."
-description: "Installs the Stock Kerbol campaign catalog for Custom Science Contracts. This is the recommended default for games that do not use the SOL planet pack."
+abstract: >-
+  The recommended Custom Science Contracts campaign profile for the normal Stock
+  Kerbol system.
+description: >-
+  Installs the Stock Kerbol campaign catalog for Custom Science Contracts. This
+  is the recommended default for games that do not use the SOL planet pack.
 author: timduebi
 license: GPL-3.0
 $kref: '#/ckan/github/timduebi/ksp-custom-science-contracts/version_from_asset/^CustomScienceContracts-v(?<version>[0-9.]+)\.zip$'
-x_netkan_github:
-  use_source_archive: false
-  prerelease: false
-ksp_version_min: '1.12.0'
-ksp_version_max: '1.12.99'
+$vref: '#/ckan/ksp-avc'
 tags:
   - config
   - science
@@ -20,7 +20,3 @@ conflicts:
 install:
   - find: Contracts
     install_to: GameData/CustomScienceContracts
-resources:
-  homepage: https://github.com/timduebi/ksp-custom-science-contracts
-  repository: https://github.com/timduebi/ksp-custom-science-contracts
-  bugtracker: https://github.com/timduebi/ksp-custom-science-contracts/issues

--- a/NetKAN/CustomScienceContracts.netkan
+++ b/NetKAN/CustomScienceContracts.netkan
@@ -1,0 +1,24 @@
+identifier: CustomScienceContracts
+name: Custom Science Contracts
+abstract: "A structured science campaign for KSP's Science Mode: a clear mission path from your first flight to deep-space exploration, run from its own in-game menu."
+description: "Adds a structured campaign on top of Science Mode - first flights, orbit, robotic scouting, crewed missions, stations, bases, supply routes and deep-space exploration - instead of random, disconnected contracts. The default catalog targets the Sol planet pack (a real/quarter/stock-scale recreation of our solar system, with body names like Earth, Moon and Mars). An optional stock-Kerbol catalog and a German catalog are available as config swaps on the GitHub release page. Recommended together with Kerbalism and a probe-first tech tree."
+author: timduebi
+license: GPL-3.0
+$kref: '#/ckan/github/timduebi/ksp-custom-science-contracts/version_from_asset/^CustomScienceContracts-v(?<version>[0-9.]+)\.zip$'
+x_netkan_github:
+  use_source_archive: false
+  prerelease: true
+ksp_version: '1.12'
+tags:
+  - science
+  - career
+recommends:
+  - name: Kerbalism
+  - name: ProbesBeforeCrew
+install:
+  - find: CustomScienceContracts
+    install_to: GameData
+resources:
+  homepage: https://github.com/timduebi/ksp-custom-science-contracts
+  repository: https://github.com/timduebi/ksp-custom-science-contracts
+  bugtracker: https://github.com/timduebi/ksp-custom-science-contracts/issues

--- a/NetKAN/CustomScienceContracts.netkan
+++ b/NetKAN/CustomScienceContracts.netkan
@@ -1,23 +1,32 @@
+spec_version: v1.31
 identifier: CustomScienceContracts
 name: Custom Science Contracts
-abstract: "A structured science campaign for KSP's Science Mode: a clear mission path from your first flight to deep-space exploration, run from its own in-game menu."
-description: "Adds a structured campaign on top of Science Mode - first flights, orbit, robotic scouting, crewed missions, stations, bases, supply routes and deep-space exploration - instead of random, disconnected contracts. The default catalog targets the Sol planet pack (a real/quarter/stock-scale recreation of our solar system, with body names like Earth, Moon and Mars). An optional stock-Kerbol catalog and a German catalog are available as config swaps on the GitHub release page. Recommended together with Kerbalism and a probe-first tech tree."
+abstract: "A structured science campaign for KSP's Science Mode, from first flight to deep-space exploration."
+description: "Adds a structured campaign on top of Science Mode with an in-game mission menu, campaign atlas, stations, bases, supply routes and deep-space exploration. CKAN installs the plugin separately from its campaign profile and asks whether to use the recommended Stock Kerbol campaign or the optional SOL real-solar-system campaign."
 author: timduebi
 license: GPL-3.0
 $kref: '#/ckan/github/timduebi/ksp-custom-science-contracts/version_from_asset/^CustomScienceContracts-v(?<version>[0-9.]+)\.zip$'
 x_netkan_github:
   use_source_archive: false
-  prerelease: true
-ksp_version: '1.12'
+  prerelease: false
+ksp_version_min: '1.12.0'
+ksp_version_max: '1.12.99'
 tags:
   - science
   - career
+depends:
+  - name: Harmony2
+  - any_of:
+      - name: CustomScienceContracts-StockConfig
+      - name: CustomScienceContracts-SOLConfig
+    choice_help_text: "Choose Stock for the normal Kerbol system (recommended). Choose SOL only when the SOL planet pack is installed."
 recommends:
   - name: Kerbalism
   - name: ProbesBeforeCrew
 install:
   - find: CustomScienceContracts
     install_to: GameData
+    filter: Contracts
 resources:
   homepage: https://github.com/timduebi/ksp-custom-science-contracts
   repository: https://github.com/timduebi/ksp-custom-science-contracts

--- a/NetKAN/CustomScienceContracts.netkan
+++ b/NetKAN/CustomScienceContracts.netkan
@@ -1,17 +1,22 @@
-spec_version: v1.31
 identifier: CustomScienceContracts
 name: Custom Science Contracts
-abstract: "A structured science campaign for KSP's Science Mode, from first flight to deep-space exploration."
-description: "Adds a structured campaign on top of Science Mode with an in-game mission menu, campaign atlas, stations, bases, supply routes and deep-space exploration. CKAN installs the plugin separately from its campaign profile and asks whether to use the recommended Stock Kerbol campaign or the optional SOL real-solar-system campaign."
+abstract: >-
+  A structured science campaign for KSP's Science Mode, from first flight to
+  deep-space exploration.
+description: >-
+  Adds a structured campaign on top of Science Mode with an in-game mission
+  menu, campaign atlas, stations, bases, supply routes and deep-space
+  exploration. CKAN installs the plugin separately from its campaign profile and
+  asks whether to use the recommended Stock Kerbol campaign or the optional SOL
+  real-solar-system campaign.
 author: timduebi
-license: GPL-3.0
+license:
+  - GPL-3.0
+  - MIT
 $kref: '#/ckan/github/timduebi/ksp-custom-science-contracts/version_from_asset/^CustomScienceContracts-v(?<version>[0-9.]+)\.zip$'
-x_netkan_github:
-  use_source_archive: false
-  prerelease: false
-ksp_version_min: '1.12.0'
-ksp_version_max: '1.12.99'
+$vref: '#/ckan/ksp-avc'
 tags:
+  - plugin
   - science
   - career
 depends:
@@ -27,7 +32,3 @@ install:
   - find: CustomScienceContracts
     install_to: GameData
     filter: Contracts
-resources:
-  homepage: https://github.com/timduebi/ksp-custom-science-contracts
-  repository: https://github.com/timduebi/ksp-custom-science-contracts
-  bugtracker: https://github.com/timduebi/ksp-custom-science-contracts/issues


### PR DESCRIPTION
Adds CKAN metadata for **Custom Science Contracts**, a structured Science Mode campaign for KSP 1.12.x.

## Current release

- **Release:** v0.9.1 (stable GitHub release)
- **Main asset:** `CustomScienceContracts-vX.Y.Z.zip`
- **Optional SOL overlay:** `CustomScienceContracts-vX.Y.Z_SOL-Config.zip`
- **Required dependency:** `Harmony2`

## CKAN package layout

This PR now defines three modules:

1. `CustomScienceContracts` installs the plugin and non-catalog assets, and filters the bundled Stock `Contracts` folder out of the main archive.
2. `CustomScienceContracts-StockConfig` installs the Stock Kerbol campaign catalog.
3. `CustomScienceContracts-SOLConfig` installs the handcrafted SOL campaign catalog from the SOL overlay asset.

The main module depends on Harmony2 and on one of the two campaign profiles. A `choice_help_text` prompt tells users to choose Stock by default and SOL only for a SOL installation. Both profiles provide and conflict with the same virtual config identifier so they cannot be installed together.

The previous `prerelease: true` setting has been replaced with `prerelease: false`, because current releases are stable. KSP compatibility is declared as 1.12.0-1.12.99.

## Validation

- All three files validate against the current NetKAN schema.
- Asset regexes match the v0.9.1 release files.
- The main v0.9.1 archive contains the plugin plus four Stock catalog files.
- The SOL v0.9.1 overlay contains exactly the four replacement catalog files.

SOL itself is not currently indexed in NetKAN, so CKAN cannot yet detect a manually installed SOL planet pack automatically. The selection prompt is explicit and recommends Stock; once SOL has its own CKAN identifier, the profile relationships can be extended for automatic resolver-based selection.

Mod author: @timduebi