### PR TITLE
Add KSPKoreanLocalization.netkan

### DIFF
--- a/NetKAN/KSPKoreanLocalization.netkan
+++ b/NetKAN/KSPKoreanLocalization.netkan
@@ -1,0 +1,11 @@
+identifier: KSPKoreanLocalization
+name: KSP Korean Localization
+abstract: Korean localization for KSP and both DLCs (Making History, Breaking Ground). Injects the language at runtime without modifying any stock files.
+$kref: '#/ckan/github/synml/KSP-Korean-Localization/asset_match/\.zip$'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+tags:
+  - plugin
+install:
+  - find: KSPKorean
+    install_to: GameData


### PR DESCRIPTION
Adds [KSP Korean Localization](https://github.com/synml/KSP-Korean-Localization) — Korean localization for KSP and both DLCs (Making History, Breaking Ground). It injects the language at runtime, so no stock files are modified.

A couple of notes on the netkan:

- `$kref` uses `asset_match/\.zip$` because every release also ships `install.cmd` and `KSPKorean.version` next to the mod archive.
- `$vref: '#/ckan/ksp-avc'` resolves against the `KSPKorean.version` asset attached to each release.

This replaces #11379, which I had opened from my fork's `master` branch by mistake.

I'm a first-time contributor here, so the `Inflate` workflow run is sitting in `action_required` and needs a maintainer to approve it. Would appreciate it if someone could kick it off — happy to fix anything the inflation turns up. Thanks!
