### PR TITLE
Harmony2 Required

### DIFF
--- a/NetKAN/Sandcastle.netkan
+++ b/NetKAN/Sandcastle.netkan
@@ -13,6 +13,7 @@ depends:
   - name: ModuleManager
   - name: WildBlueCore
   - name: NearFutureProps
+  - name: Harmony2
 recommends:
   - name: ExtraPlanetaryLaunchpads
   - name: KSP-PartVolume

--- a/NetKAN/SunkWorks.netkan
+++ b/NetKAN/SunkWorks.netkan
@@ -13,6 +13,7 @@ tags:
 depends:
   - name: ModuleManager
   - name: WildBlueCore
+  - name: Harmony2
 install:
   - find: SunkWorks
     install_to: GameData/WildBlueIndustries


### PR DESCRIPTION
Adds NetKAN dependency to SunkWorks and Sandcastle for Harmony2.