### PR TITLE
Add kOS-StockAlarm

### DIFF
--- a/NetKAN/kOS-StockAlarm.netkan
+++ b/NetKAN/kOS-StockAlarm.netkan
@@ -1,0 +1,23 @@
+spec_version: v1.4
+identifier: kOS-StockAlarm
+$kref: '#/ckan/github/schuyler/kOS-StockAlarm'
+$vref: '#/ckan/ksp-avc'
+name: kOS-StockAlarm
+abstract: Exposes the stock KSP alarm clock to kOS scripts.
+author: schuyler
+license: MIT
+tags:
+  - plugin
+  - control
+resources:
+  repository: https://github.com/schuyler/kOS-StockAlarm
+depends:
+  - name: kOS
+conflicts:
+  # This mod takes over the ADDALARM and LISTALARMS script functions, which kOS
+  # otherwise routes to Kerbal Alarm Clock. Installing both would silently change
+  # what those functions mean, so treat it as a conflict rather than a surprise.
+  - name: KerbalAlarmClock
+install:
+  - file: GameData/kOS-StockAlarm
+    install_to: GameData

--- a/NetKAN/kOS-StockAlarm.netkan
+++ b/NetKAN/kOS-StockAlarm.netkan
@@ -1,23 +1,12 @@
-spec_version: v1.4
 identifier: kOS-StockAlarm
 $kref: '#/ckan/github/schuyler/kOS-StockAlarm'
 $vref: '#/ckan/ksp-avc'
-name: kOS-StockAlarm
 abstract: Exposes the stock KSP alarm clock to kOS scripts.
-author: schuyler
 license: MIT
 tags:
   - plugin
   - control
-resources:
-  repository: https://github.com/schuyler/kOS-StockAlarm
 depends:
   - name: kOS
 conflicts:
-  # This mod takes over the ADDALARM and LISTALARMS script functions, which kOS
-  # otherwise routes to Kerbal Alarm Clock. Installing both would silently change
-  # what those functions mean, so treat it as a conflict rather than a surprise.
   - name: KerbalAlarmClock
-install:
-  - file: GameData/kOS-StockAlarm
-    install_to: GameData


### PR DESCRIPTION
Adds `kOS-StockAlarm`, exposing the stock KSP alarm clock (not the KAC mod) to kOS scripts.

- Author/maintainer: me (schuyler)
- License: MIT
- Repository: https://github.com/schuyler/kOS-StockAlarm (indexed via `$kref` GitHub source)
- Compatibility: KSP-AVC `.version` file included, indexed via `$vref: '#/ckan/ksp-avc'`
- Depends on `kOS`; conflicts with `KerbalAlarmClock` (both would silently redefine `ADDALARM`/`LISTALARMS`)
- Current release: v0.1.0 (https://github.com/schuyler/kOS-StockAlarm/releases/tag/v0.1.0)

Validated locally with `netkan.exe --verbose`, inflates cleanly to a `.ckan` file with a valid download/checksum from the v0.1.0 release asset.