### PR TITLE
Fix ContractConfigurator-KSP2ForScience craft installs

### DIFF
--- a/NetKAN/ContractConfigurator-KSP2ForScience.netkan
+++ b/NetKAN/ContractConfigurator-KSP2ForScience.netkan
@@ -11,9 +11,3 @@ suggests:
 install:
   - find: ContractPacks
     install_to: GameData
-    filter_regexp: \.craft$
-  - file: GameData/ContractPacks/KSP2Exploration/Vessels/croissant.craft
-    install_to: Ships/VAB
-  - file: GameData/ContractPacks/KSP2Exploration/Vessels/stargazer.craft
-    install_to: Ships/VAB
-x_via: Automated SpaceDock CKAN submission

--- a/NetKAN/ContractConfigurator-KSP2ForScience.netkan
+++ b/NetKAN/ContractConfigurator-KSP2ForScience.netkan
@@ -11,3 +11,5 @@ suggests:
 install:
   - find: ContractPacks
     install_to: GameData
+  - find: Ships/VAB
+    install_to: Ships


### PR DESCRIPTION
This mod installs some craft files. In #11348, the bot set them up to be installed to `Ships/VAB`, but contract packs' craft files are supposed to be installed where the mod puts them in GameData.

However, after the mod was indexed, the author updated it to look in `Ships/VAB`! But this broke the `install` stanza that looked for them in GameData.

<img width="1851" height="132" alt="image" src="https://github.com/user-attachments/assets/578565bf-5c88-41df-bf6b-c501a1f72bc1" />

Now the GameData filter and craft-specific installs are removed, and a new one is added for `Ships/VAB`.
