### PR TITLE
Add SystemHeatMKS compatibility package

### DIFF
--- a/NetKAN/SystemHeatMKS.netkan
+++ b/NetKAN/SystemHeatMKS.netkan
@@ -1,0 +1,20 @@
+identifier: SystemHeatMKS
+name: SystemHeat MKS
+abstract: >-
+  Adds SystemHeat support for MKS/USI converters, harvesters, and heat pumps.
+author: maddavo
+license: MIT
+$kref: '#/ckan/github/maddavo/SystemHeatMKS'
+$vref: '#/ckan/ksp-avc/SystemHeatMKS.version'
+resources:
+  repository: https://github.com/maddavo/SystemHeatMKS
+tags:
+  - parts
+  - plugin
+depends:
+  - name: ModuleManager
+  - name: SystemHeat
+  - name: UKS
+install:
+  - find: SystemHeatMKS
+    install_to: GameData


### PR DESCRIPTION
## Summary

Add CKAN metadata for the standalone [SystemHeatMKS](https://github.com/maddavo/SystemHeatMKS) compatibility add-on.

The package provides optional SystemHeat integration for MKS/USI converters, harvesters, and heat pumps. It is released under the MIT license and depends on `SystemHeat` and `UKS`.

The first release is available as `v0.1.0.0` with a GitHub release ZIP.

This provides an external compatibility package for the MKS drill-support capability requested in [KSPModStewards/SystemHeat#132](https://github.com/KSPModStewards/SystemHeat/issues/132). It does not propose changes to SystemHeat core.

## Verification

- Release asset exists: `SystemHeatMKS-0.1.0.0.zip`
- NetKAN installation target is `GameData/SystemHeatMKS`.
- Metadata uses the existing GitHub and KSP-AVC reference conventions.