### PR TITLE
Add KSP Store & Forward

### DIFF
--- a/NetKAN/KSPStoreForward.netkan
+++ b/NetKAN/KSPStoreForward.netkan
@@ -1,0 +1,26 @@
+identifier: KSPStoreForward
+$kref: '#/ckan/github/Xordas/KSPStoreForward/asset_match/^KSPStoreForward-[0-9]+\.[0-9]+\.[0-9]+\.zip$'
+abstract: >-
+  Allows qualified CommNet relay vessels to forward through a direct antenna
+  on the same vessel.
+license: MIT
+ksp_version: 1.12.5
+ksp_version_strict: true
+tags:
+  - plugin
+  - information
+  - comms
+  - uncrewed
+depends:
+  - name: Harmony2
+  - name: ModuleManager
+conflicts:
+  - name: RemoteTech
+  - name: RealAntennas
+install:
+  - find: KSPStoreForward
+    install_to: GameData
+x_netkan_staging: true
+x_netkan_staging_reason: >-
+  New CommNet routing plugin. Review dependency, conflict, KSP version, and
+  installation metadata before indexing.

--- a/NetKAN/KSPStoreForward.netkan
+++ b/NetKAN/KSPStoreForward.netkan
@@ -1,11 +1,10 @@
 identifier: KSPStoreForward
-$kref: '#/ckan/github/Xordas/KSPStoreForward/asset_match/^KSPStoreForward-[0-9]+\.[0-9]+\.[0-9]+\.zip$'
+$kref: '#/ckan/github/Xordas/KSPStoreForward'
+$vref: '#/ckan/ksp-avc'
+name: KSP Store & Forward
 abstract: >-
   Allows qualified CommNet relay vessels to forward through a direct antenna
   on the same vessel.
-license: MIT
-ksp_version: 1.12.5
-ksp_version_strict: true
 tags:
   - plugin
   - information
@@ -17,10 +16,3 @@ depends:
 conflicts:
   - name: RemoteTech
   - name: RealAntennas
-install:
-  - find: KSPStoreForward
-    install_to: GameData
-x_netkan_staging: true
-x_netkan_staging_reason: >-
-  New CommNet routing plugin. Review dependency, conflict, KSP version, and
-  installation metadata before indexing.


### PR DESCRIPTION
Adds KSP Store & Forward, a KSP 1.12.5 CommNet plugin that allows qualified relay vessels to receive through a relay antenna and forward through a direct antenna on the same vessel.

- Source: https://github.com/Xordas/KSPStoreForward
- Release: https://github.com/Xordas/KSPStoreForward/releases/tag/v1.0.0
- License: MIT
- Game version: KSP 1.12.5 only
- Dependencies: Harmony2 and ModuleManager
- Conflicts: RemoteTech and RealAntennas

Testing completed on KSP 1.12.5 includes:

- Enabling and disabling the store-and-forward processor.
- Retracting either antenna and confirming that the route is removed.
- Engineer, pilot, scientist, EVA, and capable-probe-core eligibility cases.
- Save, reload, time warp, and switching away from the relay vessel.
- Loaded and unloaded third-party antennas from Near Future Exploration and ReStock+.
- Nearby ModuleProbeControlPoint gating.
- A ten-minute run in a save with roughly 25 vessels while repeatedly opening the CommNet tooltip, with no KSPStoreForward warning growth or recurring frame spikes.
