### PR TITLE
Update ProbesBeforeCrew suggests/supports/conflicts list

### DIFF
--- a/NetKAN/ProbesBeforeCrew.netkan
+++ b/NetKAN/ProbesBeforeCrew.netkan
@@ -18,28 +18,59 @@ depends:
 suggests:
   - name: ContractConfigurator
   - name: Strategia
+  - name: HideEmptyTechNodes
 supports:
   - name: B9
+  - name: CryoEngines
+  - name: CryoEnginesExtensions
+  - name: CryoTanks
   - name: DMagicOrbitalScience
+  - name: HeatControl
   - name: KAS
   - name: KIS
   - name: kOS
+  - name: KerbalEngineerRedux
+  - name: KerbalAtomics
   - name: Kerbalism
   - name: KerbalPlanetaryBaseSystems
   - name: MarkIVSpaceplaneSystem
+  - name: NearFutureAeronautics
   - name: NearFutureConstruction
   - name: NearFutureElectrical
+  - name: NearFutureExploration
   - name: NearFutureLaunchVehicles
   - name: NearFutureSolar
   - name: NearFutureSpacecraft
   - name: NearFuturePropulsion
+  - name: KerbalActuators
   - name: MissingHistory
+  - name: OuterPlanetsMod
+  - name: MinorPlanetsExpansion
+  - name: ProceduralFairings
   - name: ProbeControlRoom
   - name: RealChute
   - name: RemoteTech
+  - name: RemoteTechRedevAntennas
+  - name: ReStockPlus
   - name: RLAReborn
   - name: SCANsat
+  - name: ScienceLabInfo
+  - name: SpaceDust
   - name: StationPartsExpansionRedux
+  - name: SupplementaryElectricEngines
+  - name: SystemHeat
   - name: TACLS
   - name: UniversalStorage2
   - name: USI-LS
+conflicts:
+  - name: UnKerballedStart
+  - name: GradualProgressionTechTree
+  - name: KiwiTechTree
+  - name: SkyhawkScienceSystem
+  - name: ETT
+  - name: CrusoeSpaceIndustriesTechTree
+  - name: BetterEarlyTree
+  - name: SimplexTechTree
+  - name: QUARTIXTechTree
+  - name: TETRIXTechTree
+  - name: ImprovedTreeEnginePlacement


### PR DESCRIPTION
PBC's list of supported mods has expanded since it was moved to GitHub, so here's a metadata update to match. Filing this on behalf of the PBC maintenance team as a collaborator. Closes #11303 

- <https://github.com/Moonlington/ProbesBeforeCrew>
