### PR TITLE
Add ExoInstruments

### DIFF
--- a/NetKAN/ExoInstruments.netkan
+++ b/NetKAN/ExoInstruments.netkan
@@ -1,29 +1,23 @@
-{
-    "spec_version": "v1.4",
-    "identifier": "ExoInstruments",
-    "$kref": "#/ckan/github/batistitooo/ExoInstruments",
-    "license": "restricted",
-    "author": "batistitooo",
-    "abstract": "A ground-based exoplanet survey mod built on real observational astrophysics: transit photometry, radial velocity, and direct imaging detection pipelines against a real star catalog.",
-    "description": "Replaces KSP's stock science-experiment loop with an actual exoplanet survey program. Select a real star from an exoplanet.eu-derived catalog, choose an instrument appropriate to its brightness and detection method, and extract a signal from simulated, photon-noise-limited data exactly the way an observational astronomer would. Includes transit timing variations (TTV), the Rossiter-McLaughlin effect, and a career-mode instrument-acquisition economy.",
-    "ksp_version_min": "1.8.0",
-    "resources": {
-        "homepage": "https://github.com/batistitooo/ExoInstruments",
-        "repository": "https://github.com/batistitooo/ExoInstruments",
-        "license": "https://github.com/batistitooo/ExoInstruments/blob/main/LICENSE"
-    },
-    "depends": [
-        { "name": "ModuleManager" },
-        { "name": "KerbalKonstructs" }
-    ],
-    "recommends": [
-        { "name": "BetterTimeWarpCont" }
-    ],
-    "install": [
-        {
-            "find": "ExoInstruments",
-            "install_to": "GameData"
-        }
-    ],
-    "tags": ["science", "physics"]
-}
+identifier: ExoInstruments
+$kref: '#/ckan/github/batistitooo/ExoInstruments'
+abstract: >-
+  A ground-based exoplanet survey mod built on real observational astrophysics:
+  transit photometry, radial velocity, and direct imaging detection pipelines
+  against a real star catalog.
+description: >-
+  Replaces KSP's stock science-experiment loop with an actual exoplanet survey
+  program. Select a real star from an exoplanet.eu-derived catalog, choose an
+  instrument appropriate to its brightness and detection method, and extract a
+  signal from simulated, photon-noise-limited data exactly the way an
+  observational astronomer would. Includes transit timing variations (TTV), the
+  Rossiter-McLaughlin effect, and a career-mode instrument-acquisition economy.
+ksp_version_min: 1.8.0
+license: restricted
+tags:
+  - science
+  - physics
+depends:
+  - name: ModuleManager
+  - name: KerbalKonstructs
+recommends:
+  - name: BetterTimeWarpCont

--- a/NetKAN/ExoInstruments.netkan
+++ b/NetKAN/ExoInstruments.netkan
@@ -1,0 +1,29 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "ExoInstruments",
+    "$kref": "#/ckan/github/batistitooo/ExoInstruments",
+    "license": "restricted",
+    "author": "batistitooo",
+    "abstract": "A ground-based exoplanet survey mod built on real observational astrophysics: transit photometry, radial velocity, and direct imaging detection pipelines against a real star catalog.",
+    "description": "Replaces KSP's stock science-experiment loop with an actual exoplanet survey program. Select a real star from an exoplanet.eu-derived catalog, choose an instrument appropriate to its brightness and detection method, and extract a signal from simulated, photon-noise-limited data exactly the way an observational astronomer would. Includes transit timing variations (TTV), the Rossiter-McLaughlin effect, and a career-mode instrument-acquisition economy.",
+    "ksp_version_min": "1.8.0",
+    "resources": {
+        "homepage": "https://github.com/batistitooo/ExoInstruments",
+        "repository": "https://github.com/batistitooo/ExoInstruments",
+        "license": "https://github.com/batistitooo/ExoInstruments/blob/main/LICENSE"
+    },
+    "depends": [
+        { "name": "ModuleManager" },
+        { "name": "KerbalKonstructs" }
+    ],
+    "recommends": [
+        { "name": "BetterTimeWarpCont" }
+    ],
+    "install": [
+        {
+            "find": "ExoInstruments",
+            "install_to": "GameData"
+        }
+    ],
+    "tags": ["science", "physics"]
+}


### PR DESCRIPTION
New mod submission: ExoInstruments, a ground-based exoplanet survey mod for KSP1 built on real observational astrophysics (real star catalog, transit photometry / radial velocity / direct imaging detection pipelines, TTV, Rossiter-McLaughlin).

- Repo: https://github.com/batistitooo/ExoInstruments
- Release: https://github.com/batistitooo/ExoInstruments/releases/tag/v0.1.0
- Hard dependencies: ModuleManager, KerbalKonstructs
- Recommended (soft dependency): BetterTimeWarpCont