### PR TITLE
Add TouristTransfer

### DIFF
--- a/NetKAN/TouristTransfer.netkan
+++ b/NetKAN/TouristTransfer.netkan
@@ -3,7 +3,6 @@ name: Tourist Transfer
 abstract: Transfer tourists between crew compartments by tourism contract.
 author: maddavo
 license: MIT
-release_status: testing
 ksp_version: 1.12.5
 $kref: '#/ckan/github/maddavo/TouristTransfer'
 tags:

--- a/NetKAN/TouristTransfer.netkan
+++ b/NetKAN/TouristTransfer.netkan
@@ -1,0 +1,22 @@
+identifier: TouristTransfer
+name: Tourist Transfer
+abstract: Transfer tourists between crew compartments by tourism contract.
+author: maddavo
+license: MIT
+release_status: testing
+ksp_version: 1.12.5
+$kref: '#/ckan/github/maddavo/TouristTransfer'
+tags:
+  - plugin
+  - convenience
+  - crew
+  - contracts
+depends:
+  - name: ModuleManager
+resources:
+  homepage: https://github.com/maddavo/TouristTransfer
+  repository: https://github.com/maddavo/TouristTransfer
+  bugtracker: https://github.com/maddavo/TouristTransfer/issues
+install:
+  - find: GameData/TouristTransfer
+    install_to: GameData


### PR DESCRIPTION
## TouristTransfer

Adds CKAN metadata for [TouristTransfer](https://github.com/maddavo/TouristTransfer), a KSP 1 mod that transfers tourists between crew compartments by tourism contract.

- GitHub release: [v0.1.7](https://github.com/maddavo/TouristTransfer/releases/tag/v0.1.7)
- KSP version: 1.12.5
- License: MIT
- Dependency: ModuleManager
- Install layout verified from the release ZIP

The metadata uses the GitHub NetKAN reference so later tagged releases can be indexed automatically.