### PR TITLE
Add KSPKoreanLocalization.netkan

### DIFF
--- a/NetKAN/KSPKoreanLocalization.netkan
+++ b/NetKAN/KSPKoreanLocalization.netkan
@@ -1,0 +1,11 @@
+identifier: KSPKoreanLocalization
+name: KSP Korean Localization
+abstract: Korean localization for KSP and both DLCs (Making History, Breaking Ground). Injects the language at runtime without modifying any stock files.
+$kref: '#/ckan/github/synml/KSP-Korean-Localization'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+install:
+  - find: KSPKorean
+    install_to: GameData


### PR DESCRIPTION
This PR adds KSP Korean Localization, a Korean language pack for KSP 1.12.x
covering the base game and both DLCs (Making History, Breaking Ground).

- Source: https://github.com/synml/KSP-Korean-Localization
- Install stanza uses `find: KSPKorean` → `GameData`.
- Versioning: GitHub releases (`$kref`) + KSP-AVC `.version` release asset
  (`$vref`), KSP 1.12.x.