### PR TITLE
Add Injection Velocity Indicator

### DIFF
--- a/NetKAN/InjectionVelocityIndicator.netkan
+++ b/NetKAN/InjectionVelocityIndicator.netkan
@@ -5,17 +5,8 @@ author: Pzixel
 $kref: '#/ckan/github/Pzixel/injection-velocity-indicator'
 $vref: '#/ckan/ksp-avc'
 license: MIT
-release_status: stable
 tags:
   - plugin
   - information
 depends:
   - name: Harmony2
-resources:
-  homepage: https://github.com/Pzixel/injection-velocity-indicator
-  repository: https://github.com/Pzixel/injection-velocity-indicator
-  bugtracker: https://github.com/Pzixel/injection-velocity-indicator/issues
-  license: https://raw.githubusercontent.com/Pzixel/injection-velocity-indicator/master/LICENSE
-install:
-  - find: InjectionVelocityIndicator
-    install_to: GameData

--- a/NetKAN/InjectionVelocityIndicator.netkan
+++ b/NetKAN/InjectionVelocityIndicator.netkan
@@ -1,32 +1,21 @@
-{
-  "spec_version": "v1.28",
-  "identifier": "InjectionVelocityIndicator",
-  "$kref": "#/ckan/github/Pzixel/injection-velocity-indicator",
-  "$vref": "#/ckan/ksp-avc",
-  "name": "Injection Velocity Indicator",
-  "abstract": "Adds target-relative speed to the stock celestial-body closest-approach tooltip.",
-  "author": "Pzixel",
-  "license": "MIT",
-  "release_status": "stable",
-  "resources": {
-    "homepage": "https://github.com/Pzixel/injection-velocity-indicator",
-    "repository": "https://github.com/Pzixel/injection-velocity-indicator",
-    "bugtracker": "https://github.com/Pzixel/injection-velocity-indicator/issues",
-    "license": "https://raw.githubusercontent.com/Pzixel/injection-velocity-indicator/master/LICENSE"
-  },
-  "tags": [
-    "plugin",
-    "information"
-  ],
-  "depends": [
-    {
-      "name": "Harmony2"
-    }
-  ],
-  "install": [
-    {
-      "find": "InjectionVelocityIndicator",
-      "install_to": "GameData"
-    }
-  ]
-}
+identifier: InjectionVelocityIndicator
+name: Injection Velocity Indicator
+abstract: Adds target-relative speed to the stock celestial-body closest-approach tooltip.
+author: Pzixel
+$kref: '#/ckan/github/Pzixel/injection-velocity-indicator'
+$vref: '#/ckan/ksp-avc'
+license: MIT
+release_status: stable
+tags:
+  - plugin
+  - information
+depends:
+  - name: Harmony2
+resources:
+  homepage: https://github.com/Pzixel/injection-velocity-indicator
+  repository: https://github.com/Pzixel/injection-velocity-indicator
+  bugtracker: https://github.com/Pzixel/injection-velocity-indicator/issues
+  license: https://raw.githubusercontent.com/Pzixel/injection-velocity-indicator/master/LICENSE
+install:
+  - find: InjectionVelocityIndicator
+    install_to: GameData

--- a/NetKAN/InjectionVelocityIndicator.netkan
+++ b/NetKAN/InjectionVelocityIndicator.netkan
@@ -1,0 +1,32 @@
+{
+  "spec_version": "v1.28",
+  "identifier": "InjectionVelocityIndicator",
+  "$kref": "#/ckan/github/Pzixel/injection-velocity-indicator",
+  "$vref": "#/ckan/ksp-avc",
+  "name": "Injection Velocity Indicator",
+  "abstract": "Adds target-relative speed to the stock celestial-body closest-approach tooltip.",
+  "author": "Pzixel",
+  "license": "MIT",
+  "release_status": "stable",
+  "resources": {
+    "homepage": "https://github.com/Pzixel/injection-velocity-indicator",
+    "repository": "https://github.com/Pzixel/injection-velocity-indicator",
+    "bugtracker": "https://github.com/Pzixel/injection-velocity-indicator/issues",
+    "license": "https://raw.githubusercontent.com/Pzixel/injection-velocity-indicator/master/LICENSE"
+  },
+  "tags": [
+    "plugin",
+    "information"
+  ],
+  "depends": [
+    {
+      "name": "Harmony2"
+    }
+  ],
+  "install": [
+    {
+      "find": "InjectionVelocityIndicator",
+      "install_to": "GameData"
+    }
+  ]
+}


### PR DESCRIPTION
Adds Injection Velocity Indicator, a KSP 1.12.5 plugin that adds target-relative speed to the stock celestial-body closest-approach tooltip. Reason: high eccentricity orbits (such as moho) are tricky to deal with, you can see the closest approach but have no idea what is the relative speed, which might mean that some upfront burning can actually save a lot on arrival. This helps plotting without using advanced tools such as mechjeb autoplanner.

- Source: GitHub releases (`v1.0.0` published)
- Compatibility: KSP-AVC metadata, KSP 1.12.5
- Install: `GameData/InjectionVelocityIndicator`
- Required dependency: `Harmony2`
- The release does not bundle `0Harmony.dll` or modify another mod's folder

Validated with CKAN-NetKAN 1.36.5.26198. A clean CKAN 1.36.4 test install auto-installed Harmony2 into `GameData/000_Harmony` and installed this mod into its own folder.