### PR TITLE
ExoInstruments: require BetterTimeWarpCont, recommend EVE Redux + Spectra

### DIFF
--- a/NetKAN/ExoInstruments.netkan
+++ b/NetKAN/ExoInstruments.netkan
@@ -19,5 +19,7 @@ tags:
 depends:
   - name: ModuleManager
   - name: KerbalKonstructs
-recommends:
   - name: BetterTimeWarpCont
+recommends:
+  - name: EnvironmentalVisualEnhancements
+  - name: Spectra


### PR DESCRIPTION
BetterTimeWarpCont is now required rather than merely recommended, since the mod's time-warp integration is core to its observation-scheduling workflow.

Also adds EnvironmentalVisualEnhancements and Spectra as recommendations: the mod's RC20 astrograph reads live cloud cover from EVE when installed, and Spectra is the stock-system EVE config pack needed for that to actually show anything.