### PR TITLE
Add Relativity

### DIFF
--- a/NetKAN/Relativity.netkan
+++ b/NetKAN/Relativity.netkan
@@ -19,7 +19,8 @@
     "resources": {
         "homepage": "https://github.com/Vannadin/Relativity",
         "repository": "https://github.com/Vannadin/Relativity",
-        "bugtracker": "https://github.com/Vannadin/Relativity/issues"
+        "bugtracker": "https://github.com/Vannadin/Relativity/issues",
+        "spacedock": "https://spacedock.info/mod/4404/Relativity"
     },
     "x_netkan_github": {
         "use_source_archive": false

--- a/NetKAN/Relativity.netkan
+++ b/NetKAN/Relativity.netkan
@@ -14,7 +14,7 @@
     "suggests": [
         { "name": "ModuleManager" },
         { "name": "Kerbalism" },
-        { "name": "RP-1" }
+        { "name": "FarFutureTechnologies" }
     ],
     "resources": {
         "homepage": "https://github.com/Vannadin/Relativity",

--- a/NetKAN/Relativity.netkan
+++ b/NetKAN/Relativity.netkan
@@ -1,5 +1,6 @@
 identifier: Relativity
 $kref: '#/ckan/github/Vannadin/Relativity'
+x_netkan_version_edit: ^v?(?<version>.+)$
 ---
 identifier: Relativity
 $kref: '#/ckan/spacedock/4404'

--- a/NetKAN/Relativity.netkan
+++ b/NetKAN/Relativity.netkan
@@ -1,28 +1,16 @@
-{
-    "spec_version": "v1.18",
-    "identifier": "Relativity",
-    "name": "Relativity",
-    "abstract": "A sub-light special-relativity layer: near c, effective thrust falls as 1/gamma^3 while a fast crew ages and consumes supplies slower by 1/gamma, and an optional visual layer shows it (Doppler colour, relativistic beaming, star-bunching aberration). Modulates force and rate only, never the integrator, so it rides alongside Principia and the stock profile.",
-    "$kref": "#/ckan/github/Vannadin/Relativity",
-    "$vref": "#/ckan/ksp-avc",
-    "license": "MIT",
-    "author": "VaNnadin",
-    "tags": [ "physics", "gameplay", "plugin" ],
-    "depends": [
-        { "name": "Harmony2" }
-    ],
-    "suggests": [
-        { "name": "ModuleManager" },
-        { "name": "Kerbalism" },
-        { "name": "FarFutureTechnologies" }
-    ],
-    "resources": {
-        "homepage": "https://github.com/Vannadin/Relativity",
-        "repository": "https://github.com/Vannadin/Relativity",
-        "bugtracker": "https://github.com/Vannadin/Relativity/issues",
-        "spacedock": "https://spacedock.info/mod/4404/Relativity"
-    },
-    "x_netkan_github": {
-        "use_source_archive": false
-    }
-}
+identifier: Relativity
+$kref: '#/ckan/github/Vannadin/Relativity'
+---
+identifier: Relativity
+$kref: '#/ckan/spacedock/4404'
+$vref: '#/ckan/ksp-avc'
+tags:
+  - physics
+  - gameplay
+  - plugin
+depends:
+  - name: Harmony2
+suggests:
+  - name: ModuleManager
+  - name: Kerbalism
+  - name: FarFutureTechnologies

--- a/NetKAN/Relativity.netkan
+++ b/NetKAN/Relativity.netkan
@@ -1,0 +1,27 @@
+{
+    "spec_version": "v1.18",
+    "identifier": "Relativity",
+    "name": "Relativity",
+    "abstract": "A sub-light special-relativity layer: near c, effective thrust falls as 1/gamma^3 while a fast crew ages and consumes supplies slower by 1/gamma, and an optional visual layer shows it (Doppler colour, relativistic beaming, star-bunching aberration). Modulates force and rate only, never the integrator, so it rides alongside Principia and the stock profile.",
+    "$kref": "#/ckan/github/Vannadin/Relativity",
+    "$vref": "#/ckan/ksp-avc",
+    "license": "MIT",
+    "author": "VaNnadin",
+    "tags": [ "physics", "gameplay", "plugin" ],
+    "depends": [
+        { "name": "Harmony2" }
+    ],
+    "suggests": [
+        { "name": "ModuleManager" },
+        { "name": "Kerbalism" },
+        { "name": "RP-1" }
+    ],
+    "resources": {
+        "homepage": "https://github.com/Vannadin/Relativity",
+        "repository": "https://github.com/Vannadin/Relativity",
+        "bugtracker": "https://github.com/Vannadin/Relativity/issues"
+    },
+    "x_netkan_github": {
+        "use_source_archive": false
+    }
+}


### PR DESCRIPTION
Adds Relativity: sub-light special-relativity layer for KSP 1.12.x: near c, effective thrust falls as 1/gamma^3 while a fast crew ages and consumes supplies slower by 1/gamma, plus an optional relativistic visual layer (Doppler colour, beaming, star-bunching aberration). Force/rate modulation only, never the integrator, so it rides alongside Principia.

- Repository / homepage: https://github.com/Vannadin/Relativity
- First indexed release: [v1.0.0](https://github.com/Vannadin/Relativity/releases/tag/v1.0.0) (`$kref` github, `$vref` ksp-avc from the bundled `.version`)
- License: MIT. Depends: Harmony2. Suggests: ModuleManager, Kerbalism, FarFutureTechnologies.
- The zip roots at `GameData/` with the standard `GameData/Relativity` layout (no install stanza needed).