### PR TITLE
Add kOS-Kerbcast (KerbcastKos) from SpaceDock

### DIFF
--- a/NetKAN/KerbcastKos.netkan
+++ b/NetKAN/KerbcastKos.netkan
@@ -1,0 +1,11 @@
+{
+    "spec_version": "v1.34",
+    "identifier": "KerbcastKos",
+    "$kref": "#/ckan/spacedock/4419",
+    "$vref": "#/ckan/ksp-avc",
+    "license": "GPL-3.0-only",
+    "depends": [
+        { "name": "Kerbcast", "min_version": "1.6.0" },
+        { "name": "kOS" }
+    ]
+}

--- a/NetKAN/KerbcastKos.netkan
+++ b/NetKAN/KerbcastKos.netkan
@@ -1,10 +1,9 @@
-{
-    "identifier": "KerbcastKos",
-    "$kref": "#/ckan/spacedock/4419",
-    "$vref": "#/ckan/ksp-avc",
-    "license": "GPL-3.0",
-    "depends": [
-        { "name": "Kerbcast", "min_version": "1.6.0" },
-        { "name": "kOS" }
-    ]
-}
+identifier: KerbcastKos
+$kref: '#/ckan/spacedock/4419'
+$vref: '#/ckan/ksp-avc'
+license: GPL-3.0
+depends:
+  - name: Kerbcast
+    min_version: '1.6.0'
+  - name: kOS
+    min_version: '1.6.0'

--- a/NetKAN/KerbcastKos.netkan
+++ b/NetKAN/KerbcastKos.netkan
@@ -1,9 +1,8 @@
 {
-    "spec_version": "v1.34",
     "identifier": "KerbcastKos",
     "$kref": "#/ckan/spacedock/4419",
     "$vref": "#/ckan/ksp-avc",
-    "license": "GPL-3.0-only",
+    "license": "GPL-3.0",
     "depends": [
         { "name": "Kerbcast", "min_version": "1.6.0" },
         { "name": "kOS" }

--- a/NetKAN/KerbcastKos.netkan
+++ b/NetKAN/KerbcastKos.netkan
@@ -2,6 +2,9 @@ identifier: KerbcastKos
 $kref: '#/ckan/spacedock/4419'
 $vref: '#/ckan/ksp-avc'
 license: GPL-3.0
+tags:
+  - plugin
+  - control
 depends:
   - name: Kerbcast
     min_version: '1.6.0'

--- a/NetKAN/KerbcastKos.netkan
+++ b/NetKAN/KerbcastKos.netkan
@@ -1,6 +1,13 @@
 identifier: KerbcastKos
+$kref: '#/ckan/github/ksp-gonogo/kerbcast/asset_match/KerbcastKos'
+$vref: '#/ckan/ksp-avc'
+x_netkan_version_edit: '^v?(?<version>.+)$'
+license: GPL-3.0
+---
+identifier: KerbcastKos
 $kref: '#/ckan/spacedock/4419'
 $vref: '#/ckan/ksp-avc'
+x_netkan_version_edit: '^v?(?<version>.+)$'
 license: GPL-3.0
 tags:
   - plugin


### PR DESCRIPTION
Adds [kOS-Kerbcast](https://spacedock.info/mod/4366/Kerbcast), a kOS camera-control addon. It lets a you enumerate vessel Kerbcast cameras and control field of view, pan, and target tracking.

- SpaceDock: https://spacedock.info/mod/4419/kOS-Kerbcast (id 4419)
- Identifier `KerbcastKos` (the install folder and AVC name; the SpaceDock display name is kOS-Kerbcast)