### PR TITLE
Kerbalism: recommend SystemHeat Core and Compat

### DIFF
--- a/NetKAN/Kerbalism-Config-Default.netkan
+++ b/NetKAN/Kerbalism-Config-Default.netkan
@@ -18,6 +18,7 @@ depends:
   - name: Kerbalism
 recommends:
   - name: KerbalismEngineFailures
+  - name: Kerbalism-SystemHeat
 conflicts:
   - name: Kerbalism-Config
   - name: UKS

--- a/NetKAN/Kerbalism-SystemHeat.netkan
+++ b/NetKAN/Kerbalism-SystemHeat.netkan
@@ -10,7 +10,7 @@ depends:
   - name: ModuleManager
   - name: Kerbalism-Config
   - name: SystemHeat
-suggests:
+recommends:
   - name: KerbalismSystemHeatCompat
 conflicts:
   - name: Kerbalism-FarFutureTechnologies


### PR DESCRIPTION
1. Recommend `Kerbalism-SystemHeat` from `Kerbalism-Config-Default`
2. Strengthen `KerbalismSystemHeatCompat` from `suggests` to `recommends` on `Kerbalism-SystemHeat`