### PR TITLE
Add conflict between MicroSatRevived and its ancestor mod

### DIFF
--- a/NetKAN/MicroSatRevived.netkan
+++ b/NetKAN/MicroSatRevived.netkan
@@ -9,6 +9,8 @@ license: CC-BY-NC-SA-4.0
 tags:
   - parts
   - uncrewed
+conflicts:
+  - name: SSRMicroSat
 depends:
   - name: ModuleManager
 recommends:


### PR DESCRIPTION
#6452 indexed an adopted mod under a new identifier, which means you can try to install both mods, which results in a file conflict.

Now they conflict.

Fixes #11488.
