### PR TITLE
Remove OverkillPlumes conflcit with KerbalAtomics and update version relationships

### DIFF
--- a/NetKAN/OverkillPlumes.netkan
+++ b/NetKAN/OverkillPlumes.netkan
@@ -15,9 +15,11 @@ depends:
 recommends:
   - name: FarFutureTechnologies
   - name: StockWaterfallEffects
+supports:
+  - name: FarFutureTechnologies
+  - name: StockWaterfallEffects
 suggests:
   - name: ReStock
   - name: ReStockPlus
-conflicts:
-  - name: KerbalAtomics
-x_via: Automated SpaceDock CKAN submission
+  - name: SterlingSystemsThermals
+  - name: ZTheme


### PR DESCRIPTION
These should be all the corrected relationships for the 0.2.0 version of Overkill Plumes, reflecting my findings regarding mod interactions from [before partial support was added](https://github.com/QuantumsHevy/OverkillPlumes/commit/afd55eb3d1113be62e73d40215ea904433c07770). See #11529 for my initial thoughts. Version 0.3.0 of the mod will come with a `.ckan` file within `OverkillPlume/Versioning/` for any new relationships. 

Fixes #11529.
