### PR TITLE
Add DeepFreeze Suit Support

### DIFF
--- a/NetKAN/DeepFreezeSuitSupport.netkan
+++ b/NetKAN/DeepFreezeSuitSupport.netkan
@@ -5,10 +5,6 @@ author: javap
 $kref: '#/ckan/github/javapythonsean-rgb/DeepFreezeSuitSupport'
 $vref: '#/ckan/ksp-avc'
 license: MIT
-resources:
-  homepage: https://github.com/javapythonsean-rgb/DeepFreezeSuitSupport
-  repository: https://github.com/javapythonsean-rgb/DeepFreezeSuitSupport
-  bugtracker: https://github.com/javapythonsean-rgb/DeepFreezeSuitSupport/issues
 tags:
   - plugin
   - crewed
@@ -18,6 +14,3 @@ depends:
     min_version: V1.32.0
   - name: Harmony2
     min_version: 2.2.1.0
-install:
-  - find: DeepFreezeSuitSupport
-    install_to: GameData

--- a/NetKAN/DeepFreezeSuitSupport.netkan
+++ b/NetKAN/DeepFreezeSuitSupport.netkan
@@ -1,0 +1,23 @@
+identifier: DeepFreezeSuitSupport
+name: DeepFreeze Suit Support
+abstract: Keeps stock Vintage and Future suits intact when DeepFreeze thaws Kerbals
+author: javap
+$kref: '#/ckan/github/javapythonsean-rgb/DeepFreezeSuitSupport'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+resources:
+  homepage: https://github.com/javapythonsean-rgb/DeepFreezeSuitSupport
+  repository: https://github.com/javapythonsean-rgb/DeepFreezeSuitSupport
+  bugtracker: https://github.com/javapythonsean-rgb/DeepFreezeSuitSupport/issues
+tags:
+  - plugin
+  - crewed
+  - convenience
+depends:
+  - name: DeepFreeze
+    min_version: V1.32.0
+  - name: Harmony2
+    min_version: 2.2.1.0
+install:
+  - find: DeepFreezeSuitSupport
+    install_to: GameData


### PR DESCRIPTION
Adds CKAN metadata for DeepFreeze Suit Support 1.1.0.\n\n- KSP-AVC supplies KSP 1.12.x compatibility and the version.\n- Requires DeepFreeze V1.32.0+ and Harmony2 2.2.1.0+.\n- GitHub release archive inflates successfully with CKAN-NetKAN 1.36.4.\n- Generated metadata resolves the intended ZIP, install path, dependencies, and SHA-256.\n\nI am the mod author and submit this metadata under CC0.