### PR TITLE
Fix incorrect regex in systemheatcompat

### DIFF
--- a/NetKAN/KerbalismSystemHeatCompat.netkan
+++ b/NetKAN/KerbalismSystemHeatCompat.netkan
@@ -2,7 +2,7 @@ identifier: KerbalismSystemHeatCompat
 name: Kerbalism - SystemHeat Compat
 abstract: Optional Kerbalism SystemHeat support for stock and third-party parts. Requires Kerbalism-SystemHeat.
 author: Kerbalism Contributors
-$kref: '#/ckan/github/Kerbalism/Kerbalism/asset_match/KerbalismSystemHeatExtras*'
+$kref: '#/ckan/github/Kerbalism/Kerbalism/asset_match/KerbalismSystemHeatExtras'
 license: MIT
 tags:
   - config


### PR DESCRIPTION
I accidentally merged in the netkan without noticing the incorrect regex here, there doesn't need to be one here, so this should fix it