### PR TITLE
Make TURD modules depend on the mods they're for

### DIFF
--- a/NetKAN/TURD-BDArmory.netkan
+++ b/NetKAN/TURD-BDArmory.netkan
@@ -10,7 +10,6 @@ tags:
 depends:
   - name: ModuleManager
   - name: TexturesUnlimited
-suggests:
   - name: BDArmory
 install:
   - find: TU_BD_Recolour

--- a/NetKAN/TURD-BreakingGround.netkan
+++ b/NetKAN/TURD-BreakingGround.netkan
@@ -10,6 +10,7 @@ tags:
 depends:
   - name: ModuleManager
   - name: TexturesUnlimited
+  - name: BreakingGround-DLC
 install:
   - find: TURD/TU_BG_AllInOne
     install_to: GameData/TURD

--- a/NetKAN/TURD-KerbalFoundries.netkan
+++ b/NetKAN/TURD-KerbalFoundries.netkan
@@ -12,8 +12,7 @@ tags:
 depends:
   - name: ModuleManager
   - name: TexturesUnlimited
-suggests:
-  - name: KerbalFoundriesContinued
+  - name: KerbalFoundries
 install:
   - find: TURD
     install_to: GameData

--- a/NetKAN/TURD-MakingHistory.netkan
+++ b/NetKAN/TURD-MakingHistory.netkan
@@ -10,6 +10,7 @@ tags:
 depends:
   - name: ModuleManager
   - name: TexturesUnlimited
+  - name: MakingHistory-DLC
 install:
   - find: TURD/TU_MH_AllInOne
     install_to: GameData/TURD


### PR DESCRIPTION
#10715 added several `TURD-*` modules that modify other mods, but those mods weren't dependencies, meaning you can install these but not have any of the parts that are supposed to be changed.

Now they're dependencies.
