### PR TITLE
Add Heat Tile Painter

### DIFF
--- a/NetKAN/HeatTilePainter.netkan
+++ b/NetKAN/HeatTilePainter.netkan
@@ -1,0 +1,27 @@
+spec_version: v1.26
+identifier: HeatTilePainter
+name: Heat Tile Painter
+abstract: Paint heat-tile patterns or flat colors onto craft with editable layers and optional heat protection.
+author: peachyG
+license: MIT
+$kref: '#/ckan/github/peachyGT/HeatTilePainter/asset_match/^HeatTilePainter-[0-9]+\.[0-9]+\.[0-9]+\.zip$'
+$vref: '#/ckan/ksp-avc'
+x_netkan_version_edit:
+  find: '^v?(?<version>.+)$'
+  replace: '${version}'
+  strict: true
+release_status: stable
+resources:
+  homepage: https://forum.kerbalspaceprogram.com/topic/231652-1125-heat-tile-painter-0241-very-simple-way-to-add-heat-shielding-to-sstosspaceplanes/
+  repository: https://github.com/peachyGT/HeatTilePainter
+  bugtracker: https://github.com/peachyGT/HeatTilePainter/issues
+tags:
+  - plugin
+  - editor
+  - graphics
+  - physics
+depends:
+  - name: ModuleManager
+install:
+  - find: HeatTileOverlayPrototype
+    install_to: GameData

--- a/NetKAN/HeatTilePainter.netkan
+++ b/NetKAN/HeatTilePainter.netkan
@@ -3,18 +3,14 @@ identifier: HeatTilePainter
 name: Heat Tile Painter
 abstract: Paint heat-tile patterns or flat colors onto craft with editable layers and optional heat protection.
 author: peachyG
-license: MIT
 $kref: '#/ckan/github/peachyGT/HeatTilePainter/asset_match/^HeatTilePainter-[0-9]+\.[0-9]+\.[0-9]+\.zip$'
 $vref: '#/ckan/ksp-avc'
 x_netkan_version_edit:
   find: '^v?(?<version>.+)$'
   replace: '${version}'
   strict: true
-release_status: stable
 resources:
   homepage: https://forum.kerbalspaceprogram.com/topic/231652-1125-heat-tile-painter-0241-very-simple-way-to-add-heat-shielding-to-sstosspaceplanes/
-  repository: https://github.com/peachyGT/HeatTilePainter
-  bugtracker: https://github.com/peachyGT/HeatTilePainter/issues
 tags:
   - plugin
   - editor


### PR DESCRIPTION
Adds Heat Tile Painter 0.24.1 by peachyG.

- KSP 1.12.5
- GitHub release with KSP-AVC metadata
- Depends on ModuleManager
- Installs GameData/HeatTileOverlayPrototype
- Forum: https://forum.kerbalspaceprogram.com/topic/231652-1125-heat-tile-painter-0241-very-simple-way-to-add-heat-shielding-to-sstosspaceplanes/
- MIT License

Validated locally with netkan.exe v1.36.5.26198; inflation succeeds and the generated SHA-256 matches the published release asset. The validator reports a nonfatal manual-install detection warning because the legacy assembly and folder name remain HeatTileOverlayPrototype for saved-craft compatibility.