### PR TITLE
Add Kerbal Proportions

### DIFF
--- a/NetKAN/KerbalProportions.netkan
+++ b/NetKAN/KerbalProportions.netkan
@@ -1,5 +1,6 @@
 identifier: KerbalProportions
 $kref: '#/ckan/github/NickDeVeau/Kerbal-Proportions'
+x_netkan_version_edit: ^v?(?<version>.+)$
 ---
 identifier: KerbalProportions
 $kref: '#/ckan/spacedock/4513'

--- a/NetKAN/KerbalProportions.netkan
+++ b/NetKAN/KerbalProportions.netkan
@@ -2,7 +2,7 @@ spec_version: v1.4
 identifier: KerbalProportions
 name: Kerbal Proportions
 abstract: Live visual rig and proportion editor for EVA and IVA Kerbals
-author: NickDeVeau
+author: Biggus
 license: MIT
 $kref: '#/ckan/github/NickDeVeau/Kerbal-Proportions/asset_match/^KerbalProportions-v.+\.zip$'
 $vref: '#/ckan/ksp-avc'

--- a/NetKAN/KerbalProportions.netkan
+++ b/NetKAN/KerbalProportions.netkan
@@ -1,0 +1,23 @@
+spec_version: v1.4
+identifier: KerbalProportions
+name: Kerbal Proportions
+abstract: Live visual rig and proportion editor for EVA and IVA Kerbals
+author: NickDeVeau
+license: MIT
+$kref: '#/ckan/github/NickDeVeau/Kerbal-Proportions/asset_match/^KerbalProportions-v.+\.zip$'
+$vref: '#/ckan/ksp-avc'
+x_netkan_github:
+  use_source_archive: false
+  prereleases: false
+tags:
+  - plugin
+  - graphics
+  - crewed
+install:
+  - find: KerbalProportions
+    install_to: GameData
+resources:
+  homepage: https://github.com/NickDeVeau/Kerbal-Proportions
+  spacedock: https://spacedock.info/mod/4513
+  repository: https://github.com/NickDeVeau/Kerbal-Proportions
+  bugtracker: https://github.com/NickDeVeau/Kerbal-Proportions/issues

--- a/NetKAN/KerbalProportions.netkan
+++ b/NetKAN/KerbalProportions.netkan
@@ -1,23 +1,10 @@
-spec_version: v1.4
 identifier: KerbalProportions
-name: Kerbal Proportions
-abstract: Live visual rig and proportion editor for EVA and IVA Kerbals
-author: Biggus
-license: MIT
-$kref: '#/ckan/github/NickDeVeau/Kerbal-Proportions/asset_match/^KerbalProportions-v.+\.zip$'
+$kref: '#/ckan/github/NickDeVeau/Kerbal-Proportions'
+---
+identifier: KerbalProportions
+$kref: '#/ckan/spacedock/4513'
 $vref: '#/ckan/ksp-avc'
-x_netkan_github:
-  use_source_archive: false
-  prereleases: false
 tags:
   - plugin
   - graphics
   - crewed
-install:
-  - find: KerbalProportions
-    install_to: GameData
-resources:
-  homepage: https://github.com/NickDeVeau/Kerbal-Proportions
-  spacedock: https://spacedock.info/mod/4513
-  repository: https://github.com/NickDeVeau/Kerbal-Proportions
-  bugtracker: https://github.com/NickDeVeau/Kerbal-Proportions/issues


### PR DESCRIPTION
Adds Kerbal Proportions, an author-submitted live visual rig and proportion editor for EVA and IVA Kerbals.

- GitHub release assets are the authoritative CKAN download source.
- KSP-AVC metadata supplies KSP 1.12.5 compatibility.
- Installs `KerbalProportions` to `GameData`.
- No third-party dependencies.
- Public author credit is **Biggus**; the source repository is hosted under the same author's GitHub account, **NickDeVeau**.
- SpaceDock listing: https://spacedock.info/mod/4513
- Source and support: https://github.com/NickDeVeau/Kerbal-Proportions

Validated successfully with CKAN-NetKAN 1.36.5 against release v2.5.0. The generated CKAN metadata resolves the 35,054-byte release asset with SHA-256 `5F44C01DCA2EC26C58673A74110FF71A529DC16D77024F52CFAF8F6846DB9F56`.

I contribute this metadata under CC0 as required by the NetKAN repository.