### PR TITLE
Fix Kerbal Proportions release source

### DIFF
--- a/NetKAN/KerbalProportions.netkan
+++ b/NetKAN/KerbalProportions.netkan
@@ -1,11 +1,23 @@
+spec_version: v1.4
 identifier: KerbalProportions
-$kref: '#/ckan/github/NickDeVeau/Kerbal-Proportions'
-x_netkan_version_edit: ^v?(?<version>.+)$
----
-identifier: KerbalProportions
-$kref: '#/ckan/spacedock/4513'
+name: Kerbal Proportions
+abstract: Live visual rig and proportion editor for EVA and IVA Kerbals
+author: Biggus
+license: MIT
+$kref: '#/ckan/github/NickDeVeau/Kerbal-Proportions/asset_match/^KerbalProportions-v.+\.zip$'
 $vref: '#/ckan/ksp-avc'
+x_netkan_github:
+  use_source_archive: false
+  prereleases: false
 tags:
   - plugin
   - graphics
   - crewed
+install:
+  - find: KerbalProportions
+    install_to: GameData
+resources:
+  homepage: https://github.com/NickDeVeau/Kerbal-Proportions
+  spacedock: https://spacedock.info/mod/4513
+  repository: https://github.com/NickDeVeau/Kerbal-Proportions
+  bugtracker: https://github.com/NickDeVeau/Kerbal-Proportions/issues


### PR DESCRIPTION
Kerbal Proportions is published to GitHub first and mirrored to SpaceDock. The current two-document metadata fails whenever the mirrors temporarily have different latest versions (currently: `Generated 2 modules but only 1 requested`).

This makes the GitHub release asset authoritative, reads version compatibility from the packaged KSP-AVC file, and keeps SpaceDock in `resources`. It also preserves the package install rule and public author name used by the project.