### PR TITLE
Add Bennu

### DIFF
--- a/NetKAN/Bennu.netkan
+++ b/NetKAN/Bennu.netkan
@@ -1,0 +1,33 @@
+identifier: Bennu
+name: Bennu
+abstract: >-
+  101955 Bennu as a real Kopernicus celestial body rather than a stock asteroid
+  vessel - landable procedural terrain with colliders, thirteen IAU-named biomes
+  with their own science, a Kerbin-crossing orbit, and a resource distribution
+  taken from the OSIRIS-REx sample.
+author:
+  - CritZitGaming
+$kref: >-
+  #/ckan/github/CritZitGaming/KSP-Bennu/version_from_asset/^Bennu-(?<version>[0-9.]+)\.zip$
+$vref: '#/ckan/ksp-avc/GameData/Bennu/Bennu.version'
+license: CC-BY-NC-SA-4.0
+tags:
+  - config
+  - planet-pack
+depends:
+  - name: ModuleManager
+  - name: Kopernicus
+recommends:
+  - name: ParallaxContinued
+  - name: PlanetShine
+suggests:
+  - name: CommunityResourcePack
+  - name: SCANsat
+  - name: KerbalFX
+resources:
+  homepage: https://github.com/CritZitGaming/KSP-Bennu
+  repository: https://github.com/CritZitGaming/KSP-Bennu
+  bugtracker: https://github.com/CritZitGaming/KSP-Bennu/issues
+install:
+  - find: Bennu
+    install_to: GameData

--- a/NetKAN/Bennu.netkan
+++ b/NetKAN/Bennu.netkan
@@ -1,15 +1,8 @@
 identifier: Bennu
 name: Bennu
-abstract: >-
-  101955 Bennu as a real Kopernicus celestial body rather than a stock asteroid
-  vessel - landable procedural terrain with colliders, thirteen IAU-named biomes
-  with their own science, a Kerbin-crossing orbit, and a resource distribution
-  taken from the OSIRIS-REx sample.
-author:
-  - CritZitGaming
-$kref: >-
-  #/ckan/github/CritZitGaming/KSP-Bennu/version_from_asset/^Bennu-(?<version>[0-9.]+)\.zip$
-$vref: '#/ckan/ksp-avc/GameData/Bennu/Bennu.version'
+$kref: '#/ckan/github/CritZitGaming/KSP-Bennu'
+$vref: '#/ckan/ksp-avc/Bennu/Bennu.version'
+x_netkan_version_edit: ^v?(?<version>.+)$
 license: CC-BY-NC-SA-4.0
 tags:
   - config
@@ -23,11 +16,5 @@ recommends:
 suggests:
   - name: CommunityResourcePack
   - name: SCANsat
-  - name: KerbalFX
-resources:
-  homepage: https://github.com/CritZitGaming/KSP-Bennu
-  repository: https://github.com/CritZitGaming/KSP-Bennu
-  bugtracker: https://github.com/CritZitGaming/KSP-Bennu/issues
-install:
-  - find: Bennu
-    install_to: GameData
+  - name: KerbalFX-RoverDust
+  - name: KerbalFX-ImpactPuffs


### PR DESCRIPTION
Adding **Bennu**, a Kopernicus planet pack that adds 101955 Bennu as a real celestial body rather than a stock asteroid vessel — landable PQS terrain with colliders, thirteen IAU-named biomes with their own science, a Kerbin-crossing orbit, and a resource distribution based on the OSIRIS-REx sample.

I'm the mod author, so this is submitted with permission. I understand this metadata contribution is made under CC-0; the mod itself is CC-BY-NC-SA-4.0.

- Repo: https://github.com/CritZitGaming/KSP-Bennu
- Release: https://github.com/CritZitGaming/KSP-Bennu/releases/tag/v1.0.0
- Asset: `Bennu-1.0.0.zip`, `GameData/Bennu/` at the zip root

Notes on the metadata:

- `$kref` uses `version_from_asset` against `^Bennu-(?<version>[0-9.]+)\.zip$`, which the release workflow guarantees the asset name matches.
- `$vref` reads `GameData/Bennu/Bennu.version` from inside the zip. The release workflow fails the build if that file and the git tag disagree, so they can't drift.
- `homepage` currently points at the GitHub repo — there's no forum thread yet. Happy to submit a follow-up pointing it at one if that's preferred.
- Requires Kopernicus and Module Manager. Every other integration (Parallax Continued, PlanetShine, KerbalFX, SCANsat, CRP) is gated behind `:NEEDS[…]` and is genuinely optional, hence recommends/suggests rather than depends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)