### PR TITLE
Change Kerbal Civilization Project (KCP) license from GPL-3.0 to Apache-2.0

### DIFF
--- a/NetKAN/KerbalCivilizationProject.netkan
+++ b/NetKAN/KerbalCivilizationProject.netkan
@@ -3,7 +3,7 @@ $kref: '#/ckan/github/KerbalMissile/Kerbal-Civilization-Project'
 ---
 identifier: KerbalCivilizationProject
 $kref: '#/ckan/spacedock/4544'
-license: GPL-3.0
+license: Apache-2.0
 tags:
   - plugin
   - buildings


### PR DESCRIPTION
I'm not sure if CKAN automatically checks for license updates on GitHub / SpaceDock, so I made a PR to change it.

I've re-licensed KCP from GPL-3.0 to Apache-2.0 just for future preparation so this PR reflects that change onto KCP on CKAN.