### PR TITLE
BoundlessMissions Addition to NETKAN

### DIFF
--- a/NetKAN/BoundlessMissions.netkan
+++ b/NetKAN/BoundlessMissions.netkan
@@ -1,0 +1,3 @@
+spec_version: v1.27
+identifier: BoundlessMissions
+$kref: '#/ckan/netkan/https://raw.githubusercontent.com/Boundless-Missions/boundlessmissions-modside/master/BoundlessMissions.netkan'


### PR DESCRIPTION
**Boundless Missions** is a player-to-player mod for KSP 1. It adds contracts written by
other players, reverse auctions, rescue missions, craft transfer between differently
modded saves, and a shared economy, all driven from inside the game.

- **Release:** https://github.com/Boundless-Missions/boundlessmissions-modside/releases/tag/v1.0.0
- **Homepage:** https://boundlessmissions.com
- **Source:** https://github.com/Boundless-Missions/boundlessmissions-modside (GPL-3.0)

### Submitted as a metanetkan

The three lines here point at the netkan in our own repo, so the authoritative metadata
lives with the mod and stays in step with it:

https://raw.githubusercontent.com/Boundless-Missions/boundlessmissions-modside/master/BoundlessMissions.netkan

Its current contents, so review does not need a fetch:

```json
{
    "spec_version": "v1.27",
    "identifier": "BoundlessMissions",
    "name": "Boundless Missions",
    "abstract": "Boundless Missions is a inter-player mod for Kerbal Space Program 1 that allows you to create and complete player-issued contracts, rescue vessels, transfer vessels between players, and participate in an in-game economy.",
    "author": [ "Boundless-Missions" ],
    "license": "GPL-3.0",
    "tags": [ "plugin", "app", "career", "crewed" ],
    "$kref": "#/ckan/github/Boundless-Missions/boundlessmissions-modside",
    "$vref": "#/ckan/ksp-avc",
    "resources": {
        "homepage": "https://boundlessmissions.com",
        "repository": "https://github.com/Boundless-Missions/boundlessmissions-modside",
        "bugtracker": "https://github.com/Boundless-Missions/boundlessmissions-modside/issues"
    },
    "depends":    [ { "name": "ModuleManager" } ],
    "recommends": [ { "name": "ClickThroughBlocker" }, { "name": "JanitorsCloset" } ],
    "install": [
        {
            "find": "BoundlessMissions",
            "install_to": "GameData",
            "filter": [ "settings.cfg" ]
        }
    ]
}
```

### Review checklist

| Item | Status |
|---|---|
| License matches the ZIP | GPL-3.0, and `LICENSE` ships inside the release archive |
| Homepage | Our own site rather than a forum thread. See the note below |
| `$vref` set (the ZIP carries a `.version`) | `#/ckan/ksp-avc`, reading `GameData/BoundlessMissions/GeneKerman.version` |
| Tags | `plugin`, `app`, `career`, `crewed` |
| Dependencies / conflicts | ModuleManager required; ClickThroughBlocker and Janitor's Closet recommended. No conflicts |

**On the homepage field.** The checklist asks for a forum thread and we currently point at
our own site, which carries the documentation, the marketplace and the account pages. As we are planning a planned announcement for thsi mod a KSP forum entry is not made yet, and discussion systems will be implemented after upload to NETKAN. After this, we would be happy to repoint it at the forum thread instead, or to move the site to `resources.manual` and put the thread in `homepage`, whichever you prefer. Since this is a metanetkan I can make that change without a further PR here.

Thanks for taking a look.
