### PR TITLE
Add RuKER mod

### DIFF
--- a/NetKAN/RuKER.netkan
+++ b/NetKAN/RuKER.netkan
@@ -1,0 +1,25 @@
+{
+    "spec_version": 1,
+    "identifier": "RuKER",
+    "name": "Kerbal Engineer Redux - Русская версия",
+    "abstract": "Полностью переведённая на русский язык версия мода Kerbal Engineer Redux. Не требует установки оригинального KER.",
+    "author": "sherhan19",
+    "license": "GPL-3.0",
+    "ksp_version": "1.12.5",
+    "depends": [],
+    "conflicts": [
+        { "name": "KerbalEngineerRedux" }
+    ],
+    "provides": [ "KerbalEngineerRedux" ],
+    "install": [
+        {
+            "find": "GameData/RuKER",
+            "install_to": "GameData"
+        }
+    ],
+    "resources": {
+        "homepage": "https://github.com/sherhan19/RuKER",
+        "repository": "https://github.com/sherhan19/RuKER",
+        "bugs": "https://github.com/sherhan19/RuKER/issues"
+    }
+}


### PR DESCRIPTION
RuKER — Russian version of Kerbal Engineer Redux

This is a fully translated Russian version of the Kerbal Engineer Redux mod.

Important:
- RuKER is a standalone replacement for the original Kerbal Engineer Redux.
- It is NOT compatible with the original KER. Users must remove KerbalEngineer folder before installation.
- The mod is distributed under the GPL-3.0 license, same as the original KER.

Repository: https://github.com/sherhan19/RuKER
Original KER: https://github.com/jrbudda/KerbalEngineer