### PR TITLE
KoobalSearchEngine: version_edit on both hosts

### DIFF
--- a/NetKAN/KoobalSearchEngine.netkan
+++ b/NetKAN/KoobalSearchEngine.netkan
@@ -1,10 +1,12 @@
 identifier: KoobalSearchEngine
 $kref: '#/ckan/github/timbrwolf1121-cpu/Koobal-Search-Engine'
 $vref: '#/ckan/ksp-avc'
+x_netkan_version_edit: ^v?(?<version>.+)$
 ---
 identifier: KoobalSearchEngine
 $kref: '#/ckan/spacedock/4394'
 $vref: '#/ckan/ksp-avc'
+x_netkan_version_edit: ^v?(?<version>.+)$
 tags:
   - config
   - plugin


### PR DESCRIPTION
﻿## Summary
- Add `x_netkan_version_edit: ^v?(?<version>.+)$` to **both** GitHub and SpaceDock stanzas in `KoobalSearchEngine.netkan`.
- Follow-up to #11342: HebaruSan made inflate pass by removing the GitHub-only edit so both hosts kept the `v` prefix; this keeps hosts aligned while normalizing to unprefixed versions (e.g. `0.8.5.2b`).

## Test plan
- [ ] Inflate CI passes
- [ ] Both hosts produce the same module version string
