### PR TITLE
Add kOS-AFBW

### DIFF
--- a/NetKAN/kOS-AFBW.netkan
+++ b/NetKAN/kOS-AFBW.netkan
@@ -1,19 +1,10 @@
-spec_version: v1.4
 identifier: kOS-AFBW
 $kref: '#/ckan/github/schuyler/kOS-AFBW'
 $vref: '#/ckan/ksp-avc'
-name: kOS-AFBW
 abstract: Bridge mod exposing AFBW's enable/disable toggle to kOS scripts.
-author: schuyler
-license: MIT
 tags:
   - plugin
   - control
-resources:
-  repository: https://github.com/schuyler/kOS-AFBW
 depends:
   - name: kOS
   - name: AdvancedFlyByWire
-install:
-  - file: GameData/kOS-AFBW
-    install_to: GameData

--- a/NetKAN/kOS-AFBW.netkan
+++ b/NetKAN/kOS-AFBW.netkan
@@ -1,0 +1,19 @@
+spec_version: v1.4
+identifier: kOS-AFBW
+$kref: '#/ckan/github/schuyler/kOS-AFBW'
+$vref: '#/ckan/ksp-avc'
+name: kOS-AFBW
+abstract: Bridge mod exposing AFBW's enable/disable toggle to kOS scripts.
+author: schuyler
+license: MIT
+tags:
+  - plugin
+  - control
+resources:
+  repository: https://github.com/schuyler/kOS-AFBW
+depends:
+  - name: kOS
+  - name: AdvancedFlyByWire
+install:
+  - file: GameData/kOS-AFBW
+    install_to: GameData


### PR DESCRIPTION
Adds `kOS-AFBW`, a bridge mod exposing [Advanced FlyByWire](https://github.com/DBooots/AdvancedFlyByWire)'s enable/disable toggle to kOS scripts.

- Author/maintainer: me (schuyler)
- License: MIT
- Repository: https://github.com/schuyler/kOS-AFBW (indexed via `$kref` GitHub source)
- Compatibility: KSP-AVC `.version` file included, indexed via `$vref: '#/ckan/ksp-avc'`
- Depends on `kOS` and `AdvancedFlyByWire`
- Current release: v0.1.0 (https://github.com/schuyler/kOS-AFBW/releases/tag/v0.1.0)

Validated locally with `netkan.exe --verbose`, inflates cleanly to a `.ckan` file with a valid download/checksum from the v0.1.0 release asset.