### PR TITLE
Add OuterParallax dependency on VertexHeightOblateAdvanced

### DIFF
--- a/NetKAN/OuterParallax.netkan
+++ b/NetKAN/OuterParallax.netkan
@@ -13,6 +13,7 @@ depends:
   - name: ModuleManager
   - name: Kopernicus
   - name: VertexMitchellNetravaliHeightMap
+  - name: VertexHeightOblateAdvanced
   - name: ParallaxContinued
 suggests:
   - name: OuterParallax-OPM


### PR DESCRIPTION
<img width="634" height="183" alt="image" src="https://github.com/user-attachments/assets/da8d3f19-186d-4f81-bd42-9a249cfd65c7" />

Confirmed that this is present in what look like an attempt at internal .ckan files (but with a .yaml extension, so the bot won't use them):

- <https://github.com/jthero3/OuterParallaxContinued/tree/main/CKAN>

FYI to @jthero3.
