### PR TITLE
Add OPEnginesMod

### DIFF
--- a/NetKAN/OPEnginesMod.netkan
+++ b/NetKAN/OPEnginesMod.netkan
@@ -1,0 +1,17 @@
+identifier: OPEnginesMod
+name: KSP OP Engines Mod
+abstract: Overpowered stock-engine replacements for sandbox players
+$kref: '#/ckan/github/S1xinch/KSP-OPEnginesMod'
+license: MIT
+author: S1xinch
+resources:
+  repository: https://github.com/S1xinch/KSP-OPEnginesMod
+depends:
+  - name: ModuleManager
+install:
+  - file: GameData/OPEnginesMod
+    install_to: GameData
+  - file: GameData/000_FilterExtensions
+    install_to: GameData
+  - file: GameData/000_FilterExtensions_Configs
+    install_to: GameData


### PR DESCRIPTION
## Summary
- Adds NetKAN metadata for [KSP OP Engines Mod](https://github.com/S1xinch/KSP-OPEnginesMod), a mod that replaces several stock KSP engines with overpowered variants for sandbox players.
- Source is GitHub releases (`$kref: github`); the mod is MIT-licensed and its release zips are rooted at `GameData/`.
- Depends on ModuleManager; installs the mod folder plus its optional Filter Extensions integration files.

## Test plan
- [ ] Validate the `.netkan` file against the CKAN schema
- [ ] Confirm identifier/install paths against the `v1.1.0` release asset (`OPEnginesMod.zip`)


Partially made using Claude code only for the fork and the new engine