### PR TITLE
Add KoKo (Kerbal Orbital Kompany)

### DIFF
--- a/NetKAN/KoKo.netkan
+++ b/NetKAN/KoKo.netkan
@@ -1,0 +1,26 @@
+{
+    "spec_version": "v1.4",
+    "identifier": "KoKo",
+    "name": "KoKo - Kerbal Orbital Kompany",
+    "abstract": "Story-driven career overhaul: build off-world businesses and logistics networks, then scout and destroy a hostile Syndicate before it completes a fortress on Eeloo.",
+    "author": "timlumnah",
+    "license": "MIT",
+    "resources": {
+        "homepage": "https://github.com/timlumnah/kerbal-orbital-kompany",
+        "repository": "https://github.com/timlumnah/kerbal-orbital-kompany",
+        "bugtracker": "https://github.com/timlumnah/kerbal-orbital-kompany/issues"
+    },
+    "$kref": "#/ckan/github/timlumnah/kerbal-orbital-kompany",
+    "ksp_version_min": "1.8",
+    "ksp_version_max": "1.12.5",
+    "install": [
+        {
+            "find": "KoKo",
+            "install_to": "GameData"
+        }
+    ],
+    "depends": [
+        { "name": "ModuleManager" }
+    ],
+    "tags": [ "career", "logistics", "economy", "story" ]
+}

--- a/NetKAN/KoKo.netkan
+++ b/NetKAN/KoKo.netkan
@@ -1,26 +1,26 @@
-{
-    "spec_version": "v1.4",
-    "identifier": "KoKo",
-    "name": "KoKo - Kerbal Orbital Kompany",
-    "abstract": "Story-driven career overhaul: build off-world businesses and logistics networks, then scout and destroy a hostile Syndicate before it completes a fortress on Eeloo.",
-    "author": "timlumnah",
-    "license": "MIT",
-    "resources": {
-        "homepage": "https://github.com/timlumnah/kerbal-orbital-kompany",
-        "repository": "https://github.com/timlumnah/kerbal-orbital-kompany",
-        "bugtracker": "https://github.com/timlumnah/kerbal-orbital-kompany/issues"
-    },
-    "$kref": "#/ckan/github/timlumnah/kerbal-orbital-kompany",
-    "ksp_version_min": "1.8",
-    "ksp_version_max": "1.12.5",
-    "install": [
-        {
-            "find": "KoKo",
-            "install_to": "GameData"
-        }
-    ],
-    "depends": [
-        { "name": "ModuleManager" }
-    ],
-    "tags": [ "career", "logistics", "economy", "story" ]
-}
+identifier: KoKo
+name: KoKo - Kerbal Orbital Kompany
+abstract: >-
+  Story-driven career overhaul: build off-world businesses and logistics
+  networks, then scout and destroy a hostile Syndicate before it completes
+  a fortress on Eeloo.
+author: timlumnah
+$kref: '#/ckan/github/timlumnah/kerbal-orbital-kompany'
+ksp_version_min: '1.8'
+ksp_version_max: '1.12.5'
+license: MIT
+resources:
+  homepage: https://github.com/timlumnah/kerbal-orbital-kompany
+  repository: https://github.com/timlumnah/kerbal-orbital-kompany
+  bugtracker: https://github.com/timlumnah/kerbal-orbital-kompany/issues
+tags:
+  - plugin
+  - parts
+  - career
+  - combat
+  - science
+  - tech-tree
+depends:
+  - name: ModuleManager
+suggests:
+  - name: MechJeb2


### PR DESCRIPTION
New mod submission.

**KoKo (Kerbal Orbital Kompany)** — a story-driven KSP1 career-mode
overhaul: off-world business/logistics economy, a hostile Syndicate to
scout and destroy before it completes a fortress on Eeloo, an on-rails
weapon system, and a full campaign arc.

- Repo: https://github.com/timlumnah/kerbal-orbital-kompany
- Release: https://github.com/timlumnah/kerbal-orbital-kompany/releases/tag/v0.1.0
- License: MIT

Currently in beta / active development — flagged as such in the mod's
README. Happy to fix up the metadata if anything's off.